### PR TITLE
config server e2e tests bug fix

### DIFF
--- a/.github/workflows/cli_core_e2e_test.yaml
+++ b/.github/workflows/cli_core_e2e_test.yaml
@@ -3,8 +3,8 @@ name: Tanzu CLI Core Tests
 on:
   pull_request:
     branches: [main, release-*]
-    paths:
-      - "*"
+  push:
+    branches: [main, release-*]
 
 jobs:
   build:

--- a/test/e2e/config/config_test.go
+++ b/test/e2e/config/config_test.go
@@ -24,7 +24,6 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:config]", func() {
 	)
 	BeforeEach(func() {
 		tf = framework.NewFramework()
-		randomFeatureFlag = "features.global." + "e2e-test-" + framework.RandomString(4)
 	})
 	Context("config feature flag operations", func() {
 		When("new config flag set with value", func() {
@@ -60,6 +59,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:config]", func() {
 			})
 			It("should able to set new feature flag", func() {
 				// set feature flag
+				randomFeatureFlag = "features.global." + "e2e-test-" + framework.RandomString(4)
 				err := tf.Config.ConfigSetFeatureFlag(randomFeatureFlag, TRUE)
 				Expect(err).To(BeNil())
 

--- a/test/e2e/framework/config_lifecycle_operations.go
+++ b/test/e2e/framework/config_lifecycle_operations.go
@@ -107,7 +107,8 @@ func (co *configOps) ConfigInit() (err error) {
 
 // ConfigServerList returns the server list
 func (co *configOps) ConfigServerList() ([]Server, error) {
-	stdOut, _, err := co.Exec(ConfigServerList)
+	ConfigServerListWithJSONOutput := ConfigServerList + JSONOutput
+	stdOut, _, err := co.Exec(ConfigServerListWithJSONOutput)
 	if err != nil {
 		log.Errorf("error while executing `config server list`, error:%s", err.Error())
 		return nil, err

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -23,7 +23,7 @@ const (
 	ConfigUnset        = "tanzu config unset "
 	ConfigInit         = "tanzu config init"
 	ConfigServerList   = "tanzu config server list"
-	ConfigServerDelete = "tanzu config server delete %s"
+	ConfigServerDelete = "tanzu config server delete %s -y"
 
 	// Plugin commands
 	AddPluginSource      = "tanzu plugin source add --name %s --type %s --uri %s"


### PR DESCRIPTION
### What this PR does / why we need it
This PR is to fix a bug in `tanzu config server`  specific end-to-end test cases and github workflow `Tanzu CLI Core Tests` has been updated to pick the E2E tests for the push.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Successfully executed the config e2e test cases locally: 
```
❯ export PATH=/Users/cpamuluri/tkg/tasks/e2e_tests/core_main/tanzu-cli/bin:/Users/cpamuluri/tkg/tasks/e2e_tests/core_main/tanzu-cli/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin:/Users/cpamuluri/.fig/bin:/Users/cpamuluri/.local/bin
❯ 
❯ go test ./test/e2e/config -timeout 60m -race -coverprofile coverage.txt -v
=== RUN   TestConfig
Running Suite: Config Suite
===========================
Random Seed: 1679095791
Will run 9 of 9 specs

••••••••[x] error while running: tanzu config server delete 3h2Y -y: error while running 'tanzu config server delete 3h2Y -y', stdOut: , stdErr: [i] Deleting entry for cluster 3h2Y
[x] : server 3h2Y not found in list of known servers
%!(EXTRA *exec.ExitError=exit status 1)
•
Ran 9 of 9 Specs in 26.325 seconds
SUCCESS! -- 9 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestConfig (26.34s)
PASS
coverage: [no statements]
ok      github.com/vmware-tanzu/tanzu-cli/test/e2e/config       26.816s coverage: [no statements]
❯ 
```
### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer
It's a follow bug fix for the e2e test cases and tooling implemented https://github.com/vmware-tanzu/tanzu-cli/pull/89
<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
