### PR TITLE
Use latest `tanzu-plugin-runtime` and add `Target` field to the PluginDescriptor

### DIFF
--- a/cmd/plugin/builder/main.go
+++ b/cmd/plugin/builder/main.go
@@ -6,12 +6,14 @@ package main
 import (
 	"github.com/aunum/log"
 
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/plugin"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo"
 )
 
 var descriptor = plugin.PluginDescriptor{
 	Name:        "builder",
+	Target:      types.TargetGlobal,
 	Description: "Build Tanzu components",
 	Group:       plugin.AdminCmdGroup,
 	Version:     buildinfo.Version,

--- a/cmd/plugin/test/main.go
+++ b/cmd/plugin/test/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aunum/log"
 	"github.com/spf13/cobra"
 
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/plugin"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo"
 
@@ -19,6 +20,7 @@ import (
 
 var descriptor = plugin.PluginDescriptor{
 	Name:        "test",
+	Target:      types.TargetGlobal,
 	Description: "Test the CLI",
 	Group:       plugin.AdminCmdGroup,
 	Version:     buildinfo.Version,

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/tj/assert v0.0.3
 	github.com/vmware-tanzu/carvel-ytt v0.40.0
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230130173350-eeda69d80a24
-	github.com/vmware-tanzu/tanzu-plugin-runtime v0.0.0-20230221194443-4d4c14fcdb5c
+	github.com/vmware-tanzu/tanzu-plugin-runtime v0.0.0-20230223175026-9c303222c664
 	go.pinniped.dev v0.20.0
 	go.uber.org/multierr v1.8.0
 	golang.org/x/mod v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -910,8 +910,8 @@ github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20221207131309-7323ca04b
 github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20221207131309-7323ca04b86c/go.mod h1:ukZpKQ0hf5bjWdJLjn2M6qXP+9giZWQPxt8nOfrCR+o=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230130173350-eeda69d80a24 h1:zz3XDCLPqvhtx8OMMRNjSn/krxhqkYnuw9Z9DBh6ruA=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230130173350-eeda69d80a24/go.mod h1:rcIfoGpdav3evsyEMMzYH0xhGZOkIy+Ra3koypM8Aco=
-github.com/vmware-tanzu/tanzu-plugin-runtime v0.0.0-20230221194443-4d4c14fcdb5c h1:3OtCPkTKPs42BAczDx7amQhraW1iUCWETNGxpiCDJjI=
-github.com/vmware-tanzu/tanzu-plugin-runtime v0.0.0-20230221194443-4d4c14fcdb5c/go.mod h1:WBPd6bftNpIMkFje0Hh+oh/AcjGNGFaHDlyMajbVP0Y=
+github.com/vmware-tanzu/tanzu-plugin-runtime v0.0.0-20230223175026-9c303222c664 h1:rMPf1aRLkIHBcRIm1L98GtSCNvJ29c6+Z3RoxBhIN1s=
+github.com/vmware-tanzu/tanzu-plugin-runtime v0.0.0-20230223175026-9c303222c664/go.mod h1:WBPd6bftNpIMkFje0Hh+oh/AcjGNGFaHDlyMajbVP0Y=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -569,7 +569,7 @@ func listCtx(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	if !configtypes.IsValidTarget(targetStr) {
+	if !configtypes.IsValidTarget(targetStr, false, true) {
 		return errors.New("invalid target specified. Please specify correct value of `--target` or `-t` flag from 'kubernetes/k8s/mission-control/tmc'")
 	}
 
@@ -729,7 +729,7 @@ func displayContextListOutputListView(cfg *configtypes.ClientConfig, writer io.W
 
 	op := component.NewOutputWriter(writer, outputFormat, "Name", "Type", "IsManagementCluster", "IsCurrent", "Endpoint", "KubeConfigPath", "KubeContext")
 	for _, ctx := range cfg.KnownContexts {
-		if target != configtypes.TargetNone && ctx.Target != target {
+		if target != configtypes.TargetUnknown && ctx.Target != target {
 			continue
 		}
 		isMgmtCluster := ctx.IsManagementCluster()
@@ -758,7 +758,7 @@ func displayContextListOutputSplitViewTarget(cfg *configtypes.ClientConfig, writ
 	outputWriterK8sTarget := component.NewOutputWriter(writer, outputFormat, "Name", "IsActive", "Endpoint", "KubeConfigPath", "KubeContext")
 	outputWriterTMCTarget := component.NewOutputWriter(writer, outputFormat, "Name", "IsActive", "Endpoint")
 	for _, ctx := range cfg.KnownContexts {
-		if target != configtypes.TargetNone && ctx.Target != target {
+		if target != configtypes.TargetUnknown && ctx.Target != target {
 			continue
 		}
 		isCurrent := ctx.Name == cfg.CurrentContext[ctx.Target]
@@ -781,11 +781,11 @@ func displayContextListOutputSplitViewTarget(cfg *configtypes.ClientConfig, writ
 
 	cyanBold := color.New(color.FgCyan).Add(color.Bold)
 	cyanBoldItalic := color.New(color.FgCyan).Add(color.Bold, color.Italic)
-	if target == configtypes.TargetNone || target == configtypes.TargetK8s {
+	if target == configtypes.TargetUnknown || target == configtypes.TargetK8s {
 		_, _ = cyanBold.Println("Target: ", cyanBoldItalic.Sprintf("%s", configtypes.TargetK8s))
 		outputWriterK8sTarget.Render()
 	}
-	if target == configtypes.TargetNone || target == configtypes.TargetTMC {
+	if target == configtypes.TargetUnknown || target == configtypes.TargetTMC {
 		_, _ = cyanBold.Println("Target: ", cyanBoldItalic.Sprintf("%s", configtypes.TargetTMC))
 		outputWriterTMCTarget.Render()
 	}

--- a/pkg/command/plugin.go
+++ b/pkg/command/plugin.go
@@ -178,7 +178,7 @@ func newDescribePluginCmd() *cobra.Command {
 			}
 			pluginName := args[0]
 
-			if !configtypes.IsValidTarget(targetStr) {
+			if !configtypes.IsValidTarget(targetStr, true, true) {
 				return errors.New("invalid target specified. Please specify correct value of `--target` or `-t` flag from 'kubernetes/k8s/mission-control/tmc'")
 			}
 
@@ -209,7 +209,7 @@ func newInstallPluginCmd() *cobra.Command {
 
 			pluginName := args[0]
 
-			if !configtypes.IsValidTarget(targetStr) {
+			if !configtypes.IsValidTarget(targetStr, true, true) {
 				return errors.New("invalid target specified. Please specify correct value of `--target` or `-t` flag from 'kubernetes/k8s/mission-control/tmc'")
 			}
 
@@ -279,7 +279,7 @@ func newUpgradePluginCmd() *cobra.Command {
 			}
 			pluginName := args[0]
 
-			if !configtypes.IsValidTarget(targetStr) {
+			if !configtypes.IsValidTarget(targetStr, true, true) {
 				return errors.New("invalid target specified. Please specify correct value of `--target` or `-t` flag from 'kubernetes/k8s/mission-control/tmc'")
 			}
 
@@ -317,7 +317,7 @@ func newDeletePluginCmd() *cobra.Command {
 			}
 			pluginName := args[0]
 
-			if !configtypes.IsValidTarget(targetStr) {
+			if !configtypes.IsValidTarget(targetStr, true, true) {
 				return errors.New("invalid target specified. Please specify correct value of `--target` or `-t` flag from 'kubernetes/k8s/mission-control/tmc'")
 			}
 

--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -146,7 +146,7 @@ func findSubCommand(rootCmd, subCmd *cobra.Command) *cobra.Command {
 
 func isPluginRootCmdTargeted(pluginInfo *cli.PluginInfo) bool {
 	// Only '<none>' targeted and `k8s` targeted plugins are considered root cmd targeted plugins
-	return pluginInfo != nil && (pluginInfo.Target == configtypes.TargetNone || pluginInfo.Target == configtypes.TargetK8s)
+	return pluginInfo != nil && (pluginInfo.Target == configtypes.TargetUnknown || pluginInfo.Target == configtypes.TargetK8s)
 }
 
 func isStandalonePluginCommand(cmd *cobra.Command) bool {

--- a/pkg/pluginmanager/manager.go
+++ b/pkg/pluginmanager/manager.go
@@ -294,7 +294,7 @@ func combineDuplicatePlugins(availablePlugins []discovery.Discovered) []discover
 	}
 
 	for i := range availablePlugins {
-		if availablePlugins[i].Target == configtypes.TargetNone {
+		if availablePlugins[i].Target == configtypes.TargetUnknown {
 			// As we are considering None targeted and k8s target plugin to be treated as same plugins
 			// in the case of plugin name conflicts, using `k8s` target to determine the plugin already
 			// exists or not.
@@ -561,7 +561,7 @@ func GetRecommendedVersionOfPlugin(pluginName string, target configtypes.Target)
 }
 
 func installOrUpgradePlugin(p *discovery.Discovered, version string, installTestPlugin bool) error {
-	if p.Target == configtypes.TargetNone {
+	if p.Target == configtypes.TargetUnknown {
 		log.Infof("Installing plugin '%v:%v'", p.Name, version)
 	} else {
 		log.Infof("Installing plugin '%v:%v' with target '%v'", p.Name, version, p.Target)

--- a/pkg/pluginmanager/manager_test.go
+++ b/pkg/pluginmanager/manager_test.go
@@ -54,7 +54,7 @@ var expectedDiscoveredStandalonePlugins = []discovery.Discovered{
 		RecommendedVersion: "v0.2.0",
 		Scope:              common.PluginScopeStandalone,
 		ContextName:        "",
-		Target:             configtypes.TargetNone,
+		Target:             configtypes.TargetUnknown,
 	},
 	{
 		Name:               "management-cluster",
@@ -115,12 +115,12 @@ func Test_InstallPlugin_InstalledPlugins(t *testing.T) {
 	defer func() { execCommand = exec.Command }()
 
 	// Try installing nonexistent plugin
-	err := InstallPlugin("not-exists", "v0.2.0", configtypes.TargetNone)
+	err := InstallPlugin("not-exists", "v0.2.0", configtypes.TargetUnknown)
 	assertions.NotNil(err)
 	assertions.Contains(err.Error(), "unable to find plugin 'not-exists'")
 
 	// Install login (standalone) plugin
-	err = InstallPlugin("login", "v0.2.0", configtypes.TargetNone)
+	err = InstallPlugin("login", "v0.2.0", configtypes.TargetUnknown)
 	assertions.Nil(err)
 	// Verify installed plugin
 	installedPlugins, err := pluginsupplier.GetInstalledPlugins()
@@ -129,7 +129,7 @@ func Test_InstallPlugin_InstalledPlugins(t *testing.T) {
 	assertions.Equal("login", installedPlugins[0].Name)
 
 	// Try installing cluster plugin with no context-type
-	err = InstallPlugin("cluster", "v0.2.0", configtypes.TargetNone)
+	err = InstallPlugin("cluster", "v0.2.0", configtypes.TargetUnknown)
 	assertions.NotNil(err)
 	assertions.Contains(err.Error(), "unable to uniquely identify plugin 'cluster'. Please specify correct Target(kubernetes[k8s]/mission-control[tmc]) of the plugin with `--target` flag")
 
@@ -147,7 +147,7 @@ func Test_InstallPlugin_InstalledPlugins(t *testing.T) {
 	assertions.Nil(err)
 
 	// Try installing management-cluster plugin from standalone discovery without context-type
-	err = InstallPlugin("management-cluster", "v1.6.0", configtypes.TargetNone)
+	err = InstallPlugin("management-cluster", "v1.6.0", configtypes.TargetUnknown)
 	assertions.NotNil(err)
 	assertions.Contains(err.Error(), "unable to uniquely identify plugin 'management-cluster'. Please specify correct Target(kubernetes[k8s]/mission-control[tmc]) of the plugin with `--target` flag")
 
@@ -182,7 +182,7 @@ func Test_InstallPlugin_InstalledPlugins(t *testing.T) {
 			Name:    "login",
 			Version: "v0.2.0",
 			Scope:   common.PluginScopeStandalone,
-			Target:  configtypes.TargetNone,
+			Target:  configtypes.TargetUnknown,
 		},
 		{
 			Name:    "management-cluster",
@@ -218,12 +218,12 @@ func Test_InstallPlugin_InstalledPlugins_Central_Repo(t *testing.T) {
 	assertions.Nil(err)
 
 	// Try installing nonexistent plugin
-	err = InstallPlugin("not-exists", "v0.2.0", configtypes.TargetNone)
+	err = InstallPlugin("not-exists", "v0.2.0", configtypes.TargetUnknown)
 	assertions.NotNil(err)
 	assertions.Contains(err.Error(), "unable to find plugin 'not-exists'")
 
 	// Install login (standalone) plugin
-	err = InstallPlugin("login", "v0.2.0", configtypes.TargetNone)
+	err = InstallPlugin("login", "v0.2.0", configtypes.TargetUnknown)
 	assertions.Nil(err)
 	// Verify installed plugin
 	installedPlugins, err := pluginsupplier.GetInstalledPlugins()
@@ -232,7 +232,7 @@ func Test_InstallPlugin_InstalledPlugins_Central_Repo(t *testing.T) {
 	assertions.Equal("login", installedPlugins[0].Name)
 
 	// Try installing myplugin plugin with no context-type
-	err = InstallPlugin("myplugin", "v0.2.0", configtypes.TargetNone)
+	err = InstallPlugin("myplugin", "v0.2.0", configtypes.TargetUnknown)
 	assertions.NotNil(err)
 	assertions.Contains(err.Error(), "unable to uniquely identify plugin 'myplugin'. Please specify correct Target(kubernetes[k8s]/mission-control[tmc]) of the plugin with `--target` flag")
 
@@ -266,7 +266,7 @@ func Test_InstallPlugin_InstalledPlugins_Central_Repo(t *testing.T) {
 			Name:    "login",
 			Version: "v0.2.0",
 			Scope:   common.PluginScopeStandalone,
-			Target:  configtypes.TargetNone,
+			Target:  configtypes.TargetUnknown,
 		},
 		{
 			Name:    "management-cluster",
@@ -316,7 +316,7 @@ func Test_AvailablePlugins(t *testing.T) {
 	}
 
 	// Install login, cluster plugins
-	mockInstallPlugin(assertions, "login", "v0.2.0", configtypes.TargetNone)
+	mockInstallPlugin(assertions, "login", "v0.2.0", configtypes.TargetUnknown)
 	mockInstallPlugin(assertions, "cluster", "v0.2.0", configtypes.TargetTMC)
 
 	expectedInstallationStatusOfPlugins := []discovery.Discovered{
@@ -334,7 +334,7 @@ func Test_AvailablePlugins(t *testing.T) {
 		},
 		{
 			Name:             "login",
-			Target:           configtypes.TargetNone,
+			Target:           configtypes.TargetUnknown,
 			InstalledVersion: "v0.2.0",
 			Status:           common.PluginStatusInstalled,
 		},
@@ -377,7 +377,7 @@ func Test_AvailablePlugins(t *testing.T) {
 		},
 		{
 			Name:             "login",
-			Target:           configtypes.TargetNone,
+			Target:           configtypes.TargetUnknown,
 			InstalledVersion: "v0.2.0",
 			Status:           common.PluginStatusInstalled,
 		},
@@ -407,7 +407,7 @@ func Test_AvailablePlugins_With_K8s_None_Target_Plugin_Name_Conflict_With_One_In
 	assertions.Equal(len(expectedDiscoveredPlugins), len(discoveredPlugins))
 
 	// Install login, cluster plugins
-	mockInstallPlugin(assertions, "login", "v0.2.0", configtypes.TargetNone)
+	mockInstallPlugin(assertions, "login", "v0.2.0", configtypes.TargetUnknown)
 
 	// Considering `login` plugin with `<none>` target is already installed and
 	// getting discovered through some discoveries source
@@ -460,7 +460,7 @@ func Test_AvailablePlugins_With_K8s_None_Target_Plugin_Name_Conflict_With_Plugin
 	assertions.Equal(len(expectedDiscoveredPlugins), len(discoveredPlugins))
 
 	// Install login, cluster plugins
-	mockInstallPlugin(assertions, "login", "v0.2.0", configtypes.TargetNone)
+	mockInstallPlugin(assertions, "login", "v0.2.0", configtypes.TargetUnknown)
 
 	// Considering `login` plugin with `<none>` target is already installed and
 	// getting discovered through some discoveries source
@@ -576,12 +576,12 @@ func Test_InstallPlugin_InstalledPlugins_From_LocalSource(t *testing.T) {
 	localPluginSourceDir := filepath.Join(currentDirAbsPath, "test", "local")
 
 	// Try installing nonexistent plugin
-	err := InstallPluginsFromLocalSource("not-exists", "v0.2.0", configtypes.TargetNone, localPluginSourceDir, false)
+	err := InstallPluginsFromLocalSource("not-exists", "v0.2.0", configtypes.TargetUnknown, localPluginSourceDir, false)
 	assertions.NotNil(err)
 	assertions.Contains(err.Error(), "unable to find plugin 'not-exists'")
 
 	// Install login from local source directory
-	err = InstallPluginsFromLocalSource("login", "v0.2.0", configtypes.TargetNone, localPluginSourceDir, false)
+	err = InstallPluginsFromLocalSource("login", "v0.2.0", configtypes.TargetUnknown, localPluginSourceDir, false)
 	assertions.Nil(err)
 	// Verify installed plugin
 	installedStandalonePlugins, err := pluginsupplier.GetInstalledStandalonePlugins()
@@ -611,15 +611,15 @@ func Test_DescribePlugin(t *testing.T) {
 	defer setupLocalDistoForTesting()()
 
 	// Try to describe plugin when plugin is not installed
-	_, err := DescribePlugin("login", configtypes.TargetNone)
+	_, err := DescribePlugin("login", configtypes.TargetUnknown)
 	assertions.NotNil(err)
 	assertions.Contains(err.Error(), "unable to find plugin 'login'")
 
 	// Install login (standalone) package
-	mockInstallPlugin(assertions, "login", "v0.2.0", configtypes.TargetNone)
+	mockInstallPlugin(assertions, "login", "v0.2.0", configtypes.TargetUnknown)
 
 	// Try to describe plugin when plugin after installing plugin
-	pd, err := DescribePlugin("login", configtypes.TargetNone)
+	pd, err := DescribePlugin("login", configtypes.TargetUnknown)
 	assertions.Nil(err)
 	assertions.Equal("login", pd.Name)
 	assertions.Equal("v0.2.0", pd.Version)
@@ -645,12 +645,12 @@ func Test_DeletePlugin(t *testing.T) {
 	defer setupLocalDistoForTesting()()
 
 	// Try to delete plugin when plugin is not installed
-	err := DeletePlugin(DeletePluginOptions{PluginName: "login", Target: configtypes.TargetNone, ForceDelete: true})
+	err := DeletePlugin(DeletePluginOptions{PluginName: "login", Target: configtypes.TargetUnknown, ForceDelete: true})
 	assertions.NotNil(err)
 	assertions.Contains(err.Error(), "unable to find plugin 'login'")
 
 	// Install login (standalone) package
-	mockInstallPlugin(assertions, "login", "v0.2.0", configtypes.TargetNone)
+	mockInstallPlugin(assertions, "login", "v0.2.0", configtypes.TargetUnknown)
 
 	// Try to delete plugin when plugin is installed
 	err = DeletePlugin(DeletePluginOptions{PluginName: "cluster", Target: configtypes.TargetTMC, ForceDelete: true})
@@ -777,7 +777,7 @@ func Test_setAvailablePluginsStatus(t *testing.T) {
 	assertions := assert.New(t)
 
 	availablePlugins := []discovery.Discovered{{Name: "fake1", DiscoveryType: "oci", RecommendedVersion: "v1.0.0", Status: common.PluginStatusNotInstalled, Target: configtypes.TargetK8s}}
-	installedPlugin := []cli.PluginInfo{{Name: "fake2", Version: "v2.0.0", Discovery: "local", DiscoveredRecommendedVersion: "v2.0.0", Target: configtypes.TargetNone}}
+	installedPlugin := []cli.PluginInfo{{Name: "fake2", Version: "v2.0.0", Discovery: "local", DiscoveredRecommendedVersion: "v2.0.0", Target: configtypes.TargetUnknown}}
 
 	// If installed plugin is not part of available(discovered) plugins then
 	// installed version == ""
@@ -790,7 +790,7 @@ func Test_setAvailablePluginsStatus(t *testing.T) {
 	assertions.Equal(common.PluginStatusNotInstalled, availablePlugins[0].Status)
 
 	// If installed plugin is not part of available(discovered) plugins because of the Target mismatch
-	installedPlugin = []cli.PluginInfo{{Name: "fake1", Version: "v1.0.0", Discovery: "local", DiscoveredRecommendedVersion: "v1.0.0", Target: configtypes.TargetNone}}
+	installedPlugin = []cli.PluginInfo{{Name: "fake1", Version: "v1.0.0", Discovery: "local", DiscoveredRecommendedVersion: "v1.0.0", Target: configtypes.TargetUnknown}}
 	setAvailablePluginsStatus(availablePlugins, installedPlugin)
 	assertions.Equal(len(availablePlugins), 1)
 	assertions.Equal("fake1", availablePlugins[0].Name)
@@ -858,13 +858,13 @@ func Test_DiscoverPluginsFromLocalSourceWithLegacyDirectoryStructure(t *testing.
 	assertions.Equal("Foo plugin", discoveredPlugins[0].Description)
 	assertions.Equal("v0.12.0", discoveredPlugins[0].RecommendedVersion)
 	assertions.Equal(common.PluginScopeStandalone, discoveredPlugins[0].Scope)
-	assertions.Equal(configtypes.TargetNone, discoveredPlugins[0].Target)
+	assertions.Equal(configtypes.TargetUnknown, discoveredPlugins[0].Target)
 
 	assertions.Equal("bar", discoveredPlugins[1].Name)
 	assertions.Equal("Bar plugin", discoveredPlugins[1].Description)
 	assertions.Equal("v0.10.0", discoveredPlugins[1].RecommendedVersion)
 	assertions.Equal(common.PluginScopeStandalone, discoveredPlugins[1].Scope)
-	assertions.Equal(configtypes.TargetNone, discoveredPlugins[1].Target)
+	assertions.Equal(configtypes.TargetUnknown, discoveredPlugins[1].Target)
 }
 
 func Test_InstallPluginsFromLocalSourceWithLegacyDirectoryStructure(t *testing.T) {
@@ -875,7 +875,7 @@ func Test_InstallPluginsFromLocalSourceWithLegacyDirectoryStructure(t *testing.T
 
 	// Using generic InstallPluginsFromLocalSource to test the legacy directory install
 	// When passing legacy directory structure which contains manifest.yaml file
-	err := InstallPluginsFromLocalSource("all", "", configtypes.TargetNone, filepath.Join("test", "legacy"), false)
+	err := InstallPluginsFromLocalSource("all", "", configtypes.TargetUnknown, filepath.Join("test", "legacy"), false)
 	assertions.Nil(err)
 
 	// Verify installed plugin
@@ -1052,7 +1052,7 @@ func Test_removeDuplicates(t *testing.T) {
 			inputPlugins: []discovery.Discovered{
 				{
 					Name:   "foo",
-					Target: configtypes.TargetNone,
+					Target: configtypes.TargetUnknown,
 					Scope:  common.PluginScopeStandalone,
 				},
 				{
@@ -1084,7 +1084,7 @@ func Test_removeDuplicates(t *testing.T) {
 			inputPlugins: []discovery.Discovered{
 				{
 					Name:   "foo",
-					Target: configtypes.TargetNone,
+					Target: configtypes.TargetUnknown,
 					Scope:  common.PluginScopeStandalone,
 				},
 				{
@@ -1116,7 +1116,7 @@ func Test_removeDuplicates(t *testing.T) {
 			inputPlugins: []discovery.Discovered{
 				{
 					Name:   "foo",
-					Target: configtypes.TargetNone,
+					Target: configtypes.TargetUnknown,
 					Scope:  common.PluginScopeStandalone,
 				},
 				{


### PR DESCRIPTION
### What this PR does / why we need it

This change updates the PluginDescriptor to provide `target` information as part of the contract as required by tanzu-plugin-runtime ([tanzu-plugin-runtime/pull/17](https://github.com/vmware-tanzu/tanzu-plugin-runtime/pull/17))

Also renames `TargetNone` to `TargetUnknown`.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
- Existing Unit test should cover the changes made

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
N/A
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
