### PR TITLE
Make the `artifacts` and `optional` fields in CLIPlugin CRD optional

### DIFF
--- a/apis/cli/v1alpha1/cliplugin_types.go
+++ b/apis/cli/v1alpha1/cliplugin_types.go
@@ -37,13 +37,13 @@ type CLIPluginSpec struct {
 	// https://semver.org/. E.g., 2.0.1
 	RecommendedVersion string `json:"recommendedVersion"`
 	// Artifacts contains an artifact list for every supported version.
-	Artifacts map[string]ArtifactList `json:"artifacts"`
+	Artifacts map[string]ArtifactList `json:"artifacts,omitempty"`
 	// Optional specifies whether the plugin is mandatory or optional
 	// If optional, the plugin will not get auto-downloaded as part of
 	// `tanzu login` or `tanzu plugin sync` command
 	// To view the list of plugin, user can use `tanzu plugin list` and
 	// to download a specific plugin run, `tanzu plugin install <plugin-name>`
-	Optional bool `json:"optional"`
+	Optional bool `json:"optional,omitempty"`
 	// Target specifies the target of the plugin. Only needed for standalone plugins
 	Target configtypes.Target `json:"target,omitempty"`
 }

--- a/apis/config/crd/bases/cli.tanzu.vmware.com_cliplugins.yaml
+++ b/apis/config/crd/bases/cli.tanzu.vmware.com_cliplugins.yaml
@@ -94,9 +94,7 @@ spec:
                   for standalone plugins
                 type: string
             required:
-            - artifacts
             - description
-            - optional
             - recommendedVersion
             type: object
         required:


### PR DESCRIPTION
### What this PR does / why we need it

- Make the `artifacts` and `optional` fields in CLIPlugin CRD optional.
- With central repository implementation, the plugin location specified under `artifacts` (for context-scoped plugin downloads), will be ignored completely and plugins always get downloaded from the default or configured central repository on the client side. The version of the plugin is selected based on the `recommendedVersion` specified with the CLIPlugin CR.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Update the `artifacts` and `optional` fields in `CLIPlugin` CRD to be optional
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
