### PR TITLE
Fix version and status in plugin search/list

### DIFF
--- a/pkg/command/plugin.go
+++ b/pkg/command/plugin.go
@@ -431,12 +431,21 @@ func displayInstalledPluginList(installedPlugins []cli.PluginInfo, writer io.Wri
 		//    context = installedPlugins[index].ContextName
 		// }
 
+		status := common.PluginStatusNotInstalled
+		if installedPlugins[index].Status == common.PluginStatusInstalled ||
+			installedPlugins[index].Status == common.PluginStatusUpdateAvailable {
+			// TODO(khouzam): For the moment, only show the plugin as installed.
+			// Please see https://github.com/vmware-tanzu/tanzu-cli/issues/65
+
+			status = common.PluginStatusInstalled
+		}
+
 		outputWriter.AddRow(
 			installedPlugins[index].Name,
 			installedPlugins[index].Description,
 			string(installedPlugins[index].Target),
 			installedPlugins[index].Version,
-			installedPlugins[index].Status,
+			status,
 			// context,
 		)
 	}


### PR DESCRIPTION
### What this PR does / why we need it

In the output of "plugin search" and "plugin list", the "status" column no longer shows "update available" but only "installed" or "not installed" for the following reason:

Say I'm using TKG 1.6, with the Central Repo, I would see a "update available" message because the TKG 2.1 plugins would be available; this would be confusing.  This was not the case before the Central Repo because only TKG 1.6 plugins would have been discovered.
The "update available" feature, will need to be evaluated to be properly re-enabled.

Also, in the output of "plugin search", if a plugin is installed, the installed version is now displayed instead of the recommendedVersion.  This was technically a bug.

### Describe testing done for PR

First reproduce the behaviour we are fixing by testing with `main`:
```
$ git checkout main
Switched to branch 'main'
$ make build
build darwin-arm64 CLI with version: v0.0.1-dev
$ rm ~/.config/tanzu/config*
$ tz plugin clean
✔  successfully cleaned up all plugins

$ tz config set features.global.central-repository true
$ tz plugin source add -n default2 -t oci -u localhost:9876/tanzu-cli/plugins/central:large
✔  successfully added discovery source default2
$ tz plugin install cluster --version v0.0.1 --target tmc
ℹ  Installing plugin 'cluster:v0.0.1' with target 'mission-control'
✔  successfully installed 'cluster' plugin

# Notice below the "update available" which this PR will remove
$ tz plugin list
  NAME     DESCRIPTION            TARGET           VERSION  STATUS
  cluster  cluster functionality  mission-control  v0.0.1   update available

# Notice below the that TMC cluster plugin is showing version v9.9.9 by mistake
# when we installed v0.0.1.  It normally would show "update available" if the proper
# version was being displayed 
$ tz plugin search | grep cluster
  isolated-cluster    Desc for isolated-cluster                     v9.9.9   not installed
  cluster             Desc for cluster             kubernetes       v9.9.9   not installed
  management-cluster  Desc for management-cluster  kubernetes       v9.9.9   not installed
  cluster             Desc for cluster             mission-control  v9.9.9   installed
  clustergroup        Desc for clustergroup        mission-control  v9.9.9   not installed
  ekscluster          Desc for ekscluster          mission-control  v9.9.9   not installed
  management-cluster  Desc for management-cluster  mission-control  v9.9.9   not installed
```

Now test with this PR:
```
$ git pr 60
Switched to branch '60'
$ make build
build darwin-arm64 CLI with version: v0.0.1-dev
$ rm ~/.config/tanzu/config*
$ tz plugin clean
✔  successfully cleaned up all plugins

$ tz config set features.global.central-repository true
$ tz plugin source add -n default2 -t oci -u localhost:9876/tanzu-cli/plugins/central:large
✔  successfully added discovery source default2
$ tz plugin install cluster --version v0.0.1 --target tmc
ℹ  Installing plugin 'cluster:v0.0.1' with target 'mission-control'
✔  successfully installed 'cluster' plugin

# Notice below the plugin now shows as "installed" instead of "update available"
$ tz plugin list
  NAME     DESCRIPTION            TARGET           VERSION  STATUS
  cluster  cluster functionality  mission-control  v0.0.1   installed

# Notice below the that TMC cluster plugin is showing the proper v0.0.1 version
# and that its status shows "installed" instead of "update available"
$ tz plugin search | grep cluster
  isolated-cluster    Desc for isolated-cluster                     v9.9.9   not installed
  cluster             Desc for cluster             kubernetes       v9.9.9   not installed
  management-cluster  Desc for management-cluster  kubernetes       v9.9.9   not installed
  cluster             Desc for cluster             mission-control  v0.0.1   installed
  clustergroup        Desc for clustergroup        mission-control  v9.9.9   not installed
  ekscluster          Desc for ekscluster          mission-control  v9.9.9   not installed
  management-cluster  Desc for management-cluster  mission-control  v9.9.9   not installed
```

#### Special notes for your reviewer

