### PR TITLE
Add a feature flag for the Central Repository

### DIFF
--- a/pkg/config/featureflags.go
+++ b/pkg/config/featureflags.go
@@ -22,6 +22,8 @@ const (
 	FeatureContextAwareCLIForPlugins = "features.global.context-aware-cli-for-plugins"
 	// FeatureContextCommand determines whether to surface the context command. This is disabled by default.
 	FeatureContextCommand = "features.global.context-target-v2"
+	// FeatureCentralRepository determines if the CLI uses the Central Repository of plugins.
+	FeatureCentralRepository = "features.global.central-repository"
 )
 
 // DefaultCliFeatureFlags is used to populate an initially empty config file with default values for feature flags.
@@ -39,6 +41,8 @@ var (
 	DefaultCliFeatureFlags = map[string]bool{
 		FeatureContextAwareCLIForPlugins: contextAwareDiscoveryEnabled(),
 		FeatureContextCommand:            true,
+		// TODO(khouzam) turn this on before the 1.0 release, or remove the flag completely
+		FeatureCentralRepository: false,
 	}
 )
 


### PR DESCRIPTION
### What this PR does / why we need it

This PR adds a feature-flag for the Central Repository feature.  It is disabled by default for the moment so that we can gradually introduce the Central Repository feature without preventing the CLI from continue to work as it does at the moment.

The plan is to enable the feature by default once it is fully implemented.

### Which issue(s) this PR fixes

Part of #31

### Describe testing done for PR

Run:
```
tz config get
``` 
then verify that the configuration contains the new flag `central-repository` and that it is set to false.

Run:
```
tz config set features.global.central-repository true
tz config get
``` 
then verify that the configuration contains the new flag `central-repository` and that it is set to true.

#### Special notes for your reviewer

I'm trying to make the PR review as simple as possible by only including a single concept.
However, if reviewers feel it is too detailed, creates too many commits, or too much overhead, I can include this change in a bigger one.

