### PR TITLE
Move constant for default artifacts dir to builder

### DIFF
--- a/cmd/plugin/builder/cli.go
+++ b/cmd/plugin/builder/cli.go
@@ -9,7 +9,6 @@ import (
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/component"
 
 	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/command"
-	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 )
 
 var (
@@ -17,11 +16,15 @@ var (
 	description string
 )
 
+// defaultArtifactsDirectory is the root of the default directory where a plugin is built.
+// This can be overridden by the `--artifacts` flag of the `builder cli compile` command.
+const defaultArtifactsDirectory = "artifacts"
+
 var compileArgs = &command.PluginCompileArgs{
 	Match:        "*",
 	TargetArch:   []string{"all"},
 	SourcePath:   "./cmd/plugin",
-	ArtifactsDir: cli.DefaultArtifactsDirectory,
+	ArtifactsDir: defaultArtifactsDirectory,
 }
 
 // NewCLICmd creates the CLI builder commands.

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -12,8 +12,6 @@ const (
 	ManifestFileName = "manifest.yaml"
 	// PluginDescriptorFileName is the file name for the plugin descriptor.
 	PluginDescriptorFileName = "plugin.yaml"
-	// DefaultArtifactsDirectory is the root artifacts directory
-	DefaultArtifactsDirectory = "artifacts"
 	// AllPlugins is the keyword for all plugins.
 	AllPlugins = "all"
 )

--- a/pkg/common/defaults.go
+++ b/pkg/common/defaults.go
@@ -24,7 +24,4 @@ var (
 	// DefaultLocalPluginDistroDir is the default Local plugin distribution root directory
 	// This directory will be used for local discovery and local distribute of plugins
 	DefaultLocalPluginDistroDir = filepath.Join(xdg.Home, ".config", "_tanzu-plugins")
-
-	// DefaultArtifactsDir is the root artifacts directory
-	DefaultArtifactsDir = "artifacts"
 )


### PR DESCRIPTION
### What this PR does / why we need it

Small code cleanup moving the concept of "default artifacts" directory from the CLI to the `builder` plugin.
I didn't see why the CLI needed to know about this build directory.

### Which issue(s) this PR fixes

Fixes #25

### Describe testing done for PR

make all

### Additional information

Note that the `DefaultArtifactsDir` constant was also removed from `defaults.go`, as it was not used.