### PR TITLE
Ignore empty plugin from REST discovery

### DIFF
--- a/pkg/discovery/rest.go
+++ b/pkg/discovery/rest.go
@@ -121,6 +121,9 @@ func (d *RESTDiscovery) List() ([]Discovered, error) {
 		if err != nil {
 			return nil, err
 		}
+		if dp.Name == "" {
+			continue
+		}
 		dp.Source = d.name
 		plugins = append(plugins, dp)
 	}


### PR DESCRIPTION
### What this PR does / why we need it

It is possible for a REST endpoint to return an empty plugin entry. The CLI now ignores such an entry instead of trying to install the empty plugin.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #100

### Describe testing done for PR

Before the PR with an endpoint returning an empty plugin:
```
$ rm ~/.config/tanzu/config*
$ tz config set features.global.central-repository true
$ export TANZU_CLI_PRE_RELEASE_REPO_IMAGE=localhost:9876/tanzu-cli/plugins/central:small
$ make start-test-central-repo
[...]

# Notice the "plugin sync" will fail during the creation of the context
$ tz context create --name tmc --endpoint unstable.tmc-dev.cloud.vmware.com --staging
[i] API token env var is set

[ok] successfully created a TMC context
[i] Checking for required plugins...
[i] Installing plugin 'management-cluster:v0.0.1' with target 'mission-control'
[i] Installing plugin 'cluster:v0.0.1' with target 'mission-control'
[...]
[i] Installing plugin 'inspection:v0.0.1' with target 'mission-control'
[!] unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually

# Notice the empty plugin that the CLI tries to find
$ tz plugin sync
[i] Checking for required plugins...
[i] Installing plugin 'iam:v0.0.1' with target 'mission-control'
[i] Installing plugin 'policy:v0.0.1' with target 'mission-control'
[...]
[i] Installing plugin 'account:v0.0.1' with target 'mission-control'
[x] : unable to find plugin '' for target 'mission-control'

# Notice the missing section with an empty plugin
$ tz plugin list
Installed Plugins
  NAME                DESCRIPTION                                                       TARGET           VERSION      STATUS
  builder             Build Tanzu components                                                             v0.0.2-dev   installed
  isolated-cluster    Prepopulating images/bundle for internet-restricted environments                   v0.29.0-dev  installed
[...]
  tanzupackage        tanzupackage functionality                                        mission-control  v0.0.1       installed
  workspace           workspace functionality                                           mission-control  v0.0.1       installed

Missing Plugins from Context:  tmc
  NAME  DESCRIPTION  TARGET           VERSION  STATUS
                     mission-control           not installed

[!] As shown above, some recommended plugins have not been installed. To install them please run 'tanzu plugin sync'.
```

With this PR and the same endpoint.
```
$ tz plugin clean

# Notice the plugin sync works now (the empty plugin is ignored)
$ tz plugin sync
[i] Checking for required plugins...
[i] Installing plugin 'tanzupackage:v0.0.1' with target 'mission-control'
[i] Installing plugin 'ekscluster:v0.0.1' with target 'mission-control'
[...]
[i] Installing plugin 'events:v0.0.1' with target 'mission-control'
[i] Successfully installed all required plugins
[ok] Done

# Notice no missing plugin in the list
$ tz plugin list
Installed Plugins
  NAME                DESCRIPTION                                                       TARGET           VERSION      STATUS
  builder             Build Tanzu components                                                             v0.0.2-dev   installed
  isolated-cluster    Prepopulating images/bundle for internet-restricted environments                   v0.29.0-dev  installed
  test                Test the CLI                                                                       v0.0.2-dev   installed
[...]
  tanzupackage        tanzupackage functionality                                        mission-control  v0.0.1       installed
  workspace           workspace functionality                                           mission-control  v0.0.1       installed
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

A unit test was added to make sure this case is handled properly in the future.