### PR TITLE
Add E2E test framework and tooling

### DIFF
--- a/.github/workflows/cli_core_e2e_test.yaml
+++ b/.github/workflows/cli_core_e2e_test.yaml
@@ -1,0 +1,46 @@
+name: Tanzu CLI Core Tests
+
+on:
+  pull_request:
+    branches: [main, release-*]
+    paths:
+      - "*"
+
+jobs:
+  build:
+    name: Tanzu CLI Core E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+        id: go
+
+      - name: go cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Setup dependencies
+        run: make tools
+
+      - name: Build CLI Core
+        run: |
+          make build
+
+      - name: Start local OCI registry
+        run: |
+          make local-registry
+
+      - name: Tests
+        run: |
+          make e2e-cli-core

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ GOLANGCI_LINT      := $(TOOLS_BIN_DIR)/golangci-lint
 VALE               := $(TOOLS_BIN_DIR)/vale
 MISSPELL           := $(TOOLS_BIN_DIR)/misspell
 CONTROLLER_GEN     := $(TOOLS_BIN_DIR)/controller-gen
-TOOLING_BINARIES   := $(GOIMPORTS) $(GOLANGCI_LINT) $(VALE) $(MISSPELL) $(CONTROLLER_GEN)
+IMGPKG             := $(TOOLS_BIN_DIR)/imgpkg
+TOOLING_BINARIES   := $(GOIMPORTS) $(GOLANGCI_LINT) $(VALE) $(MISSPELL) $(CONTROLLER_GEN) $(IMGPKG)
 
 # Build and version information
 
@@ -47,9 +48,9 @@ NUL = /dev/null
 ifeq ($(GOHOSTOS),windows)
 	NUL = NUL
 endif
-BUILD_SHA ?= $$(git describe --match=$(git rev-parse --short HEAD) --always --dirty)
-BUILD_DATE ?= $$(date -u +"%Y-%m-%d")
-BUILD_VERSION ?= $$(git describe --tags --abbrev=0 2>$(NUL))
+BUILD_SHA ?= $(shell git describe --match=$(git rev-parse --short HEAD) --always --dirty)
+BUILD_DATE ?= $(shell date -u +"%Y-%m-%d")
+BUILD_VERSION ?= $(shell git describe --tags --abbrev=0 2>$(NUL))
 
 ifeq ($(strip $(BUILD_VERSION)),)
 BUILD_VERSION = dev
@@ -93,10 +94,12 @@ all: gomod build-all test lint ## Run all major targets (lint, test, build)
 cross-build: ${CLI_TARGETS} ${PLUGIN_TARGETS} publish-admin-plugins-all-local## Build the Tanzu Core CLI and plugins for all supported platforms and also publish admin plugins locally
 
 .PHONY: build-all
-build-all: build-cli-${GOHOSTOS}-${GOHOSTARCH} build-publish-admin-plugins-local ## Build the Tanzu Core CLI, admin plugins and publish admin plugins locally for the local platform
+build-all: build build-publish-admin-plugins-local ## Build the Tanzu Core CLI, admin plugins and publish admin plugins locally for the local platform
 
 .PHONY: build
 build: build-cli-${GOHOSTOS}-${GOHOSTARCH} ## Build the Tanzu Core CLI for the local platform
+	mkdir -p bin
+	cp $(ARTIFACTS_DIR)/$(GOHOSTOS)/$(GOHOSTARCH)/cli/core/$(BUILD_VERSION)/tanzu-cli-$(GOHOSTOS)_$(GOHOSTARCH) ./bin/tanzu
 
 .PHONY: build-publish-admin-plugins-local
 build-publish-admin-plugins-local: build-plugin-admin-${GOHOSTOS}-${GOHOSTARCH}  publish-admin-plugins-local
@@ -118,7 +121,6 @@ build-cli-%: ##Build the Tanzu Core CLI for a platform
 	else \
 		GOOS=$(OS) GOARCH=$(ARCH) $(GO) build --ldflags "$(LD_FLAGS)"  -o "$(ARTIFACTS_DIR)/$(OS)/$(ARCH)/cli/core/$(BUILD_VERSION)/tanzu-cli-$(OS)_$(ARCH)" ./cmd/tanzu/main.go;\
 	fi
-
 
 ## --------------------------------------
 ## Plugins-specific
@@ -202,7 +204,11 @@ choco-package: ## Build a Chocolatey package
 
 .PHONY: test
 test: fmt ## Run Tests
-	${GO} test ./... -timeout 60m -race -coverprofile coverage.txt ${GOTEST_VERBOSE}
+	${GO} test `go list ./... | grep -v test/e2e` -timeout 60m -race -coverprofile coverage.txt ${GOTEST_VERBOSE}
+
+.PHONY: e2e-cli-core
+e2e-cli-core: ## Run CLI Core E2E Tests
+	${GO} test ./test/e2e/... -timeout 60m -race -coverprofile coverage.txt ${GOTEST_VERBOSE}
 
 .PHONY: fmt
 fmt: $(GOIMPORTS) ## Run goimports
@@ -266,6 +272,18 @@ generate-manifests:  ## Generate API manifests e.g. CRD
 generate: generate-controller-code generate-manifests 	## Generate controller code and manifests e.g. CRD etc.
 
 ## --------------------------------------
+## docker
+## --------------------------------------
+
+.PHONY: local-registry
+local-registry: clean-registry ## Starts up a local docker registry for the e2e tests
+	docker run -d -p 5001:5000 --name registry mirror.gcr.io/library/registry:2
+
+.PHONY: clean-registry
+clean-registry: ## Stops and removes local docker registry
+	docker stop registry && docker rm -v registry || true
+
+## --------------------------------------
 ## Tooling Binaries
 ## --------------------------------------
 
@@ -273,3 +291,4 @@ tools: $(TOOLING_BINARIES) ## Build tooling binaries
 .PHONY: $(TOOLING_BINARIES)
 $(TOOLING_BINARIES):
 	make -C $(TOOLS_DIR) $(@F)
+

--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -24,6 +24,7 @@ VALE_VERSION=2.20.1
 GOLANGCI_LINT_VERSION=1.46.0
 MISSPELL_VERSION=0.3.4
 CONTROLLER_TOOLS_VERSION=0.9.2
+IMGPKG_VERSION=v0.35.0
 
 # Host information.
 HOST_OS=$(shell go env GOOS)
@@ -35,6 +36,7 @@ VALE               := $(BIN_DIR)/vale
 GOLANGCI_LINT      := $(BIN_DIR)/golangci-lint
 MISSPELL           := $(BIN_DIR)/misspell
 CONTROLLER_GEN     := $(BIN_DIR)/controller-gen
+IMGPKG			   := $(BIN_DIR)/imgpkg
 ## --------------------------------------
 ## Help
 ## --------------------------------------
@@ -76,6 +78,13 @@ misspell: $(MISSPELL) ## Install misspell
 $(MISSPELL):
 	mkdir -p $(BIN_DIR)
 	GOBIN=$(ROOT_DIR)/hack/tools/$(BIN_DIR) go install  github.com/client9/misspell/cmd/misspell@v$(MISSPELL_VERSION)
+
+imgpkg: $(IMGPKG) ## Install imgpkg 
+$(IMGPKG):
+	mkdir -p $(BIN_DIR)
+	curl -LO https://github.com/vmware-tanzu/carvel-imgpkg/releases/download/$(IMGPKG_VERSION)/imgpkg-$(HOST_OS)-$(HOST_ARCH)
+	mv imgpkg-$(HOST_OS)-$(HOST_ARCH) $(@)
+	chmod a+x $(@)
 
 ## --------------------------------------
 ## Cleanup

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,158 @@
+# End-to-End testing in Tanzu CLI Core
+
+## E2E tests
+
+End-to-End (E2E) test cases validate the Tanzu CLI Core product functionality in an environment which resembles a real production environment. They also validate the backward compatibility of plugins which are developed with versions of the Tanzu Plugin Runtime library older than the one used by the current CLI Core. The CLI Core project has unit and integration test cases covering current functionality, but the E2E tests perform validation from an end user's perspective and test the product as a whole in a production-like environment.
+
+E2E tests ensure the consistent and reliable behavior of the CLI Core code base. CLI Core E2E CI pipelines are the final signal to ensure that the CLI Core product is functional according to product specifications, and ready for release.
+
+## E2E Framework and Tools
+
+The End-to-End (E2E) test framework provides basic tooling and utility functions to write E2E test cases. This framework includes: generating and publishing plugin binaries/bundles, creating k8s clusters, executing unix commands, and performing CLI core commands and processing their output.
+Apart from the basic framework tooling, the test cases are written and executed using the Ginkgo Test Framework. Before writing E2E tests one should be familiar with how to write test cases using Ginkgo and how to add logging information using that framework. One should also be familiar with the E2E framework itself so as to use the existing tooling instead of potentially re-writing utility functions.
+
+**E2E Framework Interfaces**:
+
+The CLI Core E2E framework has a struct type called `Framework` which provides all the interfaces and utility functions mentioned in the previous section.
+To write an E2E test, one should create an object of type `Framework` using `framework.NewFramework()`, then use the object to trigger different CLI core commands lifecycle operations and access helper functions.
+
+```go
+// Framework has all CLI Core commands lifecycle operations and helper functions to write CLI e2e test cases
+type Framework struct {
+    CliOps
+    Config ConfigLifecycleOps
+    ClusterOps
+    PluginCmd    PluginCmdOps // performs plugin command operations
+    PluginHelper PluginHelperOps // helper (pre-setup) for plugin cmd operations
+}
+```
+
+Below are the major interfaces defined and implemented as part of the E2E Framework (which are part of the `Framework` struct type). These interfaces are used to write E2E test cases using the Ginkgo test framework. The interfaces are self-explanatory:
+
+To execute unix commands:
+
+```go
+// CmdOps performs the Command line exec operations
+type CmdOps interface {
+    Exec(command string) (stdOut, stdErr *bytes.Buffer, err error)
+    ExecContainsString(command, contains string) error
+    ExecContainsAnyString(command string, contains []string) error
+    ExecContainsErrorString(command, contains string) error
+    ExecNotContainsStdErrorString(command, contains string) error
+    ExecNotContainsString(command, contains string) error
+}
+```
+
+To generate plugins and publish plugin binaries and bundles to a local OCI repository and TMC (yet to implement)
+
+```go
+// GeneratePluginOps helps to generate script-based plugin binaries, and plugin binaries can be used to perform plugin testing
+// like, add plugin source, list, and install plugins. And call sub-commands such as info and version.
+type GeneratePluginOps interface {
+    // GeneratePluginBinaries generates plugin binaries for given plugin metadata and return generated plugin binary file paths
+    GeneratePluginBinaries(pluginsMeta []*PluginMeta) ([]string, []error)
+}
+
+// PublishPluginOps helps to publish plugin binaries and plugin bundles
+type PublishPluginOps interface {
+    // PublishPluginBinary publishes the plugin binaries to given registry bucket and returns the plugin distribution urls
+    PublishPluginBinary(pluginsInfo []*PluginMeta) (distributionUrls []string, errs []error)
+    // GeneratePluginBundle generates plugin bundle in local file system for given plugin metadata
+    GeneratePluginBundle(pluginsMeta []*PluginMeta) ([]string, []error)
+    // PublishPluginBundle publishes the plugin bundles to given registry bucket and returns the plugins discovery urls
+    PublishPluginBundle(pluginsInfo []*PluginMeta) (discoveryUrls []string, errs []error)
+}
+
+// PluginHelperOps helps to generate and publish plugins
+type PluginHelperOps interface {
+    GeneratePluginOps
+    PublishPluginOps
+}
+```
+
+To perform tanzu plugin command operations:
+
+```go
+// PluginBasicOps helps to perform the plugin command operations
+type PluginBasicOps interface {
+    // ListPlugins lists all plugins by running 'tanzu plugin list' command
+    ListPlugins() ([]PluginListInfo, error)
+    // TODO: more plugin command operations will be added, such as clean, delete, describe, install, sync and upgrade
+}
+
+// PluginSourceOps helps 'plugin source' commands
+type PluginSourceOps interface {
+    // AddPluginDiscoverySource adds plugin discovery source
+    AddPluginDiscoverySource(discoveryOpts *DiscoveryOptions) error
+}
+
+// PluginCmdOps helps to perform the plugin and its sub-commands lifecycle operations
+type PluginCmdOps interface {
+    PluginBasicOps
+    PluginSourceOps
+}
+```
+
+To perform cluster specific operations:
+
+```go
+// ClusterOps has helper operations to perform on cluster
+type ClusterOps interface {
+    CreateCluster(name string, args []string) (output string, err error)
+    DeleteCluster(name string, args []string) (output string, err error)
+    ClusterStatus(name string, args []string) (output string, err error)
+}
+
+// KindCluster performs k8s KIND cluster operations
+type KindCluster interface {
+    ClusterOps
+}
+```
+
+To perform tanzu config command and CLI lifecycle operations:
+
+```go
+// ConfigLifecycleOps performs "tanzu config" command operations
+type ConfigLifecycleOps interface {
+    ConfigSetFeatureFlag(path, value string) error
+    ConfigGetFeatureFlag(path string) (string, error)
+    ConfigUnsetFeature(path string) error
+    ConfigInit() error
+    ConfigServerList() error
+    ConfigServerDelete(serverName string) error
+    DeleteCLIConfigurationFiles() error
+    IsCLIConfigurationFilesExists() bool
+}
+
+// CliOps performs basic cli operations
+type CliOps interface {
+    CliInit() error
+    CliVersion() (string, error)
+    InstallCLI(version string) error
+    UninstallCLI(version string) error
+}
+```
+
+## Use cases covered in E2E tests
+
+### End user operations
+
+E2E tests are written to validate all CLI Core functionalities from the end-user perspective. They cover all CLI Core commands lifecycle operations. Below is the list of CLI Core commands or use cases covered by the E2E tests:
+
+- CLI lifecycle operations, like build and install the CLI in all possible ways and on all platforms (TODO)
+- CLI Config command lifecycle operations, like init, get, set, unset and server related operations (In-progress)
+- CLI Plugin command lifecycle operations, like install, upgrade, list, delete and discovery source operations (In-progress)
+- CLI Context command lifecycle operations, like create, get, list, delete and use context operations, including target (k8s and TMC) specific use cases (In-progress)
+- Other CLI commands lifecycle operations, like update, version, completion and init (TODO)
+
+### plugin compatibility/coexistence tests
+
+The E2E framework tests plugin compatibility by using the current version of the CLI Core and performing basic plugin operations (add/list/delete plugins, and invoke plugin basic commands such as info, help) on plugins built using older versions of the CLI Plugin Runtime library. This ensures that the current CLI supports all older plugins and all plugins can coexists.
+
+## How and when E2E tests are executed
+
+E2E tests are executed as Github runner CI pipelines. The CLI Core E2E test CI pipelines will be executed for every PR created on the CLI Core repository. The E2E tests are organized a list of CLI commands/use cases and plugin compatibility tests in Github CI pipelines, it does shows the test cases results also.
+
+### What is not covered in E2E tests
+
+CLI Core E2E tests do not execute any test cases to validate specific plugin functionalities. For example, for a plugin name `Cluster`, the CLI Core has test cases to validate to discovery and installation of the plugin, but does not test actual functionality of the `Cluster` plugin itself.

--- a/test/e2e/cli_lifecycle/cli_lifecycle_suite_test.go
+++ b/test/e2e/cli_lifecycle/cli_lifecycle_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package clilifecycle
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCliLifecycle(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CliLifecycle Suite")
+}

--- a/test/e2e/cli_lifecycle/init_version_cmds_test.go
+++ b/test/e2e/cli_lifecycle/init_version_cmds_test.go
@@ -1,0 +1,36 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package clilifecycle provides cli installation life cycle E2E test cases
+package clilifecycle
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware-tanzu/tanzu-cli/test/e2e/framework"
+)
+
+var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Command-init-version]", func() {
+	var (
+		tf *framework.Framework
+	)
+	BeforeEach(func() {
+		tf = framework.NewFramework()
+	})
+	Context("tests for tanzu init and version commands", func() {
+		When("init command executed", func() {
+			It("should initialize cli successfully", func() {
+				err := tf.CliInit()
+				Expect(err).To(BeNil())
+			})
+		})
+		When("version command executed", func() {
+			It("should return version info", func() {
+				version, err := tf.CliVersion()
+				Expect(version).NotTo(BeNil())
+				Expect(err).To(BeNil())
+			})
+		})
+	})
+})

--- a/test/e2e/config/config_suite_test.go
+++ b/test/e2e/config/config_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package confige2e
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config Suite")
+}

--- a/test/e2e/config/config_test.go
+++ b/test/e2e/config/config_test.go
@@ -1,0 +1,78 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package config_e2e_test provides config command specific E2E test cases
+package confige2e
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware-tanzu/tanzu-cli/test/e2e/framework"
+)
+
+var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Command-Config]", func() {
+	var (
+		tf *framework.Framework
+	)
+	BeforeEach(func() {
+		tf = framework.NewFramework()
+	})
+	Context("config feature flag operations", func() {
+		When("new config flag set with value", func() {
+			It("should set flag and unset flag successfully", func() {
+				randomFlagName := "e2e-test-" + framework.RandomString(4)
+				randomFeatureFlagPath := "features.global." + randomFlagName
+				flagVal := "true"
+				err := tf.Config.ConfigSetFeatureFlag(randomFeatureFlagPath, flagVal)
+				Expect(err).To(BeNil())
+
+				val, err := tf.Config.ConfigGetFeatureFlag(randomFeatureFlagPath)
+				Expect(err).To(BeNil())
+				Expect(val).Should(Equal("true"))
+
+				err = tf.Config.ConfigUnsetFeature(randomFeatureFlagPath)
+				Expect(err).To(BeNil())
+
+				val, err = tf.Config.ConfigGetFeatureFlag(randomFeatureFlagPath)
+				Expect(err).To(BeNil())
+				Expect(val).Should(Equal(""))
+			})
+		})
+		When("config init called when config files not exists", func() {
+			It("should initialize configuration successfully", func() {
+				// delete config files
+				err := tf.Config.DeleteCLIConfigurationFiles()
+				Expect(err).To(BeNil())
+				// call init
+				err = tf.Config.ConfigInit()
+				Expect(err).To(BeNil())
+				// should create config files
+				Expect(tf.Config.IsCLIConfigurationFilesExists()).To(BeTrue())
+
+				// set feature flag
+				randomFlagName := "e2e-test-" + framework.RandomString(4)
+				randomFeatureFlagPath := "features.global." + randomFlagName
+				flagVal := "true"
+				err = tf.Config.ConfigSetFeatureFlag(randomFeatureFlagPath, flagVal)
+				Expect(err).To(BeNil())
+
+				val, err := tf.Config.ConfigGetFeatureFlag(randomFeatureFlagPath)
+				Expect(err).To(BeNil())
+				Expect(val).Should(Equal("true"))
+
+				// call init
+				err = tf.Config.ConfigInit()
+				Expect(err).To(BeNil())
+				// second run of init should not remove the existing feature flag
+				val, err = tf.Config.ConfigGetFeatureFlag(randomFeatureFlagPath)
+				Expect(err).To(BeNil())
+				Expect(val).Should(Equal("true"))
+
+				// unset the feature flag
+				err = tf.Config.ConfigUnsetFeature(randomFeatureFlagPath)
+				Expect(err).To(BeNil())
+			})
+		})
+	})
+})

--- a/test/e2e/framework/cli_lifecycle_operations.go
+++ b/test/e2e/framework/cli_lifecycle_operations.go
@@ -1,0 +1,43 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package framework
+
+// CliOps performs basic cli operations
+type CliOps interface {
+	CliInit() error
+	CliVersion() (string, error)
+	InstallCLI(version string) error
+	UninstallCLI(version string) error
+}
+
+type cliOps struct {
+	CmdOps
+}
+
+func NewCliOps() CliOps {
+	return &cliOps{
+		CmdOps: NewCmdOps(),
+	}
+}
+
+// Init() initializes the CLI
+func (co *cliOps) CliInit() error {
+	_, _, err := co.Exec(TanzuInit)
+	return err
+}
+
+// Version returns the CLI version info
+func (co *cliOps) CliVersion() (string, error) {
+	stdOut, _, err := co.Exec(TanzuVersion)
+	return string(stdOut.Bytes()), err
+}
+
+// InstallCLI installs specific CLI version
+func (co *cliOps) InstallCLI(version string) (err error) {
+	return nil
+}
+
+// UninstallCLI uninstalls specific CLI version
+func (co *cliOps) UninstallCLI(version string) (err error) {
+	return nil
+}

--- a/test/e2e/framework/cluster_container_runtime.go
+++ b/test/e2e/framework/cluster_container_runtime.go
@@ -1,0 +1,59 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import "fmt"
+
+// ContainerRuntime has operations to perform on container runtime
+type ContainerRuntime interface {
+	StartContainerRuntime() (output string, err error)
+	ContainerRuntimeStatus() (status string, err error)
+	StopContainerRuntime() (output string, err error)
+}
+
+// Docker is the container runtime of type docker
+type Docker interface {
+	ContainerRuntime
+}
+
+// Docker is the implementation of ContainerRuntime for docker specific
+type docker struct {
+	CmdOps
+}
+
+func NewDocker() Docker {
+	return &docker{
+		CmdOps: NewCmdOps(),
+	}
+}
+
+// StartContainerRuntime starts docker daemon if not already running
+func (dc *docker) StartContainerRuntime() (output string, err error) {
+	if status, err := dc.ContainerRuntimeStatus(); err == nil {
+		return status, nil
+	}
+	stdOut, stdErr, err := dc.Exec(StartDockerUbuntu)
+	if err != nil {
+		return stdOut.String(), fmt.Errorf(stdErr.String(), err)
+	}
+	return stdOut.String(), err
+}
+
+// ContainerRuntimeStatus returns docker daemon daemon status
+func (dc *docker) ContainerRuntimeStatus() (status string, err error) {
+	stdOut, stdErr, err := dc.Exec(DockerInfo)
+	if err != nil {
+		return stdOut.String(), fmt.Errorf(stdErr.String(), err)
+	}
+	return stdOut.String(), err
+}
+
+// StopContainerRuntime returns docker daemon daemon status
+func (dc *docker) StopContainerRuntime() (output string, err error) {
+	stdOut, stdErr, err := dc.Exec(StopDockerUbuntu)
+	if err != nil {
+		return stdOut.String(), fmt.Errorf(stdErr.String(), err)
+	}
+	return stdOut.String(), err
+}

--- a/test/e2e/framework/cluster_interface.go
+++ b/test/e2e/framework/cluster_interface.go
@@ -1,0 +1,11 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+// ClusterOps has helper operations to perform on cluster
+type ClusterOps interface {
+	CreateCluster(name string, args []string) (output string, err error)
+	DeleteCluster(name string, args []string) (output string, err error)
+	ClusterStatus(name string, args []string) (output string, err error)
+}

--- a/test/e2e/framework/cluster_kind.go
+++ b/test/e2e/framework/cluster_kind.go
@@ -1,0 +1,69 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"fmt"
+	"strings"
+)
+
+// KindCluster performs k8s KIND cluster operations
+type KindCluster interface {
+	ClusterOps
+}
+
+// kindCluster implements ClusterOps interface
+type kindCluster struct {
+	CmdOps
+	Docker
+}
+
+func NewKindCluster(docker Docker) KindCluster {
+	return &kindCluster{
+		CmdOps: NewCmdOps(),
+		Docker: docker,
+	}
+}
+
+// CreateCluster creates kind cluster with given name and returns stdout info
+// if container runtime not running or any error then returns stdout and error info
+func (kc *kindCluster) CreateCluster(name string, args []string) (output string, err error) {
+	stdOut, err := kc.ContainerRuntimeStatus()
+	if err != nil {
+		return stdOut, err
+	}
+	stdOutBuffer, stdErrBuffer, err := kc.Exec(KindCreateCluster + " " + name + " " + strings.Join(args, " "))
+	if err != nil {
+		return stdOutBuffer.String(), fmt.Errorf(stdErrBuffer.String(), err)
+	}
+	return stdOutBuffer.String(), err
+}
+
+// DeleteCluster creates kind cluster with given name and returns stdout info
+// if container runtime not running or any error then returns stdout and error info
+func (kc *kindCluster) DeleteCluster(name string, args []string) (output string, err error) {
+	stdOut, err := kc.ContainerRuntimeStatus()
+	if err != nil {
+		return stdOut, err
+	}
+	stdOutBuffer, stdErrBuffer, err := kc.Exec(KindCreateCluster + " " + name + " " + strings.Join(args, " "))
+	if err != nil {
+		return stdOutBuffer.String(), fmt.Errorf(stdErrBuffer.String(), err)
+	}
+	return stdOutBuffer.String(), err
+}
+
+// ClusterStatus checks given kind cluster status and returns stdout info
+// if container runtime not running or any error then returns stdout and error info
+func (kc *kindCluster) ClusterStatus(name string, args []string) (output string, err error) {
+	stdOut, err := kc.ContainerRuntimeStatus()
+	if err != nil {
+		return stdOut, err
+	}
+	stdOutBuffer, stdErrBuffer, err := kc.Exec(KindCreateCluster + " " + name + " " + strings.Join(args, " "))
+	if err != nil {
+		return stdOutBuffer.String(), fmt.Errorf(stdErrBuffer.String(), err)
+	}
+	return stdOutBuffer.String(), err
+}

--- a/test/e2e/framework/cmd_exec_operations.go
+++ b/test/e2e/framework/cmd_exec_operations.go
@@ -1,0 +1,133 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// CmdOps performs the Command line exec operations
+type CmdOps interface {
+	Exec(command string) (stdOut, stdErr *bytes.Buffer, err error)
+	ExecContainsString(command, contains string) error
+	ExecContainsAnyString(command string, contains []string) error
+	ExecContainsErrorString(command, contains string) error
+	ExecNotContainsStdErrorString(command, contains string) error
+	ExecNotContainsString(command, contains string) error
+}
+
+// cmdOps is the implementation of CmdOps
+type cmdOps struct {
+	CmdOps
+}
+
+func NewCmdOps() CmdOps {
+	return &cmdOps{}
+}
+
+// Exec the command, exit on error
+func (co *cmdOps) Exec(command string) (stdOut, stdErr *bytes.Buffer, err error) {
+	cmdInput := strings.Split(command, " ")
+	cmdName := cmdInput[0]
+	cmdArgs := cmdInput[1:]
+	cmd := exec.Command(cmdName, cmdArgs...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	if err != nil {
+		return &stdout, &stderr, fmt.Errorf(fmt.Sprintf("error while running '%s', stdOut: %s, stdErr: %s", command, stdout.String(), stderr.String()), err)
+	}
+	return &stdout, &stderr, err
+}
+
+// ExecContainsString checks that the given command output contains the string.
+func (co *cmdOps) ExecContainsString(command, contains string) error {
+	stdOut, _, err := co.Exec(command)
+	if err != nil {
+		return err
+	}
+	return ContainsString(stdOut, contains)
+}
+
+// ExecContainsAnyString checks that the given command output contains any of the given set of strings.
+func (co *cmdOps) ExecContainsAnyString(command string, contains []string) error {
+	stdOut, _, err := co.Exec(command)
+	if err != nil {
+		return err
+	}
+	return ContainsAnyString(stdOut, contains)
+}
+
+// ExecContainsErrorString checks that the given command stdErr output contains the string
+func (co *cmdOps) ExecContainsErrorString(command, contains string) error {
+	_, stdErr, err := co.Exec(command)
+	if err != nil {
+		return err
+	}
+	return ContainsString(stdErr, contains)
+}
+
+// ExecNotContainsStdErrorString checks that the given command stdErr output contains the string
+func (co *cmdOps) ExecNotContainsStdErrorString(command, contains string) error {
+	_, stdErr, err := co.Exec(command)
+	if err != nil && stdErr == nil {
+		return err
+	}
+	return NotContainsString(stdErr, contains)
+}
+
+// NotContainsString checks that the given buffer not contains the string if contains then throws error.
+func NotContainsString(stdOut *bytes.Buffer, contains string) error {
+	so := stdOut.String()
+	if strings.Contains(so, contains) {
+		return fmt.Errorf("stdOut %q contains %q", so, contains)
+	}
+	return nil
+}
+
+// ContainsString checks that the given buffer contains the string.
+func ContainsString(stdOut *bytes.Buffer, contains string) error {
+	so := stdOut.String()
+	if !strings.Contains(so, contains) {
+		return fmt.Errorf("stdOut %q did not contain %q", so, contains)
+	}
+	return nil
+}
+
+// ContainsAnyString checks that the given buffer contains any of the given set of strings.
+func ContainsAnyString(stdOut *bytes.Buffer, contains []string) error {
+	var containsAny bool
+	so := stdOut.String()
+
+	for _, str := range contains {
+		containsAny = containsAny || strings.Contains(so, str)
+	}
+
+	if !containsAny {
+		return fmt.Errorf("stdOut %q did not contain of the following %q", so, contains)
+	}
+	return nil
+}
+
+// ExecNotContainsString checks that the given command output not contains the string.
+func (co *cmdOps) ExecNotContainsString(command, contains string) error {
+	stdOut, _, err := co.Exec(command)
+	if err != nil {
+		return err
+	}
+	return co.NotContainsString(stdOut, contains)
+}
+
+// NotContainsString checks that the given buffer not contains the string.
+func (co *cmdOps) NotContainsString(stdOut *bytes.Buffer, contains string) error {
+	so := stdOut.String()
+	if strings.Contains(so, contains) {
+		return fmt.Errorf("stdOut %q does contain %q", so, contains)
+	}
+	return nil
+}

--- a/test/e2e/framework/config_lifecycle_operations.go
+++ b/test/e2e/framework/config_lifecycle_operations.go
@@ -1,0 +1,138 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+
+	configapi "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
+)
+
+const (
+	ConfigFileName   = "config.yaml"
+	ConfigNGFileName = "config-ng.yaml"
+	ConfigFileDir    = ".config/tanzu/"
+)
+
+// ConfigLifecycleOps performs "tanzu config" command operations
+type ConfigLifecycleOps interface {
+	ConfigSetFeatureFlag(path, value string) error
+	ConfigGetFeatureFlag(path string) (string, error)
+	ConfigUnsetFeature(path string) error
+	ConfigInit() error
+	GetConfig() (*configapi.ClientConfig, error)
+	ConfigServerList() error
+	ConfigServerDelete(serverName string) error
+	DeleteCLIConfigurationFiles() error
+	IsCLIConfigurationFilesExists() bool
+}
+
+// configOps is the implementation of ConfOps interface
+type configOps struct {
+	CmdOps
+}
+
+func NewConfOps() ConfigLifecycleOps {
+	return &configOps{
+		CmdOps: NewCmdOps(),
+	}
+}
+
+// GetConfig gets the tanzu config
+func (co *configOps) GetConfig() (*configapi.ClientConfig, error) {
+	out, _, err := co.Exec(ConfigGet)
+	var cnf *configapi.ClientConfig
+	if err != nil {
+		return cnf, err
+	}
+	err = yaml.Unmarshal(out.Bytes(), &cnf)
+	if err != nil {
+		return cnf, errors.Wrap(err, "failed to construct yaml node from config get output")
+	}
+	return cnf, nil
+}
+
+// ConfigSetFeature sets the tanzu config feature flag
+func (co *configOps) ConfigSetFeatureFlag(path, value string) (err error) {
+	confSetCmd := ConfigSet + path + " " + value
+	_, _, err = co.Exec(confSetCmd)
+	return err
+}
+
+// ConfigSetFeature sets the tanzu config feature flag
+func (co *configOps) ConfigGetFeatureFlag(path string) (string, error) {
+	cnf, err := co.GetConfig()
+	if err != nil {
+		return "", err
+	}
+	featureName := strings.Split(path, ".")[len(strings.Split(path, "."))-1]
+	pluginName := strings.Split(path, ".")[len(strings.Split(path, "."))-2]
+	if cnf != nil && cnf.ClientOptions.Features[pluginName] != nil {
+		return cnf.ClientOptions.Features[pluginName][featureName], nil
+	}
+	return "", err
+}
+
+// ConfigUnsetFeature un-sets the tanzu config feature flag
+func (co *configOps) ConfigUnsetFeature(path string) (err error) {
+	unsetFeatureCmd := ConfigUnset + path
+	_, _, err = co.Exec(unsetFeatureCmd)
+	return
+}
+
+// ConfigInit performs "tanzu config init"
+func (co *configOps) ConfigInit() (err error) {
+	_, _, err = co.Exec(ConfigInit)
+	return
+}
+
+// ConfigServerList returns the server list
+// TODO: should return the servers info in proper format
+func (co *configOps) ConfigServerList() (err error) {
+	_, _, err = co.Exec(ConfigServerList)
+	return
+}
+
+// ConfigServerDelete deletes a server from tanzu config
+func (co *configOps) ConfigServerDelete(serverName string) error {
+	_, _, err := co.Exec(ConfigServerDelete + serverName)
+	return err
+}
+
+// DeleteCLIConfigurationFiles deletes cli configuration files
+func (co *configOps) DeleteCLIConfigurationFiles() error {
+	homeDir, _ := os.UserHomeDir()
+	configFile := filepath.Join(homeDir, ConfigFileDir, ConfigFileName)
+	_, err := os.Stat(configFile)
+	if err == nil {
+		if ferr := os.Remove(configFile); ferr != nil {
+			return ferr
+		}
+	}
+	configNGFile := filepath.Join(homeDir, ConfigFileDir, ConfigNGFileName)
+	if _, err := os.Stat(configNGFile); err == nil {
+		if ferr := os.Remove(configNGFile); ferr != nil {
+			return ferr
+		}
+	}
+	return nil
+}
+
+// IsCLIConfigurationFilesExists checks the existence of cli configuration files
+func (co *configOps) IsCLIConfigurationFilesExists() bool {
+	homeDir, _ := os.UserHomeDir()
+	configFilePath := filepath.Join(homeDir, ConfigFileDir, ConfigFileName)
+	configNGFilePath := filepath.Join(homeDir, ConfigFileDir, ConfigNGFileName)
+	_, err1 := os.Stat(configFilePath)
+	_, err2 := os.Stat(configNGFilePath)
+	if err1 == nil && err2 == nil {
+		return true
+	}
+	return false
+}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -1,0 +1,78 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package test defines the integration and end-to-end test case for cli core
+package framework
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/onsi/ginkgo"
+)
+
+const (
+	CliCore = "[CLI-Core]"
+
+	TanzuInit    = "tanzu init"
+	TanzuVersion = "tanzu version"
+
+	ConfigSet          = "tanzu config set "
+	ConfigGet          = "tanzu config get "
+	ConfigUnset        = "tanzu config unset "
+	ConfigInit         = "tanzu config init"
+	ConfigServerList   = "tanzu config server list"
+	ConfigServerDelete = "tanzu config server delete "
+	AddPluginSource    = "tanzu plugin source add --name %s --type %s --uri %s"
+	DeletePluginSource = "tanzu plugin source delete %s"
+	ListPluginsCmd     = "tanzu plugin list -o json"
+
+	KindCreateCluster = "kind create cluster --name "
+	DockerInfo        = "docker info"
+	StartDockerUbuntu = "sudo systemctl start docker"
+	StopDockerUbuntu  = "sudo systemctl stop docker"
+
+	TestDir         = ".tanzu-cli-e2e"
+	TestPluginsDir  = ".e2e-test-plugins"
+	HackToolsBinDir = "/../../../hack/tools/bin"
+	TanzuBinDir     = "/../../../bin"
+)
+
+var TestDirPath string
+var TestPluginsDirPath string
+var TestStandalonePluginsPath string
+
+// CLICoreDescribe annotates the test with the CLICore label.
+func CLICoreDescribe(text string, body func()) bool {
+	return ginkgo.Describe(CliCore+text, body)
+}
+
+// Framework has all helper functions to write CLI e2e test cases
+type Framework struct {
+	CliOps
+	Config ConfigLifecycleOps
+	ClusterOps
+	PluginCmd    PluginCmdOps    // performs plugin command operations
+	PluginHelper PluginHelperOps // helper (pre-setup) for plugin cmd operations
+}
+
+func NewFramework() *Framework {
+	return &Framework{
+		CliOps:       NewCliOps(),
+		Config:       NewConfOps(),
+		ClusterOps:   NewKindCluster(NewDocker()),
+		PluginCmd:    NewPluginLifecycleOps(),
+		PluginHelper: NewPluginOps(NewScriptBasedPlugins(), NewLocalOCIPluginOps(NewLocalOCIRegistry(DefaultRegistryName, DefaultRegistryPort))),
+	}
+}
+
+func init() {
+	homeDir, _ := os.UserHomeDir()
+	TestDirPath = filepath.Join(homeDir, TestDir)
+	os.Setenv("HOME", TestDirPath)
+	pwd, _ := os.Getwd()
+	os.Setenv("PATH", pwd+HackToolsBinDir+":"+pwd+TanzuBinDir+":"+os.Getenv("PATH"))
+	TestPluginsDirPath = filepath.Join(TestDirPath, TestPluginsDir)
+	TestStandalonePluginsPath = filepath.Join(filepath.Join(filepath.Join(filepath.Join(TestDirPath, ".config"), "tanzu-plugins"), "discovery"), "standalone")
+	_ = CreateDir(TestStandalonePluginsPath)
+}

--- a/test/e2e/framework/imgpkg_operations.go
+++ b/test/e2e/framework/imgpkg_operations.go
@@ -1,0 +1,72 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type ImgpkgOps interface {
+	PushBinary(filepath, registryBucketURL string) (registryURL string, err error)
+	PushBundle(filepath, registryBucketURL string) (registryURL string, err error)
+	PullBinary(url string, outputPath string) (stdOut string, err error)
+	PullBundle(url string, outputPath string) (stdOut string, err error)
+}
+
+func NewImgpkgOps() ImgpkgOps {
+	return &imgpkgOps{
+		cmdExe: NewCmdOps(),
+	}
+}
+
+type imgpkgOps struct {
+	cmdExe CmdOps
+}
+
+func (ip *imgpkgOps) PushBinary(artifactImage, registryBucketURL string) (url string, err error) {
+	cmd := "imgpkg " + "push " + "-i " + registryBucketURL + " -f " + artifactImage + " --json"
+	return ip.pushAndProcessOutput(cmd)
+}
+
+func (ip *imgpkgOps) PushBundle(artifactFile, registryBucketURL string) (url string, err error) {
+	cmd := "imgpkg " + "push " + "-b " + registryBucketURL + " -f " + artifactFile + " --json"
+	return ip.pushAndProcessOutput(cmd)
+}
+
+func (ip *imgpkgOps) pushAndProcessOutput(cmd string) (url string, err error) {
+	out, stdErr, err := ip.cmdExe.Exec(cmd)
+	stdErrStr := stdErr.String()
+	outStr := out.String()
+	if err != nil {
+		return "", errors.Wrap(err, stdErrStr)
+	}
+	pushStr := "\"Pushed '"
+	i := strings.Index(outStr, pushStr)
+	if i < 0 {
+		return "", errors.New("invalid out from imgpkg push command")
+	}
+	remStr := outStr[(i + len(pushStr)):]
+	j := strings.Index(remStr, "'")
+	if j < 0 {
+		return "", errors.New("invalid out from imgpkg push command")
+	}
+	registryBinaryUrl := remStr[:j]
+	return registryBinaryUrl, nil
+}
+
+func (ip *imgpkgOps) PullBinary(registryURL, outputPath string) (stdOut string, err error) {
+	cmd := "imgpkg " + " pull " + " -i " + registryURL + " -o " + outputPath + " --json "
+	return ip.pullAndProcessOutput(cmd)
+}
+func (ip *imgpkgOps) PullBundle(registryURL, outputPath string) (stdOut string, err error) {
+	cmd := "imgpkg " + " pull " + " -b " + registryURL + " -o " + outputPath + " --json "
+	return ip.pullAndProcessOutput(cmd)
+}
+
+func (ip *imgpkgOps) pullAndProcessOutput(cmd string) (stdOut string, err error) {
+	stdOutBuffer, _, err := ip.cmdExe.Exec(cmd)
+	return stdOutBuffer.String(), err
+}

--- a/test/e2e/framework/output_handling.go
+++ b/test/e2e/framework/output_handling.go
@@ -1,0 +1,13 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+type PluginListInfo struct {
+	Description string `json:"description"`
+	Discovery   string `json:"discovery"`
+	Name        string `json:"name"`
+	Scope       string `json:"scope"`
+	Status      string `json:"status"`
+	Version     string `json:"version"`
+}

--- a/test/e2e/framework/plugin_lifecycle_operations.go
+++ b/test/e2e/framework/plugin_lifecycle_operations.go
@@ -1,0 +1,76 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"fmt"
+
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
+// PluginBasicOps helps to perform the plugin command operations
+type PluginBasicOps interface {
+	// ListPlugins lists all plugins by running 'tanzu plugin list' command
+	ListPlugins() ([]PluginListInfo, error)
+}
+
+// PluginSourceOps helps 'plugin source' commands
+type PluginSourceOps interface {
+	// AddPluginDiscoverySource adds plugin discovery source, and returns stdOut and error info
+	AddPluginDiscoverySource(discoveryOpts *DiscoveryOptions) (string, error)
+
+	// DeletePluginDiscoverySource removes the plugin discovery source, and returns stdOut and error info
+	DeletePluginDiscoverySource(discoveryOpts *DiscoveryOptions) (string, error)
+}
+
+// PluginCmdOps helps to perform the plugin and its sub-commands lifecycle operations
+type PluginCmdOps interface {
+	PluginBasicOps
+	PluginSourceOps
+}
+
+type DiscoveryOptions struct {
+	Name       string
+	SourceType string
+	URI        string
+}
+
+type pluginCmdOps struct {
+	cmdExe CmdOps
+	PluginCmdOps
+}
+
+func NewPluginLifecycleOps() PluginCmdOps {
+	return &pluginCmdOps{
+		cmdExe: NewCmdOps(),
+	}
+}
+
+func (po *pluginCmdOps) AddPluginDiscoverySource(discoveryOpts *DiscoveryOptions) (string, error) {
+	addCmd := fmt.Sprintf(AddPluginSource, discoveryOpts.Name, discoveryOpts.SourceType, discoveryOpts.URI)
+	out, _, err := po.cmdExe.Exec(addCmd)
+	return out.String(), err
+}
+
+func (po *pluginCmdOps) DeletePluginDiscoverySource(discoveryOpts *DiscoveryOptions) (string, error) {
+	deleteCmd := fmt.Sprintf(DeletePluginSource, discoveryOpts.Name)
+	out, _, err := po.cmdExe.Exec(deleteCmd)
+	return out.String(), err
+}
+
+func (po *pluginCmdOps) ListPlugins() ([]PluginListInfo, error) {
+	out, _, err := po.cmdExe.Exec(ListPluginsCmd)
+	if err != nil {
+		return nil, err
+	}
+	jsonStr := out.String()
+	var list []PluginListInfo
+	err = json.Unmarshal([]byte(jsonStr), &list)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to construct json node from config get output")
+	}
+	return list, nil
+}

--- a/test/e2e/framework/plugin_meta.go
+++ b/test/e2e/framework/plugin_meta.go
@@ -1,0 +1,99 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+type PluginMeta struct {
+	name          string
+	target        string
+	version       string
+	description   string
+	help          string
+	sha           string
+	group         string
+	arch          string
+	os            string
+	discoveryType string
+	hidden        bool
+	optional      bool
+	aliases       []string
+
+	pluginLocalPath      string
+	pluginBinaryFileName string
+	pluginBinaryFilePath string
+
+	registryDiscoveryURL  string
+	binaryDistributionURL string
+}
+
+func NewPluginMeta() *PluginMeta {
+	return &PluginMeta{}
+}
+
+func (p *PluginMeta) SetName(name string) *PluginMeta {
+	p.name = name
+	return p
+}
+
+func (p *PluginMeta) GetName() string {
+	return p.name
+}
+
+func (p *PluginMeta) SetTarget(target string) *PluginMeta {
+	p.target = target
+	return p
+}
+
+func (p *PluginMeta) SetVersion(version string) *PluginMeta {
+	p.version = version
+	return p
+}
+
+func (p *PluginMeta) SetDescription(description string) *PluginMeta {
+	p.description = description
+	return p
+}
+
+func (p *PluginMeta) SetSHA(sha string) *PluginMeta {
+	p.sha = sha
+	return p
+}
+
+func (p *PluginMeta) SetGroup(group string) *PluginMeta {
+	p.group = group
+	return p
+}
+
+func (p *PluginMeta) SetArch(arch string) *PluginMeta {
+	p.arch = arch
+	return p
+}
+
+func (p *PluginMeta) SetOS(OSType string) *PluginMeta {
+	p.os = OSType
+	return p
+}
+
+func (p *PluginMeta) SetDiscoveryType(discoveryType string) *PluginMeta {
+	p.discoveryType = discoveryType
+	return p
+}
+
+func (p *PluginMeta) SetOptional(optional bool) *PluginMeta {
+	p.optional = optional
+	return p
+}
+
+func (p *PluginMeta) SetHidden(hidden bool) *PluginMeta {
+	p.hidden = hidden
+	return p
+}
+
+func (p *PluginMeta) SetAliases(alias []string) *PluginMeta {
+	p.aliases = alias
+	return p
+}
+
+func (p *PluginMeta) GetRegistryDiscoveryURL() string {
+	return p.registryDiscoveryURL
+}

--- a/test/e2e/framework/plugin_operations.go
+++ b/test/e2e/framework/plugin_operations.go
@@ -1,0 +1,303 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cliv1alpha1 "github.com/vmware-tanzu/tanzu-cli/apis/cli/v1alpha1"
+)
+
+// GeneratePluginOps helps to generate script-based plugin binaries, and plugin binaries can be used to perform plugin testing
+// like, add plugin source, list, and install plugins. And call sub-commands such as info and version.
+type GeneratePluginOps interface {
+	// GeneratePluginBinaries generates plugin binaries for given plugin metadata and return generated plugin binary file paths
+	GeneratePluginBinaries(pluginsMeta []*PluginMeta) ([]string, []error)
+}
+
+// PublishPluginOps helps to publish plugin binaries and plugin bundles
+type PublishPluginOps interface {
+	// PublishPluginBinary publishes the plugin binaries to given registry bucket and returns the plugin distribution urls
+	PublishPluginBinary(pluginsInfo []*PluginMeta) (distributionUrls []string, errs []error)
+
+	// GeneratePluginBundle generates plugin bundle in local file system for given plugin metadata
+	GeneratePluginBundle(pluginsMeta []*PluginMeta) ([]string, []error)
+
+	// PublishPluginBundle publishes the plugin bundles to given registry bucket and returns the plugins discovery urls
+	PublishPluginBundle(pluginsInfo []*PluginMeta) (discoveryUrls []string, errs []error)
+}
+
+// PluginHelperOps helps to generate and publish plugins
+type PluginHelperOps interface {
+	GeneratePluginOps
+	PublishPluginOps
+}
+
+type pluginHelperOps struct {
+	GeneratePluginOps
+	PublishPluginOps
+}
+
+func NewPluginOps(generatePluginOps GeneratePluginOps, publishPluginOps PublishPluginOps) PluginHelperOps {
+	return &pluginHelperOps{
+		GeneratePluginOps: generatePluginOps,
+		PublishPluginOps:  publishPluginOps,
+	}
+}
+
+// CLIPlugin for plugin overlay info
+type CLIPlugin struct {
+	metav1.TypeMeta `yaml:",inline"`
+	Metadata        metav1.ObjectMeta         `json:"metadata"`
+	Spec            cliv1alpha1.CLIPluginSpec `json:"spec"`
+}
+
+// localOCIPluginOps is the implementation of PublishPluginOps interface
+type localOCIPluginOps struct {
+	PublishPluginOps
+	cmdExe    CmdOps
+	registry  PluginRegistry
+	imgpkgOps ImgpkgOps
+}
+
+func NewLocalOCIPluginOps(registry PluginRegistry) PublishPluginOps {
+	return &localOCIPluginOps{
+		cmdExe:    NewCmdOps(),
+		registry:  registry,
+		imgpkgOps: NewImgpkgOps(),
+	}
+}
+
+// scriptBasedPlugins is the implementation of GeneratePluginOps interface
+type scriptBasedPlugins struct {
+	GeneratePluginOps
+	cmdExe CmdOps
+}
+
+func NewScriptBasedPlugins() GeneratePluginOps {
+	return &scriptBasedPlugins{
+		cmdExe: NewCmdOps(),
+	}
+}
+
+// GeneratePluginBinaries generates script based plugin binaries for given plugin metadata and return generated plugin binary file paths
+func (sp *scriptBasedPlugins) GeneratePluginBinaries(pluginsMeta []*PluginMeta) ([]string, []error) {
+	pluginsProcessed := make(map[string]bool)
+	size := len(pluginsMeta)
+	pluginBinaryFilePaths := make([]string, size)
+	errs := make([]error, size)
+	for i, pm := range pluginsMeta {
+		nameWithTarget := pm.target + "_" + pm.name
+		if _, exists := pluginsProcessed[nameWithTarget]; exists {
+			errs[i] = errors.New("plugin name already exists, currently multiple versions of same plugin not supported")
+			continue
+		}
+		pluginsProcessed[nameWithTarget] = true
+
+		// Set plugin local dir path if not, to generate binary image and bundle to publish to registry
+		if pm.pluginLocalPath == "" {
+			pm.pluginLocalPath = filepath.Join(TestPluginsDirPath, nameWithTarget)
+		}
+
+		pluginBinaryFilePath, err := sp.generatePluginBinary(pm)
+		if err != nil {
+			errs[i] = err
+			continue
+		}
+		pm.pluginBinaryFilePath = pluginBinaryFilePath
+		pluginBinaryFilePaths[i] = pm.pluginBinaryFilePath
+	}
+	return pluginBinaryFilePaths, errs
+}
+
+// PublishPluginBinary publishes the plugin binaries to given registry bucket and returns the plugin distribution urls
+func (po *localOCIPluginOps) PublishPluginBinary(pluginsMeta []*PluginMeta) (discoveryUrls []string, errs []error) {
+	size := len(pluginsMeta)
+	distributionUrls := make([]string, size)
+	errs = make([]error, size)
+	for i, pm := range pluginsMeta {
+		// Set registry discovery url if not set already
+		if pm.registryDiscoveryURL == "" {
+			pm.registryDiscoveryURL = filepath.Join(po.registry.GetRegistryURLWithDefaultCLIPluginsBucket(), ("/" + pm.target + "/" + pm.name + "/"))
+		}
+		imageRegistryURL, err := po.imgpkgOps.PushBinary(pm.pluginBinaryFilePath, pm.registryDiscoveryURL)
+		if err != nil {
+			errs[i] = err
+			continue
+		}
+		pm.binaryDistributionURL = imageRegistryURL
+		distributionUrls[i] = imageRegistryURL
+	}
+	return distributionUrls, errs
+}
+
+// GeneratePluginBundle generates plugin bundle in local file system for given plugin metadata
+func (po *localOCIPluginOps) GeneratePluginBundle(pluginsMeta []*PluginMeta) ([]string, []error) {
+	pluginsProcessed := make(map[string]bool)
+	size := len(pluginsMeta)
+	pluginBundlePath := make([]string, size)
+	errs := make([]error, size)
+	for i, pm := range pluginsMeta {
+		nameWithTarget := pm.target + "_" + pm.name
+		if _, exists := pluginsProcessed[nameWithTarget]; exists {
+			errs[i] = errors.New("plugin name already exists, currently multiple versions of same plugin not supported")
+			continue
+		}
+		pluginsProcessed[nameWithTarget] = true
+
+		// Set registry discovery url if not set already
+		if pm.registryDiscoveryURL == "" {
+			pm.registryDiscoveryURL = filepath.Join(po.registry.GetRegistryURLWithDefaultCLIPluginsBucket(), ("/" + pm.target + "/" + pm.name + "/"))
+		}
+
+		if pm.binaryDistributionURL == "" {
+			errs[i] = errors.New("plugin binary distribution url is empty")
+			continue
+		}
+
+		pluginOverlayObj, err := po.generatePluginDiscoveryOverlay(pm)
+		if err != nil {
+			errs[i] = err
+			continue
+		}
+
+		pluginBundlePathLocal, err := po.createLocalPluginBundle(pm, pluginOverlayObj)
+		if err != nil {
+			errs[i] = err
+			continue
+		}
+
+		pluginBundlePath[i] = pluginBundlePathLocal
+	}
+	return pluginBundlePath, errs
+}
+
+// PublishPluginBundle publishes the plugin bundles to given registry bucket and returns the plugins discovery urls
+func (po *localOCIPluginOps) PublishPluginBundle(pluginsMeta []*PluginMeta) ([]string, []error) {
+	size := len(pluginsMeta)
+	discoveryUrls := make([]string, size)
+	errs := make([]error, size)
+	for i, pm := range pluginsMeta {
+		// Set registry discovery url if not set already
+		if pm.registryDiscoveryURL == "" {
+			pm.registryDiscoveryURL = filepath.Join(po.registry.GetRegistryURLWithDefaultCLIPluginsBucket(), ("/" + pm.target + "/" + pm.name + "/"))
+		}
+
+		_, err := po.imgpkgOps.PushBundle(pm.pluginLocalPath, pm.registryDiscoveryURL)
+		if err != nil {
+			errs[i] = err
+			continue
+		}
+		discoveryUrls[i] = pm.registryDiscoveryURL
+	}
+
+	return discoveryUrls, errs
+}
+
+// createLocalPluginBundle creates plugin bundle in local file system for given plugin metadata and plugin overlay object
+func (po *localOCIPluginOps) createLocalPluginBundle(pluginsMeta *PluginMeta, pluginOverlayObj *CLIPlugin) (string, error) {
+	dirPath := filepath.Join(pluginsMeta.pluginLocalPath, ".imgpkg")
+	if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
+		return pluginsMeta.pluginLocalPath, err
+	}
+
+	imagesFile := filepath.Join(dirPath, "images.yml")
+	f, err := os.OpenFile(imagesFile, os.O_CREATE|os.O_WRONLY, 0755)
+	if err != nil {
+		return pluginsMeta.pluginLocalPath, err
+	}
+	defer f.Close()
+	fmt.Fprintf(f, ImagesTemplate)
+
+	configDirPath := filepath.Join(pluginsMeta.pluginLocalPath, "config")
+	if err := os.MkdirAll(configDirPath, os.ModePerm); err != nil {
+		return pluginsMeta.pluginLocalPath, err
+	}
+
+	generatedValuesFile := filepath.Join(configDirPath, "zz_generated_values.yaml")
+	gf, err := os.OpenFile(generatedValuesFile, os.O_CREATE|os.O_WRONLY, 0755)
+	if err != nil {
+		return pluginsMeta.pluginLocalPath, err
+	}
+	defer gf.Close()
+	fmt.Fprintf(gf, GeneratedValuesTemplate)
+
+	overlayDirPath := filepath.Join(configDirPath, "overlay")
+	if err := os.MkdirAll(overlayDirPath, os.ModePerm); err != nil {
+		return pluginsMeta.pluginLocalPath, err
+	}
+	overlayFile := filepath.Join(configDirPath, (pluginsMeta.name + ".yaml"))
+	of, err := os.OpenFile(overlayFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0755)
+	if err != nil {
+		return pluginsMeta.pluginLocalPath, err
+	}
+	defer of.Close()
+	yamlData, err := yaml.Marshal(&pluginOverlayObj)
+	if err != nil {
+		return pluginsMeta.pluginLocalPath, err
+	}
+	err = os.WriteFile(overlayFile, yamlData, 0644)
+	if err != nil {
+		return pluginsMeta.pluginLocalPath, err
+	}
+	return pluginsMeta.pluginLocalPath, nil
+}
+
+// generatePluginBinary creates the script based plugin binary file for given plugin metadata, saves in local file system
+func (sp *scriptBasedPlugins) generatePluginBinary(pm *PluginMeta) (string, error) {
+	nameWithTarget := pm.target + "_" + pm.name
+	pm.pluginBinaryFileName = nameWithTarget + "-" + pm.os + "-" + pm.version
+	if err := CreateDir(pm.pluginLocalPath); err != nil {
+		return "", err
+	}
+	filePath := filepath.Join(pm.pluginLocalPath, (pm.pluginBinaryFileName))
+	f, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY, 0755)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	fmt.Fprintf(f, ScriptBasedPluginTemplate, pm.name, pm.target, pm.description, pm.version,
+		pm.sha, pm.group, strconv.FormatBool(pm.hidden), pm.aliases, pm.version, pm.name, pm.name)
+	return filePath, nil
+}
+
+// CreateDir creates directory if not exists
+func CreateDir(dir string) error {
+	err := os.MkdirAll(dir, 0750)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
+	return nil
+}
+
+// generatePluginDiscoveryOverlay creates plugin overly object for given plugin metadata
+func (po *localOCIPluginOps) generatePluginDiscoveryOverlay(pm *PluginMeta) (plugin *CLIPlugin, err error) {
+	plugin = &CLIPlugin{}
+	plugin.TypeMeta.Kind = "CLIPlugin"
+	plugin.TypeMeta.APIVersion = "cli.tanzu.vmware.com/v1alpha1"
+	plugin.Metadata.Name = pm.name
+
+	var artifactsMap = make(map[string]cliv1alpha1.ArtifactList)
+	artifacts := make([]cliv1alpha1.Artifact, 1)
+	artifacts[0].OS = pm.os
+	artifacts[0].Image = pm.binaryDistributionURL
+	artifacts[0].Arch = pm.arch
+	artifacts[0].Type = pm.discoveryType
+
+	artifactsMap[pm.version] = artifacts
+	plugin.Spec.Artifacts = artifactsMap
+	plugin.Spec.Description = pm.description
+	plugin.Spec.Optional = pm.optional
+	plugin.Spec.RecommendedVersion = pm.version
+
+	return plugin, nil
+}

--- a/test/e2e/framework/plugin_registry.go
+++ b/test/e2e/framework/plugin_registry.go
@@ -1,0 +1,92 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"strings"
+)
+
+const (
+	DefaultCLIPluginBucket = "/tkg/tanzu_core/tanzu-cli-plugins/"
+	DefaultRegistryName    = "registry"
+	DefaultRegistryPort    = "5001"
+)
+
+type PluginRegistry interface {
+	// StartRegistry starts plugin registry
+	StartRegistry() (url string, err error)
+
+	// StopRegistry stops plugin registry
+	StopRegistry() error
+
+	// IsRegistryRunning validates plugin registry status
+	IsRegistryRunning() (bool, error)
+
+	// GetRegistryURLWithDefaultCLIPluginsBucket returns the default registry url with default bucket for CLI plugin's
+	GetRegistryURLWithDefaultCLIPluginsBucket() (url string)
+}
+
+type localOCIRegistry struct {
+	PluginRegistry
+	docker                                 Docker
+	cmdExe                                 CmdOps
+	registryPort                           string
+	registryName                           string
+	registryURLWithDefaultCLIPluginsBucket string
+}
+
+func NewLocalOCIRegistry(registryName, port string) PluginRegistry {
+	port = strings.TrimSpace(port)
+	if port == "" {
+		port = DefaultRegistryPort
+	}
+	if registryName == "" {
+		registryName = DefaultRegistryName
+	}
+	return &localOCIRegistry{
+		cmdExe:       NewCmdOps(),
+		docker:       NewDocker(),
+		registryPort: port,
+		registryName: registryName,
+	}
+}
+
+func (rep *localOCIRegistry) StartRegistry() (url string, err error) {
+	if _, err := rep.docker.ContainerRuntimeStatus(); err != nil {
+		out, err := rep.docker.StartContainerRuntime()
+		if err != nil {
+			return out, err
+		}
+	}
+
+	ociRegStart := "docker run -d -p " + rep.registryPort + ":5000 --name " + rep.registryName + " mirror.gcr.io/library/registry:2"
+	_, _, err = rep.cmdExe.Exec(ociRegStart)
+	if err != nil {
+		return "", err
+	}
+	return "", err
+}
+
+func (rep *localOCIRegistry) StopRegistry() (err error) {
+	ociRegStop := "docker container stop registry && docker container rm -v registry || true"
+	_, _, err = rep.cmdExe.Exec(ociRegStop)
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+func (rep *localOCIRegistry) GetRegistryURLWithDefaultCLIPluginsBucket() (url string) {
+	rep.registryURLWithDefaultCLIPluginsBucket = "localhost:" + rep.registryPort + DefaultCLIPluginBucket
+	return rep.registryURLWithDefaultCLIPluginsBucket
+}
+
+func (rep *localOCIRegistry) IsRegistryRunning() (bool, error) {
+	cmdInspect := "docker container inspect " + rep.registryName
+	_, _, err := rep.cmdExe.Exec(cmdInspect)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/test/e2e/framework/templates.go
+++ b/test/e2e/framework/templates.go
@@ -1,0 +1,56 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package test defines the integration and end-to-end test case for cli core
+package framework
+
+const ScriptBasedPluginTemplate = `#!/bin/bash
+
+# Minimally Viable Dummy Tanzu CLI 'Plugin'
+
+info() {
+   cat << EOF
+{
+  "name": "%s",
+  "target":"%s",
+  "description": "%s",
+  "version": "%s",
+  "buildSHA": "%s",
+  "group": "%s",
+  "hidden": %s,
+  "aliases": %s
+}
+EOF
+  exit 0
+}
+version() { 
+	echo "%s"
+}
+
+case "$1" in
+    info)  $1;;
+    version)   $1;;
+    *) cat << EOF
+%s functionality
+
+Usage:
+  tanzu %s [command]
+
+Available Commands:
+  info     plugin details
+  version   plugin version
+EOF
+       exit 0
+       ;;
+esac
+`
+
+const ImagesTemplate = `---
+apiVersion: imgpkg.carvel.dev/v1alpha1
+images:
+kind: ImagesLock`
+
+const GeneratedValuesTemplate = `#@data/values
+#@overlay/match-child-defaults missing_ok=True
+
+---`

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1,0 +1,20 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package framework
+
+import (
+	"math/rand"
+	"time"
+)
+
+// RandomString generates random string of given length
+func RandomString(length int) string {
+	var seededRand *rand.Rand = rand.New(
+		rand.NewSource(time.Now().UnixNano()))
+	charset := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVW1234567890"
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[seededRand.Intn(len(charset))]
+	}
+	return string(b)
+}

--- a/test/e2e/plugin_lifecycle/plugin_lifecycle_helper_test.go
+++ b/test/e2e/plugin_lifecycle/plugin_lifecycle_helper_test.go
@@ -1,0 +1,88 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// plugin provides plugin command specific E2E test cases
+package plugin
+
+import (
+	"fmt"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware-tanzu/tanzu-cli/test/e2e/framework"
+)
+
+// GenerateAndPublishScriptBasedPluginsToLocalOCIRepo for given plugin metadata, it generates script based plugins and publishes the plugin bundles to local OCI repository, and updates the distribution and discovery urls in plugin metadata.
+func GenerateAndPublishScriptBasedPluginsToLocalOCIRepo(tf *framework.Framework, plugins []*framework.PluginMeta) {
+	// Initialize config
+	err := tf.Config.ConfigInit()
+	Expect(err).To(BeNil(), "should initialize config without error")
+	// Generate script based plugins
+	_, errs := tf.PluginHelper.GeneratePluginBinaries(plugins[:])
+	for _, err := range errs {
+		Expect(err).To(BeNil(), "should not occur any error while generating the plugin binaries")
+	}
+	// Publish script based plugin binaries to local OCI repository
+	_, errs = tf.PluginHelper.PublishPluginBinary(plugins[:])
+	for _, err := range errs {
+		Expect(err).To(BeNil(), "should not occur any error while publishing the plugin binaries")
+	}
+	// Generate plugin bundles by using the plugin binaries
+	paths, errs := tf.PluginHelper.GeneratePluginBundle(plugins[:])
+	for i := 0; i < len(paths); i++ {
+		Expect(errs[i]).To(BeNil(), "should not occur any error while generating the plugin bundle")
+		Expect(paths[i]).NotTo(BeNil(), "should return a local files system path for plugin bundle")
+	}
+	// Publish the generated plugin bundles in previous steps to local oci repository
+	discoveryUrls, errs := tf.PluginHelper.PublishPluginBundle(plugins[:])
+	for i, err := range errs {
+		Expect(err).To(BeNil(), "should not occur any error while publishing the plugin bundle in local oci repo")
+		Expect(discoveryUrls[i]).NotTo(BeNil(), "should return the discovery url for every plugin published to local oci repository")
+	}
+}
+
+// ListAndValidatePlugins lists plugins, validate plugin names in discoveryMap for given discovery name, and make sure find all plugin sources in discoveryMap
+func ListAndValidatePlugins(tf *framework.Framework, discoveryMap map[string]string) {
+	pluginList, err := tf.PluginCmd.ListPlugins()
+	Expect(err).To(BeNil())
+	for _, plugin := range pluginList {
+		if pluginName, ok := discoveryMap[plugin.Discovery]; ok {
+			Expect(pluginName).To(Equal(plugin.Name), "Plugin name should be same as provided in the plugin metadata")
+			delete(discoveryMap, plugin.Discovery)
+		}
+	}
+	x := len(discoveryMap)
+	Expect(x).To(Equal(0), "should find all plugin sources and plugins as in list plugin output as added in plugin discovery sources")
+}
+
+// AddPluginDiscoveryURLToPluginDiscoverySources adds the plugin discovery url to plugin discovery sources
+func AddPluginDiscoveryURLToPluginDiscoverySources(tf *framework.Framework, pluginsMeta []*framework.PluginMeta, discoveryMap map[string]string, discoverySources []string) {
+	n := len(pluginsMeta)
+	for i := 0; i < n; i++ {
+		discoveryName := "local-oci-" + framework.RandomString(3)
+		do := &framework.DiscoveryOptions{
+			Name:       discoveryName, //discovery
+			SourceType: "oci",
+			URI:        pluginsMeta[i].GetRegistryDiscoveryURL(),
+		}
+
+		_, err := tf.PluginCmd.AddPluginDiscoverySource(do)
+		Expect(err).To(BeNil(), "should be able to add plugin discovery source without any error")
+		discoveryMap[discoveryName] = pluginsMeta[i].GetName()
+		discoverySources[i] = discoveryName
+	}
+	Expect(n).To(Equal(len(discoveryMap)), "should have a discovery source for every given pluginMeta")
+}
+
+// DeleteDiscoverySources deletes the given discovery sources from the cli config
+func DeleteDiscoverySources(tf *framework.Framework, discoverySources []string) {
+	for _, dis := range discoverySources {
+		do := &framework.DiscoveryOptions{
+			Name:       dis, //discovery source name
+			SourceType: "oci",
+		}
+		fmt.Println("deleting discovery source:" + dis)
+		_, err := tf.PluginCmd.DeletePluginDiscoverySource(do)
+		Expect(err).To(BeNil(), "should be able to delete plugin discovery source without any error")
+	}
+}

--- a/test/e2e/plugin_lifecycle/plugin_lifecycle_suite_test.go
+++ b/test/e2e/plugin_lifecycle/plugin_lifecycle_suite_test.go
@@ -1,0 +1,13 @@
+package plugin
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestPluginLifecycle(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "PluginLifecycle Suite")
+}

--- a/test/e2e/plugin_lifecycle/plugin_lifecycle_test.go
+++ b/test/e2e/plugin_lifecycle/plugin_lifecycle_test.go
@@ -1,0 +1,43 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// plugin provides plugin command specific E2E test cases
+package plugin
+
+import (
+	. "github.com/onsi/ginkgo"
+
+	"github.com/vmware-tanzu/tanzu-cli/test/e2e/framework"
+)
+
+var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-lifecycle]", func() {
+	var (
+		tf               *framework.Framework
+		plugins          []*framework.PluginMeta
+		discoveryMap     map[string]string
+		discoverySources []string
+	)
+	BeforeSuite(func() {
+		tf = framework.NewFramework()
+		pm := framework.NewPluginMeta()
+		plugins = make([]*framework.PluginMeta, 1)
+		pm.SetName("dummy").SetTarget("k8s").SetVersion("1.0").SetDescription("its dummy plugin").SetSHA("345").SetGroup("admin").SetArch("amd64").SetOS("darwin").SetDiscoveryType("oci").SetHidden(false).SetOptional(false)
+		plugins[0] = pm
+		GenerateAndPublishScriptBasedPluginsToLocalOCIRepo(tf, plugins[:])
+	})
+	Context("OCI repository-based plugin lifecycle tests", func() {
+		// Test case: add plugin bundle discovery urls as plugin discovery sources
+		It("add plugin discovery sources", func() {
+			discoveryMap = make(map[string]string)
+			discoverySources = make([]string, len(plugins))
+			AddPluginDiscoveryURLToPluginDiscoverySources(tf, plugins[:], discoveryMap, discoverySources)
+		})
+		// Test case: List plugins and make sure all plugins added in setup node should be listed
+		It("list and validate plugins", func() {
+			ListAndValidatePlugins(tf, discoveryMap)
+		})
+	})
+	AfterSuite(func() {
+		DeleteDiscoverySources(tf, discoverySources)
+	})
+})


### PR DESCRIPTION
### What this PR does / why we need it
- Currently, CLI core doesn't have end-to-end test cases to test CLI core functionalities from an end-user perspective; this PR introduces the end-to-end testing basic framework and tooling to write E2E test cases.
- PR has documentation detailing the E2E framework, its usage, and use cases being covered as part of E2E testing.
- Makefile target `make e2e-cli-core` has been added to execute end-to-end test cases
- GitHub action has been added to execute end-to-end test cases as part of PR raised for any changes in CLI core repository.
- Implements the tooling to generate script-based plugins and generate and publish plugin bundles to local OCI repository.
- Implements the tooling to execute any Linux commands, tooling to setup local OCI repository, k8s KIND cluster.
- E2E pre-setup creates separate directory `$HOME/.tanzu-cli-e2e` to create config files and use while executing E2E tests, E2E tests does not touch default config files from `$HOME/.config/tanzu`
- - This E2E tests or tooling does not modify or depend on the default `~/.config` directory as it creates `~/.tanzu-cli-e2e/` folder for e2e tests

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
- Tested the Makefile target `make e2e-cli-core`
- E2E tests were executed locally and confirmed that it does not update the default config file. It creates a separate directory, `$HOME/.tanzu-cli-e2e`, to create config files and execute e2e tests
- GitHub action `Tanzu CLI Core E2E Tests` added and its executed part of this PR
- Validated the tooling by running sample test cases to generate script-based plugin bundles and publish them to the local OCI repository.
- Test cases implemented to add discovery sources and list plugins from the newly added discovery sources. 
- Test cases to validate the plugin list functionality for the newly added plugins. 

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
