### PR TITLE
Respect explicit target when trying to install

### DIFF
--- a/pkg/pluginmanager/test/local/discovery/context-tmc/cluster.yaml
+++ b/pkg/pluginmanager/test/local/discovery/context-tmc/cluster.yaml
@@ -23,4 +23,4 @@ spec:
         arch: arm64
         type: local
   recommendedVersion: v0.2.0
-  target: tmc
+  target: mission-control

--- a/pkg/pluginmanager/test/local/discovery/context-tmc/management-cluster.yaml
+++ b/pkg/pluginmanager/test/local/discovery/context-tmc/management-cluster.yaml
@@ -23,4 +23,4 @@ spec:
         arch: arm64
         type: local
   recommendedVersion: v0.2.0
-  target: tmc
+  target: mission-control

--- a/pkg/pluginmanager/test/local/discovery/default/management-cluster.yaml
+++ b/pkg/pluginmanager/test/local/discovery/default/management-cluster.yaml
@@ -23,4 +23,4 @@ spec:
         arch: arm64
         type: local
   recommendedVersion: v1.6.0
-  target: k8s
+  target: kubernetes

--- a/pkg/pluginmanager/test/local/discovery/standalone-k8s-target/feature.yaml
+++ b/pkg/pluginmanager/test/local/discovery/standalone-k8s-target/feature.yaml
@@ -1,26 +1,26 @@
 apiVersion: cli.tanzu.vmware.com/v1alpha1
 kind: CLIPlugin
 metadata:
-  name: cluster
+  name: feature
 spec:
-  description: Cluster operation for the Kubernetes Cluster
+  description: Feature plugin
   artifacts:
-    v1.6.0:
-      - uri: v1.6.0/tanzu-cluster
+    v0.2.0:
+      - uri: v0.2.0/tanzu-feature
         os: darwin
         arch: amd64
         type: local
-      - uri: v1.6.0/tanzu-cluster
+      - uri: v0.2.0/tanzu-feature
         os: linux
         arch: amd64
         type: local
-      - uri: v1.6.0/tanzu-cluster
+      - uri: v0.2.0/tanzu-feature
         os: windows
         arch: amd64
         type: local
-      - uri: v1.6.0/tanzu-cluster
+      - uri: v0.2.0/tanzu-feature
         os: darwin
         arch: arm64
         type: local
-  recommendedVersion: v1.6.0
+  recommendedVersion: v0.2.0
   target: kubernetes

--- a/pkg/pluginmanager/test/local/discovery/standalone-k8s-target/login.yaml
+++ b/pkg/pluginmanager/test/local/discovery/standalone-k8s-target/login.yaml
@@ -23,4 +23,4 @@ spec:
         arch: arm64
         type: local
   recommendedVersion: v0.2.0
-  target: k8s
+  target: kubernetes

--- a/pkg/pluginmanager/test/local/discovery/standalone-k8s-target/myplugin-k8s.yaml
+++ b/pkg/pluginmanager/test/local/discovery/standalone-k8s-target/myplugin-k8s.yaml
@@ -23,4 +23,4 @@ spec:
         arch: arm64
         type: local
   recommendedVersion: v1.6.0
-  target: k8s
+  target: kubernetes

--- a/pkg/pluginmanager/test/local/discovery/standalone-k8s-target/myplugin-tmc.yaml
+++ b/pkg/pluginmanager/test/local/discovery/standalone-k8s-target/myplugin-tmc.yaml
@@ -23,4 +23,4 @@ spec:
         arch: arm64
         type: local
   recommendedVersion: v0.2.0
-  target: tmc
+  target: mission-control

--- a/pkg/pluginmanager/test/local/discovery/standalone/feature.yaml
+++ b/pkg/pluginmanager/test/local/discovery/standalone/feature.yaml
@@ -1,26 +1,26 @@
 apiVersion: cli.tanzu.vmware.com/v1alpha1
 kind: CLIPlugin
 metadata:
-  name: cluster
+  name: feature
 spec:
-  description: Cluster operation for the Kubernetes Cluster
+  description: Feature plugin
   artifacts:
-    v1.6.0:
-      - uri: v1.6.0/tanzu-cluster
+    v0.2.0:
+      - uri: v0.2.0/tanzu-feature
         os: darwin
         arch: amd64
         type: local
-      - uri: v1.6.0/tanzu-cluster
+      - uri: v0.2.0/tanzu-feature
         os: linux
         arch: amd64
         type: local
-      - uri: v1.6.0/tanzu-cluster
+      - uri: v0.2.0/tanzu-feature
         os: windows
         arch: amd64
         type: local
-      - uri: v1.6.0/tanzu-cluster
+      - uri: v0.2.0/tanzu-feature
         os: darwin
         arch: arm64
         type: local
-  recommendedVersion: v1.6.0
+  recommendedVersion: v0.2.0
   target: kubernetes

--- a/pkg/pluginmanager/test/local/discovery/standalone/myplugin-k8s.yaml
+++ b/pkg/pluginmanager/test/local/discovery/standalone/myplugin-k8s.yaml
@@ -23,4 +23,4 @@ spec:
         arch: arm64
         type: local
   recommendedVersion: v1.6.0
-  target: k8s
+  target: kubernetes

--- a/pkg/pluginmanager/test/local/discovery/standalone/myplugin-tmc.yaml
+++ b/pkg/pluginmanager/test/local/discovery/standalone/myplugin-tmc.yaml
@@ -23,4 +23,4 @@ spec:
         arch: arm64
         type: local
   recommendedVersion: v0.2.0
-  target: tmc
+  target: mission-control

--- a/pkg/pluginmanager/test/local/distribution/v0.2.0/tanzu-feature
+++ b/pkg/pluginmanager/test/local/distribution/v0.2.0/tanzu-feature
@@ -1,0 +1,1 @@
+{"name":"feature","description":"Feature plugin","version":"v0.2.0","buildSHA":"c2dbd15","digest":"","group":"System","docURL":"","completionType":0,"aliases":["fea","feat"],"installationPath":"","discovery":"","scope":"","status":""}


### PR DESCRIPTION
### What this PR does / why we need it

When a user tries to install/upgrade/describe/delete a plugin using the `--target` flag this PR makes sure the CLI returns an error if the plugin does not exist for the specified target.  Previously, if the plugin only existed for another target, the specified target would be ignored and the existing target would be used.  For example:

Before:
```
$ tz plugin install kubernetes-release --target tmc
ℹ  Installing plugin 'kubernetes-release:v0.28.0-dev' with target 'kubernetes'
✔  successfully installed 'kubernetes-release' plugin
```
With the PR:
```
tz plugin install kubernetes-release --target tmc
✖  unable to find plugin 'kubernetes-release' for target 'mission-control'
``` 

### Which issue(s) this PR fixes

Fixes #44

### Describe testing done for PR

There were many cases to cover so many small tests.  Here is the list of tests I ran.  Further below I also include the output.
Note that unit tests have been added to cover the different cases.

```
rm ~/.config/tanzu/config*
tz plugin clean
# Test with the central repo feature
tz config set features.global.central-repository true
export TANZU_CLI_PRE_RELEASE_REPO_IMAGE=localhost:9876/tanzu-cli/plugins/central:small
make start-test-central-repo

tz plugin install feature --target tmc
tz plugin install feature --target k8s
tz plugin install feature

tz plugin install invalid --target tmc
tz plugin install invalid --target k8s
tz plugin install invalid

tz plugin upgrade feature --target tmc
tz plugin upgrade feature --target k8s
tz plugin upgrade feature

tz plugin upgrade invalid --target tmc
tz plugin upgrade invalid --target k8s
tz plugin upgrade invalid

tz plugin delete feature --target tmc
tz plugin delete feature --target k8s
tz plugin delete feature

tz plugin delete invalid --target tmc
tz plugin delete invalid --target k8s
tz plugin delete invalid

tz plugin describe feature --target tmc
tz plugin describe feature --target k8s
tz plugin describe feature

tz plugin describe invalid --target tmc
tz plugin describe invalid --target k8s
tz plugin describe invalid

tz plugin install feature --local ~/.config/tanzu-plugins --target tmc
tz plugin install feature --local ~/.config/tanzu-plugins --target k8s
tz plugin install feature --local ~/.config/tanzu-plugins

tz plugin install invalid --local ~/.config/tanzu-plugins --target tmc
tz plugin install invalid --local ~/.config/tanzu-plugins --target k8s
tz plugin install invalid --local ~/.config/tanzu-plugins

# Test without the central repo feature
tz config set features.global.central-repository false
tz plugin source add --name standalone --type local --uri /Users/kmarc/.config/_tanzu-plugins/discovery/standalone

tz plugin install feature --target tmc
tz plugin install feature --target k8s
tz plugin install feature

tz plugin install invalid --target tmc
tz plugin install invalid --target k8s
tz plugin install invalid

tz plugin upgrade feature --target tmc
tz plugin upgrade feature --target k8s
tz plugin upgrade feature

tz plugin upgrade invalid --target tmc
tz plugin upgrade invalid --target k8s
tz plugin upgrade invalid

tz plugin delete feature --target tmc
tz plugin delete feature --target k8s
tz plugin delete feature

tz plugin delete invalid --target tmc
tz plugin delete invalid --target k8s
tz plugin delete invalid

tz plugin describe feature --target tmc
tz plugin describe feature --target k8s
tz plugin describe feature

tz plugin describe invalid --target tmc
tz plugin describe invalid --target k8s
tz plugin describe invalid

tz plugin install feature --local ~/.config/_tanzu-plugins --target tmc
tz plugin install feature --local ~/.config/_tanzu-plugins --target k8s
tz plugin install feature --local ~/.config/_tanzu-plugins

tz plugin install invalid --local ~/.config/_tanzu-plugins --target tmc
tz plugin install invalid --local ~/.config/_tanzu-plugins --target k8s
tz plugin install invalid --local ~/.config/_tanzu-plugins

# Test with the 'all' argument
$ mkdir ./discovery
$ tz plugin install all --local . --target tmc
$ tz plugin install all --local . --target k8s
$ tz plugin install all --local .

```
Output of above test:
```
$ rm ~/.config/tanzu/config*
$ tz plugin clean
✔  successfully cleaned up all plugins
$ tz config set features.global.central-repository true
$ export TANZU_CLI_PRE_RELEASE_REPO_IMAGE=localhost:9876/tanzu-cli/plugins/central:small
$ make start-test-central-repo
docker container stop central 2> /dev/null || true
central
if [ ! -d /Users/kmarc/git/tanzu-cli/hack/central-repo/registry-content ]; then \
		(cd /Users/kmarc/git/tanzu-cli/hack/central-repo && tar xzf registry-content.bz2 || true;) \
	fi
docker run --rm -d -p 9876:5000 --name central \
		-v /Users/kmarc/git/tanzu-cli/hack/central-repo/registry-content:/var/lib/registry \
		mirror.gcr.io/library/registry:2
958690b0c4b32d40c43922de2812d2de9373645069d2dc26b9a90063457a3572
$ tz plugin install feature --target tmc
✖  unable to find plugin 'feature' for target 'mission-control'
$ tz plugin install feature --target k8s
ℹ  Installing plugin 'feature:v9.9.9' with target 'kubernetes'
✔  successfully installed 'feature' plugin
$ tz plugin install feature
ℹ  Installing plugin 'feature:v9.9.9' with target 'kubernetes'
✔  successfully installed 'feature' plugin
$
$ tz plugin install invalid --target tmc
✖  unable to find plugin 'invalid' for target 'mission-control'
$ tz plugin install invalid --target k8s
✖  unable to find plugin 'invalid' for target 'kubernetes'
$ tz plugin install invalid
✖  unable to find plugin 'invalid'
$ tz plugin upgrade feature --target tmc
✖  unable to find plugin 'feature' for target 'mission-control'
$ tz plugin upgrade feature --target k8s
ℹ  Installing plugin 'feature:v9.9.9' with target 'kubernetes'
✔  successfully upgraded plugin 'feature'
$ tz plugin upgrade feature
ℹ  Installing plugin 'feature:v9.9.9' with target 'kubernetes'
✔  successfully upgraded plugin 'feature'
$ tz plugin upgrade invalid --target tmc
✖  unable to find plugin 'invalid' for target 'mission-control'
$ tz plugin upgrade invalid --target k8s
✖  unable to find plugin 'invalid' for target 'kubernetes'
$ tz plugin upgrade invalid
✖  unable to find plugin 'invalid'
$ tz plugin delete feature --target tmc
✖  unable to find plugin 'feature' for target 'mission-control'
$ tz plugin delete feature --target k8s
Deleting Plugin 'feature'. Are you sure? [y/N]:
✖  aborted
$ tz plugin delete feature
Deleting Plugin 'feature'. Are you sure? [y/N]:
✖  aborted
$
$ tz plugin delete invalid --target tmc
✖  unable to find plugin 'invalid' for target 'mission-control'
$ tz plugin delete invalid --target k8s
✖  unable to find plugin 'invalid' for target 'kubernetes'
$ tz plugin delete invalid
✖  unable to find plugin 'invalid'
$ tz plugin describe feature --target tmc
✖  unable to find plugin 'feature' for target 'mission-control'
$ tz plugin describe feature --target k8s
name: feature
description: feature functionality
version: v9.9.9
buildSHA: "01234567"
digest: ""
group: System
docURL: ""
completionType: 0
installationpath: /Users/kmarc/Library/Application Support/_tanzu-cli/feature/v9.9.9_b69078c1ac9fdfa1e5000b99a42d8f1df6d565cc215780f2e8a6cc25dfee5bc9_kubernetes
discovery: default_pre_release
scope: Standalone
status: installed
discoveredrecommendedversion: v9.9.9
target: kubernetes
defaultfeatureflags: {}

$ tz plugin describe feature
name: feature
description: feature functionality
version: v9.9.9
buildSHA: "01234567"
digest: ""
group: System
docURL: ""
completionType: 0
installationpath: /Users/kmarc/Library/Application Support/_tanzu-cli/feature/v9.9.9_b69078c1ac9fdfa1e5000b99a42d8f1df6d565cc215780f2e8a6cc25dfee5bc9_kubernetes
discovery: default_pre_release
scope: Standalone
status: installed
discoveredrecommendedversion: v9.9.9
target: kubernetes
defaultfeatureflags: {}

$ tz plugin describe invalid --target tmc
✖  unable to find plugin 'invalid' for target 'mission-control'
$ tz plugin describe invalid --target k8s
✖  unable to find plugin 'invalid' for target 'kubernetes'
$ tz plugin describe invalid
✖  unable to find plugin 'invalid'
$
$ tz plugin install feature --local ~/.config/tanzu-plugins --target tmc
✖  unable to find plugin 'feature' for target 'mission-control'
$ tz plugin install feature --local ~/.config/tanzu-plugins --target k8s
ℹ  Installing plugin 'feature:v0.29.0-dev' with target 'kubernetes'
✔  successfully installed 'feature' plugin
$ tz plugin install feature --local ~/.config/tanzu-plugins
ℹ  Installing plugin 'feature:v0.29.0-dev' with target 'kubernetes'
✔  successfully installed 'feature' plugin
$ tz plugin install invalid --local ~/.config/tanzu-plugins --target tmc
✖  unable to find plugin 'invalid' for target 'mission-control'
$ tz plugin install invalid --local ~/.config/tanzu-plugins --target k8s
✖  unable to find plugin 'invalid' for target 'kubernetes'
$ tz plugin install invalid --local ~/.config/tanzu-plugins
✖  unable to find plugin 'invalid'


$ tz config set features.global.central-repository false
$ tz plugin source add --name standalone --type local --uri /Users/kmarc/.config/_tanzu-plugins/discovery/standalone
✔  successfully added discovery source standalone
$ tz plugin install feature --target tmc
✖  unable to find plugin 'feature' for target 'mission-control'
$ tz plugin install feature --target k8s
ℹ  Installing plugin 'feature:v0.29.0-dev' with target 'kubernetes'
✔  successfully installed 'feature' plugin
$ tz plugin install feature
ℹ  Installing plugin 'feature:v0.29.0-dev' with target 'kubernetes'
✔  successfully installed 'feature' plugin
$ tz plugin install invalid --target tmc
✖  unable to find plugin 'invalid' for target 'mission-control'
$ tz plugin install invalid --target k8s
✖  unable to find plugin 'invalid' for target 'kubernetes'
$ tz plugin install invalid
✖  unable to find plugin 'invalid'
$ tz plugin upgrade feature --target tmc
✖  unable to find plugin 'feature' for target 'mission-control'
$ tz plugin upgrade feature --target k8s
ℹ  Installing plugin 'feature:v0.29.0-dev' with target 'kubernetes'
✔  successfully upgraded plugin 'feature'
$ tz plugin upgrade feature
ℹ  Installing plugin 'feature:v0.29.0-dev' with target 'kubernetes'
✔  successfully upgraded plugin 'feature'
$ tz plugin upgrade invalid --target tmc
✖  unable to find plugin 'invalid' for target 'mission-control'
$ tz plugin upgrade invalid --target k8s
✖  unable to find plugin 'invalid' for target 'kubernetes'
$ tz plugin upgrade invalid
✖  unable to find plugin 'invalid'
$ tz plugin delete feature --target tmc
✖  unable to find plugin 'feature' for target 'mission-control'
$ tz plugin delete feature --target k8s
Deleting Plugin 'feature'. Are you sure? [y/N]:
✖  aborted
$ tz plugin delete feature
Deleting Plugin 'feature'. Are you sure? [y/N]:
✖  aborted
$ tz plugin delete invalid --target tmc
✖  unable to find plugin 'invalid' for target 'mission-control'
$ tz plugin delete invalid --target k8s
✖  unable to find plugin 'invalid' for target 'kubernetes'
$ tz plugin delete invalid
✖  unable to find plugin 'invalid'
$ tz plugin describe feature --target tmc
✖  unable to find plugin 'feature' for target 'mission-control'
$ tz plugin describe feature --target k8s
name: feature
description: Operate on features and featuregates
version: v0.29.0-dev
buildSHA: e403941f7
digest: ""
group: Run
docURL: ""
completionType: 0
installationpath: /Users/kmarc/Library/Application Support/_tanzu-cli/feature/v0.29.0-dev_005663602789d23378aae1eeeeb216009e58a87fadbb4c2d795e5c5e98474fce_kubernetes
discovery: standalone
scope: Standalone
status: installed
discoveredrecommendedversion: v0.29.0-dev
target: kubernetes
defaultfeatureflags: {}

$ tz plugin describe feature
name: feature
description: Operate on features and featuregates
version: v0.29.0-dev
buildSHA: e403941f7
digest: ""
group: Run
docURL: ""
completionType: 0
installationpath: /Users/kmarc/Library/Application Support/_tanzu-cli/feature/v0.29.0-dev_005663602789d23378aae1eeeeb216009e58a87fadbb4c2d795e5c5e98474fce_kubernetes
discovery: standalone
scope: Standalone
status: installed
discoveredrecommendedversion: v0.29.0-dev
target: kubernetes
defaultfeatureflags: {}

$ tz plugin describe invalid --target tmc
✖  unable to find plugin 'invalid' for target 'mission-control'
$ tz plugin describe invalid --target k8s

✖  unable to find plugin 'invalid' for target 'kubernetes'
$
$ tz plugin describe invalid
✖  unable to find plugin 'invalid'
$ tz plugin install feature --local ~/.config/_tanzu-plugins --target tmc
✖  unable to find plugin 'feature' for target 'mission-control'
$ tz plugin install feature --local ~/.config/_tanzu-plugins --target k8s
ℹ  Installing plugin 'feature:v0.29.0-dev' with target 'kubernetes'
✔  successfully installed 'feature' plugin
$ tz plugin install feature --local ~/.config/_tanzu-plugins
ℹ  Installing plugin 'feature:v0.29.0-dev' with target 'kubernetes'
✔  successfully installed 'feature' plugin
$
$ tz plugin install invalid --local ~/.config/_tanzu-plugins --target tmc
✖  unable to find plugin 'invalid' for target 'mission-control'
$ tz plugin install invalid --local ~/.config/_tanzu-plugins --target k8s
✖  unable to find plugin 'invalid' for target 'kubernetes'
$ tz plugin install invalid --local ~/.config/_tanzu-plugins
✖  unable to find plugin 'invalid'

$ mkdir ./discovery
$ tz plugin install all --local . --target tmc
✖  unable to find any plugins for target 'mission-control'
$ tz plugin install all --local . --target k8s
✖  unable to find any plugins for target 'kubernetes'
$ tz plugin install all --local .
✖  unable to find any plugins at the specified location
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

