### PR TITLE
Introduce plugin catalog

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -17,6 +17,13 @@ go env -w GOPRIVATE=github.com/vmware-tanzu/tanzu-plugin-runtime
 
 ## Source Code Changes
 
+### Default Directory Locations
+
+The names of the directories for the plugins, catalog cache and local
+plugin discovery (`<XDG_DATA_HOME>/_tanzu-cli, $HOME/.cache/_tanzu,
+$HOME/.config/_tanzu-plugins`) are all directories prefixed with '_' for
+now, so as not to conflict with their nonprefixed counterparts
+
 ## Source Code Structure
 
 ### Tests

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	golang.org/x/mod v0.6.0
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	google.golang.org/grpc v1.40.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apimachinery v0.25.4
 	k8s.io/client-go v0.25.0
 )
@@ -74,7 +75,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.25.0 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -1,0 +1,240 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+
+	cliv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/utils"
+)
+
+const (
+	// catalogCacheFileName is the name of the file which holds Catalog cache
+	catalogCacheFileName = "catalog.yaml"
+)
+
+var (
+	// PluginRoot is the plugin root where plugins are installed
+	pluginRoot = common.DefaultPluginRoot
+)
+
+// ContextCatalog denotes a local plugin catalog for a given context or
+// stand-alone.
+type ContextCatalog struct {
+	sharedCatalog *Catalog
+	plugins       PluginAssociation
+}
+
+// NewContextCatalog creates context-aware catalog
+func NewContextCatalog(context string) (*ContextCatalog, error) {
+	sc, err := getCatalogCache()
+	if err != nil {
+		return nil, err
+	}
+
+	var plugins PluginAssociation
+	if context == "" {
+		plugins = sc.StandAlonePlugins
+	} else {
+		var ok bool
+		plugins, ok = sc.ServerPlugins[context]
+		if !ok {
+			plugins = make(PluginAssociation)
+			sc.ServerPlugins[context] = plugins
+		}
+	}
+
+	return &ContextCatalog{
+		sharedCatalog: sc,
+		plugins:       plugins,
+	}, nil
+}
+
+// Upsert inserts/updates the given plugin.
+func (c *ContextCatalog) Upsert(plugin *cli.PluginInfo) error {
+	pluginNameTarget := PluginNameTarget(plugin.Name, plugin.Target)
+
+	c.plugins[pluginNameTarget] = plugin.InstallationPath
+	c.sharedCatalog.IndexByPath[plugin.InstallationPath] = *plugin
+
+	if !utils.ContainsString(c.sharedCatalog.IndexByName[pluginNameTarget], plugin.InstallationPath) {
+		c.sharedCatalog.IndexByName[pluginNameTarget] = append(c.sharedCatalog.IndexByName[pluginNameTarget], plugin.InstallationPath)
+	}
+
+	return saveCatalogCache(c.sharedCatalog)
+}
+
+// Get looks up the descriptor of a plugin given its name.
+func (c *ContextCatalog) Get(plugin string) (cli.PluginInfo, bool) {
+	pd := cli.PluginInfo{}
+	path, ok := c.plugins[plugin]
+	if !ok {
+		return pd, false
+	}
+
+	pd, ok = c.sharedCatalog.IndexByPath[path]
+	if !ok {
+		return pd, false
+	}
+
+	return pd, true
+}
+
+// List returns the list of active plugins.
+// Active plugin means the plugin that are available to the user
+// based on the current logged-in server.
+func (c *ContextCatalog) List() []cli.PluginInfo {
+	pds := make([]cli.PluginInfo, 0)
+	for _, installationPath := range c.plugins {
+		pd := c.sharedCatalog.IndexByPath[installationPath]
+		pds = append(pds, pd)
+	}
+	return pds
+}
+
+// Delete deletes the given plugin from the catalog, but it does not delete
+// the installation.
+func (c *ContextCatalog) Delete(plugin string) error {
+	_, ok := c.plugins[plugin]
+	if ok {
+		delete(c.plugins, plugin)
+	}
+
+	return saveCatalogCache(c.sharedCatalog)
+}
+
+// getCatalogCacheDir returns the local directory in which tanzu state is stored.
+func getCatalogCacheDir() (path string) {
+	return common.DefaultCacheDir
+}
+
+// newSharedCatalog creates an instance of the shared catalog file.
+func newSharedCatalog() (*Catalog, error) {
+	c := &Catalog{
+		IndexByPath:       map[string]cli.PluginInfo{},
+		IndexByName:       map[string][]string{},
+		StandAlonePlugins: map[string]string{},
+		ServerPlugins:     map[string]PluginAssociation{},
+	}
+
+	err := ensureRoot()
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// getCatalogCache retrieves the catalog from from the local directory.
+func getCatalogCache() (catalog *Catalog, err error) {
+	b, err := os.ReadFile(getCatalogCachePath())
+	if err != nil {
+		catalog, err = newSharedCatalog()
+		if err != nil {
+			return nil, err
+		}
+		return catalog, nil
+	}
+
+	var c Catalog
+	err = yaml.Unmarshal(b, &c)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not decode catalog file")
+	}
+
+	if c.IndexByPath == nil {
+		c.IndexByPath = map[string]cli.PluginInfo{}
+	}
+	if c.IndexByName == nil {
+		c.IndexByName = map[string][]string{}
+	}
+	if c.StandAlonePlugins == nil {
+		c.StandAlonePlugins = map[string]string{}
+	}
+	if c.ServerPlugins == nil {
+		c.ServerPlugins = map[string]PluginAssociation{}
+	}
+
+	return &c, nil
+}
+
+// saveCatalogCache saves the catalog in the local directory.
+func saveCatalogCache(catalog *Catalog) error {
+	catalogCachePath := getCatalogCachePath()
+	_, err := os.Stat(catalogCachePath)
+	if os.IsNotExist(err) {
+		err = os.MkdirAll(getCatalogCacheDir(), 0755)
+		if err != nil {
+			return errors.Wrap(err, "could not make tanzu cache directory")
+		}
+	} else if err != nil {
+		return errors.Wrap(err, "could not create catalog cache path")
+	}
+
+	out, err := yaml.Marshal(catalog)
+	if err != nil {
+		return errors.Wrap(err, "failed to encode catalog cache file")
+	}
+
+	if err = os.WriteFile(catalogCachePath, out, 0644); err != nil {
+		return errors.Wrap(err, "failed to write catalog cache file")
+	}
+	return nil
+}
+
+// CleanCatalogCache cleans the catalog cache
+func CleanCatalogCache() error {
+	if err := os.Remove(getCatalogCachePath()); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+// getCatalogCachePath gets the catalog cache path
+func getCatalogCachePath() string {
+	return filepath.Join(getCatalogCacheDir(), catalogCacheFileName)
+}
+
+// Ensure the root directory exists.
+func ensureRoot() error {
+	_, err := os.Stat(testPath())
+	if os.IsNotExist(err) {
+		err := os.MkdirAll(testPath(), 0755)
+		return errors.Wrap(err, "could not make root plugin directory")
+	}
+	return err
+}
+
+// Returns the test path relative to the plugin root
+func testPath() string {
+	return filepath.Join(pluginRoot, "test")
+}
+
+// UpdateCatalogCache when updating the core CLI from v0.x.x to v1.x.x. This is
+// needed to group the standalone plugins by context type.
+func UpdateCatalogCache() error {
+	c, err := getCatalogCache()
+	if err != nil {
+		return err
+	}
+
+	return saveCatalogCache(c)
+}
+
+// PluginNameTarget contructs a string to uniquely refer to a plugin associated
+// with a specific target when target is provided.
+func PluginNameTarget(pluginName string, target cliv1alpha1.Target) string {
+	if target == "" {
+		return pluginName
+	}
+	return fmt.Sprintf("%s_%s", pluginName, target)
+}

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -1,0 +1,174 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
+)
+
+func Test_ContextCatalog_With_Empty_Context(t *testing.T) {
+	assert := assert.New(t)
+
+	dir, err := os.MkdirTemp("", "test-catalog")
+	assert.Nil(err)
+	defer os.RemoveAll(dir)
+	common.DefaultCacheDir = dir
+
+	// Create catalog without context
+	cc, err := NewContextCatalog("")
+	assert.Nil(err)
+	assert.NotNil(cc)
+
+	pd1 := cli.PluginInfo{
+		Name:             "fakeplugin1",
+		InstallationPath: "/path/to/plugin/fakeplugin1",
+		Version:          "1.0.0",
+	}
+
+	err = cc.Upsert(&pd1)
+	assert.Nil(err)
+
+	pd, exists := cc.Get("fakeplugin1")
+	assert.True(exists)
+	assert.Equal(pd.Name, "fakeplugin1")
+	assert.Equal(pd.InstallationPath, "/path/to/plugin/fakeplugin1")
+	assert.Equal(pd.Version, "1.0.0")
+
+	pd2 := cli.PluginInfo{
+		Name:             "fakeplugin2",
+		InstallationPath: "/path/to/plugin/fakeplugin2",
+		Version:          "2.0.0",
+	}
+	err = cc.Upsert(&pd2)
+	assert.Nil(err)
+
+	pd, exists = cc.Get("fakeplugin2")
+	assert.True(exists)
+	assert.Equal(pd.Name, "fakeplugin2")
+	assert.Equal(pd.InstallationPath, "/path/to/plugin/fakeplugin2")
+	assert.Equal(pd.Version, "2.0.0")
+
+	pds := cc.List()
+	assert.Equal(len(pds), 2)
+	assert.ElementsMatch([]string{pds[0].Name, pds[1].Name}, []string{"fakeplugin1", "fakeplugin2"})
+	assert.ElementsMatch([]string{pds[0].InstallationPath, pds[1].InstallationPath}, []string{"/path/to/plugin/fakeplugin1", "/path/to/plugin/fakeplugin2"})
+	assert.ElementsMatch([]string{pds[0].Version, pds[1].Version}, []string{"1.0.0", "2.0.0"})
+
+	err = cc.Delete("fakeplugin2")
+	assert.Nil(err)
+
+	pd, exists = cc.Get("fakeplugin2")
+	assert.False(exists)
+	assert.NotEqual(pd.Name, "fakeplugin2")
+
+	pds = cc.List()
+	assert.Equal(len(pds), 1)
+
+	// Create another catalog without context
+	// The new catalog should also have the same information
+	cc2, err := NewContextCatalog("")
+	assert.Nil(err)
+	assert.NotNil(cc2)
+
+	pd, exists = cc2.Get("fakeplugin1")
+	assert.True(exists)
+	assert.Equal(pd.Name, "fakeplugin1")
+	assert.Equal(pd.InstallationPath, "/path/to/plugin/fakeplugin1")
+	assert.Equal(pd.Version, "1.0.0")
+
+	pds = cc2.List()
+	assert.Equal(len(pds), 1)
+
+	os.RemoveAll(common.DefaultPluginRoot)
+}
+
+func Test_ContextCatalog_With_Context(t *testing.T) {
+	assert := assert.New(t)
+
+	dir, err := os.MkdirTemp("", "test-catalog-with-context")
+	assert.Nil(err)
+	defer os.RemoveAll(dir)
+	common.DefaultCacheDir = dir
+
+	cc, err := NewContextCatalog("server")
+	assert.Nil(err)
+	assert.NotNil(cc)
+
+	pd1 := cli.PluginInfo{
+		Name:             "fakeplugin1",
+		InstallationPath: "/path/to/plugin/fakeplugin1",
+		Version:          "1.0.0",
+	}
+
+	err = cc.Upsert(&pd1)
+	assert.Nil(err)
+
+	pd, exists := cc.Get("fakeplugin1")
+	assert.True(exists)
+	assert.Equal(pd.Name, "fakeplugin1")
+	assert.Equal(pd.InstallationPath, "/path/to/plugin/fakeplugin1")
+	assert.Equal(pd.Version, "1.0.0")
+
+	pd2 := cli.PluginInfo{
+		Name:             "fakeplugin2",
+		InstallationPath: "/path/to/plugin/fakeplugin2",
+		Version:          "2.0.0",
+	}
+	err = cc.Upsert(&pd2)
+	assert.Nil(err)
+
+	pd, exists = cc.Get("fakeplugin2")
+	assert.True(exists)
+	assert.Equal(pd.Name, "fakeplugin2")
+	assert.Equal(pd.InstallationPath, "/path/to/plugin/fakeplugin2")
+	assert.Equal(pd.Version, "2.0.0")
+
+	pds := cc.List()
+	assert.Equal(len(pds), 2)
+	assert.ElementsMatch([]string{pds[0].Name, pds[1].Name}, []string{"fakeplugin1", "fakeplugin2"})
+	assert.ElementsMatch([]string{pds[0].InstallationPath, pds[1].InstallationPath}, []string{"/path/to/plugin/fakeplugin1", "/path/to/plugin/fakeplugin2"})
+	assert.ElementsMatch([]string{pds[0].Version, pds[1].Version}, []string{"1.0.0", "2.0.0"})
+
+	err = cc.Delete("fakeplugin2")
+	assert.Nil(err)
+
+	pd, exists = cc.Get("fakeplugin2")
+	assert.False(exists)
+	assert.NotEqual(pd.Name, "fakeplugin2")
+
+	pds = cc.List()
+	assert.Equal(len(pds), 1)
+
+	// Create another catalog with same context
+	// The new catalog should also have the same information
+	cc2, err := NewContextCatalog("server")
+	assert.Nil(err)
+	assert.NotNil(cc2)
+
+	pd, exists = cc2.Get("fakeplugin1")
+	assert.True(exists)
+	assert.Equal(pd.Name, "fakeplugin1")
+	assert.Equal(pd.InstallationPath, "/path/to/plugin/fakeplugin1")
+	assert.Equal(pd.Version, "1.0.0")
+
+	pds = cc2.List()
+	assert.Equal(len(pds), 1)
+
+	// Create another catalog with different context
+	// The new catalog should not have the same information
+	cc3, err := NewContextCatalog("server2")
+	assert.Nil(err)
+	assert.NotNil(cc3)
+
+	pd, exists = cc3.Get("fakeplugin1")
+	assert.False(exists)
+
+	os.RemoveAll(common.DefaultPluginRoot)
+}

--- a/pkg/catalog/catalog_types.go
+++ b/pkg/catalog/catalog_types.go
@@ -1,0 +1,59 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
+)
+
+// Distro is the Schema for the catalogs API
+// type Distro []string
+
+// PluginAssociation is a set of plugin names and their associated installation paths.
+type PluginAssociation map[string]string
+
+// Add adds plugin entry to the map
+func (pa PluginAssociation) Add(pluginName, installationPath string) {
+	if pa == nil {
+		pa = map[string]string{}
+	}
+	pa[pluginName] = installationPath
+}
+
+// Remove deletes plugin entry from the map
+func (pa PluginAssociation) Remove(pluginName string) {
+	delete(pa, pluginName)
+}
+
+// Get returns installation path for the plugin
+// If plugin doesn't exists in map it will return empty string
+func (pa PluginAssociation) Get(pluginName string) string {
+	return pa[pluginName]
+}
+
+// Map returns associated list of plugins as a map
+func (pa PluginAssociation) Map() map[string]string {
+	return pa
+}
+
+// Catalog is the Schema for the plugin catalog data
+type Catalog struct {
+	// PluginInfos is a list of PluginInfo
+	PluginInfos []*cli.PluginInfo `json:"pluginInfos,omitempty" yaml:"pluginInfos"`
+
+	// IndexByPath of PluginInfos for all installed plugins by installation path.
+	IndexByPath map[string]cli.PluginInfo `json:"indexByPath,omitempty"`
+	// IndeByName of all plugin installation paths by name.
+	IndexByName map[string][]string `json:"indexByName,omitempty"`
+	// StandAlonePlugins is a set of stand-alone plugin installations aggregated across all context types.
+	// Note: Shall be reduced to only those stand-alone plugins that are common to all context types.
+	StandAlonePlugins PluginAssociation `json:"standAlonePlugins,omitempty"`
+	// ServerPlugins links a server and a set of associated plugin installations.
+	ServerPlugins map[string]PluginAssociation `json:"serverPlugins,omitempty"`
+}
+
+// CatalogList contains a list of Catalog
+type CatalogList struct {
+	Items []Catalog `json:"items"`
+}

--- a/pkg/catalog/interface.go
+++ b/pkg/catalog/interface.go
@@ -1,7 +1,7 @@
-// Copyright 2022 VMware, Inc. All Rights Reserved.
+// Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package catalog ...
+// Package catalog implements catalog management functions
 package catalog
 
 import (
@@ -10,7 +10,23 @@ import (
 
 // PluginSupplier is responsible for keeping an inventory of installed plugins
 type PluginSupplier interface {
-
 	// GetInstalledPlugins returns a list of installed plugins
 	GetInstalledPlugins() ([]*cli.PluginInfo, error)
+}
+
+// PluginCatalog is the interface to a collection of installed plugins.
+type PluginCatalog interface {
+	// Upsert inserts/updates the given plugin.
+	Upsert(plugin cli.PluginInfo)
+
+	// Get looks up the descriptor of a plugin given its name.
+	Get(pluginName string) (cli.PluginInfo, bool)
+
+	// List returns the list of active plugins.
+	// Active plugin means the plugin that are available to the user
+	// based on the current logged-in server.
+	List() []cli.PluginInfo
+
+	// Delete deletes the given plugin from the catalog, but it does not delete the installation.
+	Delete(plugin string)
 }

--- a/pkg/cli/plugin_info.go
+++ b/pkg/cli/plugin_info.go
@@ -4,10 +4,11 @@
 package cli
 
 import (
+	cliv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/plugin"
 )
 
-// PluginInfo contains information about an installed plugin binary
+// PluginInfo contains information about a plugin binary
 type PluginInfo struct {
 	// Name is the name of the plugin.
 	Name string `json:"name" yaml:"name"`
@@ -18,15 +19,58 @@ type PluginInfo struct {
 	// Version of the plugin. Must be a valid semantic version https://semver.org/
 	Version string `json:"version" yaml:"version"`
 
+	// BuildSHA is the git commit hash the plugin was built with.
+	BuildSHA string `json:"buildSHA" yaml:"buildSHA"`
+
+	// Digest is the SHA256 hash of the plugin binary.
+	Digest string `json:"digest" yaml:"digest"`
+
 	// Command group for the plugin.
 	Group plugin.CmdGroup `json:"group" yaml:"group"`
+
+	// DocURL for the plugin.
+	DocURL string `json:"docURL" yaml:"docURL"`
 
 	// Hidden tells whether the plugin should be hidden from the help command.
 	Hidden bool `json:"hidden,omitempty" yaml:"hidden,omitempty"`
 
+	// CompletionType determines how command line completion will be determined.
+	CompletionType plugin.PluginCompletionType `json:"completionType" yaml:"completionType"`
+
+	// CompletionArgs contains the valid command line completion values if `CompletionType`
+	// is set to `StaticPluginCompletion`.
+	CompletionArgs []string `json:"completionArgs,omitempty" yaml:"completionArgs,omitempty"`
+
+	// CompletionCommand is the command to call from the plugin to retrieve a list of
+	// valid completion nouns when `CompletionType` is set to `DynamicPluginCompletion`.
+	CompletionCommand string `json:"completionCmd,omitempty" yaml:"completionCmd,omitempty"`
+
 	// Aliases are other text strings used to call this command
 	Aliases []string `json:"aliases,omitempty" yaml:"aliases,omitempty"`
 
-	// InstallationPath is the path to the plugin binary.
+	// InstallationPath is a relative installation path for a plugin binary.
+	// E.g., cluster/v0.3.2@sha256:...
 	InstallationPath string `json:"installationPath"`
+
+	// Discovery is the name of the discovery from where
+	// this plugin is discovered.
+	Discovery string `json:"discovery"`
+
+	// Scope is the scope of the plugin. Stand-Alone or Context
+	Scope string `json:"scope"`
+
+	// Status is the current plugin installation status
+	Status string `json:"status"`
+
+	// DiscoveredRecommendedVersion specifies the recommended version of the plugin that was discovered
+	DiscoveredRecommendedVersion string `json:"discoveredRecommendedVersion"`
+
+	// Target specifies the target of the plugin
+	Target cliv1alpha1.Target `json:"target"`
+
+	// PostInstallHook is function to be run post install of a plugin.
+	PostInstallHook plugin.Hook `json:"-" yaml:"-"`
+
+	// DefaultFeatureFlags is default featureflags to be configured if missing when invoking plugin
+	DefaultFeatureFlags map[string]bool `json:"defaultFeatureFlags"`
 }

--- a/pkg/common/defaults.go
+++ b/pkg/common/defaults.go
@@ -11,7 +11,17 @@ import (
 )
 
 var (
+	// TODO(vuil): all directories prefixed with '_', but are expected to be
+	// reconsolidated back to their unprefixed equivalents once backward
+	// compatibility is achieved.
+
 	// DefaultPluginRoot is the default plugin root.
-	// TODO(vuil): reconsolidate back to legacy plugin location
-	DefaultPluginRoot = filepath.Join(xdg.DataHome, ".tanzu-cli")
+	DefaultPluginRoot = filepath.Join(xdg.DataHome, "_tanzu-cli")
+
+	// DefaultCacheDir is the default cache directory
+	DefaultCacheDir = filepath.Join(xdg.Home, ".cache", "_tanzu")
+
+	// DefaultLocalPluginDistroDir is the default Local plugin distribution root directory
+	// This directory will be used for local discovery and local distribute of plugins
+	DefaultLocalPluginDistroDir = filepath.Join(xdg.Home, ".config", "_tanzu-plugins")
 )

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -1,0 +1,15 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package utils contains utility functions
+package utils
+
+// ContainsString checks the string contains in string array
+func ContainsString(arr []string, str string) bool {
+	for _, a := range arr {
+		if a == str {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/utils/common_test.go
+++ b/pkg/utils/common_test.go
@@ -1,0 +1,30 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Suite")
+}
+
+var _ = Describe("Unit tests for the common utils", func() {
+	testStrings := []string{"foo", "bar", "baz"}
+
+	It("String present in input array", func() {
+		present := ContainsString(testStrings, "bar")
+		Expect(present).To(BeTrue())
+	})
+
+	It("String not present in input array", func() {
+		present := ContainsString(testStrings, "foobar")
+		Expect(present).To(BeFalse())
+	})
+})

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -1,0 +1,39 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+// SaveFile saves the file to the provided path
+// Also creates missing directories if any
+func SaveFile(filePath string, data []byte) error {
+	dirName := filepath.Dir(filePath)
+	if _, serr := os.Stat(dirName); serr != nil {
+		merr := os.MkdirAll(dirName, os.ModePerm)
+		if merr != nil {
+			return merr
+		}
+	}
+
+	err := os.WriteFile(filePath, data, 0644)
+	if err != nil {
+		return errors.Wrapf(err, "unable to save file '%s'", filePath)
+	}
+
+	return nil
+}
+
+// PathExists returns true if file/directory exists otherwise returns false
+func PathExists(dir string) bool {
+	_, err := os.Stat(dir)
+	if err != nil && os.IsNotExist(err) {
+		return false
+	}
+	return true
+}

--- a/pkg/utils/files_test.go
+++ b/pkg/utils/files_test.go
@@ -1,0 +1,42 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Unit tests for the files utils", func() {
+	Context("Unit tests for path exists", func() {
+		It("File does not exist", func() {
+			exists := PathExists("/tmp/foo.txt")
+			Expect(exists).To(BeFalse())
+		})
+
+		It("File exists", func() {
+			path, err := os.CreateTemp("/tmp", "bar.txt")
+			Expect(err).To(BeNil())
+			exists := PathExists(path.Name())
+			Expect(exists).To(BeTrue())
+			err = os.Remove(path.Name())
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("Unit tests for saving a file", func() {
+		It("test happy path", func() {
+			filePath := "/tmp/testfile"
+			fileContent := []byte("Test Content")
+
+			err := SaveFile(filePath, fileContent)
+			Expect(err).To(BeNil())
+
+			err = os.Remove(filePath)
+			Expect(err).To(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
### What this PR does / why we need it

The catalog will record metadata about CLI plugins, including mapping of said plugins to the context with which they are associated.

It will be used in an upcoming change by the plugin manager in conjunction with various plugin lifecycle operations.

### Which issue(s) this PR fixes

Fixes #N/A

### Describe testing done for PR

Unit tests, inspected generated catalog contents.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
None
```


