### PR TITLE
Update doc for the local test central repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,16 +226,18 @@ e2e-cli-tmc-test:
 
 .PHONY: start-test-central-repo
 start-test-central-repo: stop-test-central-repo ## Starts up a test central repository locally with docker
-	if [ ! -d $(ROOT_DIR)/hack/central-repo/registry-content ]; then \
+	@if [ ! -d $(ROOT_DIR)/hack/central-repo/registry-content ]; then \
 		(cd $(ROOT_DIR)/hack/central-repo && tar xjf registry-content.bz2 || true;) \
 	fi
-	docker run --rm -d -p 9876:5000 --name central \
+	@docker run --rm -d -p 9876:5000 --name central \
 		-v $(ROOT_DIR)/hack/central-repo/registry-content:/var/lib/registry \
-		mirror.gcr.io/library/registry:2
+		mirror.gcr.io/library/registry:2 > /dev/null && \
+	    echo "Started docker test central repo with images:" && \
+		$(ROOT_DIR)/hack/central-repo/upload-plugins.sh info
 
 .PHONY: stop-test-central-repo
 stop-test-central-repo: ## Stops and removes the local test central repository
-	docker container stop central 2> /dev/null || true
+	@docker container stop central > /dev/null 2>&1 && echo "Stopped docker test central repo" || true
 
 .PHONY: fmt
 fmt: $(GOIMPORTS) ## Run goimports

--- a/hack/central-repo/README.md
+++ b/hack/central-repo/README.md
@@ -22,8 +22,7 @@ For the `sandbox2:small` image, the `v22.22.22` of the plugins can be installed.
 The steps to follow to use the test central repo are:
 
 1. Start the test repo with `make start-test-central-repo`.
-1. Configure the plugin source for the test central repo: `tz plugin source add -n default -t oci -u localhost:9876/tanzu-cli/plugins/central:small`
-1. Allow the use of a local registry: `export ALLOWED_REGISTRY=localhost:9876`
+1. Configure the plugin source for the test central repo: `tz config set env.TANZU_CLI_PRE_RELEASE_REPO_IMAGE localhost:9876/tanzu-cli/plugins/central:small`
 
 Here are the exact commands:
 
@@ -31,8 +30,8 @@ Here are the exact commands:
 cd tanzu-cli
 make build
 make start-test-central-repo
-tz plugin source add -n default -t oci -u localhost:9876/tanzu-cli/plugins/central:small
-export ALLOWED_REGISTRY=localhost:9876
+alias tz=$(pwd)/bin/tanzu
+tz config set env.TANZU_CLI_PRE_RELEASE_REPO_IMAGE localhost:9876/tanzu-cli/plugins/central:small
 
 tz plugin search
 tz plugin install cluster --target tmc
@@ -51,7 +50,7 @@ them from the test Central Repository.
 To use the large test central repo instead:
 
 ```bash
-tz plugin source update default -t oci -u localhost:9876/tanzu-cli/plugins/central:large
+tz config set env.TANZU_CLI_PRE_RELEASE_REPO_IMAGE localhost:9876/tanzu-cli/plugins/central:large
 ```
 
 To stop the central repos: `make stop-test-central-repo`.

--- a/hack/central-repo/upload-plugins.sh
+++ b/hack/central-repo/upload-plugins.sh
@@ -9,18 +9,33 @@ usage() {
     echo "upload-plugins.sh [-h | -d | --dry-run]"
     echo
     echo "Creates test central repositories:"
-    echo "- localhost:9876/tanzu-cli/plugins/central:small with a small amount of plugins"
-    echo "- localhost:9876/tanzu-cli/plugins/central:large with 100 plugins"
-    echo "- localhost:9876/tanzu-cli/plugins/sandbox1:small with v11.11.11 of the plugins of the small image"
-    echo "- localhost:9876/tanzu-cli/plugins/sandbox2:small with v22.22.22 of the plugins of the small image"
+    echoImages
     echo
     echo "  -h               Print this help"
     echo "  -d, --dry-run    Only print the commands that would be executed"
     exit 0
 }
 
+echoImages() {
+    echo "=> localhost:9876/tanzu-cli/plugins/central:small"
+    echo "    - a small amount of plugins matching product plugin names"
+    echo "    - only versions v0.0.1 and v9.9.9 can be installed"
+    echo "=> localhost:9876/tanzu-cli/plugins/central:large with 100 plugins"
+    echo "    - the same content as the small image with extra plugins for a total of 100"
+    echo "    - none of the 'stubXY' plugins can be installed"
+    echo "    - only versions v0.0.1 and v9.9.9 can be installed"
+    echo "=> localhost:9876/tanzu-cli/plugins/sandbox1:small"
+    echo "    - an extra v11.11.11 version of the plugins of the small image"
+    echo "=> localhost:9876/tanzu-cli/plugins/sandbox2:small"
+    echo "    - an extra v22.22.22 version of the plugins of the small image"
+}
 if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
     usage
+fi
+
+if [ "$1" = "info" ]; then
+    echoImages
+    exit 0
 fi
 
 dry_run=""


### PR DESCRIPTION
### What this PR does / why we need it

This PR updates an out-of-date doc for the local test central repos

Also provide informative output when starting the local test central repos.

### Describe testing done for PR

```
$ make start-test-central-repo
Started docker test central repo with images:
=> localhost:9876/tanzu-cli/plugins/central:small
    - a small amount of plugins matching product plugin names
    - only versions v0.0.1 and v9.9.9 can be installed
=> localhost:9876/tanzu-cli/plugins/central:large with 100 plugins
    - the same content as the small image with extra plugins for a total of 100
    - none of the 'stubXY' plugins can be installed
    - only versions v0.0.1 and v9.9.9 can be installed
=> localhost:9876/tanzu-cli/plugins/sandbox1:small
    - an extra v11.11.11 version of the plugins of the small image
=> localhost:9876/tanzu-cli/plugins/sandbox2:small
    - an extra v22.22.22 version of the plugins of the small image

# Notice the extra line about first stopping the test central repo
$ make start-test-central-repo
Stopped docker test central repo
Started docker test central repo with images:
=> localhost:9876/tanzu-cli/plugins/central:small
    - a small amount of plugins matching product plugin names
    - only versions v0.0.1 and v9.9.9 can be installed
=> localhost:9876/tanzu-cli/plugins/central:large with 100 plugins
    - the same content as the small image with extra plugins for a total of 100
    - none of the 'stubXY' plugins can be installed
    - only versions v0.0.1 and v9.9.9 can be installed
=> localhost:9876/tanzu-cli/plugins/sandbox1:small
    - an extra v11.11.11 version of the plugins of the small image
=> localhost:9876/tanzu-cli/plugins/sandbox2:small
    - an extra v22.22.22 version of the plugins of the small image

$ make stop-test-central-repo
Stopped docker test central repo
```
I also tried regenerating the test central repo content to see I didn't break the script using:
```
cd tanzu-cli
make stop-test-central-repo
cd hack/central-repo
\rm -rf registry-content registry-content.bz2
./generate-central.sh
```

