### PR TITLE
Remove "Describe" from the Discovery interface

### DIFF
--- a/pkg/discovery/interface.go
+++ b/pkg/discovery/interface.go
@@ -22,9 +22,6 @@ type Discovery interface {
 	// List available plugins.
 	List() ([]Discovered, error)
 
-	// Describe a plugin.
-	Describe(name string) (Discovered, error)
-
 	// Type returns type of discovery.
 	Type() string
 }

--- a/pkg/discovery/kubernetes.go
+++ b/pkg/discovery/kubernetes.go
@@ -38,23 +38,6 @@ func (k *KubernetesDiscovery) List() ([]Discovered, error) {
 	return k.Manifest()
 }
 
-// Describe a plugin.
-func (k *KubernetesDiscovery) Describe(name string) (p Discovered, err error) {
-	plugins, err := k.Manifest()
-	if err != nil {
-		return
-	}
-
-	for i := range plugins {
-		if plugins[i].Name == name {
-			p = plugins[i]
-			return
-		}
-	}
-	err = errors.Errorf("cannot find plugin with name '%v'", name)
-	return
-}
-
 // Name of the repository.
 func (k *KubernetesDiscovery) Name() string {
 	return k.name

--- a/pkg/discovery/local.go
+++ b/pkg/discovery/local.go
@@ -41,23 +41,6 @@ func (l *LocalDiscovery) List() ([]Discovered, error) {
 	return l.Manifest()
 }
 
-// Describe a plugin.
-func (l *LocalDiscovery) Describe(name string) (p Discovered, err error) {
-	plugins, err := l.Manifest()
-	if err != nil {
-		return
-	}
-
-	for i := range plugins {
-		if plugins[i].Name == name {
-			p = plugins[i]
-			return
-		}
-	}
-	err = errors.Errorf("cannot find plugin with name '%v'", name)
-	return
-}
-
 // Name of the repository.
 func (l *LocalDiscovery) Name() string {
 	return l.name

--- a/pkg/discovery/oci.go
+++ b/pkg/discovery/oci.go
@@ -39,23 +39,6 @@ func (od *OCIDiscovery) List() (plugins []Discovered, err error) {
 	return od.Manifest()
 }
 
-// Describe a plugin.
-func (od *OCIDiscovery) Describe(name string) (p Discovered, err error) {
-	plugins, err := od.Manifest()
-	if err != nil {
-		return
-	}
-
-	for i := range plugins {
-		if plugins[i].Name == name {
-			p = plugins[i]
-			return
-		}
-	}
-	err = errors.Errorf("cannot find plugin with name '%v'", name)
-	return
-}
-
 // Name of the repository.
 func (od *OCIDiscovery) Name() string {
 	return od.name

--- a/pkg/discovery/rest.go
+++ b/pkg/discovery/rest.go
@@ -48,11 +48,6 @@ type Plugin struct {
 	Target configtypes.Target `json:"target"`
 }
 
-// DescribePluginResponse defines the response from Describe Plugin API.
-type DescribePluginResponse struct {
-	Plugin Plugin `json:"plugin"`
-}
-
 // ListPluginsResponse defines the response from List Plugins API.
 type ListPluginsResponse struct {
 	Plugins []Plugin `json:"plugins"`
@@ -130,31 +125,6 @@ func (d *RESTDiscovery) List() ([]Discovered, error) {
 	}
 
 	return plugins, nil
-}
-
-// Describe a plugin.
-func (d *RESTDiscovery) Describe(name string) (p Discovered, err error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/%s/%s", d.endpoint, d.basePath, name), http.NoBody)
-	if err != nil {
-		return p, err
-	}
-
-	var res DescribePluginResponse
-	if err := d.doRequest(req, &res); err != nil {
-		return p, err
-	}
-
-	// Convert the CLIPlugin resource to Discovered object
-	p, err = DiscoveredFromREST(&res.Plugin)
-	if err != nil {
-		return p, err
-	}
-	p.Source = d.name
-
-	return p, nil
 }
 
 // Name of the repository.

--- a/pkg/discovery/rest_test.go
+++ b/pkg/discovery/rest_test.go
@@ -5,7 +5,6 @@ package discovery
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -114,27 +113,6 @@ func createTestServer() *httptest.Server {
 			w.WriteHeader(http.StatusInternalServerError)
 		}
 	})
-	m.HandleFunc(fmt.Sprintf("%s/%s", basePath, "{plugin}"), func(w http.ResponseWriter, req *http.Request) {
-		v := mux.Vars(req)
-		name := v["plugin"]
-		var plugin Plugin
-		for _, p := range plugins {
-			if p.Name == name {
-				plugin = p
-				break
-			}
-		}
-		res := DescribePluginResponse{plugin}
-		b, err := json.Marshal(res)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-		}
-
-		_, err = w.Write(b)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-		}
-	})
 	return httptest.NewServer(m)
 }
 
@@ -154,12 +132,4 @@ func TestRESTDiscovery(t *testing.T) {
 	actList, err := d.List()
 	assert.NoError(t, err)
 	assert.Equal(t, expList, actList)
-
-	plugin, err := d.Describe("foo")
-	assert.NoError(t, err)
-	assert.Equal(t, expList[0], plugin)
-
-	plugin, err = d.Describe("bar")
-	assert.NoError(t, err)
-	assert.Equal(t, expList[1], plugin)
 }


### PR DESCRIPTION
### What this PR does / why we need it

A plugin is now associated with a target, so to uniquely identify a plugin, we normally need a name-target combination.

The Describe function of the Discovery interface only took a plugin name so if the discovery contained plugins using the same name for two different targets, the function would not know which plugin to return.  Since the return value is a single plugin, we didn't have the option to return all plugins of a certain name.

We considered adding a "target" parameter to the Describe function signature.  However, this was a little complex for a REST discovery as its current endpoint support did not explicitly support the specification of a target.

Since the Describe function is actually never used, we decided that instead of spending time fixing these issues, we would simply remove it.

### Which issue(s) this PR fixes

Fixes #43

### Describe testing done for PR

make all
