### PR TITLE
Support installing a plugin as both standalone and context at the same time

### DIFF
--- a/pkg/pluginmanager/manager.go
+++ b/pkg/pluginmanager/manager.go
@@ -878,9 +878,8 @@ func DeletePlugin(options DeletePluginOptions) error {
 		return err
 	}
 
-	var plugin cli.PluginInfo
-	var matchedPluginCatalog *catalog.ContextCatalog
-	matchedPluginCount := 0
+	var matchedCatalogNames []string
+	var matchedPlugins []cli.PluginInfo
 
 	// Add empty serverName for standalone plugins
 	serverNames = append(serverNames, "")
@@ -895,34 +894,58 @@ func DeletePlugin(options DeletePluginOptions) error {
 		for i := range plugins {
 			if plugins[i].Name == options.PluginName &&
 				(options.Target == configtypes.TargetUnknown || options.Target == plugins[i].Target) {
-				plugin = plugins[i]
-				matchedPluginCatalog = c
-				matchedPluginCount++
+				matchedPlugins = append(matchedPlugins, plugins[i])
+				matchedCatalogNames = append(matchedCatalogNames, serverName)
 			}
 		}
 	}
 
-	if matchedPluginCount == 0 {
+	if len(matchedPlugins) == 0 {
 		if options.Target != configtypes.TargetUnknown {
 			return errors.Errorf("unable to find plugin '%v' for target '%s'", options.PluginName, string(options.Target))
 		}
 		return errors.Errorf("unable to find plugin '%v'", options.PluginName)
 	}
-	if matchedPluginCount > 1 {
-		return errors.Errorf("unable to uniquely identify plugin '%v'. Please specify correct Target(kubernetes[k8s]/mission-control[tmc]) of the plugin with `--target` flag", options.PluginName)
+
+	// It is possible that the catalog contains two entries for a name/target combination:
+	// a context-scope installation and a standalone installation.  We need to delete both in this case.
+	// If all matched plugins are from the same target, this is when we can still delete them all.
+	uniqueTarget := matchedPlugins[0].Target
+	for i := range matchedPlugins {
+		if matchedPlugins[i].Target != uniqueTarget {
+			return errors.Errorf("unable to uniquely identify plugin '%v'. Please specify correct Target(kubernetes[k8s]/mission-control[tmc]) of the plugin with `--target` flag", options.PluginName)
+		}
 	}
 
 	if !options.ForceDelete {
-		if err := component.AskForConfirmation(fmt.Sprintf("Deleting Plugin '%s'. Are you sure?", options.PluginName)); err != nil {
+		if err := component.AskForConfirmation(
+			fmt.Sprintf("Deleting Plugin '%s' for target '%s'. Are you sure?",
+				options.PluginName, string(uniqueTarget))); err != nil {
 			return err
 		}
 	}
-	err = matchedPluginCatalog.Delete(catalog.PluginNameTarget(plugin.Name, plugin.Target))
-	if err != nil {
-		return fmt.Errorf("plugin %q could not be deleted from cache", options.PluginName)
-	}
+	// Delete all plugins that match since they are all from the same target
+	return doDeletePluginFromCatalog(options.PluginName, uniqueTarget, matchedCatalogNames)
 
 	// TODO: delete the plugin binary if it is not used by any server
+}
+
+func doDeletePluginFromCatalog(pluginName string, target configtypes.Target, catalogNames []string) error {
+	for _, n := range catalogNames {
+		// We must create one catalog at a time to be able to delete a plugin.
+		// If we re-use the catalogs created above, when we delete the plugin
+		// in one catalog, the next catalog will put it back since that catalog
+		// was created before the plugin was deleted.
+		c, err := catalog.NewContextCatalog(n)
+		if err != nil {
+			continue
+		}
+
+		err = c.Delete(catalog.PluginNameTarget(pluginName, target))
+		if err != nil {
+			return fmt.Errorf("plugin %q could not be deleted from cache", pluginName)
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
### What this PR does / why we need it

This PR allows to properly handle the installation of the same plugin as both standalone and context-scope.
Although both forms of the plugins can be installed at the same time, the CLI can only use one of the two; we give precedence to the context-scope one in this case.

`plugin list` is updated to only show the context-scope version.

It is now also possible to delete a context plugin and then re-install it as a standalone using `plugin install`.
If a `plugin sync` is then done, the version of the context-scope plugin will be re-installed.
If the context is deleted (or deactivated), the context plugin is no longer shown, and the standalone plugin now becomes accessible.
In summary, a context-scope plugin installation takes precedence, but we keep track of a manual installation

The second commit allows `plugin delete` to handle the above situation properly. Normally, when more than one plugin matches a name/target, it implies the target is "unknown" and we have one plugin for `k8s` and another for `tmc`, in which case the user must specify the target though the `--target` flag.  In the case of a plugin being installed both as standalone and context-scope at the same time, two plugin instances will match the name/target although both are for the same target.  The code now handles this. I believe this was a bug even before the Central Repo feature.

### Describe testing done for PR

```
# Reset the CLI
$ rm ~/.config/tanzu/config*
$ tz plugin clean
[ok] successfully cleaned up all plugins
$ tz config set env.TANZU_CLI_PRE_RELEASE_REPO_IMAGE localhost:9876/tanzu-cli/plugins/central:small
$ make start-test-central-repo

# The catalog is properly empty
$ cat ~/.cache/_tanzu/catalog.yaml
cat: /Users/kmarc/.cache/_tanzu/catalog.yaml: No such file or directory

$ # Create a context with v.0.0.1 of some TKG plugins
$ tz context create --name k3d --kubecontext k3d --kubeconfig /Users/kmarc/.kube/config.k3d
[ok] successfully created a kubernetes context using the kubeconfig /Users/kmarc/.kube/config.k3d
[i] Checking for required plugins...
[i] Installing plugin 'cluster:v0.0.1' with target 'kubernetes'
[i] Installing plugin 'feature:v0.0.1' with target 'kubernetes'
[i] Installing plugin 'kubernetes-release:v0.0.1' with target 'kubernetes'
[i] Installing plugin 'package:v0.0.1' with target 'kubernetes'
[i] Successfully installed all required plugins

$ tz plugin list
Standalone Plugins
  NAME  DESCRIPTION  TARGET  VERSION  STATUS

Plugins from Context:  k3d
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v0.0.1   installed
  feature             Operate on features and featuregates  kubernetes  v0.0.1   installed
  kubernetes-release  Kubernetes release operations         kubernetes  v0.0.1   installed
  package             Operate on packages                   kubernetes  v0.0.1   installed

# Now install the same plugins as standalone with version v9.9.9 using a group
$ tz plugin install --group vmware-tkg/v9.9.9
[i] Installing plugin 'cluster:v9.9.9' with target 'kubernetes'
[i] Installing plugin 'feature:v9.9.9' with target 'kubernetes'
[i] Installing plugin 'kubernetes-release:v9.9.9' with target 'kubernetes'
[i] Installing plugin 'management-cluster:v9.9.9' with target 'kubernetes'
[i] Installing plugin 'package:v9.9.9' with target 'kubernetes'
[i] Installing plugin 'secret:v9.9.9' with target 'kubernetes'
[i] Installing plugin 'telemetry:v9.9.9' with target 'kubernetes'
[ok] successfully installed all plugins from group 'vmware-tkg/v9.9.9'

# Notice that the context-scope versions are shown and not the same standalone version
# for the cluster, feature, kubernetes-release and package plugins
$ tz plugin list
Standalone Plugins
  NAME                DESCRIPTION                       TARGET      VERSION  STATUS
  management-cluster  management-cluster functionality  kubernetes  v9.9.9   installed
  secret              secret functionality              kubernetes  v9.9.9   installed
  telemetry           telemetry functionality           kubernetes  v9.9.9   installed

Plugins from Context:  k3d
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v0.0.1   installed
  feature             Operate on features and featuregates  kubernetes  v0.0.1   installed
  kubernetes-release  Kubernetes release operations         kubernetes  v0.0.1   installed
  package             Operate on packages                   kubernetes  v0.0.1   installed

# But, as expected, all 4 context plugins are also installed as standalone in the catalog
$ cat ~/.cache/_tanzu/catalog.yaml
[...]
standaloneplugins:
    cluster_kubernetes: /Users/kmarc/Library/Application Support/_tanzu-cli/cluster/v9.9.9_7d1744e805826cc8cd9987aa6cad4460adbe0180030769ff8674ea807585a53c_kubernetes
    feature_kubernetes: /Users/kmarc/Library/Application Support/_tanzu-cli/feature/v9.9.9_f81a3204964370a23a49c59b12e59ccd05097e57f400350285c21a7e68db6a6a_kubernetes
    kubernetes-release_kubernetes: /Users/kmarc/Library/Application Support/_tanzu-cli/kubernetes-release/v9.9.9_d3a2ac7baa4a99b01d4aef7fae9b21083f9c4447c9290495d6f3e0c8d413582c_kubernetes
    management-cluster_kubernetes: /Users/kmarc/Library/Application Support/_tanzu-cli/management-cluster/v9.9.9_5e6d137035d8846df2f6346bdbe2ec12effe535b44ae3d885ffc82aba6eba5dd_kubernetes
    package_kubernetes: /Users/kmarc/Library/Application Support/_tanzu-cli/package/v9.9.9_496c59809c7db44235a162f7d9397896b82756743b5b5420651fd635805a9a71_kubernetes
    secret_kubernetes: /Users/kmarc/Library/Application Support/_tanzu-cli/secret/v9.9.9_9ad13f41fd06a5bfd7e4a2d5f6d6f7135ba1929ff46dc32976d0396ba01502b8_kubernetes
    telemetry_kubernetes: /Users/kmarc/Library/Application Support/_tanzu-cli/telemetry/v9.9.9_61ee314f18213426dc76e83063f7860747470b10b31d9bc5ceca7dfe26a6bd3d_kubernetes
serverplugins:
    k3d:
        cluster_kubernetes: /Users/kmarc/Library/Application Support/_tanzu-cli/cluster/v0.0.1_2ddee7c0a8ecbef610a651bc8d83657fd3438f1038e817b4a7d44f2d0b3bac72_kubernetes
        feature_kubernetes: /Users/kmarc/Library/Application Support/_tanzu-cli/feature/v0.0.1_81ee9befd66314134ae94d1d063d1b3bd34466c9360a333741541f719179f6cb_kubernetes
        kubernetes-release_kubernetes: /Users/kmarc/Library/Application Support/_tanzu-cli/kubernetes-release/v0.0.1_d76dc7b8f865d04b96b1aaa4a2ac4c8911a9b00e741c18a9bde16399d72e3bf3_kubernetes
        package_kubernetes: /Users/kmarc/Library/Application Support/_tanzu-cli/package/v0.0.1_87353352ce06c5450a1730a5c808b3e1a5c13c23d893f52875dbc409593d721f_kubernetes

# Now delete the cluster plugin
$ tz plugin delete cluster
Deleting Plugin 'cluster' for target 'kubernetes'. Are you sure? [y/N]: y
[ok] successfully deleted plugin 'cluster'

# Notice that both the standalone and context-scope version are removed
Standalone Plugins
  NAME                DESCRIPTION                       TARGET      VERSION  STATUS
  management-cluster  management-cluster functionality  kubernetes  v9.9.9   installed
  secret              secret functionality              kubernetes  v9.9.9   installed
  telemetry           telemetry functionality           kubernetes  v9.9.9   installed

Plugins from Context:  k3d
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v0.0.1   not installed
  feature             Operate on features and featuregates  kubernetes  v0.0.1   installed
  kubernetes-release  Kubernetes release operations         kubernetes  v0.0.1   installed
  package             Operate on packages                   kubernetes  v0.0.1   installed

[!] As shown above, some recommended plugins have not been installed. To install them please run 'tanzu plugin sync'.

# Now, let's install the v9.9.9 by hand (i.e., as standalone)
$ tz plugin install cluster --target k8s --version v9.9.9
[i] Installing plugin 'cluster:v9.9.9' with target 'kubernetes'
[ok] successfully installed 'cluster' plugin
$ tz plugin list
Standalone Plugins
  NAME                DESCRIPTION                       TARGET      VERSION  STATUS
  cluster             cluster functionality             kubernetes  v9.9.9   installed
  management-cluster  management-cluster functionality  kubernetes  v9.9.9   installed
  secret              secret functionality              kubernetes  v9.9.9   installed
  telemetry           telemetry functionality           kubernetes  v9.9.9   installed

Plugins from Context:  k3d
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v0.0.1   not installed
  feature             Operate on features and featuregates  kubernetes  v0.0.1   installed
  kubernetes-release  Kubernetes release operations         kubernetes  v0.0.1   installed
  package             Operate on packages                   kubernetes  v0.0.1   installed

[!] As shown above, some recommended plugins have not been installed. To install them please run 'tanzu plugin sync'.

# We can now run the v9.9.9 version even though the context recommends v0.0.1
$ tz cluster
Stub plugin "cluster" "v9.9.9" for "k8s"

# A plugin sync will re-install the context version, as expected
$ tz plugin sync
[i] Checking for required plugins...
[i] Installing plugin 'cluster:v0.0.1' with target 'kubernetes'
[i] Successfully installed all required plugins
[ok] Done
$ tz cluster
Stub plugin "cluster" "v0.0.1" for "k8s"
$ tz plugin list
Standalone Plugins
  NAME                DESCRIPTION                       TARGET      VERSION  STATUS
  management-cluster  management-cluster functionality  kubernetes  v9.9.9   installed
  secret              secret functionality              kubernetes  v9.9.9   installed
  telemetry           telemetry functionality           kubernetes  v9.9.9   installed

Plugins from Context:  k3d
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v0.0.1   installed
  feature             Operate on features and featuregates  kubernetes  v0.0.1   installed
  kubernetes-release  Kubernetes release operations         kubernetes  v0.0.1   installed
  package             Operate on packages                   kubernetes  v0.0.1   installed
```

### Special notes for your reviewer

A noticeable side-effect of this change, is that the higher level of CLI logic no longer need to explicitly deal with a plugin installed both as standalone and context-scope.  For example in `root.go:NewRootCmd()`, there is no more conflict between standalone and context-scope plugins, so the warning "Warning, Masking commands for plugins %q because a core command or other plugin with that name already exists" will no longer appear for this particular case.
 