### PR TITLE
Update "plugin list" to show missing context plugins

### DIFF
--- a/pkg/command/plugin_test.go
+++ b/pkg/command/plugin_test.go
@@ -17,25 +17,27 @@ import (
 	"github.com/vmware-tanzu/tanzu-cli/pkg/catalog"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/plugin"
 )
 
 func TestPluginList(t *testing.T) {
 	tests := []struct {
-		test            string
-		plugins         []string
-		versions        []string
-		args            []string
-		expected        string
-		expectedFailure bool
+		test               string
+		centralRepoFeature bool
+		plugins            []string
+		versions           []string
+		args               []string
+		expected           string
+		expectedFailure    bool
 	}{
 		{
 			test:            "With empty config file(no discovery sources added) and no plugins installed",
 			plugins:         []string{},
-			versions:        []string{"v0.1.0"},
 			args:            []string{"plugin", "list"},
 			expectedFailure: false,
-			expected:        "NAME DESCRIPTION SCOPE DISCOVERY VERSION STATUS",
+			expected:        "NAME DESCRIPTION TARGET DISCOVERY VERSION STATUS",
 		},
 		{
 			test:            "With empty config file(no discovery sources added) and when one additional plugin installed",
@@ -43,7 +45,7 @@ func TestPluginList(t *testing.T) {
 			versions:        []string{"v0.1.0"},
 			args:            []string{"plugin", "list"},
 			expectedFailure: false,
-			expected:        "NAME DESCRIPTION SCOPE DISCOVERY VERSION STATUS foo some foo description Standalone v0.1.0 installed",
+			expected:        "NAME DESCRIPTION TARGET DISCOVERY VERSION STATUS foo some foo description v0.1.0 installed",
 		},
 		{
 			test:            "With empty config file(no discovery sources added) and when more than one plugin is installed",
@@ -51,7 +53,7 @@ func TestPluginList(t *testing.T) {
 			versions:        []string{"v0.1.0", "v0.2.0"},
 			args:            []string{"plugin", "list"},
 			expectedFailure: false,
-			expected:        "NAME DESCRIPTION SCOPE DISCOVERY VERSION STATUS bar some bar description Standalone v0.2.0 installed foo some foo description Standalone v0.1.0 installed",
+			expected:        "NAME DESCRIPTION TARGET DISCOVERY VERSION STATUS bar some bar description v0.2.0 installed foo some foo description v0.1.0 installed",
 		},
 		{
 			test:            "when json output is requested",
@@ -69,6 +71,57 @@ func TestPluginList(t *testing.T) {
 			expectedFailure: false,
 			expected:        `- description: some foo description discovery: "" name: foo scope: Standalone status: installed version: v0.1.0`,
 		},
+		{
+			test:               "no '--local' option with central repo",
+			centralRepoFeature: true,
+			args:               []string{"plugin", "list", "--local", "someDirectory"},
+			expectedFailure:    true,
+			expected:           "the '--local' flag does not apply to this command. Please use 'tanzu plugin search --local'",
+		},
+		{
+			test:               "With empty config file(no discovery sources added) and no plugins installed with central repo",
+			centralRepoFeature: true,
+			plugins:            []string{},
+			args:               []string{"plugin", "list"},
+			expectedFailure:    false,
+			expected:           "NAME DESCRIPTION TARGET VERSION STATUS",
+		},
+		{
+			test:               "With empty config file(no discovery sources added) and when one additional plugin installed with central repo",
+			centralRepoFeature: true,
+			plugins:            []string{"foo"},
+			versions:           []string{"v0.1.0"},
+			args:               []string{"plugin", "list"},
+			expectedFailure:    false,
+			expected:           "NAME DESCRIPTION TARGET VERSION STATUS foo some foo description v0.1.0 installed",
+		},
+		{
+			test:               "With empty config file(no discovery sources added) and when more than one plugin is installed with central repo",
+			centralRepoFeature: true,
+			plugins:            []string{"foo", "bar"},
+			versions:           []string{"v0.1.0", "v0.2.0"},
+			args:               []string{"plugin", "list"},
+			expectedFailure:    false,
+			expected:           "NAME DESCRIPTION TARGET VERSION STATUS bar some bar description v0.2.0 installed foo some foo description v0.1.0 installed",
+		},
+		{
+			test:               "when json output is requested with central repo",
+			centralRepoFeature: true,
+			plugins:            []string{"foo"},
+			versions:           []string{"v0.1.0"},
+			args:               []string{"plugin", "list", "-o", "json"},
+			expectedFailure:    false,
+			expected:           `[ { "description": "some foo description", "name": "foo", "status": "installed", "target": "", "version": "v0.1.0" } ]`,
+		},
+		{
+			test:               "when yaml output is requested with central repo",
+			centralRepoFeature: true,
+			plugins:            []string{"foo"},
+			versions:           []string{"v0.1.0"},
+			args:               []string{"plugin", "list", "-o", "yaml"},
+			expectedFailure:    false,
+			expected:           `- description: some foo description name: foo status: installed target: "" version: v0.1.0`,
+		},
 	}
 
 	for _, spec := range tests {
@@ -76,10 +129,26 @@ func TestPluginList(t *testing.T) {
 		os.Setenv("TANZU_CONFIG", tkgConfigFile.Name())
 		defer os.RemoveAll(tkgConfigFile.Name())
 
+		tkgConfigFileNG, _ := os.CreateTemp("", "config_ng")
+		os.Setenv("TANZU_CONFIG_NEXT_GEN", tkgConfigFileNG.Name())
+		defer os.RemoveAll(tkgConfigFileNG.Name())
+
 		dir, err := os.MkdirTemp("", "tanzu-cli-root-cmd")
 		assert.Nil(t, err)
 		defer os.RemoveAll(dir)
 		os.Setenv("TEST_CUSTOM_CATALOG_CACHE_DIR", dir)
+
+		// Always turn on the context feature
+		featureArray := strings.Split(constants.FeatureContextCommand, ".")
+		err = config.SetFeature(featureArray[1], featureArray[2], "true")
+		assert.Nil(t, err)
+
+		// Set the Central Repository feature
+		if spec.centralRepoFeature {
+			featureArray := strings.Split(constants.FeatureCentralRepository, ".")
+			err := config.SetFeature(featureArray[1], featureArray[2], "true")
+			assert.Nil(t, err)
+		}
 
 		var completionType uint8
 		t.Run(spec.test, func(t *testing.T) {
@@ -96,6 +165,7 @@ func TestPluginList(t *testing.T) {
 					Aliases:          []string{pluginName[:2]},
 					Version:          spec.versions[i],
 					InstallationPath: filepath.Join(common.DefaultPluginRoot, pluginName),
+					Status:           common.PluginStatusInstalled,
 				}
 				assert.Nil(err)
 				err = cc.Upsert(pi)
@@ -110,19 +180,23 @@ func TestPluginList(t *testing.T) {
 			rootCmd.SetOut(b)
 
 			err = rootCmd.Execute()
-			assert.Nil(err)
-
-			got, err := io.ReadAll(b)
-
 			assert.Equal(err != nil, spec.expectedFailure)
 
 			if spec.expected != "" {
-				// whitespace-agnostic match
-				assert.Contains(strings.Join(strings.Fields(string(got)), " "), spec.expected)
+				if spec.expectedFailure {
+					assert.Contains(err.Error(), spec.expected)
+				} else {
+					got, err := io.ReadAll(b)
+					assert.Nil(err)
+
+					// whitespace-agnostic match
+					assert.Contains(strings.Join(strings.Fields(string(got)), " "), spec.expected)
+				}
 			}
 		})
 		os.Unsetenv("TEST_CUSTOM_CATALOG_CACHE_DIR")
 		os.Unsetenv("TANZU_CONFIG")
+		os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
 	}
 }
 


### PR DESCRIPTION
### What this PR does / why we need it

We have agreed that it would be valuable for users if the output of `plugin list` included any missing context-scope plugins that for some reason where not installed.  This PR does this.

The PR adds unit tests for the modifications to `plugin list` that were done for the Central Repository feature.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Part of #31

### Describe testing done for PR

```
$ rm ~/.cache/_tanzu/catalog.yaml
$ rm ~/.config/tanzu/config*
$
$ make build
build darwin-amd64 CLI with version: v0.0.2-dev
mkdir -p bin
cp /Users/kmarc/git/tanzu-cli/artifacts/darwin/amd64/cli/core/v0.0.2-dev/tanzu-cli-darwin_amd64 ./bin/tanzu
$ tz config set features.global.central-repository true

# List when no plugin installed and no context created
$ tz plugin list
Installed Plugins
  NAME  DESCRIPTION  TARGET  VERSION  STATUS

# List when a plugin is installed but no context created
$ tz plugin install management-cluster --target k8s
ℹ  Installing plugin 'management-cluster:v0.28.0' with target 'kubernetes'
✔  successfully installed 'management-cluster' plugin
$ tz plugin list
Installed Plugins
  NAME                DESCRIPTION                               TARGET      VERSION  STATUS
  management-cluster  Kubernetes management cluster operations  kubernetes  v0.28.0  installed

# Create context BUT interrupt the plugin sync mid-way, then list
$ tz context create --name tmc-unstable --endpoint unstable.tmc-dev.cloud.vmware.com --staging

ℹ  If you don't have an API token, visit the VMware Cloud Services console, select your organization, and create an API token with the TMC service roles:
  https://console.cloud.vmware.com/csp/gateway/portal/#/user/tokens

? API Token ****************************************************************

✔  successfully created a TMC context
ℹ  Checking for required plugins...
ℹ  Installing plugin 'data-protection:v0.0.1' with target 'mission-control'
ℹ  Installing plugin 'clustergroup:v0.0.1' with target 'mission-control'
ℹ  Installing plugin 'secret:v0.0.1' with target 'kubernetes'
ℹ  Installing plugin 'inspection:v0.0.1' with target 'mission-control'
ℹ  Installing plugin 'cluster:v0.0.1' with target 'mission-control'
ℹ  Installing plugin 'integration:v0.0.1' with target 'mission-control'
ℹ  Installing plugin 'audit:v0.0.1' with target 'mission-control'
ℹ  Installing plugin 'apply:v0.0.1' with target 'mission-control'
^C
$ tz plugin list
Installed Plugins
  NAME                DESCRIPTION                                                      TARGET           VERSION  STATUS
  management-cluster  Kubernetes management cluster operations                         kubernetes       v0.28.0  installed
  audit               Run an audit request on an organization                          mission-control  v0.0.1   installed
  cluster             A TMC managed Kubernetes cluster                                 mission-control  v0.0.1   installed
  clustergroup        A group of Kubernetes clusters                                   mission-control  v0.0.1   installed
  data-protection     Backup, restore, or migrate cluster data.                        mission-control  v0.0.1   installed
  inspection          Run an inspection on a cluster                                   mission-control  v0.0.1   installed
  integration         Get available integrations and their information from registry.  mission-control  v0.0.1   installed

Missing Plugins from Context:  tmc-unstable
  NAME                DESCRIPTION                                                     TARGET           VERSION  STATUS
  account             Account for tmc resources                                       mission-control  v0.0.1   not installed
  apply               Create/Update a resource with a resource file                   mission-control  v0.0.1   not installed
  continuousdelivery  Continuousdelivery for tmc resources                            mission-control  v0.0.1   not installed
  ekscluster                                                                          mission-control  v0.0.1   not installed
  events              Events for any meaningful user activity or system state change  mission-control  v0.0.1   not installed
  helm                helm for tmc resources                                          mission-control  v0.0.1   not installed
  iam                 IAM Policies for tmc resources                                  mission-control  v0.0.1   not installed
  management-cluster  A TMC registered Management cluster                             mission-control  v0.0.1   not installed
  policy              Policy for tmc resources                                        mission-control  v0.0.1   not installed
  secret              secret for tmc resources                                        mission-control  v0.0.1   not installed
  tanzupackage        Tanzupackage for tmc resources                                  mission-control  v0.0.1   not installed
  workspace           A group of Kubernetes namespaces                                mission-control  v0.0.1   not installed

!  As shown above, some recommended plugins have not been installed. To install them please run 'tanzu plugin sync'.
$

# Notice the warning message at the end of the output

# Create another context and interrupt the plugin sync
$ tz context create --name k3d --kubecontext k3d-k3s-default --kubeconfig /Users/kmarc/.config/k3d/k3s-default/kubeconfig.yaml
✔  successfully created a kubernetes context using the kubeconfig /Users/kmarc/.config/k3d/k3s-default/kubeconfig.yaml
ℹ  Checking for required plugins...
ℹ  Installing plugin 'feature:v0.28.0-dev' with target 'kubernetes'
ℹ  Installing plugin 'kubernetes-release:v0.28.0-dev' with target 'kubernetes'
ℹ  Installing plugin 'cluster:v0.38.0-dev' with target 'kubernetes'
ℹ  Installing plugin 'integration:v0.0.1' with target 'mission-control'
ℹ  Installing plugin 'inspection:v0.0.1' with target 'mission-control'
^C
$ tz plugin list
Installed Plugins
  NAME                DESCRIPTION                                                      TARGET           VERSION  STATUS
  management-cluster  Kubernetes management cluster operations                         kubernetes       v0.28.0  installed
  audit               Run an audit request on an organization                          mission-control  v0.0.1   installed
  cluster             A TMC managed Kubernetes cluster                                 mission-control  v0.0.1   installed
  clustergroup        A group of Kubernetes clusters                                   mission-control  v0.0.1   installed
  data-protection     Backup, restore, or migrate cluster data.                        mission-control  v0.0.1   installed
  inspection          Run an inspection on a cluster                                   mission-control  v0.0.1   installed
  integration         Get available integrations and their information from registry.  mission-control  v0.0.1   installed

Missing Plugins from Context:  k3d
  NAME                DESCRIPTION                           TARGET      VERSION      STATUS
  cluster             Kubernetes cluster operations         kubernetes  v0.38.0-dev  not installed
  feature             Operate on features and featuregates  kubernetes  v0.28.0-dev  not installed
  kubernetes-release  Kubernetes release operations         kubernetes  v0.28.0-dev  not installed

Missing Plugins from Context:  tmc-unstable
  NAME                DESCRIPTION                                                     TARGET           VERSION  STATUS
  account             Account for tmc resources                                       mission-control  v0.0.1   not installed
  apply               Create/Update a resource with a resource file                   mission-control  v0.0.1   not installed
  continuousdelivery  Continuousdelivery for tmc resources                            mission-control  v0.0.1   not installed
  ekscluster                                                                          mission-control  v0.0.1   not installed
  events              Events for any meaningful user activity or system state change  mission-control  v0.0.1   not installed
  helm                helm for tmc resources                                          mission-control  v0.0.1   not installed
  iam                 IAM Policies for tmc resources                                  mission-control  v0.0.1   not installed
  management-cluster  A TMC registered Management cluster                             mission-control  v0.0.1   not installed
  policy              Policy for tmc resources                                        mission-control  v0.0.1   not installed
  secret              secret for tmc resources                                        mission-control  v0.0.1   not installed
  tanzupackage        Tanzupackage for tmc resources                                  mission-control  v0.0.1   not installed
  workspace           A group of Kubernetes namespaces                                mission-control  v0.0.1   not installed

!  As shown above, some recommended plugins have not been installed. To install them please run 'tanzu plugin sync'.
$

# Notice the different table output for each context above

# Delete a context plugin and see it appear in the list of missing plugins
$ tz plugin delete audit
Deleting Plugin 'audit'. Are you sure? [y/N]: y
✔  successfully deleted plugin 'audit'
$ tz plugin list
Installed Plugins
  NAME                DESCRIPTION                                                      TARGET           VERSION  STATUS
  management-cluster  Kubernetes management cluster operations                         kubernetes       v0.28.0  installed
  cluster             A TMC managed Kubernetes cluster                                 mission-control  v0.0.1   installed
  clustergroup        A group of Kubernetes clusters                                   mission-control  v0.0.1   installed
  data-protection     Backup, restore, or migrate cluster data.                        mission-control  v0.0.1   installed
  inspection          Run an inspection on a cluster                                   mission-control  v0.0.1   installed
  integration         Get available integrations and their information from registry.  mission-control  v0.0.1   installed

Missing Plugins from Context:  k3d
  NAME                DESCRIPTION                           TARGET      VERSION      STATUS
  cluster             Kubernetes cluster operations         kubernetes  v0.38.0-dev  not installed
  feature             Operate on features and featuregates  kubernetes  v0.28.0-dev  not installed
  kubernetes-release  Kubernetes release operations         kubernetes  v0.28.0-dev  not installed

Missing Plugins from Context:  tmc-unstable
  NAME                DESCRIPTION                                                     TARGET           VERSION  STATUS
  account             Account for tmc resources                                       mission-control  v0.0.1   not installed
  apply               Create/Update a resource with a resource file                   mission-control  v0.0.1   not installed
  audit               Run an audit request on an org                                  mission-control  v0.0.1   not installed
  continuousdelivery  Continuousdelivery for tmc resources                            mission-control  v0.0.1   not installed
  ekscluster                                                                          mission-control  v0.0.1   not installed
  events              Events for any meaningful user activity or system state change  mission-control  v0.0.1   not installed
  helm                helm for tmc resources                                          mission-control  v0.0.1   not installed
  iam                 IAM Policies for tmc resources                                  mission-control  v0.0.1   not installed
  management-cluster  A TMC registered Management cluster                             mission-control  v0.0.1   not installed
  policy              Policy for tmc resources                                        mission-control  v0.0.1   not installed
  secret              secret for tmc resources                                        mission-control  v0.0.1   not installed
  tanzupackage        Tanzupackage for tmc resources                                  mission-control  v0.0.1   not installed
  workspace           A group of Kubernetes namespaces                                mission-control  v0.0.1   not installed

!  As shown above, some recommended plugins have not been installed. To install them please run 'tanzu plugin sync'.
$

# Delete a standalone context and notice it is not in any output anymore, as expected
 tz plugin delete management-cluster
Deleting Plugin 'management-cluster'. Are you sure? [y/N]: y
✔  successfully deleted plugin 'management-cluster'
$ tz plugin list
Installed Plugins
  NAME             DESCRIPTION                                                      TARGET           VERSION  STATUS
  cluster          A TMC managed Kubernetes cluster                                 mission-control  v0.0.1   installed
  clustergroup     A group of Kubernetes clusters                                   mission-control  v0.0.1   installed
  data-protection  Backup, restore, or migrate cluster data.                        mission-control  v0.0.1   installed
  inspection       Run an inspection on a cluster                                   mission-control  v0.0.1   installed
  integration      Get available integrations and their information from registry.  mission-control  v0.0.1   installed

Missing Plugins from Context:  k3d
  NAME                DESCRIPTION                           TARGET      VERSION      STATUS
  cluster             Kubernetes cluster operations         kubernetes  v0.38.0-dev  not installed
  feature             Operate on features and featuregates  kubernetes  v0.28.0-dev  not installed
  kubernetes-release  Kubernetes release operations         kubernetes  v0.28.0-dev  not installed

Missing Plugins from Context:  tmc-unstable
  NAME                DESCRIPTION                                                     TARGET           VERSION  STATUS
  account             Account for tmc resources                                       mission-control  v0.0.1   not installed
  apply               Create/Update a resource with a resource file                   mission-control  v0.0.1   not installed
  audit               Run an audit request on an org                                  mission-control  v0.0.1   not installed
  continuousdelivery  Continuousdelivery for tmc resources                            mission-control  v0.0.1   not installed
  ekscluster                                                                          mission-control  v0.0.1   not installed
  events              Events for any meaningful user activity or system state change  mission-control  v0.0.1   not installed
  helm                helm for tmc resources                                          mission-control  v0.0.1   not installed
  iam                 IAM Policies for tmc resources                                  mission-control  v0.0.1   not installed
  management-cluster  A TMC registered Management cluster                             mission-control  v0.0.1   not installed
  policy              Policy for tmc resources                                        mission-control  v0.0.1   not installed
  secret              secret for tmc resources                                        mission-control  v0.0.1   not installed
  tanzupackage        Tanzupackage for tmc resources                                  mission-control  v0.0.1   not installed
  workspace           A group of Kubernetes namespaces                                mission-control  v0.0.1   not installed

!  As shown above, some recommended plugins have not been installed. To install them please run 'tanzu plugin sync'.
$

# Delete a context
$ tz context delete tmc-unstable
Deleting the context entry from the config will remove it from the list of tracked contexts. You will need to use `tanzu context create` to re-create this context. Are you sure you want to continue? [y/N]: y
ℹ  Deleting entry for cluster tmc-unstable
$ tz plugin list
Installed Plugins
  NAME             DESCRIPTION                                                      TARGET           VERSION  STATUS
  cluster          A TMC managed Kubernetes cluster                                 mission-control  v0.0.1   installed
  clustergroup     A group of Kubernetes clusters                                   mission-control  v0.0.1   installed
  data-protection  Backup, restore, or migrate cluster data.                        mission-control  v0.0.1   installed
  inspection       Run an inspection on a cluster                                   mission-control  v0.0.1   installed
  integration      Get available integrations and their information from registry.  mission-control  v0.0.1   installed

Missing Plugins from Context:  k3d
  NAME                DESCRIPTION                           TARGET      VERSION      STATUS
  cluster             Kubernetes cluster operations         kubernetes  v0.38.0-dev  not installed
  feature             Operate on features and featuregates  kubernetes  v0.28.0-dev  not installed
  kubernetes-release  Kubernetes release operations         kubernetes  v0.28.0-dev  not installed

!  As shown above, some recommended plugins have not been installed. To install them please run 'tanzu plugin sync'.
$

# Delete all context and see the missing ones listed
$ tz plugin clean
✔  successfully cleaned up all plugins
$ tz plugin list
Installed Plugins
  NAME  DESCRIPTION  TARGET  VERSION  STATUS

Missing Plugins from Context:  k3d
  NAME                DESCRIPTION                           TARGET      VERSION      STATUS
  cluster             Kubernetes cluster operations         kubernetes  v0.38.0-dev  not installed
  feature             Operate on features and featuregates  kubernetes  v0.28.0-dev  not installed
  kubernetes-release  Kubernetes release operations         kubernetes  v0.28.0-dev  not installed

!  As shown above, some recommended plugins have not been installed. To install them please run 'tanzu plugin sync'.
$

# Delete second context and see no plugins listed anymore
$ tz context delete k3d
Deleting the context entry from the config will remove it from the list of tracked contexts. You will need to use `tanzu context create` to re-create this context. Are you sure you want to continue? [y/N]: y
ℹ  Deleting entry for cluster k3d
$ tz plugin list
Installed Plugins
  NAME  DESCRIPTION  TARGET  VERSION  STATUS
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The `tanzu plugin list` command now includes the list of any context-scope plugins that are not installed and warns the user that they should run `tanzu plugin sync`.
```

#### Special notes for your reviewer

1. How do you feel about the warning message?  It is output on stdout.  Should it instead be on stderr?  Other such warnings are on stdout for our CLI, so I did the same.
2. Unit tests were added for the `plugin list` command with the Central Repo.  The coverage for `plugin.go` increased by 13% to 54%.  However, I wasn't able to test the listing of the missing plugins because, as pointed out in previous PRs, the pluginmanager's current implementation does not lend itself to unit tests.
3. There is one part of the planned `plugin list` improvement that is still missing, which is the part about showing if an installed plugin was installed from a context.  This will be done in a follow-up PR as it need more substantial changes.
