### PR TITLE
Trust pre-release plugin repository

### DIFF
--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 
@@ -123,6 +124,13 @@ func GetTrustedRegistries() []string {
 	// If custom image repository is defined add it to the list of trusted registries
 	if customImageRepo := os.Getenv(constants.ConfigVariableCustomImageRepository); customImageRepo != "" {
 		trustedRegistries = append(trustedRegistries, customImageRepo)
+	}
+
+	// If the pre-release plugin repo variable is set, add its host to the list of trusted registries
+	if preReleaseRepoImage := os.Getenv(constants.ConfigVariablePreReleasePluginRepoImage); preReleaseRepoImage != "" {
+		if u, err := url.ParseRequestURI("https://" + preReleaseRepoImage); err == nil {
+			trustedRegistries = append(trustedRegistries, u.Hostname())
+		}
 	}
 
 	// If ALLOWED_REGISTRY environment variable is specified, allow those registries as well

--- a/pkg/config/defaults_test.go
+++ b/pkg/config/defaults_test.go
@@ -4,8 +4,12 @@
 package config
 
 import (
+	"os"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 )
 
 var _ = Describe("defaults test cases", func() {
@@ -19,6 +23,19 @@ var _ = Describe("defaults test cases", func() {
 			trustedRegis := GetTrustedRegistries()
 			Expect(trustedRegis).NotTo(BeNil())
 			DefaultAllowedPluginRepositories = ""
+		})
+		It("trusted registries should include hostname of env var", func() {
+			testHost := "example.com"
+			oldValue := os.Getenv(constants.ConfigVariablePreReleasePluginRepoImage)
+			err := os.Setenv(constants.ConfigVariablePreReleasePluginRepoImage, testHost+"/test/path")
+			Expect(err).To(BeNil())
+
+			trustedRegis := GetTrustedRegistries()
+			Expect(trustedRegis).NotTo(BeNil())
+			Expect(trustedRegis).Should(ContainElement(testHost))
+
+			err = os.Setenv(constants.ConfigVariablePreReleasePluginRepoImage, oldValue)
+			Expect(err).To(BeNil())
 		})
 	})
 })

--- a/pkg/constants/config_variables.go
+++ b/pkg/constants/config_variables.go
@@ -14,4 +14,5 @@ const (
 	ConfigVariableDefaultStandaloneDiscoveryImageTag  = "TKG_DEFAULT_STANDALONE_DISCOVERY_IMAGE_TAG"
 	ConfigVariableDefaultStandaloneDiscoveryType      = "TKG_DEFAULT_STANDALONE_DISCOVERY_TYPE"
 	ConfigVariableDefaultStandaloneDiscoveryLocalPath = "TKG_DEFAULT_STANDALONE_DISCOVERY_LOCAL_PATH"
+	ConfigVariablePreReleasePluginRepoImage           = "TANZU_CLI_PRE_RELEASE_REPO_IMAGE"
 )

--- a/pkg/pluginmanager/manager.go
+++ b/pkg/pluginmanager/manager.go
@@ -136,17 +136,16 @@ func DiscoverStandalonePlugins() ([]discovery.Discovered, error) {
 }
 
 // getPreReleasePluginDiscovery
-// For pre-alpha we use an environment variable to point to the
-// central repo.  This is because the content of
+// For our pre-releases we use an environment variable to point to the
+// repository of plugins.  This is because the configuration
 // cfg.ClientOptions.CLI.DiscoverySources
 // is read by older CLIs so we don't want to modify it.
 // TODO(khouzam): remove before 1.0
 func getPreReleasePluginDiscovery() (configtypes.PluginDiscovery, error) {
-	const tempVarNameForPluginImage = "TANZU_CLI_PRE_RELEASE_REPO_IMAGE"
-	centralRepoTestImage := os.Getenv(tempVarNameForPluginImage)
+	centralRepoTestImage := os.Getenv(constants.ConfigVariablePreReleasePluginRepoImage)
 	if centralRepoTestImage == "" {
 		// Don't set a default value.  This test repo URI is not meant to be public.
-		return configtypes.PluginDiscovery{}, fmt.Errorf("you must set the environment variable %s to the URI of the image of the plugin repository.  Please see the documentation", tempVarNameForPluginImage)
+		return configtypes.PluginDiscovery{}, fmt.Errorf("you must set the environment variable %s to the URI of the image of the plugin repository.  Please see the documentation", constants.ConfigVariablePreReleasePluginRepoImage)
 	}
 	return configtypes.PluginDiscovery{
 		OCI: &configtypes.OCIDiscovery{


### PR DESCRIPTION
### What this PR does / why we need it

For pre-release testing we will be using a test Central Repository configured through `TANZU_CLI_PRE_RELEASE_REPO_IMAGE`.  To make it smoother for consumers, this commit automatically adds the host specified in that variable as an allowed source for plugins.

### Describe testing done for PR

Before this PR:
```
$ git checkout main
$ make build
$ tz config set features.global.central-repository true
$ export TANZU_CLI_PRE_RELEASE_REPO_IMAGE=<redacted>
$ unset ALLOWED_REGISTRY
$ tz plugin install cluster --target tmc
ℹ  Installing plugin 'cluster:v0.0.1' with target 'mission-control'
✖  "cluster" plugin pre-download verification failed: untrusted registry detected with image "<redacted>". Allowed registries are []
```
With this PR:
```
$ make build
$ tz config set features.global.central-repository true
$ export TANZU_CLI_PRE_RELEASE_REPO_IMAGE=<redacted>
$ unset ALLOWED_REGISTRY
$ tz plugin install cluster --target tmc
ℹ  Installing plugin 'cluster:v0.0.1' with target 'mission-control'
✔  successfully installed 'cluster' plugin

$ export TANZU_CLI_PRE_RELEASE_REPO_IMAGE=localhost:9876/tanzu-cli/plugins/central:small
$ tz plugin install cluster --target tmc
ℹ  Installing plugin 'cluster:v9.9.9' with target 'mission-control'
✔  successfully installed 'cluster' plugin
```

#### Special notes for your reviewer

I purposefully did not add a release notes section.  This change is temporary, not visible to users and I didn't feel it should be advertised any more than this PR.
