### PR TITLE
Root-targeted plugins now include "global" plugins

### DIFF
--- a/pkg/cli/plugin_cmd.go
+++ b/pkg/cli/plugin_cmd.go
@@ -26,6 +26,7 @@ func GetCmdForPlugin(p *PluginInfo) *cobra.Command {
 		DisableFlagParsing: true,
 		Annotations: map[string]string{
 			"group": string(p.Group),
+			"scope": p.Scope,
 		},
 		Hidden:  p.Hidden,
 		Aliases: p.Aliases,

--- a/pkg/pluginmanager/manager.go
+++ b/pkg/pluginmanager/manager.go
@@ -437,6 +437,7 @@ func DiscoveredFromPlugininfo(p *cli.PluginInfo) discovery.Discovered {
 		RecommendedVersion: p.Version,
 		Source:             p.Discovery,
 		SupportedVersions:  []string{p.Version},
+		Target:             p.Target,
 	}
 	return dp
 }


### PR DESCRIPTION
### What this PR does / why we need it

Allows to invoke plugins that use the new "global" target.  For example the `builder` plugin.
Without this, the latest version of the `builder` plugin cannot be invoked from the CLI.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #91

### Describe testing done for PR

Before the PR:
```
$ git checkout main
$ make build-all
[...]
$ tz plugin install builder --local ./artifacts-admin/darwin/amd64
ℹ  Installing plugin 'builder:v0.0.2-dev' with target 'global'
✔  successfully installed 'builder' plugin

$ tz builder -h
✖  unknown command "builder" for "tanzu"
```
After the PR:
```
$ make build-all
[...]
$ tz plugin install builder --local ./artifacts-admin/darwin/amd64
ℹ  Installing plugin 'builder:v0.0.2-dev' with target 'global'
✔  successfully installed 'builder' plugin

$ tz builder -h
Build Tanzu components

Usage:
  tanzu builder [command]
[...]
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

I added unit test to verify that the correct targets where invokable.
This (of course 🙄 ) triggered some unexpected failures which I had to chase down.  This is why `manager.go` has a small fix.
