### PR TITLE
Set configured environment variables

### DIFF
--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
+	cliconfig "github.com/vmware-tanzu/tanzu-cli/pkg/config"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/pluginsupplier"
 )
@@ -36,6 +37,10 @@ func NewRootCmd() (*cobra.Command, error) {
 
 	uFunc := cli.NewMainUsage().UsageFunc()
 	rootCmd.SetUsageFunc(uFunc)
+
+	// Configure defined environment variables found in the config file
+	cliconfig.ConfigureEnvVariables()
+
 	rootCmd.AddCommand(
 		newVersionCmd(),
 		newPluginCmd(),


### PR DESCRIPTION
### What this PR does / why we need it

This PR sets the environment variables found in the CLI config files.
This was missed when we migrated the code to the new repo as can be seen in the old repo: https://github.com/vmware-tanzu/tanzu-framework/blob/3ae5649552f81ff59b84883d9f5ba662d1c3f126/cli/core/pkg/command/root.go#L42

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #102

### Describe testing done for PR

Before the PR I did the tests of #102

With the PR, I repeated the same tests, checking for success:
```
$ rm ~/.config/tanzu/config*
$ make build
$ tz config set features.global.central-repository true
$ make start-test-central-repo
[...]

# Make sure the shell env var is not set
$ unset TANZU_CLI_PRE_RELEASE_REPO_IMAGE
# Set the env var in the CLI
$ tz config set env.TANZU_CLI_PRE_RELEASE_REPO_IMAGE localhost:9876/tanzu-cli/plugins/central:small

# Notice no error reported and the plugins are found
$ tz plugin search
  NAME                DESCRIPTION                  TARGET           VERSION  STATUS         CONTEXT
  isolated-cluster    Desc for isolated-cluster    global           v9.9.9   not installed
  pinniped-auth       Desc for pinniped-auth       global           v9.9.9   not installed
  cluster             Desc for cluster             kubernetes       v9.9.9   not installed
  feature             Desc for feature             kubernetes       v9.9.9   not installed
  kubernetes-release  Desc for kubernetes-release  kubernetes       v9.9.9   not installed
[...]
```

A unit test was added to make sure this continues to work.