### PR TITLE
Make plugin list only show installed plugins

### DIFF
--- a/pkg/cli/plugin_info.go
+++ b/pkg/cli/plugin_info.go
@@ -74,3 +74,15 @@ type PluginInfo struct {
 	// DefaultFeatureFlags is default featureflags to be configured if missing when invoking plugin
 	DefaultFeatureFlags map[string]bool `json:"defaultFeatureFlags"`
 }
+
+// PluginInfoSorter sorts PluginInfo objects.
+type PluginInfoSorter []PluginInfo
+
+func (p PluginInfoSorter) Len() int      { return len(p) }
+func (p PluginInfoSorter) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
+func (p PluginInfoSorter) Less(i, j int) bool {
+	if p[i].Target != p[j].Target {
+		return p[i].Target < p[j].Target
+	}
+	return p[i].Name < p[j].Name
+}

--- a/pkg/pluginmanager/manager.go
+++ b/pkg/pluginmanager/manager.go
@@ -599,7 +599,12 @@ func installAndDescribePlugin(p *discovery.Discovered, version string, binary []
 	plugin.Discovery = p.Source
 	plugin.DiscoveredRecommendedVersion = p.RecommendedVersion
 	plugin.Target = p.Target
-
+	plugin.Scope = p.Scope
+	if plugin.Version == p.RecommendedVersion {
+		plugin.Status = common.PluginStatusInstalled
+	} else {
+		plugin.Status = common.PluginStatusUpdateAvailable
+	}
 	return &plugin, nil
 }
 


### PR DESCRIPTION
### What this PR does / why we need it

For the Central Repo feature, "plugin list" only shows installed plugins.  A new "plugin search" command will be introduced to allow getting the list of available plugins.  

Basically, this commit shows whatever is part of the catalog and no longer shows plugins that are discovered but not installed.

Also, the commit disables the `--local` flag for the `plugin list` command, since it does not really apply anymore.

### Which issue(s) this PR fixes

Part of #31 

### Describe testing done for PR

The below tests installs plugins and compares the output without and with the change to `plugin list`.

```
$ rm ~/.config/tanzu/config*

$ tz context create --name tmc-unstable --endpoint unstable.tmc-dev.cloud.vmware.com --staging
ℹ  If you don't have an API token, visit the VMware Cloud Services console, select your organization, and create an API token with the TMC service roles:
  https://console.cloud.vmware.com/csp/gateway/portal/#/user/tokens

? API Token ****************************************************************

✔  successfully created a TMC context
ℹ  Checking for required plugins...
ℹ  Installing plugin 'cluster:v0.0.1' with target 'mission-control'
ℹ  Installing plugin 'iam:v0.0.1' with target 'mission-control'
ℹ  Installing plugin 'clustergroup:v0.0.1' with target 'mission-control'
^C

# THIS IS THE OLD OUTPUT with the Central Repo feature OFF
# All discovered plugins are listed.
$ tz plugin list
Standalone Plugins
  NAME  DESCRIPTION  TARGET  DISCOVERY  VERSION  STATUS

Plugins from Context:  tmc-unstable
  NAME                DESCRIPTION                                                     TARGET           VERSION  STATUS
  account             Account for tmc resources                                       mission-control  v0.0.1   not installed
  apply               Create/Update a resource with a resource file                   mission-control  v0.0.1   not installed
  audit               Run an audit request on an org                                  mission-control  v0.0.1   not installed
  cluster                                                                             mission-control  v0.0.1   installed
  clustergroup        A group of Kubernetes clusters                                  mission-control  v0.0.1   not installed
  data-protection     Data protection for tmc resources                               mission-control  v0.0.1   not installed
  ekscluster                                                                          mission-control  v0.0.1   not installed
  events              Events for any meaningful user activity or system state change  mission-control  v0.0.1   not installed
  iam                 IAM Policies for tmc resources                                  mission-control  v0.0.1   installed
  inspection          Inspection for tmc resources                                    mission-control  v0.0.1   not installed
  integration         Get available integrations and their information from registry  mission-control  v0.0.1   not installed
  management-cluster  A TMC registered Management cluster                             mission-control  v0.0.1   not installed
  policy              Policy for tmc resources                                        mission-control  v0.0.1   not installed
  workspace           A group of Kubernetes namespaces                                mission-control  v0.0.1   not installed

# Turn on the Central Repo feature
$ tz config set features.global.central-repository true
# New output where only installed plugins are shown
$ tz plugin list
  NAME     DESCRIPTION                       TARGET           VERSION  STATUS
  cluster  A TMC managed Kubernetes cluster  mission-control  v0.0.1   installed
  iam      IAM Policies for tmc resources    mission-control  v0.0.1   installed

$ tz plugin install all --local ~/.config/_tanzu-plugins/
ℹ  Installing plugin 'cluster:v0.28.0' with target 'kubernetes'
ℹ  Installing plugin 'feature:v0.28.0-dev' with target 'kubernetes'
ℹ  Installing plugin 'isolated-cluster:v0.28.0-dev'
ℹ  Installing plugin 'kubernetes-release:v0.28.0-dev' with target 'kubernetes'
ℹ  Installing plugin 'login:v0.28.0-dev'
ℹ  Installing plugin 'management-cluster:v0.28.0-dev' with target 'kubernetes'
ℹ  Installing plugin 'package:v0.28.0-dev' with target 'kubernetes'
ℹ  Installing plugin 'pinniped-auth:v0.28.0-dev'
ℹ  Installing plugin 'secret:v0.28.0-dev' with target 'kubernetes'
ℹ  Installing plugin 'telemetry:v0.28.0-dev' with target 'kubernetes'

$ tz plugin list
Warning, Masking commands for plugins "login" because a core command or other plugin with that name already exists.
  NAME                DESCRIPTION                                                        TARGET           VERSION      STATUS
  isolated-cluster    Prepopulating images/bundle for internet-restricted environments                    v0.28.0-dev  installed
  login               Login to the platform                                                               v0.28.0-dev  installed
  pinniped-auth       Pinniped authentication operations (usually not directly invoked)                   v0.28.0-dev  installed
  cluster             Kubernetes cluster operations                                      kubernetes       v0.28.0-dev  update available
  feature             Operate on features and featuregates                               kubernetes       v0.28.0-dev  installed
  kubernetes-release  Kubernetes release operations                                      kubernetes       v0.28.0-dev  installed
  management-cluster  Kubernetes management cluster operations                           kubernetes       v0.28.0-dev  installed
  package             Tanzu package management                                           kubernetes       v0.28.0-dev  installed
  secret              Tanzu secret management                                            kubernetes       v0.28.0-dev  installed
  telemetry           configure cluster-wide settings for vmware tanzu telemetry         kubernetes       v0.28.0-dev  installed
  cluster             A TMC managed Kubernetes cluster                                   mission-control  v0.0.1       installed
  iam                 IAM Policies for tmc resources                                     mission-control  v0.0.1       installed

  $ tz plugin delete isolated-cluster
Warning, Masking commands for plugins "login" because a core command or other plugin with that name already exists.
Deleting Plugin 'isolated-cluster'. Are you sure? [y/N]: y
✔  successfully deleted plugin 'isolated-cluster'

# Notice below that "isolated-cluster" is no longer shown since it is no longer installed
$ tz plugin list
Warning, Masking commands for plugins "login" because a core command or other plugin with that name already exists.
  NAME                DESCRIPTION                                                        TARGET           VERSION      STATUS
  login               Login to the platform                                                               v0.28.0-dev  installed
  pinniped-auth       Pinniped authentication operations (usually not directly invoked)                   v0.28.0-dev  installed
  cluster             Kubernetes cluster operations                                      kubernetes       v0.28.0-dev  update available
  feature             Operate on features and featuregates                               kubernetes       v0.28.0-dev  installed
  kubernetes-release  Kubernetes release operations                                      kubernetes       v0.28.0-dev  installed
  management-cluster  Kubernetes management cluster operations                           kubernetes       v0.28.0-dev  installed
  package             Tanzu package management                                           kubernetes       v0.28.0-dev  installed
  secret              Tanzu secret management                                            kubernetes       v0.28.0-dev  installed
  telemetry           configure cluster-wide settings for vmware tanzu telemetry         kubernetes       v0.28.0-dev  installed
  cluster             A TMC managed Kubernetes cluster                                   mission-control  v0.0.1       installed
  iam                 IAM Policies for tmc resources
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The command `tanzu plugin list` now only shows installed plugins.  A new `tanzu plugin search` command will be used to list all plugins.
```

#### Special notes for your reviewer

This commit is for the pre-alpha release, so the output of "plugin list" does not include the information of if a plugin was recommended by a context.  This part will be added later as it needs more involved changes.
