### PR TITLE
Move feature flags constants to the constants pkg

### DIFF
--- a/pkg/command/discovery_source.go
+++ b/pkg/command/discovery_source.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 
 	"github.com/aunum/log"
 	"github.com/pkg/errors"
@@ -18,7 +19,6 @@ import (
 	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
-	"github.com/vmware-tanzu/tanzu-cli/pkg/config"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/discovery"
 )
 
@@ -82,7 +82,7 @@ func newListDiscoverySourceCmd() *cobra.Command {
 
 			// If context-target feature is activated, get discovery sources from all active context
 			// else get discovery sources from current server
-			if configlib.IsFeatureActivated(config.FeatureContextCommand) {
+			if configlib.IsFeatureActivated(constants.FeatureContextCommand) {
 				mapContexts, err := configlib.GetAllCurrentContextsMap()
 				if err == nil {
 					for _, context := range mapContexts {

--- a/pkg/command/plugin.go
+++ b/pkg/command/plugin.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
-	cliconfig "github.com/vmware-tanzu/tanzu-cli/pkg/config"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/discovery"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/pluginmanager"
 )
@@ -62,7 +62,7 @@ func newPluginCmd() *cobra.Command {
 	installPluginCmd.Flags().StringVarP(&version, "version", "v", cli.VersionLatest, "version of the plugin")
 	deletePluginCmd.Flags().BoolVarP(&forceDelete, "yes", "y", false, "delete the plugin without asking for confirmation")
 
-	if config.IsFeatureActivated(cliconfig.FeatureContextCommand) {
+	if config.IsFeatureActivated(constants.FeatureContextCommand) {
 		installPluginCmd.Flags().StringVarP(&targetStr, "target", "t", "", "target of the plugin (kubernetes[k8s]/mission-control[tmc])")
 		upgradePluginCmd.Flags().StringVarP(&targetStr, "target", "t", "", "target of the plugin (kubernetes[k8s]/mission-control[tmc])")
 		deletePluginCmd.Flags().StringVarP(&targetStr, "target", "t", "", "target of the plugin (kubernetes[k8s]/mission-control[tmc])")
@@ -105,7 +105,7 @@ func newListPluginCmd() *cobra.Command {
 			}
 			sort.Sort(discovery.DiscoveredSorter(availablePlugins))
 
-			if config.IsFeatureActivated(cliconfig.FeatureContextCommand) && (outputFormat == "" || outputFormat == string(component.TableOutputType)) {
+			if config.IsFeatureActivated(constants.FeatureContextCommand) && (outputFormat == "" || outputFormat == string(component.TableOutputType)) {
 				displayPluginListOutputSplitViewContext(availablePlugins, cmd.OutOrStdout())
 			} else {
 				displayPluginListOutputListView(availablePlugins, cmd.OutOrStdout())

--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
-	cliconfig "github.com/vmware-tanzu/tanzu-cli/pkg/config"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/pluginmanager"
 )
 
@@ -47,7 +47,7 @@ func NewRootCmd() (*cobra.Command, error) {
 	)
 
 	// If the context and target feature is enabled, add the corresponding commands under root.
-	if config.IsFeatureActivated(cliconfig.FeatureContextCommand) {
+	if config.IsFeatureActivated(constants.FeatureContextCommand) {
 		rootCmd.AddCommand(
 			contextCmd,
 			k8sCmd,

--- a/pkg/config/init.go
+++ b/pkg/config/init.go
@@ -7,6 +7,7 @@ package config
 import (
 	"github.com/aunum/log"
 
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 )
 
@@ -23,7 +24,7 @@ func init() {
 	//      Users have to add the discovery sources by using `tanzu plugin source add` command
 	// TODO: update/delete the below line after CLI make changes related to centralized repository
 	// addedDefaultDiscovery := populateDefaultStandaloneDiscovery(c)
-	addedFeatureFlags := AddDefaultFeatureFlagsIfMissing(c, DefaultCliFeatureFlags)
+	addedFeatureFlags := AddDefaultFeatureFlagsIfMissing(c, constants.DefaultCliFeatureFlags)
 	addedEdition := addDefaultEditionIfMissing(c)
 	addedBomRepo := AddBomRepoIfMissing(c)
 	addedCompatabilityFile := AddCompatibilityFileIfMissing(c)

--- a/pkg/constants/featureflags.go
+++ b/pkg/constants/featureflags.go
@@ -1,7 +1,7 @@
 // Copyright 2022 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package config
+package constants
 
 // This block is for global feature constants, to allow them to be used more broadly
 const (

--- a/pkg/pluginmanager/manager.go
+++ b/pkg/pluginmanager/manager.go
@@ -32,6 +32,7 @@ import (
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/config"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/discovery"
 )
 
@@ -124,7 +125,7 @@ func DiscoverStandalonePlugins() (plugins []discovery.Discovered, err error) {
 func DiscoverServerPlugins() ([]discovery.Discovered, error) {
 	// If the context and target feature is enabled, discover plugins from all currentContexts
 	// Else discover plugin based on current Server
-	if configlib.IsFeatureActivated(config.FeatureContextCommand) {
+	if configlib.IsFeatureActivated(constants.FeatureContextCommand) {
 		return discoverServerPluginsBasedOnAllCurrentContexts()
 	}
 	return discoverServerPluginsBasedOnCurrentServer()


### PR DESCRIPTION

### What this PR does / why we need it

The feature flags contants where part of the "config" package and the "config" package uses the "discovery" package.  Such a setup prevents the discovery package from using feature flags as it would cause a circular dependency.

By moving the feature flag constants to the "constants" package, the "discovery" package can now use it.

### Which issue(s) this PR fixes

Fixes #34

### Describe testing done for PR

`make all`
and started using a feature flag from the `discovery` package as part of future development.

#### Special notes for your reviewer

goimports don't seem to be ordered properly, but this was a pre-existing situation.  I suggest we ignore it for this PR and look into it more generally.
