### PR TITLE
Enable the Central Repo feature by default

### DIFF
--- a/hack/central-repo/README.md
+++ b/hack/central-repo/README.md
@@ -18,7 +18,6 @@ Also, only versions `v0.0.1` and `v9.9.9` for the other plugins can be installed
 The steps to follow to use the test central repo are:
 
 1. Start the test repo with `make start-test-central-repo`.
-1. Enable the central repository using the temporary feature flag: `tz config set features.global.central-repository true`
 1. Configure the plugin source for the test central repo: `tz plugin source add -n default -t oci -u localhost:9876/tanzu-cli/plugins/central:small`
 1. Allow the use of a local registry: `export ALLOWED_REGISTRY=localhost:9876`
 
@@ -28,7 +27,6 @@ Here are the exact commands:
 cd tanzu-cli
 make build
 make start-test-central-repo
-tz config set features.global.central-repository true
 tz plugin source add -n default -t oci -u localhost:9876/tanzu-cli/plugins/central:small
 export ALLOWED_REGISTRY=localhost:9876
 

--- a/pkg/command/plugin.go
+++ b/pkg/command/plugin.go
@@ -60,7 +60,7 @@ func newPluginCmd() *cobra.Command {
 
 	listPluginCmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format (yaml|json|table)")
 	listPluginCmd.Flags().StringVarP(&local, "local", "l", "", "path to local plugin source")
-	if config.IsFeatureActivated(constants.FeatureCentralRepository) {
+	if !config.IsFeatureActivated(constants.FeatureDisableCentralRepositoryForTesting) {
 		// The --local flag no longer applies to the "list" command.
 		// Instead of removing it completely, we mark it hidden and print out an error
 		// in the RunE() function if it is used.  This provides better guidance to the user.
@@ -93,7 +93,7 @@ func newPluginCmd() *cobra.Command {
 		discoverySourceCmd,
 	)
 
-	if config.IsFeatureActivated(constants.FeatureCentralRepository) {
+	if !config.IsFeatureActivated(constants.FeatureDisableCentralRepositoryForTesting) {
 		installPluginCmd.MarkFlagsMutuallyExclusive("group", "local")
 		installPluginCmd.MarkFlagsMutuallyExclusive("group", "version")
 		installPluginCmd.MarkFlagsMutuallyExclusive("group", "target")
@@ -111,7 +111,7 @@ func newListPluginCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List available plugins",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if config.IsFeatureActivated(constants.FeatureCentralRepository) {
+			if !config.IsFeatureActivated(constants.FeatureDisableCentralRepositoryForTesting) {
 				if local != "" {
 					return fmt.Errorf("the '--local' flag does not apply to this command. Please use 'tanzu plugin search --local'")
 				}
@@ -218,7 +218,7 @@ func newInstallPluginCmd() *cobra.Command {
 				return errors.New("invalid target specified. Please specify correct value of `--target` or `-t` flag from 'kubernetes/k8s/mission-control/tmc'")
 			}
 
-			if !config.IsFeatureActivated(constants.FeatureCentralRepository) {
+			if config.IsFeatureActivated(constants.FeatureDisableCentralRepositoryForTesting) {
 				return legacyPluginInstall(cmd, args)
 			}
 
@@ -353,7 +353,7 @@ func newUpgradePluginCmd() *cobra.Command {
 			}
 
 			var pluginVersion string
-			if config.IsFeatureActivated(constants.FeatureCentralRepository) {
+			if !config.IsFeatureActivated(constants.FeatureDisableCentralRepositoryForTesting) {
 				// With the Central Repository feature we can simply request to install
 				// the recommendedVersion.
 				pluginVersion = cli.VersionLatest

--- a/pkg/command/root_test.go
+++ b/pkg/command/root_test.go
@@ -13,11 +13,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/plugin"
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/catalog"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
+	configcli "github.com/vmware-tanzu/tanzu-cli/pkg/config"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 )
 
 const (
@@ -316,6 +319,15 @@ func TestEnvVarsSet(t *testing.T) {
 	configFileNG, _ := os.CreateTemp("", "config_ng")
 	os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
 	defer os.RemoveAll(configFileNG.Name())
+
+	// Setup default feature flags since we have created new config files
+	// TODO(khouzam): This is because AddDefaultFeatureFlagsIfMissing() has already
+	// been called in an init() function.  We should fix that in a more generic way.
+	c, err := config.GetClientConfigNoLock()
+	assert.Nil(err)
+	if configcli.AddDefaultFeatureFlagsIfMissing(c, constants.DefaultCliFeatureFlags) {
+		_ = config.StoreClientConfig(c)
+	}
 
 	rootCmd, err := NewRootCmd()
 	assert.Nil(err)

--- a/pkg/constants/featureflags.go
+++ b/pkg/constants/featureflags.go
@@ -7,8 +7,8 @@ package constants
 const (
 	// FeatureContextCommand determines whether to surface the context command. This is disabled by default.
 	FeatureContextCommand = "features.global.context-target-v2"
-	// FeatureCentralRepository determines if the CLI uses the Central Repository of plugins.
-	FeatureCentralRepository = "features.global.central-repository"
+	// FeatureDisableCentralRepositoryForTesting determines if the CLI uses the Central Repository of plugins.
+	FeatureDisableCentralRepositoryForTesting = "features.global.no-central-repo-test-only"
 )
 
 // DefaultCliFeatureFlags is used to populate an initially empty config file with default values for feature flags.
@@ -25,7 +25,8 @@ const (
 var (
 	DefaultCliFeatureFlags = map[string]bool{
 		FeatureContextCommand: true,
-		// TODO(khouzam) turn this on before the 1.0 release, or remove the flag completely
-		FeatureCentralRepository: false,
+		// Do NOT include the test feature flag to disable the central repo.
+		// We don't want to publicize this feature flag.
+		// It defaults to false when not specified, which is what is needed.
 	}
 )

--- a/pkg/discovery/oci.go
+++ b/pkg/discovery/oci.go
@@ -33,7 +33,7 @@ type OCIDiscovery struct {
 
 // NewOCIDiscovery returns a new Discovery using the specified OCI image.
 func NewOCIDiscovery(name, image string, criteria *PluginDiscoveryCriteria) Discovery {
-	if config.IsFeatureActivated(constants.FeatureCentralRepository) {
+	if !config.IsFeatureActivated(constants.FeatureDisableCentralRepositoryForTesting) {
 		// The plugin inventory uses relative image URIs to be future-proof.
 		// Determine the image prefix from the main image.
 		// E.g., if the main image is at project.registry.vmware.com/tanzu-cli/plugins/plugin-inventory:latest

--- a/pkg/discovery/oci_dbbacked_test.go
+++ b/pkg/discovery/oci_dbbacked_test.go
@@ -5,17 +5,14 @@ package discovery
 
 import (
 	"os"
-	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
-	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/distribution"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/plugininventory"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/utils"
-	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
 
@@ -374,11 +371,6 @@ var _ = Describe("Unit tests for DB-backed OCI discovery", func() {
 			tkgConfigFileNG, err = os.CreateTemp("", "config_ng")
 			Expect(err).To(BeNil())
 			os.Setenv("TANZU_CONFIG_NEXT_GEN", tkgConfigFileNG.Name())
-
-			// Turn on central repo feature
-			featureArray := strings.Split(constants.FeatureCentralRepository, ".")
-			err = config.SetFeature(featureArray[1], featureArray[2], "true")
-			Expect(err).To(BeNil())
 		})
 		AfterEach(func() {
 			os.Unsetenv("TANZU_CONFIG")
@@ -492,11 +484,6 @@ var _ = Describe("Unit tests for DB-backed OCI discovery", func() {
 			tkgConfigFileNG, err = os.CreateTemp("", "config_ng")
 			Expect(err).To(BeNil())
 			os.Setenv("TANZU_CONFIG_NEXT_GEN", tkgConfigFileNG.Name())
-
-			// Turn on central repo feature
-			featureArray := strings.Split(constants.FeatureCentralRepository, ".")
-			err = config.SetFeature(featureArray[1], featureArray[2], "true")
-			Expect(err).To(BeNil())
 		})
 		AfterEach(func() {
 			os.Unsetenv("TANZU_CONFIG")

--- a/pkg/discovery/oci_test.go
+++ b/pkg/discovery/oci_test.go
@@ -162,11 +162,6 @@ func Test_NewOCIDiscovery(t *testing.T) {
 	criteriaName := "test-criteria"
 	discoveryCriteria := PluginDiscoveryCriteria{Name: criteriaName}
 
-	// Turn on central repo feature
-	featureArray = strings.Split(constants.FeatureCentralRepository, ".")
-	err = config.SetFeature(featureArray[1], featureArray[2], "true")
-	assert.Nil(err)
-
 	// Check that the correct discovery type is returned
 	pd := NewOCIDiscovery(discoveryName, discoveryImage, &discoveryCriteria)
 	assert.NotNil(pd)
@@ -180,8 +175,8 @@ func Test_NewOCIDiscovery(t *testing.T) {
 	assert.Equal(discoveryCriteria, *dbDiscovery.criteria)
 
 	// Turn off central repo feature
-	featureArray = strings.Split(constants.FeatureCentralRepository, ".")
-	err = config.SetFeature(featureArray[1], featureArray[2], "false")
+	featureArray = strings.Split(constants.FeatureDisableCentralRepositoryForTesting, ".")
+	err = config.SetFeature(featureArray[1], featureArray[2], "true")
 	assert.Nil(err)
 
 	// Check that the correct discovery type is returned

--- a/pkg/pluginmanager/manager.go
+++ b/pkg/pluginmanager/manager.go
@@ -563,7 +563,7 @@ func InstallPluginFromContext(pluginName, version string, target configtypes.Tar
 // we are installing a standalone plugin.
 // nolint: gocyclo
 func installPlugin(pluginName, version string, target configtypes.Target, contextName string) error {
-	if !configlib.IsFeatureActivated(constants.FeatureCentralRepository) {
+	if configlib.IsFeatureActivated(constants.FeatureDisableCentralRepositoryForTesting) {
 		// The legacy installation can figure out if the plugin is from a context
 		// because it searches all contexts for plugins.  So, we don't need to pass on that parameter.
 		return legacyPluginInstall(pluginName, version, target)
@@ -927,14 +927,13 @@ func DeletePlugin(options DeletePluginOptions) error {
 	return nil
 }
 
-// SyncPlugins when the "central-repository" feature flag is enabled, will
-// automatically install the plugins required by the current contexts.
-// If that feature flag is disabled, all discovered plugins will be installed.
+// SyncPlugins will install the plugins required by the current contexts.
+// If the central-repo is disabled, all discovered plugins will be installed.
 func SyncPlugins() error {
 	log.Info("Checking for required plugins...")
 	var plugins []discovery.Discovered
 	var err error
-	if configlib.IsFeatureActivated(constants.FeatureCentralRepository) {
+	if !configlib.IsFeatureActivated(constants.FeatureDisableCentralRepositoryForTesting) {
 		// We no longer sync standalone plugins.
 		// With a centralized approach to discovering plugins, synchronizing
 		// standalone plugins would install ALL plugins available for ALL
@@ -1329,7 +1328,7 @@ func FindVersion(recommendedPluginVersion, requestedVersion string) string {
 
 // getPluginDiscoveries returns the plugin discoveries found in the configuration file.
 func getPluginDiscoveries() ([]configtypes.PluginDiscovery, error) {
-	if configlib.IsFeatureActivated(constants.FeatureCentralRepository) {
+	if !configlib.IsFeatureActivated(constants.FeatureDisableCentralRepositoryForTesting) {
 		pd, err := getPreReleasePluginDiscovery()
 		if err != nil {
 			return nil, err

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -37,9 +37,7 @@ const (
 	PluginSubCommand     = "tanzu %s"
 
 	// Central repository
-	CentralRepositoryFeatureFlag         = "features.global.central-repository"
-	CentralRepositoryPreReleaseRepoImage = "TANZU_CLI_PRE_RELEASE_REPO_IMAGE"
-	TanzuCliE2ETestCentralRepositoryURL  = "TANZU_CLI_E2E_TEST_CENTRAL_REPO_URL"
+	TanzuCliE2ETestCentralRepositoryURL = "TANZU_CLI_E2E_TEST_CENTRAL_REPO_URL"
 
 	// General constants
 	True      = "true"

--- a/test/e2e/plugins_compatibility/plugins_compatibility_test.go
+++ b/test/e2e/plugins_compatibility/plugins_compatibility_test.go
@@ -26,12 +26,9 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Compatibility]", f
 		tf      *framework.Framework
 		plugins []string
 	)
-	// In the BeforeSuite sets the "features.global.central-repository" flag
-	// and searches for the test-plugin-'s from the TANZU_CLI_E2E_TEST_CENTRAL_REPO_URL test central repository
+	// In the BeforeSuite search for the test-plugin-'s from the TANZU_CLI_E2E_TEST_CENTRAL_REPO_URL test central repository
 	BeforeSuite(func() {
 		tf = framework.NewFramework()
-		err := tf.Config.ConfigSetFeatureFlag(framework.CentralRepositoryFeatureFlag, framework.True)
-		Expect(err).To(BeNil())
 		// get all plugins with name prefix "test-plugin-"
 		plugins = PluginsForCompatibilityTesting(tf)
 		Expect(len(plugins)).NotTo(BeZero(), fmt.Sprintf("there are no test-plugin-'s in test central repo:%s , make sure its valid test central repo with test-plugins", os.Getenv(framework.TanzuCliE2ETestCentralRepositoryURL)))


### PR DESCRIPTION
### What this PR does / why we need it

This PR enables the Central Repo feature by default.
See special notes for an explanation on the approach taken.

### Describe testing done for PR

Check that the central repo feature is enabled by default:
```
$ rm ~/.config/tanzu/config*
$ tz plugin clean
[ok] successfully cleaned up all plugins
$ tz config set env.TANZU_CLI_PRE_RELEASE_REPO_IMAGE localhost:9876/tanzu-cli/plugins/central:small
$ make start-test-central-repo

# Notice that the config file does not contain any indication of
# a feature flag for the Central Repo.
$ tz config get
clientOptions:
    cli:
        edition: tkg
        bomRepo: projects.registry.vmware.com/tkg
        compatibilityFilePath: tkg-compatibility
    features:
        global:
            context-target-v2: "true"
    env:
        TANZU_CLI_PRE_RELEASE_REPO_IMAGE: localhost:9876/tanzu-cli/plugins/central:small

# "plugin search" exists, this means the Central Repo feature is enabled
$ tz plugin search
  NAME                DESCRIPTION                  TARGET           VERSION  STATUS         CONTEXT
  isolated-cluster    Desc for isolated-cluster    global           v9.9.9   not installed
  pinniped-auth       Desc for pinniped-auth       global           v9.9.9   not installed
  cluster             Desc for cluster             kubernetes       v9.9.9   not installed
  feature             Desc for feature             kubernetes       v9.9.9   not installed
[...]
```

Test it is possible to disable the central repo feature.
Disable the feature and check that "tanzu plugin search" is no longer accessible.
```
$ tz config set features.global.no-central-repo-test-only true
$ tz plugin search
Manage CLI plugins

Usage:
  tanzu plugin [command]

Available Commands:
  clean       Clean the plugins
  delete      Delete a plugin
  describe    Describe a plugin
  install     Install a plugin
  list        List available plugins
  source      Manage plugin discovery sources
  sync        Sync the plugins
  upgrade     Upgrade a plugin

Flags:
  -h, --help   help for plugin

Use "tanzu plugin [command] --help" for more information about a command.
```
### Release note
```release-note
The Tanzu CLI now discovers and installs all its plugins from a Central Repository of plugins.  This simplifies the user experience and provides a uniform experience for all plugins. 
```

Re-enable the feature by turning the feature flag to "false":
```
$ tz config set features.global.no-central-repo-test-only false

# Notice the "plugin search" command is again accessible.
$ tz plugin search
  NAME                DESCRIPTION                  TARGET           VERSION  STATUS         CONTEXT
  isolated-cluster    Desc for isolated-cluster    global           v9.9.9   not installed
  pinniped-auth       Desc for pinniped-auth       global           v9.9.9   not installed
  cluster             Desc for cluster             kubernetes       v9.9.9   not installed
  feature             Desc for feature             kubernetes       v9.9.9   not installed
[...]
```

I have also performed some plugin lifecycle tests to make sure everything continues to work as before.
- plugin list
- context create
- plugin install
- plugin install --group

### Additional information

#### Special notes for your reviewer

We want the central-repo feature to be enabled by default, but we want  a *hidden* way to disable it, just in case.  Therefore, we don't want the feature flag to be present in the config file unless we actually turn off the feature. This is important so that users don't think they can turn off the feature.

However, if a feature flag is not set, it defaults to false.  This means the central-repo feature would be disabled by default.  To work around that, we flip the feature flag to be a way to *disable* the central repo feature instead of enabling it like before.

So the feature flag becomes "no-central-repo-test-only":
    - false -> central-repo feature enabled
    - true  -> central-repo feature disabled

This change implies that in the code, every check for the feature flag has to be flipped to continue working like before.  You will see this in the code changes.