### PR TITLE
config and context test update

### DIFF
--- a/test/e2e/config/config_init_feature_flag_test.go
+++ b/test/e2e/config/config_init_feature_flag_test.go
@@ -19,28 +19,25 @@ const TRUE = "true"
 // tests `tanzu config set` and `tanzu config unset` commands
 var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:config]", func() {
 	var (
-		tf                *framework.Framework
 		randomFeatureFlag string
 	)
-	BeforeEach(func() {
-		tf = framework.NewFramework()
-	})
 	Context("config feature flag operations", func() {
 		When("new config flag set with value", func() {
 			It("should set flag and unset flag successfully", func() {
 				flagName := "e2e-test-" + framework.RandomString(4)
 				randomFeatureFlagPath := "features.global." + flagName
 				flagVal := TRUE
+				// Set random feature flag
 				err := tf.Config.ConfigSetFeatureFlag(randomFeatureFlagPath, flagVal)
 				Expect(err).To(BeNil())
-
+				// Validate the value of random feature flag set in previous step
 				val, err := tf.Config.ConfigGetFeatureFlag(randomFeatureFlagPath)
 				Expect(err).To(BeNil())
 				Expect(val).Should(Equal(TRUE))
-
+				// Unset random feature flag which was set in previous step
 				err = tf.Config.ConfigUnsetFeature(randomFeatureFlagPath)
 				Expect(err).To(BeNil())
-
+				// Validate the unset random feature flag in previous step
 				val, err = tf.Config.ConfigGetFeatureFlag(randomFeatureFlagPath)
 				Expect(err).To(BeNil())
 				Expect(val).Should(Equal(""))

--- a/test/e2e/config/config_suite_test.go
+++ b/test/e2e/config/config_suite_test.go
@@ -9,9 +9,34 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/vmware-tanzu/tanzu-cli/test/e2e/context"
+	"github.com/vmware-tanzu/tanzu-cli/test/e2e/framework"
 )
 
 func TestConfig(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Config Suite")
 }
+
+var (
+	tf           *framework.Framework
+	clusterInfo  *framework.ClusterInfo
+	contextNames []string
+)
+
+// BeforeSuite creates KIND cluster needed to test 'tanzu config server' use cases
+// initializes the tf
+var _ = BeforeSuite(func() {
+	tf = framework.NewFramework()
+	// Create KIND cluster, which is used in test cases to create server's/context's
+	clusterInfo = context.CreateKindCluster(tf, "config-e2e-"+framework.RandomNumber(4))
+	contextNames = make([]string, 0)
+})
+
+// AfterSuite deletes the KIND which is created in BeforeSuite
+var _ = AfterSuite(func() {
+	// delete the KIND cluster which was created in the suite setup
+	_, err := tf.KindCluster.DeleteCluster(clusterInfo.Name)
+	Expect(err).To(BeNil(), "kind cluster should be deleted without any error")
+})

--- a/test/e2e/context/context_lifecycle_helper.go
+++ b/test/e2e/context/context_lifecycle_helper.go
@@ -44,6 +44,18 @@ func GetAvailableContexts(tf *framework.Framework, contextNames []string) []stri
 	return available
 }
 
+// IsContextExists checks the given context is exists in the config file by listing the existing contexts in the config file
+func IsContextExists(tf *framework.Framework, contextName string) bool {
+	list, err := tf.ContextCmd.ListContext()
+	gomega.Expect(err).To(gomega.BeNil(), "list context should not return any error")
+	for _, context := range list {
+		if context.Name == contextName {
+			return true
+		}
+	}
+	return false
+}
+
 // GetAvailableServers takes list of servers and returns which are available in the 'tanzu config server list' command
 func GetAvailableServers(tf *framework.Framework, serverNames []string) []string {
 	var available []string

--- a/test/e2e/context/context_suite_test.go
+++ b/test/e2e/context/context_suite_test.go
@@ -7,9 +7,35 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/vmware-tanzu/tanzu-cli/test/e2e/framework"
 )
 
 func TestContext(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Context-K8S Suite")
 }
+
+const ContextShouldNotExists = "the context %s should not exists"
+const ContextShouldExistsAsCreated = "the context %s should exists as its been created"
+
+var (
+	tf           *framework.Framework
+	clusterInfo  *framework.ClusterInfo
+	contextNames []string
+)
+
+// BeforeSuite created KIND cluster
+var _ = BeforeSuite(func() {
+	tf = framework.NewFramework()
+	// Create KIND cluster, which is used in test cases to create context's
+	clusterInfo = CreateKindCluster(tf, "context-e2e-"+framework.RandomNumber(4))
+	contextNames = make([]string, 0)
+})
+
+// AfterSuite deletes the KIND cluster created in BeforeSuite
+var _ = AfterSuite(func() {
+	// delete the KIND cluster which was created in the suite setup
+	_, err := tf.KindCluster.DeleteCluster(clusterInfo.Name)
+	Expect(err).To(BeNil(), "kind cluster should be deleted without any error")
+})

--- a/test/e2e/framework/config_lifecycle_operations.go
+++ b/test/e2e/framework/config_lifecycle_operations.go
@@ -115,7 +115,10 @@ func (co *configOps) ConfigServerDelete(serverName string) error {
 	configDelCmd := fmt.Sprintf(ConfigServerDelete, serverName)
 	_, _, err := co.cmdExe.Exec(configDelCmd)
 	if err != nil {
+		log.Infof("failed to delete config server: %s", serverName)
 		log.Error(err, "error while running: "+configDelCmd)
+	} else {
+		log.Infof(ConfigServerDeleted, serverName)
 	}
 	return err
 }
@@ -126,14 +129,14 @@ func (co *configOps) DeleteCLIConfigurationFiles() error {
 	configFile := filepath.Join(homeDir, ConfigFileDir, ConfigFileName)
 	_, err := os.Stat(configFile)
 	if err == nil {
-		if ferr := os.Remove(configFile); ferr != nil {
-			return ferr
+		if fileErr := os.Remove(configFile); fileErr != nil {
+			return fileErr
 		}
 	}
 	configNGFile := filepath.Join(homeDir, ConfigFileDir, ConfigNGFileName)
 	if _, err := os.Stat(configNGFile); err == nil {
-		if ferr := os.Remove(configNGFile); ferr != nil {
-			return ferr
+		if fileErr := os.Remove(configNGFile); fileErr != nil {
+			return fileErr
 		}
 	}
 	return nil

--- a/test/e2e/framework/context_create_operations.go
+++ b/test/e2e/framework/context_create_operations.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
 
 // ContextCreateOps helps to run context create command
@@ -32,16 +34,14 @@ func NewContextCreateOps() ContextCreateOps {
 	}
 }
 
-const FailedToCreateContext = "failed to create context"
-const FailedToCreateContextWithStdout = FailedToCreateContext + ", stdout:%s"
-
 func (cc *contextCreateOps) CreateConextWithEndPoint(contextName, endpoint string) error {
 	createContextCmd := fmt.Sprintf(CreateContextWithEndPoint, endpoint, contextName)
 	out, _, err := cc.cmdExe.Exec(createContextCmd)
 	if err != nil {
+		log.Info(fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
 		return errors.Wrap(err, fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
 	}
-
+	log.Infof(ContextCreated, contextName)
 	return err
 }
 
@@ -49,8 +49,10 @@ func (cc *contextCreateOps) CreateConextWithEndPointStaging(contextName, endpoin
 	createContextCmd := fmt.Sprintf(CreateContextWithEndPointStaging, endpoint, contextName)
 	out, _, err := cc.cmdExe.Exec(createContextCmd)
 	if err != nil {
+		log.Info(fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
 		return errors.Wrap(err, fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
 	}
+	log.Infof(ContextCreated, contextName)
 	return err
 }
 
@@ -58,8 +60,10 @@ func (cc *contextCreateOps) CreateConextWithKubeconfig(contextName, kubeconfigPa
 	createContextCmd := fmt.Sprintf(CreateContextWithKubeconfigFile, kubeconfigPath, kubeContext, contextName)
 	out, _, err := cc.cmdExe.Exec(createContextCmd)
 	if err != nil {
+		log.Info(fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
 		return errors.Wrap(err, fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
 	}
+	log.Infof(ContextCreated, contextName)
 	return err
 }
 
@@ -67,7 +71,9 @@ func (cc *contextCreateOps) CreateContextWithDefaultKubeconfig(contextName, kube
 	createContextCmd := fmt.Sprintf(CreateContextWithDefaultKubeconfigFile, kubeContext, contextName)
 	out, _, err := cc.cmdExe.Exec(createContextCmd)
 	if err != nil {
+		log.Info(fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
 		return errors.Wrap(err, fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
 	}
+	log.Infof(ContextCreated, contextName)
 	return err
 }

--- a/test/e2e/framework/context_lifecycle_operations.go
+++ b/test/e2e/framework/context_lifecycle_operations.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
 
 // ContextCmdOps helps to run Context lifecycle operations
@@ -38,8 +40,6 @@ func NewContextCmdOps() ContextCmdOps {
 		ContextCreateOps: NewContextCreateOps(),
 	}
 }
-
-const FailedToDeleteContext = "failed to delete context"
 
 func (cc *contextCmdOps) UseContext(contextName string) error {
 	useContextCmd := fmt.Sprintf(UseContext, contextName)
@@ -87,7 +87,9 @@ func (cc *contextCmdOps) DeleteContext(contextName string) error {
 	deleteContextCmd := fmt.Sprintf(DeleteContext, contextName)
 	stdOut, stdErr, err := cc.cmdExe.Exec(deleteContextCmd)
 	if err != nil {
+		log.Infof("failed to delete context:%s", contextName)
 		return errors.Wrapf(err, FailedToDeleteContext+", stderr:%s stdout:%s , ", stdErr.String(), stdOut.String())
 	}
+	log.Infof(ContextCreated, contextName)
 	return err
 }

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -96,6 +96,14 @@ const (
 	ErrorLogForCommandWithErrAndStdErr            = "error while executing command:'%s', error:'%s' stdErr:'%s'"
 	FailedToConstructJSONNodeFromOutputAndErrInfo = "failed to construct json node from output:'%s' error:'%s' "
 	FailedToConstructJSONNodeFromOutput           = "failed to construct json node from output:'%s'"
+
+	// config related constants
+	FailedToCreateContext           = "failed to create context"
+	FailedToCreateContextWithStdout = FailedToCreateContext + ", stdout:%s"
+	ContextCreated                  = "context %s created successfully"
+	ContextDeleted                  = "context %s deleted successfully"
+	ConfigServerDeleted             = "config server %s deleted successfully"
+	FailedToDeleteContext           = "failed to delete context"
 )
 
 var (


### PR DESCRIPTION
### What this PR does / why we need it
This PR is to update the config and context test cases; here are the updates:

- Deletes contexts if any, before running actual test cases
- Deletes servers if any, before running actual test cases
- Validate the context/server being created after create 
- Validate the context/server being deleted after delete


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
Config and Context tests executed locally:
```
1. Get this PR code and build it
2. Update path for tanzu binary: 
❯ export PATH=/Users/cpamuluri/tkg/tasks/e2e_tests/pluginGroupTests/latest2/tanzu-cli/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Library/Apple/usr/bin:/Users/cpamuluri/.fig/bin:/Users/cpamuluri/.local/bin
❯ export TANZU_API_TOKEN=<tmc token>
❯ export TANZU_CLI_TMC_UNSTABLE_URL=unstable.tmc-dev.cloud.vmware.com
❯ go test /Users/cpamuluri/tkg/tasks/e2e_tests/pluginGroupTests/latest2/tanzu-cli/test/e2e/config -timeout 60m -race -coverprofile coverage.txt  -v
=== RUN   TestConfig
Running Suite: Config Suite
===========================
Random Seed: 1679589213
Will run 10 of 10 specs

[i] Executing command: docker info
[i] Executing command: kind create cluster --name config-e2e-2022
[i] Executing command: docker info
[i] Executing command: tanzu config server list -o json
[i] Executing command: tanzu config server list -o json
•[i] Executing command: tanzu context create --kubeconfig /Users/cpamuluri/.tanzu-cli-e2e/.kube/config --kubecontext kind-config-e2e-2022 --name config-k8s-kSbk
•[i] Executing command: tanzu context create --kubecontext kind-config-e2e-2022 --name context-defaultConfig-xE6o
•[i] Executing command: tanzu config server list -o json
•[i] Executing command: tanzu config server delete config-k8s-kSbk -y
[i] Executing command: tanzu config server delete context-defaultConfig-xE6o -y
[i] Executing command: tanzu config server list -o json
•[i] Executing command: tanzu config server delete crFu -y
[x] error while running: tanzu config server delete crFu -y: error while running 'tanzu config server delete crFu -y', stdOut: , stdErr: [i] Deleting entry for cluster crFu
[x] : server crFu not found in list of known servers
%!(EXTRA *exec.ExitError=exit status 1)
•[i] Executing command: tanzu config set features.global.e2e-test-cYhm true
[i] Executing command: tanzu config get 
[i] Executing command: tanzu config unset features.global.e2e-test-cYhm
[i] Executing command: tanzu config get 
•[i] Executing command: tanzu config init
•[i] Executing command: tanzu config set features.global.e2e-test-jzM8 true
[i] Executing command: tanzu config get 
•[i] Executing command: tanzu config init
[i] Executing command: tanzu config get 
[i] Executing command: tanzu config unset features.global.e2e-test-jzM8
•[i] Executing command: docker info
[i] Executing command: kind delete cluster --name config-e2e-2022

Ran 10 of 10 Specs in 23.864 seconds
SUCCESS! -- 10 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestConfig (23.88s)
PASS
coverage: [no statements]
ok      github.com/vmware-tanzu/tanzu-cli/test/e2e/config       24.117s coverage: [no statements]
❯ go test /Users/cpamuluri/tkg/tasks/e2e_tests/pluginGroupTests/latest2/tanzu-cli/test/e2e/context -timeout 60m -race -coverprofile coverage.txt  -v
=== RUN   TestContext
Running Suite: Context-K8S Suite
================================
Random Seed: 1679589437
Will run 10 of 10 specs

[i] Executing command: docker info
[i] Executing command: kind create cluster --name context-e2e-7770
[i] Executing command: docker info
[i] Executing command: tanzu context list -o json
[i] Executing command: tanzu context list -o json
•[i] Executing command: tanzu context create --kubeconfig /Users/cpamuluri/.tanzu-cli-e2e/.kube/config --kubecontext kind-context-e2e-7770 --name context-config-k8s-BFtW
•[i] Executing command: tanzu context create --kubeconfig oAKF --kubecontext kind-context-e2e-7770 --name context-config-k8s-t3p3
•[i] Executing command: tanzu context create --kubeconfig /Users/cpamuluri/.tanzu-cli-e2e/.kube/config --kubecontext XiGS --name context-config-k8s-7W3o
•[i] Executing command: tanzu context create --kubecontext kind-context-e2e-7770 --name context-defaultConfig-D5VJ
[i] Executing command: tanzu context list -o json
•[i] Executing command: tanzu context use context-config-k8s-BFtW
[i] Executing command: tanzu context list -o json
•[i] Executing command: tanzu context use KS1v
•[i] Executing command: tanzu context list -o json
•[i] Executing command: tanzu context delete context-config-k8s-BFtW --yes
[i] Executing command: tanzu context delete context-defaultConfig-D5VJ --yes
[i] Executing command: tanzu context list -o json
•[i] Executing command: tanzu context delete o9p7 --yes
•[i] Executing command: docker info
[i] Executing command: kind delete cluster --name context-e2e-7770

Ran 10 of 10 Specs in 24.369 seconds
SUCCESS! -- 10 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestContext (24.38s)
PASS
coverage: 65.4% of statements
ok      github.com/vmware-tanzu/tanzu-cli/test/e2e/context      24.622s coverage: 65.4% of statements
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
