### PR TITLE
Plugin group lifecycle e2e framework tooling and test cases implementation

### DIFF
--- a/test/e2e/config/config_server_test.go
+++ b/test/e2e/config/config_server_test.go
@@ -33,13 +33,15 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Config-Server]", func() {
 	Context("tanzu config server command test cases ", func() {
 		// Test case: Create context for k8s target with kubeconfig and its context as input
 		It("create context with kubeconfig and context", func() {
+			By("create context with kubeconfig and context")
 			ctxName := ContextNameConfigPrefix + framework.RandomString(4)
 			err := tf.ContextCmd.CreateConextWithKubeconfig(ctxName, clusterInfo.KubeConfigPath, clusterInfo.ClusterContext)
 			Expect(err).To(BeNil(), "context should create without any error")
 			contextNames = append(contextNames, ctxName)
 		})
 		// Test case: Create context for k8s target with "default" kubeconfig and its context only as input value
-		It("create context with kubeconfig and context", func() {
+		It("create context with default kubeconfig and context", func() {
+			By("create context with default kubeconfig and context")
 			ctxName := "context-defaultConfig-" + framework.RandomString(4)
 			err := tf.ContextCmd.CreateContextWithDefaultKubeconfig(ctxName, clusterInfo.ClusterContext)
 			Expect(err).To(BeNil(), "context should create without any error")
@@ -47,12 +49,14 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Config-Server]", func() {
 		})
 		// Test case: test 'tanzu config server list' command, should list all contexts created as servers
 		It("list servers should have all added contexts", func() {
+			By("list servers should have all added contexts")
 			list, err := tf.Config.ConfigServerList()
 			Expect(err).To(BeNil(), "config server list command should list available servers")
 			Expect(len(list)).To(Equal(len(contextNames)), "list context should have all contexts (as servers) added in previous tests")
 		})
 		// Test case: test 'tanzu config server delete' command, make sure this command deletes server entry by deleting all contexts created in previous test cases
 		It("delete server command", func() {
+			By("delete servers which are created in previous tests")
 			for _, ctx := range contextNames {
 				err := tf.Config.ConfigServerDelete(ctx)
 				Expect(err).To(BeNil(), "delete server should delete server without any error")
@@ -62,6 +66,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Config-Server]", func() {
 		})
 		// Test case: (negative test) test 'tanzu context delete' command for context name which is not exists
 		It("delete server which is not exists", func() {
+			By("delete server which is not exists")
 			err := tf.Config.ConfigServerDelete(framework.RandomString(4))
 			Expect(err).ToNot(BeNil())
 		})

--- a/test/e2e/context/context_k8s_lifecycle_test.go
+++ b/test/e2e/context/context_k8s_lifecycle_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/vmware-tanzu/tanzu-cli/test/e2e/framework"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
 
 const ContextNameConfigPrefix = "context-config-k8s-"
@@ -32,6 +33,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-lifecycle-k8s]", 
 	Context("Context lifecycle tests for k8s target", func() {
 		// Test case: Create context for k8s target with kubeconfig and its context as input
 		It("create context with kubeconfig and context", func() {
+			By("create context with kubeconfig and context")
 			ctxName := ContextNameConfigPrefix + framework.RandomString(4)
 			err := tf.ContextCmd.CreateConextWithKubeconfig(ctxName, clusterInfo.KubeConfigPath, clusterInfo.ClusterContext)
 			Expect(err).To(BeNil(), "context should create without any error")
@@ -39,6 +41,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-lifecycle-k8s]", 
 		})
 		// Test case: (negative test) Create context for k8s target with incorrect kubeconfig file path and its context as input
 		It("create context with incorrect kubeconfig and context", func() {
+			By("create context with incorrect kubeconfig and context")
 			ctxName := ContextNameConfigPrefix + framework.RandomString(4)
 			err := tf.ContextCmd.CreateConextWithKubeconfig(ctxName, framework.RandomString(4), clusterInfo.ClusterContext)
 			Expect(err).ToNot(BeNil())
@@ -46,6 +49,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-lifecycle-k8s]", 
 		})
 		// Test case: (negative test) Create context for k8s target with kubeconfig file path and incorrect context as input
 		It("create context with kubeconfig and incorrect context", func() {
+			By("create context with kubeconfig and incorrect context")
 			ctxName := ContextNameConfigPrefix + framework.RandomString(4)
 			err := tf.ContextCmd.CreateConextWithKubeconfig(ctxName, clusterInfo.KubeConfigPath, framework.RandomString(4))
 			Expect(err).ToNot(BeNil())
@@ -53,19 +57,21 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-lifecycle-k8s]", 
 		})
 		// Test case: Create context for k8s target with "default" kubeconfig and its context only as input value
 		It("create context with kubeconfig and context", func() {
+			By("create context with kubeconfig and context")
 			ctxName := "context-defaultConfig-" + framework.RandomString(4)
 			err := tf.ContextCmd.CreateContextWithDefaultKubeconfig(ctxName, clusterInfo.ClusterContext)
 			Expect(err).To(BeNil(), "context should create without any error")
 			contextNames = append(contextNames, ctxName)
-			active, err := tf.ContextCmd.GetActiveContext(framework.TargetTypeK8s)
+			active, err := tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
 			Expect(err).To(BeNil(), "there should be a active context")
 			Expect(active).To(Equal(ctxName), "the active context should be recently added context")
 		})
 		// Test case: test 'tanzu context use' command with the specific context name (not the recently created one)
 		It("use context command", func() {
+			By("use context command")
 			err := tf.ContextCmd.UseContext(contextNames[0])
 			Expect(err).To(BeNil(), "use context should set context without any error")
-			active, err := tf.ContextCmd.GetActiveContext(framework.TargetTypeK8s)
+			active, err := tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
 			Expect(err).To(BeNil(), "there should be a active context")
 			Expect(active).To(Equal(contextNames[0]), "the active context should be recently set context")
 		})
@@ -76,11 +82,13 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-lifecycle-k8s]", 
 		})
 		// Test case: test 'tanzu context list' command, should list all contexts created
 		It("list context should have all added contexts", func() {
+			By("list context should have all added contexts")
 			list := GetAvailableContexts(tf, contextNames)
 			Expect(len(list)).To(Equal(len(contextNames)), "list context should have all contexts added in previous tests")
 		})
 		// Test case: test 'tanzu context delete' command, make sure to delete all context's created in previous test cases
 		It("delete context command", func() {
+			By("delete all contexts created in previous tests")
 			for _, ctx := range contextNames {
 				err := tf.ContextCmd.DeleteContext(ctx)
 				Expect(err).To(BeNil(), "delete context should delete context without any error")
@@ -90,6 +98,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-lifecycle-k8s]", 
 		})
 		// Test case: (negative test) test 'tanzu context delete' command for context name which is not exists
 		It("delete context command", func() {
+			By("delete context command with random string")
 			err := tf.ContextCmd.DeleteContext(framework.RandomString(4))
 			Expect(err).ToNot(BeNil())
 		})

--- a/test/e2e/context/tmc/context_tmc_lifecycle_test.go
+++ b/test/e2e/context/tmc/context_tmc_lifecycle_test.go
@@ -13,6 +13,7 @@ import (
 
 	context "github.com/vmware-tanzu/tanzu-cli/test/e2e/context"
 	"github.com/vmware-tanzu/tanzu-cli/test/e2e/framework"
+	types "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
 
 const ContextNamePrefix = "context-endpoint-tmc-"
@@ -61,7 +62,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-lifecycle-tmc]", 
 			err := tf.ContextCmd.CreateConextWithEndPointStaging(ctxName, clusterInfo.EndPoint)
 			Expect(err).To(BeNil(), "context should create without any error")
 			contextNames = append(contextNames, ctxName)
-			active, err := tf.ContextCmd.GetActiveContext(framework.TargetTypeTMC)
+			active, err := tf.ContextCmd.GetActiveContext(string(types.TargetTMC))
 			Expect(err).To(BeNil(), "there should be a active context")
 			Expect(active).To(Equal(ctxName), "the active context should be recently added context")
 		})
@@ -69,7 +70,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-lifecycle-tmc]", 
 		It("use context command", func() {
 			err := tf.ContextCmd.UseContext(contextNames[0])
 			Expect(err).To(BeNil(), "use context should set context without any error")
-			active, err := tf.ContextCmd.GetActiveContext(framework.TargetTypeTMC)
+			active, err := tf.ContextCmd.GetActiveContext(string(types.TargetTMC))
 			Expect(err).To(BeNil(), "there should be a active context")
 			Expect(active).To(Equal(contextNames[0]), "the active context should be same as the context set by use context command")
 		})

--- a/test/e2e/framework/cmd_exec_operations.go
+++ b/test/e2e/framework/cmd_exec_operations.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
 
 // CmdOps performs the Command line exec operations
@@ -31,6 +33,7 @@ func NewCmdOps() CmdOps {
 
 // Exec the command, exit on error
 func (co *cmdOps) Exec(command string) (stdOut, stdErr *bytes.Buffer, err error) {
+	log.Infof(ExecutingCommand, command)
 	cmdInput := strings.Split(command, " ")
 	cmdName := cmdInput[0]
 	cmdArgs := cmdInput[1:]

--- a/test/e2e/framework/context_lifecycle_operations.go
+++ b/test/e2e/framework/context_lifecycle_operations.go
@@ -19,7 +19,7 @@ type ContextCmdOps interface {
 	// GetContext helps to run `context get` command
 	GetContext(contextName string) (ContextInfo, error)
 	// ListContext helps to run `context list` command
-	ListContext() ([]ContextListInfo, error)
+	ListContext() ([]*ContextListInfo, error)
 	// DeleteContext helps to run `context delete` command
 	DeleteContext(contextName string) error
 	// GetActiveContext returns current active context
@@ -62,18 +62,8 @@ func (cc *contextCmdOps) GetContext(contextName string) (ContextInfo, error) {
 	return contextInfo, nil
 }
 
-func (cc *contextCmdOps) ListContext() ([]ContextListInfo, error) {
-	out, _, err := cc.cmdExe.Exec(ListContextOutputInJSON)
-	if err != nil {
-		return nil, err
-	}
-	jsonStr := out.String()
-	var list []ContextListInfo
-	err = json.Unmarshal([]byte(jsonStr), &list)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to construct json node from context list output:"+jsonStr)
-	}
-	return list, nil
+func (cc *contextCmdOps) ListContext() ([]*ContextListInfo, error) {
+	return ExecuteCmdAndBuildJSONOutput[ContextListInfo](cc.cmdExe, ListContextOutputInJSON)
 }
 
 func (cc *contextCmdOps) GetActiveContext(targetType string) (string, error) {

--- a/test/e2e/framework/framework_helper.go
+++ b/test/e2e/framework/framework_helper.go
@@ -6,10 +6,14 @@ package framework
 
 import (
 	"crypto/rand"
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"os"
 
+	"github.com/pkg/errors"
+
+	configapi "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
 
@@ -24,20 +28,29 @@ func SliceToSet(slice []string) map[string]struct{} {
 }
 
 // PluginListToSet converts the given PluginInfo slice to set type, key is combination  of plugin's name_target_version
-func PluginListToSet(pluginsToInstall *[]PluginInfo) map[string]struct{} {
+func PluginListToSet(pluginsToInstall []*PluginInfo) map[string]struct{} {
 	set := make(map[string]struct{})
 	exists := struct{}{}
-	for _, plugin := range *pluginsToInstall {
+	for _, plugin := range pluginsToInstall {
 		set[fmt.Sprintf(PluginKey, plugin.Name, plugin.Target, plugin.Version)] = exists
 	}
 	return set
 }
 
 // PluginListToMap converts the given PluginInfo slice to map type, key is combination  of plugin's name_target_version and value is PluginInfo
-func PluginListToMap(pluginsList *[]PluginInfo) map[string]*PluginInfo {
+func PluginListToMap(pluginsList []*PluginInfo) map[string]*PluginInfo {
 	m := make(map[string]*PluginInfo)
-	for i := range *pluginsList {
-		m[fmt.Sprintf(PluginKey, (*pluginsList)[i].Name, (*pluginsList)[i].Target, (*pluginsList)[i].Version)] = &(*pluginsList)[i]
+	for i := range pluginsList {
+		m[fmt.Sprintf(PluginKey, (pluginsList)[i].Name, (pluginsList)[i].Target, (pluginsList)[i].Version)] = pluginsList[i]
+	}
+	return m
+}
+
+// PluginGroupToMap converts the given slice of PluginGroups to map (PluginGroup name is the key) and PluginGroup is the value
+func PluginGroupToMap(pluginGroups []*PluginGroup) map[string]*PluginGroup {
+	m := make(map[string]*PluginGroup)
+	for i := range pluginGroups {
+		m[(pluginGroups)[i].Group] = pluginGroups[i]
 	}
 	return m
 }
@@ -70,4 +83,32 @@ func GetHomeDir() string {
 		log.Errorf("error while getting user home directory, error:%s", err.Error())
 	}
 	return home
+}
+
+// ExecuteCmdAndBuildJSONOutput is generic function to execute given command and build JSON output and return
+func ExecuteCmdAndBuildJSONOutput[T PluginInfo | PluginGroup | PluginSourceInfo | configapi.ClientConfig | Server | ContextListInfo](cmdExe CmdOps, cmd string) ([]*T, error) {
+	out, stdErr, err := cmdExe.Exec(cmd)
+
+	if err != nil {
+		log.Errorf(ErrorLogForCommandWithErrAndStdErr, cmd, err.Error(), stdErr.String())
+		return nil, err
+	}
+	jsonStr := out.String()
+	var list []*T
+	err = json.Unmarshal([]byte(jsonStr), &list)
+	if err != nil {
+		log.Errorf(FailedToConstructJSONNodeFromOutputAndErrInfo, jsonStr, err.Error())
+		return nil, errors.Wrapf(err, FailedToConstructJSONNodeFromOutput, jsonStr)
+	}
+	return list, nil
+}
+
+// GetMapKeys takes map[K]any and returns the slice of all map keys
+func GetMapKeys[K string, V *PluginInfo](m map[K][]V) []*K {
+	keySet := make([]*K, 0)
+	for key := range m {
+		entry := key
+		keySet = append(keySet, &entry)
+	}
+	return keySet
 }

--- a/test/e2e/framework/output_handling.go
+++ b/test/e2e/framework/output_handling.go
@@ -13,6 +13,10 @@ type PluginInfo struct {
 	Version     string `json:"version"`
 }
 
+type PluginGroup struct {
+	Group string `json:"group"`
+}
+
 type PluginSourceInfo struct {
 	Name  string `json:"name"`
 	Scope string `json:"scope"`

--- a/test/e2e/plugin_lifecycle/plugin_group_lifecycle_test.go
+++ b/test/e2e/plugin_lifecycle/plugin_group_lifecycle_test.go
@@ -1,0 +1,155 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// plugin provides plugin command specific E2E test cases
+package plugin
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware-tanzu/tanzu-cli/test/e2e/framework"
+)
+
+// This test suite covers plugin group life cycle use cases for central repository
+// it uses local central repo to discovery plugins and plugin groups, for which we need to make sure that
+// docker is running and also local central repo is running, start with 'make start-test-central-repo'
+// we need to update PATH with tanzu binary
+// run the tests with make target 'make start-test-central-repo',
+// this make target by default updates the local central repository URL to environment variable TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL
+// the use case being covered in this suite are:
+//  1. 'plugin group search' there should be some groups always
+//  2. 'tanzu plugin install <plugin|all> --group <group>'
+//     'tanzu plugin install all --group <group>' will be validated by getting list of plugins belongs to specific plugin group by mapping
+//     plugin group version ( vmware-tmc/v9.9.9 ) with plugin version from the plugin search output, tanzu plugin group get <group> is
+//     not supported yet.
+//
+// Use cases not covered:
+// 1. 'tanzu plugin group get <group>'
+// 2. 'tanzu plugin group describe <group>'
+
+var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Group-lifecycle]", func() {
+	// Use cases:
+	// a. clean, install one plugin from a plugin group and validate the installation by running plugin describe.
+	// b. install all plugins in a group (to make sure we should be able to install all plugins in a group even when some plugins in group already installed) and validate the installation by running plugin describe for all plugins in a plugin group.
+	Context("plugin install from group: install a plugin from a specific plugin group", func() {
+		// Test case: clean plugins if any installed already
+		It("clean plugins if any installed already", func() {
+			err := tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin clean")
+			pluginsList, err := tf.PluginCmd.ListPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin list")
+			Expect(len(pluginsList)).Should(BeNumerically("==", 0), "plugins list should not return any plugins after plugin clean")
+		})
+		// Test case: install a plugin from each plugin group and validate the installation
+		It("install a plugin from each plugin group and validate the plugin installation by 'plugin describe'", func() {
+			for pg := range pluginGroupToPluginListMap {
+				plugins := pluginGroupToPluginListMap[pg]
+				err := tf.PluginCmd.InstallPluginsFromGroup(plugins[0].Name, pg)
+				Expect(err).To(BeNil(), "should not get any error for plugin install from plugin group")
+
+				str, err := tf.PluginCmd.DescribePlugin(plugins[0].Name, plugins[0].Target)
+				Expect(err).To(BeNil(), "should not get any error for plugin describe")
+				Expect(str).NotTo(BeNil(), "there should be output for plugin describe")
+			}
+		})
+		// Test case: install a plugin from each plugin group and validate the installation with plugin describe
+		It("install all plugins in each group", func() {
+			for pg := range pluginGroupToPluginListMap {
+				err := tf.PluginCmd.InstallPluginsFromGroup("all", pg)
+				Expect(err).To(BeNil(), "should not get any error for plugin install from plugin group")
+				plugins := pluginGroupToPluginListMap[pg]
+				for i := range plugins {
+					str, err := tf.PluginCmd.DescribePlugin(plugins[i].Name, plugins[i].Target)
+					Expect(err).To(BeNil(), "should not get any error for plugin describe")
+					Expect(str).NotTo(BeNil(), "there should be output for plugin describe")
+				}
+			}
+		})
+	})
+	// Use cases:
+	// a. clean installation with "all": clean, install all plugin from a plugin group and validate the installation by running plugin describe.
+	// b. clean installation without "all": clean, install all plugin from a plugin group (pass empty string instead of "all") and validate the installation by running plugin describe.
+	Context("plugin install from group: perform all plugin installation in a group", func() {
+		// Test case: a. clean plugins if any installed already, before running 'tanzu plugin install all --group group_name'
+		It("clean plugins if any installed already", func() {
+			err := tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin clean")
+			pluginsList, err := tf.PluginCmd.ListPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin list")
+			Expect(len(pluginsList)).Should(BeNumerically("==", 0), "plugins list should not return any plugins after plugin clean")
+		})
+		// Test case: a. with command 'tanzu plugin install all --group group_name': when no plugins in a group has installed already: install a plugin from each plugin group and validate the installation with plugin describe
+		It("install all plugins in each group", func() {
+			for pg := range pluginGroupToPluginListMap {
+				err := tf.PluginCmd.InstallPluginsFromGroup("all", pg)
+				Expect(err).To(BeNil(), "should not get any error for plugin install from plugin group")
+				plugins := pluginGroupToPluginListMap[pg]
+				for i := range plugins {
+					str, err := tf.PluginCmd.DescribePlugin(plugins[i].Name, plugins[i].Target)
+					Expect(err).To(BeNil(), "should not get any error for plugin describe")
+					Expect(str).NotTo(BeNil(), "there should be output for plugin describe")
+				}
+			}
+		})
+		// Test case: b. clean plugins if any installed already, before running 'tanzu plugin install --group group_name'
+		It("clean plugins if any installed already", func() {
+			err := tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin clean")
+			pluginsList, err := tf.PluginCmd.ListPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin list")
+			Expect(len(pluginsList)).Should(BeNumerically("==", 0), "plugins list should not return any plugins after plugin clean")
+		})
+		// Test case: b. with command 'tanzu plugin install --group group_name': when no plugins in a group has installed already: install a plugin from each plugin group and validate the installation with plugin describe
+		It("install all plugins in each group", func() {
+			for pg := range pluginGroupToPluginListMap {
+				err := tf.PluginCmd.InstallPluginsFromGroup("", pg)
+				Expect(err).To(BeNil(), "should not get any error for plugin install from plugin group")
+				plugins := pluginGroupToPluginListMap[pg]
+				for i := range plugins {
+					str, err := tf.PluginCmd.DescribePlugin(plugins[i].Name, plugins[i].Target)
+					Expect(err).To(BeNil(), "should not get any error for plugin describe")
+					Expect(str).NotTo(BeNil(), "there should be output for plugin describe")
+				}
+			}
+		})
+	})
+	// Use cases: This context covers NEGATIVE USE CASES:
+	// a. incorrect plugin group: clean, install a plugin with incorrect plugin group name
+	// b. incorrect plugin name: install a plugin with incorrect name and correct plugin group name.
+	Context("plugin install from group: perform all plugin installation in a group", func() {
+		// Test case: clean plugins if any installed already
+		It("clean plugins if any installed already", func() {
+			err := tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin clean")
+			pluginsList, err := tf.PluginCmd.ListPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin list")
+			Expect(len(pluginsList)).Should(BeNumerically("==", 0), "plugins list should not return any plugins after plugin clean")
+		})
+		// Test case: a. install a plugin with incorrect plugin group name
+		It("install a plugin with incorrect plugin group name", func() {
+			for pg := range pluginGroupToPluginListMap {
+				plugins := pluginGroupToPluginListMap[pg]
+				err := tf.PluginCmd.InstallPluginsFromGroup(plugins[0].Name, framework.RandomString(5))
+				Expect(err).NotTo(BeNil(), "plugin installation should fail as plugin group name is incorrect")
+				break
+			}
+		})
+		// Test case: b. install a plugin with incorrect plugin name (which is not exists in given plugin group) and correct group name
+		It("install a plugin with incorrect plugin name (which does not exist in given group) and correct group name", func() {
+			for pg := range pluginGroupToPluginListMap {
+				err := tf.PluginCmd.InstallPluginsFromGroup(framework.RandomString(5), pg)
+				Expect(err).NotTo(BeNil(), "plugin installation should fail as plugin name is not exists in plugin group")
+				break
+			}
+		})
+	})
+	// TODO:
+	//	1) Use case: 	Install a plugin from a specific group eg: 'vmware-tkg/v0.0.1', plugin: secret target: kubernetes, Version: v0.0.1
+	//					Install same plugin different version but same target from another group eg: 'vmware-tkg/v9.9.9', plugin: secret target: kubernetes, Version: v9.9.9
+	//			expected results: it should install successfully
+	//	2) Use case: 	Install a same plugin (with same version) from a same group, but different targets, eg: group: 'vmware-tkg/v9.9.9' plugin: secret target: kubernetes, and another plugin:  plugin: secret target: mission-control
+	//					Install all plugins in the group: tanzu plugin install --group 'vmware-tkg/v9.9.9'
+	//		expected results: it should install all plugins, and there should be two secret plugins installed one for kubernetes and another for mission-control with same version.
+
+})

--- a/test/e2e/plugin_lifecycle/plugin_lifecycle_helper.go
+++ b/test/e2e/plugin_lifecycle/plugin_lifecycle_helper.go
@@ -10,10 +10,11 @@ import (
 	"github.com/onsi/gomega"
 
 	"github.com/vmware-tanzu/tanzu-cli/test/e2e/framework"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
 
 // IsPluginSourceExists checks the sourceName is exists in the given list of PluginSourceInfo's
-func IsPluginSourceExists(list []framework.PluginSourceInfo, sourceName string) bool {
+func IsPluginSourceExists(list []*framework.PluginSourceInfo, sourceName string) bool {
 	for _, val := range list {
 		if val.Name == sourceName {
 			return true
@@ -23,9 +24,9 @@ func IsPluginSourceExists(list []framework.PluginSourceInfo, sourceName string) 
 }
 
 // CheckAllPluginsAvailable checks requiredPlugins are exists in the allPlugins
-func CheckAllPluginsAvailable(allPlugins *[]framework.PluginInfo, requiredPlugins []framework.PluginInfo) bool {
-	set := framework.PluginListToSet(&requiredPlugins)
-	for _, plugin := range *allPlugins {
+func CheckAllPluginsAvailable(allPlugins, requiredPlugins []*framework.PluginInfo) bool {
+	set := framework.PluginListToSet(requiredPlugins)
+	for _, plugin := range allPlugins {
 		key := fmt.Sprintf(framework.PluginKey, plugin.Name, plugin.Target, plugin.Version)
 		_, ok := set[key]
 		if ok {
@@ -37,7 +38,7 @@ func CheckAllPluginsAvailable(allPlugins *[]framework.PluginInfo, requiredPlugin
 
 // CheckAllPluginsExists checks all PluginInfo's in subList are available in superList
 // superList is the super set, subList is sub set
-func CheckAllPluginsExists(superList, subList *[]framework.PluginInfo) bool {
+func CheckAllPluginsExists(superList, subList []*framework.PluginInfo) bool {
 	superSet := framework.PluginListToMap(superList)
 	subSet := framework.PluginListToMap(subList)
 	for key, val := range subSet {
@@ -51,8 +52,63 @@ func CheckAllPluginsExists(superList, subList *[]framework.PluginInfo) bool {
 }
 
 // SearchAllPlugins runs the plugin search command and returns all the plugins from the search output
-func SearchAllPlugins(tf *framework.Framework) *[]framework.PluginInfo {
+func SearchAllPlugins(tf *framework.Framework) []*framework.PluginInfo {
 	pluginsSearchList, err := tf.PluginCmd.SearchPlugins("")
 	gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin search")
-	return &pluginsSearchList
+	return pluginsSearchList
+}
+
+// SearchAllPluginGroups runs the plugin group search command and returns all the plugin groups
+func SearchAllPluginGroups(tf *framework.Framework) []*framework.PluginGroup {
+	pluginGroups, err := tf.PluginCmd.SearchPluginGroups("")
+	gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin search")
+	return pluginGroups
+}
+
+// IsAllPluginGroupsExists takes the two list of PluginGroups (super list and sub list), check if all sub list PluginGroup are exists in super list PluginGroup
+func IsAllPluginGroupsExists(superList, subList []*framework.PluginGroup) bool {
+	superMap := framework.PluginGroupToMap(superList)
+	subMap := framework.PluginGroupToMap(subList)
+	for ele := range subMap {
+		_, exists := superMap[ele]
+		if !exists {
+			return false
+		}
+	}
+	return true
+}
+
+func MapPluginsToPluginGroups(list []*framework.PluginInfo, pg []*framework.PluginGroup) map[string][]*framework.PluginInfo {
+	m := make(map[string][]*framework.PluginInfo)
+	for _, pluginGroup := range pg {
+		m[pluginGroup.Group] = make([]*framework.PluginInfo, 0)
+	}
+	for i := range list {
+		plugin := list[i]
+		key := "vmware-"
+		if plugin.Target == string(types.TargetK8s) {
+			key += framework.TKG + "/"
+		} else if plugin.Target == string(types.TargetTMC) {
+			key += framework.TMC + "/"
+		}
+		key += plugin.Version
+		pluginList, ok := m[key]
+		if ok {
+			pluginList = append(pluginList, plugin)
+			m[key] = pluginList
+		}
+	}
+	return m
+}
+
+// GetPluginFromFirstListButNotExistsInSecondList returns a plugin which is exists in first plugin list but not in second plugin list
+func GetPluginFromFirstListButNotExistsInSecondList(first, second []*framework.PluginInfo) (*framework.PluginInfo, error) {
+	m1 := framework.PluginListToMap(first)
+	m2 := framework.PluginListToMap(second)
+	for plugin := range m1 {
+		if _, ok := m2[plugin]; !ok {
+			return m1[plugin], nil
+		}
+	}
+	return nil, fmt.Errorf("there is no plugin which is not common in the given pluginInfo's")
 }

--- a/test/e2e/plugin_lifecycle/plugin_lifecycle_suite_test.go
+++ b/test/e2e/plugin_lifecycle/plugin_lifecycle_suite_test.go
@@ -5,13 +5,56 @@
 package plugin
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/vmware-tanzu/tanzu-cli/test/e2e/framework"
 )
 
 func TestPluginLifecycle(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "PluginLifecycle Suite")
 }
+
+var (
+	tf                         *framework.Framework
+	e2eTestLocalCentralRepoURL string
+	pluginsSearchList          []*framework.PluginInfo
+	pluginGroups               []*framework.PluginGroup
+	pluginGroupToPluginListMap map[string][]*framework.PluginInfo
+	pluginSourceName           string
+)
+
+// BeforeSuite initializes and set up the environment to execute the plugin life cycle and plugin group life cycle end-to-end test cases
+var _ = BeforeSuite(func() {
+	tf = framework.NewFramework()
+	// check E2E test central repo URL (TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL)
+	e2eTestLocalCentralRepoURL = os.Getenv(framework.TanzuCliE2ETestLocalCentralRepositoryURL)
+	Expect(e2eTestLocalCentralRepoURL).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with local central repository URL", framework.TanzuCliE2ETestLocalCentralRepositoryURL))
+	// set E2E test central repo URL to TANZU_CLI_PRE_RELEASE_REPO_IMAGE
+	os.Setenv(framework.CentralRepositoryPreReleaseRepoImage, e2eTestLocalCentralRepoURL)
+
+	// search plugin groups and make sure there plugin groups available
+	pluginGroups = SearchAllPluginGroups(tf)
+
+	// check all required plugin groups (framework.PluginGroupsForLifeCycleTests) need for life cycle test are available in plugin group search output
+	Expect(IsAllPluginGroupsExists(pluginGroups, framework.PluginGroupsForLifeCycleTests)).Should(BeTrue(), "all required plugin groups for life cycle tests should exists in plugin group search output")
+
+	// search plugins and make sure there are plugins available
+	pluginsSearchList = SearchAllPlugins(tf)
+	Expect(len(pluginsSearchList)).Should(BeNumerically(">", 0))
+
+	// check all required plugins (framework.PluginsForLifeCycleTests) for plugin life cycle e2e are available in plugin search output
+	CheckAllPluginsAvailable(pluginsSearchList, framework.PluginsForLifeCycleTests)
+
+	pluginGroupToPluginListMap = MapPluginsToPluginGroups(pluginsSearchList, framework.PluginGroupsForLifeCycleTests)
+
+	// check for every plugin group (in framework.PluginGroupsForLifeCycleTests) there should be plugin's available
+	for pg := range pluginGroupToPluginListMap {
+		Expect(len(pluginGroupToPluginListMap[pg])).Should(BeNumerically(">", 0), "there should be at least one plugin available for each plugin group in plugin group life cycle list")
+	}
+})

--- a/test/e2e/plugin_lifecycle/plugin_lifecycle_test.go
+++ b/test/e2e/plugin_lifecycle/plugin_lifecycle_test.go
@@ -6,7 +6,6 @@ package plugin
 
 import (
 	"fmt"
-	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -24,27 +23,6 @@ import (
 // 1. plugin search, install, delete, describe, list (with negative use cases)
 // 2. plugin source add/update/list/delete (with negative use cases)
 var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-lifecycle]", func() {
-	var (
-		tf                         *framework.Framework
-		e2eTestLocalCentralRepoURL string
-		pluginSourceName           string
-		pluginsSearchList          *[]framework.PluginInfo
-	)
-	BeforeSuite(func() {
-		tf = framework.NewFramework()
-		// check E2E test central repo URL
-		e2eTestLocalCentralRepoURL = os.Getenv(framework.TanzuCliE2ETestLocalCentralRepositoryURL)
-		Expect(e2eTestLocalCentralRepoURL).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with local central repository URL", framework.TanzuCliE2ETestLocalCentralRepositoryURL))
-		// set E2E test central repo URL to TANZU_CLI_PRE_RELEASE_REPO_IMAGE
-		os.Setenv(framework.CentralRepositoryPreReleaseRepoImage, e2eTestLocalCentralRepoURL)
-
-		// search plugins and make sure there are plugins available
-		pluginsSearchList = SearchAllPlugins(tf)
-		Expect(len(*pluginsSearchList)).Should(BeNumerically(">", 0))
-
-		// check all required plugins (framework.PluginsForLifeCycleTests) for plugin life cycle e2e are available in plugin search output
-		CheckAllPluginsAvailable(pluginsSearchList, framework.PluginsForLifeCycleTests)
-	})
 	Context("plugin source use cases: tanzu plugin source add, list, update, delete", func() {
 		// Test case: add plugin source
 		It("add plugin source", func() {
@@ -123,7 +101,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-lifecycle]", func(
 			pluginsList, err := tf.PluginCmd.ListPlugins()
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
 			Expect(len(pluginsList)).Should(Equal(len(framework.PluginsForLifeCycleTests)), "plugins list should return all installed plugins")
-			Expect(CheckAllPluginsExists(&pluginsList, &framework.PluginsForLifeCycleTests)).Should(BeTrue(), "the plugin list output is not same as the plugins being installed")
+			Expect(CheckAllPluginsExists(pluginsList, framework.PluginsForLifeCycleTests)).Should(BeTrue(), "the plugin list output is not same as the plugins being installed")
 		})
 		// Test case: delete all plugins which are installed, and validate by running list plugin command
 		It("delete all plugins and verify with plugin list", func() {

--- a/test/e2e/plugins_compatibility/plugins_compatibility_helper.go
+++ b/test/e2e/plugins_compatibility/plugins_compatibility_helper.go
@@ -15,10 +15,10 @@ import (
 )
 
 // PluginsForCompatibilityTesting search for test-plugin-'s from the test central repository and returns all test-plugin-'s
-func PluginsForCompatibilityTesting(tf *framework.Framework) []framework.PluginInfo {
+func PluginsForCompatibilityTesting(tf *framework.Framework) []*framework.PluginInfo {
 	list, err := tf.PluginCmd.SearchPlugins("")
 	gomega.Expect(err).To(gomega.BeNil(), "should not occur any error while searching for plugins")
-	testPlugins := make([]framework.PluginInfo, 0)
+	testPlugins := make([]*framework.PluginInfo, 0)
 	for _, plugin := range list {
 		if strings.HasPrefix(plugin.Name, framework.TestPluginsPrefix) {
 			testPlugins = append(testPlugins, plugin)
@@ -28,10 +28,10 @@ func PluginsForCompatibilityTesting(tf *framework.Framework) []framework.PluginI
 }
 
 // IsAllPluginsInstalled takes list of plugins and checks if all plugins are installed
-func IsAllPluginsInstalled(tf *framework.Framework, plugins []framework.PluginInfo) bool {
+func IsAllPluginsInstalled(tf *framework.Framework, plugins []*framework.PluginInfo) bool {
 	pluginListOutput, err := tf.PluginCmd.ListPlugins()
 	gomega.Expect(err).To(gomega.BeNil(), "should not occur any error while listing plugins")
-	pluginMap := framework.PluginListToSet(&plugins)
+	pluginMap := framework.PluginListToSet(plugins)
 	for _, pluginInfo := range pluginListOutput {
 		key := fmt.Sprintf(framework.PluginKey, pluginInfo.Name, pluginInfo.Target, pluginInfo.Version)
 		_, ok := pluginMap[key]
@@ -43,10 +43,10 @@ func IsAllPluginsInstalled(tf *framework.Framework, plugins []framework.PluginIn
 }
 
 // IsAllPluginsUnInstalled takes list of plugins and checks if all plugins are uninstalled
-func IsAllPluginsUnInstalled(tf *framework.Framework, plugins []framework.PluginInfo) bool {
+func IsAllPluginsUnInstalled(tf *framework.Framework, plugins []*framework.PluginInfo) bool {
 	pluginListOutput, err := tf.PluginCmd.ListPlugins()
 	gomega.Expect(err).To(gomega.BeNil(), "should not occur any error while listing plugins")
-	pluginMap := framework.PluginListToSet(&plugins)
+	pluginMap := framework.PluginListToSet(plugins)
 	for _, pluginInfo := range pluginListOutput {
 		key := fmt.Sprintf(framework.PluginKey, pluginInfo.Name, pluginInfo.Target, pluginInfo.Version)
 		_, ok := pluginMap[key]
@@ -59,10 +59,10 @@ func IsAllPluginsUnInstalled(tf *framework.Framework, plugins []framework.Plugin
 }
 
 // UninstallPlugins lists plugins and uninstalls provided plugins if any plugins are installed
-func UninstallPlugins(tf *framework.Framework, plugins []framework.PluginInfo) {
+func UninstallPlugins(tf *framework.Framework, plugins []*framework.PluginInfo) {
 	pluginListOutput, err := tf.PluginCmd.ListPlugins()
 	gomega.Expect(err).To(gomega.BeNil(), "should not occur any error while listing plugins")
-	pluginMap := framework.PluginListToSet(&plugins)
+	pluginMap := framework.PluginListToSet(plugins)
 	for _, pluginInfo := range pluginListOutput {
 		key := fmt.Sprintf(framework.PluginKey, pluginInfo.Name, pluginInfo.Target, pluginInfo.Version)
 		_, ok := pluginMap[key]

--- a/test/e2e/plugins_compatibility/plugins_compatibility_test.go
+++ b/test/e2e/plugins_compatibility/plugins_compatibility_test.go
@@ -24,7 +24,7 @@ import (
 var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Compatibility]", func() {
 	var (
 		tf      *framework.Framework
-		plugins []framework.PluginInfo
+		plugins []*framework.PluginInfo
 	)
 	// In the BeforeSuite search for the test-plugin-'s from the TANZU_CLI_E2E_TEST_CENTRAL_REPO_URL test central repository
 	BeforeSuite(func() {


### PR DESCRIPTION
### What this PR does / why we need it
**What this PR does:**
This PR implements end-to-end test framework tooling and test case for plugin group use cases, it covers below plugin group use cases:

```
tanzu plugin group search
tanzu plugin install all --group <plugin_group_name>
tanzu plugin install --group <plugin_group_name>
tanzu plugin install <specific_plugin_name> --group <plugin_group_name>
```
And this PR covers the negative use cases like, 
```
tanzu plugin install <specific_plugin_name> --group <incorrect_plugin_group_name>
tanzu plugin install <incorrect_specific_plugin_name> --group <incorrect_plugin_group_name>
tanzu plugin install <plugin_name_notExistsThisGroup> --group <plugin_group_name>
```
**Why we need this PR:**
This PR helps ensure the plugin group use cases (positive and negative) always work fine from an end-user perspective, giving confidence to the CLI team.
This test executes as part of the "Tanzu CLI Core E2E Tests" GitHub workflow for every pull request. 

**End-to-End framework tooling:**
This PR uses the existing local central repository tooling (https://github.com/vmware-tanzu/tanzu-cli/tree/main/hack/central-repo) as the central repository and also uses the current plugin groups and plugins for the life cycle tests. The required plugin groups and plugin names (for plugin life cycle tests) are hard-coded in the framework code, created issue https://github.com/vmware-tanzu/tanzu-cli/issues/122 to make it configurable.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #https://github.com/vmware-tanzu/tanzu-cli/issues/112

### Describe testing done for PR
1. Successfully tested locally:
Here are steps to test the PR locally:
```
❯ make build
build darwin-amd64 CLI with version: v0.1.0-dev
# command-line-arguments
ld: warning: -no_pie is deprecated when targeting new OS versions
ld: warning: non-standard -pagezero_size is deprecated when targeting macOS 13.0 or later
mkdir -p bin
cp /Users/cpamuluri/tkg/tasks/e2e_tests/pluginLifeCycle/tanzu-cli/artifacts/darwin/amd64/cli/core/v0.1.0-dev/tanzu-cli-darwin_amd64 ./bin/tanzu
❯                                                                                                
❯ 
❯ make start-test-central-repo
docker container stop central 2> /dev/null || true
central
if [ ! -d /Users/cpamuluri/tkg/tasks/e2e_tests/pluginLifeCycle/tanzu-cli/hack/central-repo/registry-content ]; then \
                (cd /Users/cpamuluri/tkg/tasks/e2e_tests/pluginLifeCycle/tanzu-cli/hack/central-repo && tar xjf registry-content.bz2 || true;) \
        fi
docker run --rm -d -p 9876:5000 --name central \
                -v /Users/cpamuluri/tkg/tasks/e2e_tests/pluginLifeCycle/tanzu-cli/hack/central-repo/registry-content:/var/lib/registry \
                mirror.gcr.io/library/registry:2
be34a05e5159dc5fd1edbdad503a56531db50e2c0924fe768d2f3e7f6733f6d0
❯ 
❯ 
❯ export TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL=localhost:9876/tanzu-cli/plugins/central:small
❯ 
❯ export PATH=/Users/cpamuluri/tkg/tasks/e2e_tests/pluginLifeCycle/tanzu-cli/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin:/Users/cpamuluri/.fig/bin:/Users/cpamuluri/.local/bin
❯ 
❯ make e2e-cli-plugin-lifecycle-test                                                             
=== RUN   TestPluginLifecycle
Running Suite: PluginLifecycle Suite
====================================
Random Seed: 1679350377
Will run 30 of 30 specs

••••[x] error while executing command:'tanzu plugin source delete FhYvt', error:'error while running 'tanzu plugin source delete FhYvt', stdOut: , stdErr: [x] : cli discovery source not found
%!(EXTRA *exec.ExitError=exit status 1)' stdErr:'[x] : cli discovery source not found
'
••••[x] error while executing command:'tanzu plugin describe cluster --target iMFBv', error:'error while running 'tanzu plugin describe cluster --target iMFBv', stdOut: , stdErr: [x] : invalid target specified. Please specify correct value of `--target` or `-t` flag from 'kubernetes/k8s/mission-control/tmc'
%!(EXTRA *exec.ExitError=exit status 1)' stdErr:'[x] : invalid target specified. Please specify correct value of `--target` or `-t` flag from 'kubernetes/k8s/mission-control/tmc'
'
•[x] error while executing command:'tanzu plugin describe 4nn74 --target kubernetes', error:'error while running 'tanzu plugin describe 4nn74 --target kubernetes', stdOut: , stdErr: [x] : unable to find plugin '4nn74' for target 'kubernetes'
%!(EXTRA *exec.ExitError=exit status 1)' stdErr:'[x] : unable to find plugin '4nn74' for target 'kubernetes'
'
••••••[x] error while executing command:'tanzu plugin install pinniped-auth --target global --version v9.9.9', error:'error while running 'tanzu plugin install pinniped-auth --target global --version v9.9.9', stdOut: , stdErr: [!] unable to list plugin from discovery 'default_pre_release': invalid target for plugin: global
[x] : unable to find plugin 'pinniped-auth' for target 'global'
%!(EXTRA *exec.ExitError=exit status 1)' stdErr:'[!] unable to list plugin from discovery 'default_pre_release': invalid target for plugin: global
[x] : unable to find plugin 'pinniped-auth' for target 'global'
'
•[x] error while executing command:'tanzu plugin install cluster --target U0vfp --version v9.9.9', error:'error while running 'tanzu plugin install cluster --target U0vfp --version v9.9.9', stdOut: , stdErr: [x] : invalid target specified. Please specify correct value of `--target` or `-t` flag from 'kubernetes/k8s/mission-control/tmc'
%!(EXTRA *exec.ExitError=exit status 1)' stdErr:'[x] : invalid target specified. Please specify correct value of `--target` or `-t` flag from 'kubernetes/k8s/mission-control/tmc'
'
•[x] error while executing command:'tanzu plugin install fOmeD', error:'error while running 'tanzu plugin install fOmeD', stdOut: , stdErr: [x] : unable to find plugin 'fOmeD'
%!(EXTRA *exec.ExitError=exit status 1)' stdErr:'[x] : unable to find plugin 'fOmeD'
'
•[x] error while executing command:'tanzu plugin install cluster --target kubernetes --version v9.9.9492', error:'error while running 'tanzu plugin install cluster --target kubernetes --version v9.9.9492', stdOut: , stdErr: [x] : unable to find plugin 'cluster' for target 'kubernetes'
%!(EXTRA *exec.ExitError=exit status 1)' stdErr:'[x] : unable to find plugin 'cluster' for target 'kubernetes'
'
•••••••••[x] error while executing command:'tanzu plugin install cluster --group teEbk', error:'error while running 'tanzu plugin install cluster --group teEbk', stdOut: , stdErr: [x] : could not find group 'teEbk'
%!(EXTRA *exec.ExitError=exit status 1)' stdErr:'[x] : could not find group 'teEbk'
'
•[x] error while executing command:'tanzu plugin install v1GVJ --group vmware-tkg/v9.9.9', error:'error while running 'tanzu plugin install v1GVJ --group vmware-tkg/v9.9.9', stdOut: , stdErr: [x] : plugin 'v1GVJ' is not part of the group 'vmware-tkg/v9.9.9'
%!(EXTRA *exec.ExitError=exit status 1)' stdErr:'[x] : plugin 'v1GVJ' is not part of the group 'vmware-tkg/v9.9.9'
'
•[0xc0005135a0 0xc0005135b0]
[x] error while executing command:'tanzu plugin install audit --group vmware-tkg/v9.9.9', error:'error while running 'tanzu plugin install audit --group vmware-tkg/v9.9.9', stdOut: , stdErr: [x] : plugin 'audit' is not part of the group 'vmware-tkg/v9.9.9'
%!(EXTRA *exec.ExitError=exit status 1)' stdErr:'[x] : plugin 'audit' is not part of the group 'vmware-tkg/v9.9.9'
'
•
Ran 30 of 30 Specs in 16.814 seconds
SUCCESS! -- 30 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestPluginLifecycle (16.84s)
PASS
coverage: 94.3% of statements
ok      github.com/vmware-tanzu/tanzu-cli/test/e2e/plugin_lifecycle     17.093s coverage: 94.3% of statements
❯ 
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Plugin life cycle end-to-end test cases has implemented
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer
This is the second PR after https://github.com/vmware-tanzu/tanzu-cli/pull/104 for the plugin life cycle test cases implementation
<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
