### PR TITLE
[CentralRepo] Add tanzu plugin search command

### DIFF
--- a/pkg/command/plugin.go
+++ b/pkg/command/plugin.go
@@ -79,6 +79,11 @@ func newPluginCmd() *cobra.Command {
 		syncPluginCmd,
 		discoverySourceCmd,
 	)
+
+	if config.IsFeatureActivated(constants.FeatureCentralRepository) {
+		pluginCmd.AddCommand(newSearchPluginCmd())
+	}
+
 	return pluginCmd
 }
 

--- a/pkg/command/plugin_search.go
+++ b/pkg/command/plugin_search.go
@@ -1,0 +1,108 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package command
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/discovery"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/pluginmanager"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/component"
+)
+
+var (
+	listVersions bool
+)
+
+const searchLongDesc = `Search provides the ability to search for plugins that can be installed.
+Without an argument, the command lists all plugins currently available.
+The search command can also be used with a keyword filter to filter the
+list of available plugins. If the filter is flanked with slashes, the
+filter will be treated as a regex.
+`
+
+func newSearchPluginCmd() *cobra.Command {
+	var searchCmd = &cobra.Command{
+		Use:               "search [keyword|/regex/]",
+		Short:             "Search for a keyword or regex in the list of available plugins",
+		Long:              searchLongDesc,
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: cobra.NoFileCompletions,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// TODO(khouzam): Implement the below flags
+			if len(args) == 1 {
+				return fmt.Errorf("the filter argument is not yet implemented")
+			}
+			if len(targetStr) > 0 {
+				return fmt.Errorf("filtering by target is not yet implemented")
+			}
+			if listVersions {
+				return fmt.Errorf("listing versions is not yet implemented")
+			}
+
+			var err error
+			var allPlugins []discovery.Discovered
+			if local != "" {
+				// The user requested the list of plugins from a local path
+				local, err = filepath.Abs(local)
+				if err != nil {
+					return err
+				}
+				allPlugins, err = pluginmanager.AvailablePluginsFromLocalSource(local)
+				if err != nil {
+					return err
+				}
+			} else {
+				allPlugins, err = pluginmanager.AvailablePlugins()
+				if err != nil {
+					return err
+				}
+			}
+			sort.Sort(discovery.DiscoveredSorter(allPlugins))
+			displayPluginList(allPlugins, cmd.OutOrStdout())
+
+			return nil
+		},
+	}
+
+	f := searchCmd.Flags()
+	f.BoolVar(&listVersions, "list-versions", false, "show the long listing, with each available version of plugins")
+	f.StringVarP(&outputFormat, "output", "o", "", "Output format (yaml|json|table)")
+	f.StringVarP(&local, "local", "l", "", "path to local plugin source")
+	f.StringVarP(&targetStr, "target", "t", "", "list plugins for the specified target (kubernetes[k8s]/mission-control[tmc])")
+
+	return searchCmd
+}
+
+func displayPluginList(plugins []discovery.Discovered, writer io.Writer) {
+	var outputData [][]string
+	outputWriter := component.NewOutputWriter(writer, outputFormat, "Name", "Description", "Target", "Version", "Status", "Context")
+
+	for i := range plugins {
+		pluginDetails := []string{plugins[i].Name, plugins[i].Description, string(plugins[i].Target), plugins[i].RecommendedVersion, plugins[i].Status}
+		if plugins[i].Scope == common.PluginScopeContext {
+			pluginDetails = append(pluginDetails, plugins[i].ContextName)
+		}
+		outputData = append(outputData, pluginDetails)
+	}
+
+	addDataToOutputWriter := func(output component.OutputWriter, data [][]string) {
+		for _, row := range data {
+			vals := make([]interface{}, len(row))
+			for i, val := range row {
+				vals[i] = val
+			}
+			output.AddRow(vals...)
+		}
+	}
+
+	addDataToOutputWriter(outputWriter, outputData)
+	outputWriter.Render()
+}


### PR DESCRIPTION
### What this PR does / why we need it

This commit provides the new "tanzu plugin search" command in its most basic form:
- filtering is not yet supported
- listing versions is not yet supported

This command is part of the Central Repository feature and therefore is only accessible if the `features.global.central-repository` feature flag is enabled.

The command works just as well with a Central Repo as a current plugin discovery.  Therefore the commit is directly based on the `main` branch and can be tested with TKG and TMC discoveries.

### Describe testing done for PR

```
$ rm ~/.config/tanzu/config*
$ tz config set features.global.central-repository true
$ tz context create --name k3d --kubecontext k3d-k3s-default --kubeconfig /Users/kmarc/.config/k3d/k3s-default/kubeconfig.yaml
$ tz plugin search
  NAME                DESCRIPTION                           TARGET      VERSION      STATUS         CONTEXT
  cluster             Kubernetes cluster operations         kubernetes  v0.38.0-dev  not installed  k3d
  feature             Operate on features and featuregates  kubernetes  v0.28.0-dev  not installed  k3d
  kubernetes-release  Kubernetes release operations         kubernetes  v0.28.0-dev  not installed  k3d

$ tz context create --name tmc-unstable --endpoint unstable.tmc-dev.cloud.vmware.com --staging

ℹ  If you don't have an API token, visit the VMware Cloud Services console, select your organization, and create an API token with the TMC service roles:
  https://console.cloud.vmware.com/csp/gateway/portal/#/user/tokens

? API Token ****************************************************************

✔  successfully created a TMC context
ℹ  Checking for required plugins...
ℹ  Installing plugin 'feature:v0.28.0-dev' with target 'kubernetes'
ℹ  Installing plugin 'kubernetes-release:v0.28.0-dev' with target 'kubernetes'
ℹ  Installing plugin 'cluster:v0.38.0-dev' with target 'kubernetes'
ℹ  Installing plugin 'events:v0.0.1' with target 'mission-control'
ℹ  Installing plugin 'inspection:v0.0.1' with target 'mission-control'
ℹ  Installing plugin 'cluster:v0.0.1' with target 'mission-control'
^C
$ tz plugin search
  NAME                DESCRIPTION                                                     TARGET           VERSION      STATUS         CONTEXT
  cluster             Kubernetes cluster operations                                   kubernetes       v0.38.0-dev  not installed  k3d
  feature             Operate on features and featuregates                            kubernetes       v0.28.0-dev  not installed  k3d
  kubernetes-release  Kubernetes release operations                                   kubernetes       v0.28.0-dev  not installed  k3d
  account             Account for tmc resources                                       mission-control  v0.0.1       not installed  tmc-unstable
  apply               Create/Update a resource with a resource file                   mission-control  v0.0.1       not installed  tmc-unstable
  audit               Run an audit request on an org                                  mission-control  v0.0.1       not installed  tmc-unstable
  cluster                                                                             mission-control  v0.0.1       not installed  tmc-unstable
  clustergroup        A group of Kubernetes clusters                                  mission-control  v0.0.1       not installed  tmc-unstable
  data-protection     Data protection for tmc resources                               mission-control  v0.0.1       not installed  tmc-unstable
  ekscluster                                                                          mission-control  v0.0.1       not installed  tmc-unstable
  events              Events for any meaningful user activity or system state change  mission-control  v0.0.1       installed      tmc-unstable
  iam                 IAM Policies for tmc resources                                  mission-control  v0.0.1       not installed  tmc-unstable
  inspection          Inspection for tmc resources                                    mission-control  v0.0.1       installed      tmc-unstable
  integration         Get available integrations and their information from registry  mission-control  v0.0.1       not installed  tmc-unstable
  management-cluster  A TMC registered Management cluster                             mission-control  v0.0.1       installed      tmc-unstable
  policy              Policy for tmc resources                                        mission-control  v0.0.1       not installed  tmc-unstable
  workspace           A group of Kubernetes namespaces                                mission-control  v0.0.1       not installed  tmc-unstable

$ tz plugin search hello
✖  the filter argument is not yet implemented
$ tz plugin search --list-versions
✖  listing versions is not yet implemented
$ tz plugin search --target mission-control
✖  filtering by target is not yet implemented

$ tz plugin search -o json
[
  {
    "context": "k3d",
    "description": "Kubernetes cluster operations",
    "name": "cluster",
    "status": "not installed",
    "target": "kubernetes",
    "version": "v0.38.0-dev"
  },
  {
    "context": "k3d",
[...]

$ tz plugin search --local ~/.config/tanzu-plugins/
  NAME                DESCRIPTION                                                        TARGET      VERSION      STATUS         CONTEXT
  builder             Build Tanzu components                                                         v0.28.0-dev  not installed
  codegen             Tanzu code generation tool                                                     v0.28.0-dev  not installed
  isolated-cluster    Prepopulating images/bundle for internet-restricted environments               v0.28.0-dev  not installed
  login               Login to the platform                                                          v0.28.0-dev  not installed
  pinniped-auth       Pinniped authentication operations (usually not directly invoked)              v0.28.0-dev  not installed
  test                Test the CLI                                                                   v0.28.0-dev  not installed
  cluster             Kubernetes cluster operations                                      kubernetes  v0.28.0-dev  not installed
  feature             Operate on features and featuregates                               kubernetes  v0.28.0-dev  not installed
  kubernetes-release  Kubernetes release operations                                      kubernetes  v0.28.0-dev  not installed
  management-cluster  Kubernetes management cluster operations                           kubernetes  v0.28.0-dev  not installed
  package             Tanzu package management                                           kubernetes  v0.28.0-dev  not installed
  secret              Tanzu secret management                                            kubernetes  v0.28.0-dev  not installed
  telemetry           configure cluster-wide settings for vmware tanzu telemetry         kubernetes  v0.28.0-dev  not installed
```
I also rebased this PR on top of #45 and it works fine with a test Central Repository.

### Release note
```release-note
The "tanzu plugin search" command is added.  It is meant to be used to search for plugins that can be installed.
```

### Additional information

This command is in its most basic form to be ready for a pre-alpha release.
It allows to list all discovered plugins without filtering.

#### Special notes for your reviewer

- unit tests are missing but will be added in a follow-up PR