### PR TITLE
Allow bypassing TANZU_CLI_PRE_RELEASE_REPO_IMAGE

### DIFF
--- a/pkg/constants/config_variables.go
+++ b/pkg/constants/config_variables.go
@@ -15,4 +15,5 @@ const (
 	ConfigVariableDefaultStandaloneDiscoveryType      = "TKG_DEFAULT_STANDALONE_DISCOVERY_TYPE"
 	ConfigVariableDefaultStandaloneDiscoveryLocalPath = "TKG_DEFAULT_STANDALONE_DISCOVERY_LOCAL_PATH"
 	ConfigVariablePreReleasePluginRepoImage           = "TANZU_CLI_PRE_RELEASE_REPO_IMAGE"
+	ConfigVariablePreReleasePluginRepoImageBypass     = "TEST_BYPASS"
 )

--- a/pkg/pluginmanager/manager_test.go
+++ b/pkg/pluginmanager/manager_test.go
@@ -205,8 +205,11 @@ func Test_InstallPlugin_InstalledPlugins(t *testing.T) {
 }
 
 func Test_InstallPlugin_InstalledPlugins_Central_Repo(t *testing.T) {
-	t.Skip("Skipping until TANZU_CLI_PRE_RELEASE_REPO_IMAGE is no longer used")
 	assertions := assert.New(t)
+
+	// Bypass the environment variable for testing
+	err := os.Setenv(constants.ConfigVariablePreReleasePluginRepoImage, constants.ConfigVariablePreReleasePluginRepoImageBypass)
+	assertions.Nil(err)
 
 	defer setupLocalDistoForTesting()()
 	execCommand = fakeInfoExecCommand
@@ -214,7 +217,7 @@ func Test_InstallPlugin_InstalledPlugins_Central_Repo(t *testing.T) {
 
 	// Turn on the Central Repository feature
 	featureArray := strings.Split(constants.FeatureCentralRepository, ".")
-	err := configlib.SetFeature(featureArray[1], featureArray[2], "true")
+	err = configlib.SetFeature(featureArray[1], featureArray[2], "true")
 	assertions.Nil(err)
 
 	// Try installing nonexistent plugin


### PR DESCRIPTION
### What this PR does / why we need it

Having a way to bypass the temporary `TANZU_CLI_PRE_RELEASE_REPO_IMAGE` environment variable allows for both manual and unit testing of code paths that need to be ready for when we remove the use of that variable.

Using this bypass, this PR removes the skipping of a pluginmanager test.

### Describe testing done for PR

```
$ rm ~/.config/tanzu/config*
$ tz plugin clean
✔  successfully cleaned up all plugins
$ tz config set features.global.central-repository true

# Test old behaviour
$ export TANZU_CLI_PRE_RELEASE_REPO_IMAGE=localhost:9876/tanzu-cli/plugins/central:small
$ tz plugin search
  NAME                DESCRIPTION                  TARGET           VERSION  STATUS         CONTEXT
  isolated-cluster    Desc for isolated-cluster                     v9.9.9   not installed
  pinniped-auth       Desc for pinniped-auth                        v9.9.9   not installed
  cluster             Desc for cluster             kubernetes       v9.9.9   not installed
  feature             Desc for feature             kubernetes       v9.9.9   not installed
  kubernetes-release  Desc for kubernetes-release  kubernetes       v9.9.9   not installed
  management-cluster  Desc for management-cluster  kubernetes       v9.9.9   not installed
  package             Desc for package             kubernetes       v9.9.9   not installed
  secret              Desc for secret              kubernetes       v9.9.9   not installed
  telemetry           Desc for telemetry           kubernetes       v9.9.9   not installed
  account             Desc for account             mission-control  v9.9.9   not installed
  apply               Desc for apply               mission-control  v9.9.9   not installed
  audit               Desc for audit               mission-control  v9.9.9   not installed
  cluster             Desc for cluster             mission-control  v9.9.9   not installed
  clustergroup        Desc for clustergroup        mission-control  v9.9.9   not installed
  data-protection     Desc for data-protection     mission-control  v9.9.9   not installed
  ekscluster          Desc for ekscluster          mission-control  v9.9.9   not installed
  events              Desc for events              mission-control  v9.9.9   not installed
  iam                 Desc for iam                 mission-control  v9.9.9   not installed
  inspection          Desc for inspection          mission-control  v9.9.9   not installed
  integration         Desc for integration         mission-control  v9.9.9   not installed
  management-cluster  Desc for management-cluster  mission-control  v9.9.9   not installed
  policy              Desc for policy              mission-control  v9.9.9   not installed
  workspace           Desc for workspace           mission-control  v9.9.9   not installed

$ unset TANZU_CLI_PRE_RELEASE_REPO_IMAGE
$ tz plugin search
!  unable to discover standalone plugins, you must set the environment variable TANZU_CLI_PRE_RELEASE_REPO_IMAGE to the URI of the image of the plugin repository.  Please see the documentation
  NAME  DESCRIPTION  TARGET  VERSION  STATUS  CONTEXT

# Test new bypass
$ export TANZU_CLI_PRE_RELEASE_REPO_IMAGE=TEST_BYPASS
$ tz plugin search
  NAME  DESCRIPTION  TARGET  VERSION  STATUS  CONTEXT
$ tz plugin source add -n default -t oci -u localhost:9876/tanzu-cli/plugins/central:large
✔  successfully added discovery source default
$ tz plugin search
  NAME                DESCRIPTION                  TARGET           VERSION  STATUS         CONTEXT
  isolated-cluster    Desc for isolated-cluster                     v9.9.9   not installed
  pinniped-auth       Desc for pinniped-auth                        v9.9.9   not installed
  stub10              Desc for stub10                               v9.9.9   not installed
  stub11              Desc for stub11                               v9.9.9   not installed
  stub2               Desc for stub2                                v9.9.9   not installed
  stub21              Desc for stub21                               v9.9.9   not installed
[...]
```

We can see from the last test that the plugin source is used when the variable is bypassed.