### PR TITLE
Align yaml and json parsers for the catalog

### DIFF
--- a/pkg/catalog/catalog_types.go
+++ b/pkg/catalog/catalog_types.go
@@ -37,17 +37,17 @@ func (pa PluginAssociation) Map() map[string]string {
 // Catalog is the Schema for the plugin catalog data
 type Catalog struct {
 	// PluginInfos is a list of PluginInfo
-	PluginInfos []*cli.PluginInfo `json:"pluginInfos,omitempty" yaml:"pluginInfos"`
+	PluginInfos []*cli.PluginInfo `json:"pluginInfos,omitempty" yaml:"pluginInfos,omitempty"`
 
 	// IndexByPath of PluginInfos for all installed plugins by installation path.
-	IndexByPath map[string]cli.PluginInfo `json:"indexByPath,omitempty"`
+	IndexByPath map[string]cli.PluginInfo `json:"indexByPath,omitempty" yaml:"indexByPath,omitempty"`
 	// IndeByName of all plugin installation paths by name.
-	IndexByName map[string][]string `json:"indexByName,omitempty"`
+	IndexByName map[string][]string `json:"indexByName,omitempty" yaml:"indexByName,omitempty"`
 	// StandAlonePlugins is a set of stand-alone plugin installations aggregated across all context types.
 	// Note: Shall be reduced to only those stand-alone plugins that are common to all context types.
-	StandAlonePlugins PluginAssociation `json:"standAlonePlugins,omitempty"`
+	StandAlonePlugins PluginAssociation `json:"standAlonePlugins,omitempty" yaml:"standAlonePlugins,omitempty"`
 	// ServerPlugins links a server and a set of associated plugin installations.
-	ServerPlugins map[string]PluginAssociation `json:"serverPlugins,omitempty"`
+	ServerPlugins map[string]PluginAssociation `json:"serverPlugins,omitempty" yaml:"serverPlugins,omitempty"`
 }
 
 // CatalogList contains a list of Catalog

--- a/pkg/cli/plugin_info.go
+++ b/pkg/cli/plugin_info.go
@@ -50,29 +50,29 @@ type PluginInfo struct {
 
 	// InstallationPath is a relative installation path for a plugin binary.
 	// E.g., cluster/v0.3.2@sha256:...
-	InstallationPath string `json:"installationPath"`
+	InstallationPath string `json:"installationPath" yaml:"installationPath"`
 
 	// Discovery is the name of the discovery from where
 	// this plugin is discovered.
-	Discovery string `json:"discovery"`
+	Discovery string `json:"discovery" yaml:"discovery"`
 
 	// Scope is the scope of the plugin. Stand-Alone or Context
-	Scope string `json:"scope"`
+	Scope string `json:"scope" yaml:"scope"`
 
 	// Status is the current plugin installation status
-	Status string `json:"status"`
+	Status string `json:"status" yaml:"status"`
 
 	// DiscoveredRecommendedVersion specifies the recommended version of the plugin that was discovered
-	DiscoveredRecommendedVersion string `json:"discoveredRecommendedVersion"`
+	DiscoveredRecommendedVersion string `json:"discoveredRecommendedVersion" yaml:"discoveredRecommendedVersion"`
 
 	// Target specifies the target of the plugin
-	Target configtypes.Target `json:"target"`
+	Target configtypes.Target `json:"target" yaml:"target"`
 
 	// PostInstallHook is function to be run post install of a plugin.
 	PostInstallHook plugin.Hook `json:"-" yaml:"-"`
 
 	// DefaultFeatureFlags is default featureflags to be configured if missing when invoking plugin
-	DefaultFeatureFlags map[string]bool `json:"defaultFeatureFlags"`
+	DefaultFeatureFlags map[string]bool `json:"defaultFeatureFlags" yaml:"defaultFeatureFlags"`
 }
 
 // PluginInfoSorter sorts PluginInfo objects.

--- a/pkg/fakes/cache/catalog_v0.29.yaml
+++ b/pkg/fakes/cache/catalog_v0.29.yaml
@@ -1,0 +1,67 @@
+apiVersion: cli.tanzu.vmware.com/v1alpha1
+indexByName:
+  cluster_kubernetes:
+  - /Users/test/Library/Application Support/tanzu-cli/cluster/v0.0.1_2ddee7c0a8ecbef610a651bc8d83657fd3438f1038e817b4a7d44f2d0b3bac72_kubernetes
+  iam_mission-control:
+  - /Users/test/Library/Application Support/tanzu-cli/iam/v0.0.1_2de17ef20dfb00dd8bcf5cb61cbce3cbddcd0a71fba858817343188c093cef7c_mission-control
+  isolated-cluster:
+  - /Users/test/Library/Application Support/tanzu-cli/isolated-cluster/v0.29.0_78d8b432ca369a161fca39e777aeb81fe63c2ba8b8dd25b1b8270eeab485a2ca_
+indexByPath:
+  ? /Users/test/Library/Application Support/tanzu-cli/cluster/v0.0.1_2ddee7c0a8ecbef610a651bc8d83657fd3438f1038e817b4a7d44f2d0b3bac72_kubernetes
+  : buildSHA: "01234567"
+    completionType: 0
+    defaultFeatureFlags: null
+    description: cluster functionality
+    digest: ""
+    discoveredRecommendedVersion: v0.0.1
+    discovery: test-mc
+    docURL: ""
+    group: System
+    installationPath: /Users/test/Library/Application Support/tanzu-cli/cluster/v0.0.1_2ddee7c0a8ecbef610a651bc8d83657fd3438f1038e817b4a7d44f2d0b3bac72_kubernetes
+    name: cluster
+    scope: ""
+    status: ""
+    target: kubernetes
+    version: v0.0.1
+  ? /Users/test/Library/Application Support/tanzu-cli/iam/v0.0.1_2de17ef20dfb00dd8bcf5cb61cbce3cbddcd0a71fba858817343188c093cef7c_mission-control
+  : buildSHA: "01234567"
+    completionType: 0
+    defaultFeatureFlags: null
+    description: IAM Policies for tmc resources
+    digest: ""
+    discoveredRecommendedVersion: v0.0.1
+    discovery: test-tmc-context
+    docURL: ""
+    group: Manage
+    installationPath: /Users/test/Library/Application Support/tanzu-cli/iam/v0.0.1_2de17ef20dfb00dd8bcf5cb61cbce3cbddcd0a71fba858817343188c093cef7c_mission-control
+    name: iam
+    scope: ""
+    status: ""
+    target: mission-control
+    version: v0.0.1
+  ? /Users/test/Library/Application Support/tanzu-cli/isolated-cluster/v0.29.0_78d8b432ca369a161fca39e777aeb81fe63c2ba8b8dd25b1b8270eeab485a2ca_
+  : buildSHA: e403941f7
+    completionType: 0
+    defaultFeatureFlags: null
+    description: Prepopulating images/bundle for internet-restricted environments
+    digest: ""
+    discoveredRecommendedVersion: v0.29.0
+    discovery: ""
+    docURL: ""
+    group: Run
+    installationPath: /Users/test/Library/Application Support/tanzu-cli/isolated-cluster/v0.29.0_78d8b432ca369a161fca39e777aeb81fe63c2ba8b8dd25b1b8270eeab485a2ca_
+    name: isolated-cluster
+    scope: ""
+    status: ""
+    target: ""
+    version: v0.29.0
+kind: Catalog
+metadata:
+  creationTimestamp: null
+serverPlugins:
+  test-mc:
+    cluster_kubernetes: /Users/test/Library/Application Support/tanzu-cli/cluster/v0.0.1_2ddee7c0a8ecbef610a651bc8d83657fd3438f1038e817b4a7d44f2d0b3bac72_kubernetes
+  test-tmc-context:
+    iam_mission-control: /Users/test/Library/Application Support/tanzu-cli/iam/v0.0.1_2de17ef20dfb00dd8bcf5cb61cbce3cbddcd0a71fba858817343188c093cef7c_mission-control
+standAlonePlugins:
+  isolated-cluster: /Users/test/Library/Application Support/tanzu-cli/isolated-cluster/v0.29.0_78d8b432ca369a161fca39e777aeb81fe63c2ba8b8dd25b1b8270eeab485a2ca_

--- a/pkg/pluginsupplier/plugin_supplier_test.go
+++ b/pkg/pluginsupplier/plugin_supplier_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/plugin"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -65,12 +66,12 @@ var _ = Describe("GetInstalledStandalonePlugins", func() {
 
 var _ = Describe("GetInstalledServerPlugins", func() {
 	var (
-		cdir            string
-		err             error
-		tkgConfigFile   *os.File
-		tkgConfigFileNG *os.File
-		pd1             *cli.PluginInfo
-		pd2             *cli.PluginInfo
+		cdir         string
+		err          error
+		configFile   *os.File
+		configFileNG *os.File
+		pd1          *cli.PluginInfo
+		pd2          *cli.PluginInfo
 	)
 	const (
 		tmcContextName = "test-tmc-context"
@@ -81,24 +82,24 @@ var _ = Describe("GetInstalledServerPlugins", func() {
 		Expect(err).ToNot(HaveOccurred())
 		common.DefaultCacheDir = cdir
 
-		tkgConfigFile, err = os.CreateTemp("", "config")
+		configFile, err = os.CreateTemp("", "config")
 		Expect(err).To(BeNil())
-		err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config.yaml"), tkgConfigFile.Name())
+		err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config.yaml"), configFile.Name())
 		Expect(err).To(BeNil(), "Error while copying tanzu config file for testing")
-		os.Setenv("TANZU_CONFIG", tkgConfigFile.Name())
+		os.Setenv("TANZU_CONFIG", configFile.Name())
 
-		tkgConfigFileNG, err = os.CreateTemp("", "config_ng")
+		configFileNG, err = os.CreateTemp("", "config_ng")
 		Expect(err).To(BeNil())
-		os.Setenv("TANZU_CONFIG_NEXT_GEN", tkgConfigFileNG.Name())
-		err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config_ng.yaml"), tkgConfigFileNG.Name())
+		os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
+		err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config_ng.yaml"), configFileNG.Name())
 		Expect(err).To(BeNil(), "Error while coping tanzu config-ng file for testing")
 	})
 	AfterEach(func() {
 		os.RemoveAll(cdir)
 		os.Unsetenv("TANZU_CONFIG")
 		os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
-		os.RemoveAll(tkgConfigFile.Name())
-		os.RemoveAll(tkgConfigFileNG.Name())
+		os.RemoveAll(configFile.Name())
+		os.RemoveAll(configFileNG.Name())
 	})
 
 	Context("when no server/context plugins installed", func() {
@@ -159,14 +160,14 @@ var _ = Describe("GetInstalledServerPlugins", func() {
 
 var _ = Describe("GetInstalledPlugins (both standalone and context plugins)", func() {
 	var (
-		cdir            string
-		err             error
-		tkgConfigFile   *os.File
-		tkgConfigFileNG *os.File
-		pd1             *cli.PluginInfo
-		pd2             *cli.PluginInfo
-		pd3             *cli.PluginInfo
-		pd4             *cli.PluginInfo
+		cdir         string
+		err          error
+		configFile   *os.File
+		configFileNG *os.File
+		pd1          *cli.PluginInfo
+		pd2          *cli.PluginInfo
+		pd3          *cli.PluginInfo
+		pd4          *cli.PluginInfo
 	)
 	const (
 		tmcContextName = "test-tmc-context"
@@ -177,24 +178,24 @@ var _ = Describe("GetInstalledPlugins (both standalone and context plugins)", fu
 		Expect(err).ToNot(HaveOccurred())
 		common.DefaultCacheDir = cdir
 
-		tkgConfigFile, err = os.CreateTemp("", "config")
+		configFile, err = os.CreateTemp("", "config")
 		Expect(err).To(BeNil())
-		err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config.yaml"), tkgConfigFile.Name())
+		err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config.yaml"), configFile.Name())
 		Expect(err).To(BeNil(), "Error while copying tanzu config file for testing")
-		os.Setenv("TANZU_CONFIG", tkgConfigFile.Name())
+		os.Setenv("TANZU_CONFIG", configFile.Name())
 
-		tkgConfigFileNG, err = os.CreateTemp("", "config_ng")
+		configFileNG, err = os.CreateTemp("", "config_ng")
 		Expect(err).To(BeNil())
-		os.Setenv("TANZU_CONFIG_NEXT_GEN", tkgConfigFileNG.Name())
-		err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config_ng.yaml"), tkgConfigFileNG.Name())
+		os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
+		err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config_ng.yaml"), configFileNG.Name())
 		Expect(err).To(BeNil(), "Error while coping tanzu config-ng file for testing")
 	})
 	AfterEach(func() {
 		os.RemoveAll(cdir)
 		os.Unsetenv("TANZU_CONFIG")
 		os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
-		os.RemoveAll(tkgConfigFile.Name())
-		os.RemoveAll(tkgConfigFileNG.Name())
+		os.RemoveAll(configFile.Name())
+		os.RemoveAll(configFileNG.Name())
 	})
 
 	Context("when no standalone or server plugins installed", func() {
@@ -313,6 +314,121 @@ var _ = Describe("GetInstalledPlugins (both standalone and context plugins)", fu
 			Expect(installedPlugins).Should(ContainElement(*pd2))
 			Expect(installedPlugins).Should(ContainElement(*pd3))
 			Expect(installedPlugins).Should(ContainElement(*pd4))
+		})
+	})
+	Context("with a catalog cache from an older CLI version", func() {
+		BeforeEach(func() {
+			cdir, err = os.MkdirTemp("", "test-catalog-cache")
+			Expect(err).ToNot(HaveOccurred())
+			common.DefaultCacheDir = cdir
+
+			err = copy.Copy(
+				filepath.Join("..", "fakes", "cache", "catalog_v0.29.yaml"),
+				// filepath.Join("..", "fakes", "cache", "catalog.yaml"),
+				filepath.Join(common.DefaultCacheDir, "catalog.yaml"))
+			Expect(err).To(BeNil(), "Error while copying tanzu catalog file for testing")
+
+			configFile, err = os.CreateTemp("", "config")
+			Expect(err).To(BeNil())
+			err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config.yaml"), configFile.Name())
+			Expect(err).To(BeNil(), "Error while copying tanzu config file for testing")
+			os.Setenv("TANZU_CONFIG", configFile.Name())
+
+			configFileNG, err = os.CreateTemp("", "config_ng")
+			Expect(err).To(BeNil())
+			os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
+			err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config_ng.yaml"), configFileNG.Name())
+			Expect(err).To(BeNil(), "Error while coping tanzu config-ng file for testing")
+		})
+		AfterEach(func() {
+			os.RemoveAll(cdir)
+			os.Unsetenv("TANZU_CONFIG")
+			os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
+			os.RemoveAll(configFile.Name())
+			os.RemoveAll(configFileNG.Name())
+		})
+
+		It("should find the installed server plugin", func() {
+			installedServerPlugins, err := GetInstalledServerPlugins()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(installedServerPlugins)).To(Equal(2))
+			Expect(installedServerPlugins[0]).Should(Equal(
+				cli.PluginInfo{
+					Name:                         "cluster",
+					Description:                  "cluster functionality",
+					Version:                      "v0.0.1",
+					BuildSHA:                     "01234567",
+					Digest:                       "",
+					Group:                        plugin.SystemCmdGroup,
+					DocURL:                       "",
+					Hidden:                       false,
+					CompletionType:               0,
+					CompletionArgs:               nil,
+					CompletionCommand:            "",
+					Aliases:                      nil,
+					InstallationPath:             "/Users/test/Library/Application Support/tanzu-cli/cluster/v0.0.1_2ddee7c0a8ecbef610a651bc8d83657fd3438f1038e817b4a7d44f2d0b3bac72_kubernetes",
+					Discovery:                    "test-mc",
+					Scope:                        "",
+					Status:                       "",
+					DiscoveredRecommendedVersion: "v0.0.1",
+					Target:                       types.TargetK8s,
+					DefaultFeatureFlags:          nil,
+					PostInstallHook:              nil,
+				},
+			))
+			Expect(installedServerPlugins[1]).Should(Equal(
+				cli.PluginInfo{
+					Name:                         "iam",
+					Description:                  "IAM Policies for tmc resources",
+					Version:                      "v0.0.1",
+					BuildSHA:                     "01234567",
+					Digest:                       "",
+					Group:                        plugin.ManageCmdGroup,
+					DocURL:                       "",
+					Hidden:                       false,
+					CompletionType:               0,
+					CompletionArgs:               nil,
+					CompletionCommand:            "",
+					Aliases:                      nil,
+					InstallationPath:             "/Users/test/Library/Application Support/tanzu-cli/iam/v0.0.1_2de17ef20dfb00dd8bcf5cb61cbce3cbddcd0a71fba858817343188c093cef7c_mission-control",
+					Discovery:                    "test-tmc-context",
+					Scope:                        "",
+					Status:                       "",
+					DiscoveredRecommendedVersion: "v0.0.1",
+					Target:                       types.TargetTMC,
+					DefaultFeatureFlags:          nil,
+					PostInstallHook:              nil,
+				},
+			))
+		})
+		It("should find the installed standalone plugin", func() {
+			installedStandalonePlugins, err := GetInstalledStandalonePlugins()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(installedStandalonePlugins)).To(Equal(1))
+			Expect(installedStandalonePlugins[0]).Should(Equal(
+				cli.PluginInfo{
+					Name:                         "isolated-cluster",
+					Description:                  "Prepopulating images/bundle for internet-restricted environments",
+					Version:                      "v0.29.0",
+					BuildSHA:                     "e403941f7",
+					Digest:                       "",
+					Group:                        plugin.RunCmdGroup,
+					DocURL:                       "",
+					Hidden:                       false,
+					CompletionType:               0,
+					CompletionArgs:               nil,
+					CompletionCommand:            "",
+					Aliases:                      nil,
+					InstallationPath:             "/Users/test/Library/Application Support/tanzu-cli/isolated-cluster/v0.29.0_78d8b432ca369a161fca39e777aeb81fe63c2ba8b8dd25b1b8270eeab485a2ca_",
+					Discovery:                    "",
+					Scope:                        "",
+					Status:                       "",
+					DiscoveredRecommendedVersion: "v0.29.0",
+					Target:                       types.TargetUnknown,
+					DefaultFeatureFlags:          nil,
+					PostInstallHook:              nil,
+				},
+			))
 		})
 	})
 })


### PR DESCRIPTION
### What this PR does / why we need it

When the CLI was transferred over we moved from using a json parser to a yaml parser.  For the new CLI to be able to read old CLI's catalog it is important that the fields be named the same, including case sensitivity.

This commit adds the proper annotations for 'yaml' to the different go structures that are used by the catalog, so that the parsing matches the original format.

A unit test is also added to keep testing compatibility as the CLI continues to evolve.

### Which issue(s) this PR fixes

Fixes #118

### Describe testing done for PR

Generate a catalog file using the old CLI and copy it for consumption by the new CLI as described in #118.
Then use the new CLI built from this PR to list plugins and access them successfully.
Note that only 2 plugins from TMC are listed in my test catalog file, as described in #118:
```
$ cp ~/.cache/tanzu/catalog.yaml ~/.cache/_tanzu/catalog.yaml
$ tz plugin list
Standalone Plugins
  NAME              DESCRIPTION                                                       TARGET  VERSION      STATUS
  isolated-cluster  Prepopulating images/bundle for internet-restricted environments          v0.29.0-dev  installed

Plugins from Context:  tmc
  NAME                DESCRIPTION                                                     TARGET           VERSION  STATUS
  account             Account for tmc resources                                       mission-control  v0.0.1   not installed
  apply               Create/Update a resource with a resource file                   mission-control  v0.0.1   not installed
  audit               Run an audit request on an org                                  mission-control  v0.0.1   not installed
  cluster                                                                             mission-control  v0.0.1   not installed
  clustergroup        A group of Kubernetes clusters                                  mission-control  v0.0.1   not installed
  continuousdelivery  Continuousdelivery for tmc resources                            mission-control  v0.0.1   not installed
  data-protection     Data protection for tmc resources                               mission-control  v0.0.1   not installed
  ekscluster                                                                          mission-control  v0.0.1   not installed
  events              Events for any meaningful user activity or system state change  mission-control  v0.0.1   not installed
  helm                helm for tmc resources                                          mission-control  v0.0.1   not installed
  iam                 IAM Policies for tmc resources                                  mission-control  v0.0.1   installed
  inspection          Inspection for tmc resources                                    mission-control  v0.0.1   not installed
  integration         Get available integrations and their information from registry  mission-control  v0.0.1   not installed
  management-cluster  A TMC registered Management cluster                             mission-control  v0.0.1   not installed
  policy              Policy for tmc resources                                        mission-control  v0.0.1   not installed
  secret              secret for tmc resources                                        mission-control  v0.0.1   not installed
  setting             Setting plugin for tmc resources                                mission-control  v0.0.1   installed
  tanzupackage        Tanzupackage for tmc resources                                  mission-control  v0.0.1   not installed
  workspace           A group of Kubernetes namespaces                                mission-control  v0.0.1   not installed

[!] As shown above, some recommended plugins have not been installed. To install them please run 'tanzu plugin sync'.

$ tz tmc setting
Manage default settings for some tmc features

Usage:
  tanzu setting [command]
[...]

$ tz isolated-cluster
Prepopulating images/bundle for internet-restricted environments

Usage:
  tanzu isolated-cluster [command]
[...]
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### Additional information

#### Special notes for your reviewer

Note that after building the CLI with this PR it will no longer be able to read the catalog built from older versions of the CLI of **this repository**.  This will only affect our team and only requires to re-install the plugins.