### PR TITLE
Add `--validate` flag to `builder inventory plugin add` command to validate plugin exists or not

### DIFF
--- a/cmd/plugin/builder/README.md
+++ b/cmd/plugin/builder/README.md
@@ -200,6 +200,7 @@ Below are the flags available with `tanzu builder inventory plugin add` command:
       --plugin-inventory-image-tag string   tag to which plugin inventory image needs to be published (default "latest")
       --publisher string                    name of the publisher
       --repository string                   repository to publish plugin inventory image
+      --validate                            validate whether plugins already exists in the plugin inventory or not
       --vendor string                       name of the vendor
 ```
 

--- a/cmd/plugin/builder/inventory_plugin.go
+++ b/cmd/plugin/builder/inventory_plugin.go
@@ -36,6 +36,7 @@ type inventoryPluginAddFlags struct {
 	Publisher         string
 	Vendor            string
 	DeactivatePlugins bool
+	ValidateOnly      bool
 }
 
 func newInventoryPluginAddCmd() *cobra.Command {
@@ -53,6 +54,7 @@ func newInventoryPluginAddCmd() *cobra.Command {
 				Vendor:            ipaFlags.Vendor,
 				Publisher:         ipaFlags.Publisher,
 				DeactivatePlugins: ipaFlags.DeactivatePlugins,
+				ValidateOnly:      ipaFlags.ValidateOnly,
 				ImgpkgOptions:     imgpkg.NewImgpkgCLIWrapper(),
 			}
 			return paOptions.PluginAdd()
@@ -65,6 +67,7 @@ func newInventoryPluginAddCmd() *cobra.Command {
 	pluginAddCmd.Flags().StringVarP(&ipaFlags.Vendor, "vendor", "", "", "name of the vendor")
 	pluginAddCmd.Flags().StringVarP(&ipaFlags.Publisher, "publisher", "", "", "name of the publisher")
 	pluginAddCmd.Flags().BoolVarP(&ipaFlags.DeactivatePlugins, "deactivate", "", false, "mark plugins as deactivated")
+	pluginAddCmd.Flags().BoolVarP(&ipaFlags.ValidateOnly, "validate", "", false, "validate whether plugins already exists in the plugin inventory or not")
 
 	_ = pluginAddCmd.MarkFlagRequired("repository")
 	_ = pluginAddCmd.MarkFlagRequired("vendor")

--- a/cmd/plugin/builder/plugin/publish-packages.go
+++ b/cmd/plugin/builder/plugin/publish-packages.go
@@ -41,7 +41,7 @@ func (ppo *PublishPluginPackageOptions) PublishPluginPackages() error {
 		return err
 	}
 
-	log.Infof("Using plugin package artifacts from %q", ppo.PackageArtifactDir)
+	log.Infof("using plugin package artifacts from %q", ppo.PackageArtifactDir)
 
 	for i := range pluginManifest.Plugins {
 		for _, osArch := range cli.AllOSArch {
@@ -52,16 +52,16 @@ func (ppo *PublishPluginPackageOptions) PublishPluginPackages() error {
 				}
 
 				imageRepo := fmt.Sprintf("%s/%s/%s/%s/%s/%s/%s", ppo.Repository, ppo.Vendor, ppo.Publisher, osArch.OS(), osArch.Arch(), pluginManifest.Plugins[i].Target, pluginManifest.Plugins[i].Name)
-				log.Infof("Publishing plugin 'name:%s' 'target:%s' 'os:%s' 'arch:%s' 'version:%s'", pluginManifest.Plugins[i].Name, pluginManifest.Plugins[i].Target, osArch.OS(), osArch.Arch(), version)
+				log.Infof("publishing plugin 'name:%s' 'target:%s' 'os:%s' 'arch:%s' 'version:%s'", pluginManifest.Plugins[i].Name, pluginManifest.Plugins[i].Target, osArch.OS(), osArch.Arch(), version)
 
 				if ppo.DryRun {
-					log.Infof("Command: 'imgpkg copy --tar %s --to-repo %s", pluginTarFilePath, imageRepo)
+					log.Infof("command: 'imgpkg copy --tar %s --to-repo %s", pluginTarFilePath, imageRepo)
 				} else {
 					err = ppo.ImgpkgOptions.CopyArchiveToRepo(imageRepo, pluginTarFilePath)
 					if err != nil {
 						return errors.Wrapf(err, "unable to publish plugin (name:%s, target:%s, os:%s, arch:%s, version:%s)", pluginManifest.Plugins[i].Name, pluginManifest.Plugins[i].Target, osArch.OS(), osArch.Arch(), version)
 					}
-					log.Infof("Published plugin at '%s:%s'", imageRepo, version)
+					log.Infof("published plugin at '%s:%s'", imageRepo, version)
 				}
 			}
 		}


### PR DESCRIPTION
### What this PR does / why we need it

- This PR adds a `--validate` flag to the `builder inventory plugin add` command to validate the plugin already exists or not in the plugin inventory database.
- It fails if the plugins already exist and succeeds if plugins don't exist in the database.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add the `--validate` flag to the `builder inventory plugin add` command to validate plugin exists or not
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
