### PR TITLE
Generate 'plugin_bundle.tar.gz' along with building the plugin with `make plugin-build` target

### DIFF
--- a/plugin-tooling.mk
+++ b/plugin-tooling.mk
@@ -60,7 +60,7 @@ endif
 PLUGIN_BUILD_TARGETS := $(addprefix plugin-build-,${PLUGIN_BUILD_OS_ARCH})
 
 .PHONY: plugin-build
-plugin-build: $(PLUGIN_BUILD_TARGETS) ## Build all plugin binaries for all supported os-arch
+plugin-build: $(PLUGIN_BUILD_TARGETS) generate-plugin-bundle ## Build all plugin binaries for all supported os-arch
 
 plugin-build-local: plugin-build-$(GOHOSTOS)-$(GOHOSTARCH) ## Build all plugin binaries for local platform
 	
@@ -138,3 +138,10 @@ local-registry: clean-registry ## Starts up a local docker registry for generati
 .PHONY: clean-registry
 clean-registry: ## Stops and removes local docker registry
 	docker stop temp-package-registry && docker rm -v temp-package-registry || true
+
+## --------------------------------------
+## Helpers
+## --------------------------------------
+
+generate-plugin-bundle:
+	cd $(PLUGIN_BINARY_ARTIFACTS_DIR) && tar -czvf ../plugin_bundle.tar.gz .


### PR DESCRIPTION
### What this PR does / why we need it

- This PR updates the `plugin-tooling.mk` file to generate 'plugin_bundle.tar.gz' along with building the plugin with `make plugin-build` target

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

```shell
$ make plugin-build
/Users/anujc/Documents/code/tanzu-cli/bin/builder plugin build \
                --path ./cmd/plugin \
                --binary-artifacts /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins \
                --version v0.1.0-dev-8-g6087ea00 \
                --ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-03-21' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=6087ea00-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.1.0-dev-8-g6087ea00'" \
                --os-arch linux_amd64 \
                --match "*"
2023-03-21T12:01:01-07:00 [i] building local repository at /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins, v0.1.0-dev-8-g6087ea00, [linux_amd64]
2023-03-21T12:01:01-07:00 [i] 🦁 - building plugin at path "cmd/plugin/test"
2023-03-21T12:01:01-07:00 [i] 🐱 - building plugin at path "cmd/plugin/builder"
2023-03-21T12:01:04-07:00 [i] 🐱 - $ /usr/local/go/bin/go build -o /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins/linux/amd64/global/builder/v0.1.0-dev-8-g6087ea00/tanzu-builder-linux_amd64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-03-21' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=6087ea00-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.1.0-dev-8-g6087ea00' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.1.0-dev-8-g6087ea00' -tags  ./cmd/plugin/builder
2023-03-21T12:01:06-07:00 [i] 🦁 - $ /usr/local/go/bin/go build -o /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins/linux/amd64/global/test/v0.1.0-dev-8-g6087ea00/tanzu-test-linux_amd64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-03-21' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=6087ea00-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.1.0-dev-8-g6087ea00' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.1.0-dev-8-g6087ea00' -tags  ./cmd/plugin/test
2023-03-21T12:01:10-07:00 [i] 🦁 - $ /usr/local/go/bin/go build -o /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins/linux/amd64/global/test/v0.1.0-dev-8-g6087ea00/test/tanzu-test-test-linux_amd64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-03-21' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=6087ea00-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.1.0-dev-8-g6087ea00' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.1.0-dev-8-g6087ea00' -tags  ./cmd/plugin/test/test
2023-03-21T12:01:11-07:00 [i] ========
2023-03-21T12:01:11-07:00 [ok] successfully built local repository
/Users/anujc/Documents/code/tanzu-cli/bin/builder plugin build \
                --path ./cmd/plugin \
                --binary-artifacts /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins \
                --version v0.1.0-dev-8-g6087ea00 \
                --ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-03-21' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=6087ea00-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.1.0-dev-8-g6087ea00'" \
                --os-arch windows_amd64 \
                --match "*"
2023-03-21T12:01:11-07:00 [i] building local repository at /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins, v0.1.0-dev-8-g6087ea00, [windows_amd64]
2023-03-21T12:01:11-07:00 [i] 🦁 - building plugin at path "cmd/plugin/test"
2023-03-21T12:01:11-07:00 [i] 🐱 - building plugin at path "cmd/plugin/builder"
2023-03-21T12:01:14-07:00 [i] 🐱 - $ /usr/local/go/bin/go build -o /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins/windows/amd64/global/builder/v0.1.0-dev-8-g6087ea00/tanzu-builder-windows_amd64.exe -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-03-21' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=6087ea00-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.1.0-dev-8-g6087ea00' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.1.0-dev-8-g6087ea00' -tags  ./cmd/plugin/builder
2023-03-21T12:01:16-07:00 [i] 🦁 - $ /usr/local/go/bin/go build -o /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins/windows/amd64/global/test/v0.1.0-dev-8-g6087ea00/tanzu-test-windows_amd64.exe -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-03-21' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=6087ea00-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.1.0-dev-8-g6087ea00' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.1.0-dev-8-g6087ea00' -tags  ./cmd/plugin/test
2023-03-21T12:01:20-07:00 [i] 🦁 - $ /usr/local/go/bin/go build -o /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins/windows/amd64/global/test/v0.1.0-dev-8-g6087ea00/test/tanzu-test-test-windows_amd64.exe -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-03-21' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=6087ea00-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.1.0-dev-8-g6087ea00' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.1.0-dev-8-g6087ea00' -tags  ./cmd/plugin/test/test
2023-03-21T12:01:21-07:00 [i] ========
2023-03-21T12:01:21-07:00 [ok] successfully built local repository
/Users/anujc/Documents/code/tanzu-cli/bin/builder plugin build \
                --path ./cmd/plugin \
                --binary-artifacts /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins \
                --version v0.1.0-dev-8-g6087ea00 \
                --ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-03-21' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=6087ea00-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.1.0-dev-8-g6087ea00'" \
                --os-arch darwin_amd64 \
                --match "*"
2023-03-21T12:01:21-07:00 [i] building local repository at /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins, v0.1.0-dev-8-g6087ea00, [darwin_amd64]
2023-03-21T12:01:21-07:00 [i] 🦁 - building plugin at path "cmd/plugin/test"
2023-03-21T12:01:21-07:00 [i] 🐱 - building plugin at path "cmd/plugin/builder"
2023-03-21T12:01:23-07:00 [i] 🐱 - $ /usr/local/go/bin/go build -o /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins/darwin/amd64/global/builder/v0.1.0-dev-8-g6087ea00/tanzu-builder-darwin_amd64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-03-21' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=6087ea00-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.1.0-dev-8-g6087ea00' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.1.0-dev-8-g6087ea00' -tags  ./cmd/plugin/builder
2023-03-21T12:01:26-07:00 [i] 🦁 - $ /usr/local/go/bin/go build -o /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins/darwin/amd64/global/test/v0.1.0-dev-8-g6087ea00/tanzu-test-darwin_amd64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-03-21' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=6087ea00-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.1.0-dev-8-g6087ea00' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.1.0-dev-8-g6087ea00' -tags  ./cmd/plugin/test
2023-03-21T12:01:35-07:00 [i] 🦁 - $ /usr/local/go/bin/go build -o /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins/darwin/amd64/global/test/v0.1.0-dev-8-g6087ea00/test/tanzu-test-test-darwin_amd64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-03-21' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=6087ea00-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.1.0-dev-8-g6087ea00' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.1.0-dev-8-g6087ea00' -tags  ./cmd/plugin/test/test
2023-03-21T12:01:36-07:00 [i] ========
2023-03-21T12:01:36-07:00 [ok] successfully built local repository
cd /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins && tar -czvf ../plugin_bundle.tar.gz .
a .
a ./plugin_manifest.yaml
a ./linux
a ./darwin
a ./windows
a ./windows/amd64
a ./windows/amd64/plugin_manifest.yaml
a ./windows/amd64/global
a ./windows/amd64/global/test
a ./windows/amd64/global/builder
a ./windows/amd64/global/builder/v0.1.0-dev-8-g6087ea00
a ./windows/amd64/global/builder/v0.1.0-dev-8-g6087ea00/tanzu-builder-windows_amd64.exe
a ./windows/amd64/global/test/v0.1.0-dev-8-g6087ea00
a ./windows/amd64/global/test/v0.1.0-dev-8-g6087ea00/test
a ./windows/amd64/global/test/v0.1.0-dev-8-g6087ea00/tanzu-test-windows_amd64.exe
a ./windows/amd64/global/test/v0.1.0-dev-8-g6087ea00/test/tanzu-test-test-windows_amd64.exe
a ./darwin/amd64
a ./darwin/amd64/plugin_manifest.yaml
a ./darwin/amd64/global
a ./darwin/amd64/global/test
a ./darwin/amd64/global/builder
a ./darwin/amd64/global/builder/v0.1.0-dev-8-g6087ea00
a ./darwin/amd64/global/builder/v0.1.0-dev-8-g6087ea00/tanzu-builder-darwin_amd64
a ./darwin/amd64/global/test/v0.1.0-dev-8-g6087ea00
a ./darwin/amd64/global/test/v0.1.0-dev-8-g6087ea00/test
a ./darwin/amd64/global/test/v0.1.0-dev-8-g6087ea00/tanzu-test-darwin_amd64
a ./darwin/amd64/global/test/v0.1.0-dev-8-g6087ea00/test/tanzu-test-test-darwin_amd64
a ./linux/amd64
a ./linux/amd64/plugin_manifest.yaml
a ./linux/amd64/global
a ./linux/amd64/global/test
a ./linux/amd64/global/builder
a ./linux/amd64/global/builder/v0.1.0-dev-8-g6087ea00
a ./linux/amd64/global/builder/v0.1.0-dev-8-g6087ea00/tanzu-builder-linux_amd64
a ./linux/amd64/global/test/v0.1.0-dev-8-g6087ea00
a ./linux/amd64/global/test/v0.1.0-dev-8-g6087ea00/test
a ./linux/amd64/global/test/v0.1.0-dev-8-g6087ea00/tanzu-test-linux_amd64
a ./linux/amd64/global/test/v0.1.0-dev-8-g6087ea00/test/tanzu-test-test-linux_amd64
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Update `plugin-tooling.mk` file to generate 'plugin_bundle.tar.gz' along with building the plugin with `make plugin-build`
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
