### PR TITLE
"plugin search" should only discovers from central repos

### DIFF
--- a/pkg/pluginmanager/manager_test.go
+++ b/pkg/pluginmanager/manager_test.go
@@ -1469,9 +1469,9 @@ func TestMergeDuplicatePlugins(t *testing.T) {
 			Name:               "myplugin",
 			Target:             configtypes.TargetK8s,
 			Description:        "Second description",
-			RecommendedVersion: "v1.1.1",
-			InstalledVersion:   "v1.1.1",
-			SupportedVersions:  []string{"v0.1.0", "v1.1.1"},
+			RecommendedVersion: "v3.3.3",
+			InstalledVersion:   "v0.1.0",
+			SupportedVersions:  []string{"v0.1.0", "v3.3.3"},
 			Distribution: distribution.Artifacts{
 				"v0.1.0": []distribution.Artifact{
 					{
@@ -1493,22 +1493,22 @@ func TestMergeDuplicatePlugins(t *testing.T) {
 						Arch:   "amd64",
 					},
 				},
-				"v1.1.1": []distribution.Artifact{
+				"v3.3.3": []distribution.Artifact{
 					{
-						Image:  "localhost:9876/my/discovery/darwin_amd64:v1.1.1",
-						Digest: "digest111damd",
+						Image:  "localhost:9876/my/discovery/darwin_amd64:v3.3.3",
+						Digest: "digest333damd",
 						OS:     "darwin",
 						Arch:   "amd64",
 					},
 					{
-						Image:  "localhost:9876/my/discovery/darwin_arm64:v1.1.1",
-						Digest: "digest111damd",
+						Image:  "localhost:9876/my/discovery/darwin_arm64:v3.3.3",
+						Digest: "digest333darm",
 						OS:     "darwin",
 						Arch:   "arm64",
 					},
 					{
-						Image:  "localhost:9876/my/discovery/linux_amd64:v1.1.1",
-						Digest: "digest111lamd",
+						Image:  "localhost:9876/my/discovery/linux_amd64:v3.3.3",
+						Digest: "digest333lamd",
 						OS:     "linux",
 						Arch:   "amd64",
 					},
@@ -1527,9 +1527,9 @@ func TestMergeDuplicatePlugins(t *testing.T) {
 		Name:               "myplugin",
 		Target:             configtypes.TargetK8s,
 		Description:        "First description",
-		RecommendedVersion: "v2.2.2",
-		InstalledVersion:   "v1.1.1",
-		SupportedVersions:  []string{"v0.1.0", "v1.1.1", "v2.2.2"},
+		RecommendedVersion: "v3.3.3",
+		InstalledVersion:   "v0.1.0",
+		SupportedVersions:  []string{"v0.1.0", "v2.2.2", "v3.3.3"},
 		Distribution: distribution.Artifacts{
 			"v0.1.0": []distribution.Artifact{
 				{
@@ -1551,26 +1551,6 @@ func TestMergeDuplicatePlugins(t *testing.T) {
 					Arch:   "amd64",
 				},
 			},
-			"v1.1.1": []distribution.Artifact{
-				{
-					Image:  "localhost:9876/my/discovery/darwin_amd64:v1.1.1",
-					Digest: "digest111damd",
-					OS:     "darwin",
-					Arch:   "amd64",
-				},
-				{
-					Image:  "localhost:9876/my/discovery/darwin_arm64:v1.1.1",
-					Digest: "digest111damd",
-					OS:     "darwin",
-					Arch:   "arm64",
-				},
-				{
-					Image:  "localhost:9876/my/discovery/linux_amd64:v1.1.1",
-					Digest: "digest111lamd",
-					OS:     "linux",
-					Arch:   "amd64",
-				},
-			},
 			"v2.2.2": []distribution.Artifact{
 				{
 					Image:  "localhost:9876/my/discovery/darwin_amd64:v2.2.2",
@@ -1587,6 +1567,26 @@ func TestMergeDuplicatePlugins(t *testing.T) {
 				{
 					Image:  "localhost:9876/my/discovery/linux_amd64:v2.2.2",
 					Digest: "digest222lamd",
+					OS:     "linux",
+					Arch:   "amd64",
+				},
+			},
+			"v3.3.3": []distribution.Artifact{
+				{
+					Image:  "localhost:9876/my/discovery/darwin_amd64:v3.3.3",
+					Digest: "digest333damd",
+					OS:     "darwin",
+					Arch:   "amd64",
+				},
+				{
+					Image:  "localhost:9876/my/discovery/darwin_arm64:v3.3.3",
+					Digest: "digest333darm",
+					OS:     "darwin",
+					Arch:   "arm64",
+				},
+				{
+					Image:  "localhost:9876/my/discovery/linux_amd64:v3.3.3",
+					Digest: "digest333lamd",
 					OS:     "linux",
 					Arch:   "amd64",
 				},

--- a/test/e2e/framework/framework_helper.go
+++ b/test/e2e/framework/framework_helper.go
@@ -86,7 +86,7 @@ func GetHomeDir() string {
 }
 
 // ExecuteCmdAndBuildJSONOutput is generic function to execute given command and build JSON output and return
-func ExecuteCmdAndBuildJSONOutput[T PluginInfo | PluginGroup | PluginSourceInfo | configapi.ClientConfig | Server | ContextListInfo](cmdExe CmdOps, cmd string) ([]*T, error) {
+func ExecuteCmdAndBuildJSONOutput[T PluginInfo | PluginSearch | PluginGroup | PluginSourceInfo | configapi.ClientConfig | Server | ContextListInfo](cmdExe CmdOps, cmd string) ([]*T, error) {
 	out, stdErr, err := cmdExe.Exec(cmd)
 
 	if err != nil {

--- a/test/e2e/framework/output_handling.go
+++ b/test/e2e/framework/output_handling.go
@@ -13,6 +13,13 @@ type PluginInfo struct {
 	Version     string `json:"version"`
 }
 
+type PluginSearch struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Target      string `json:"target"`
+	Latest      string `json:"latest"`
+}
+
 type PluginGroup struct {
 	Group string `json:"group"`
 }

--- a/test/e2e/framework/plugin_lifecycle_operations.go
+++ b/test/e2e/framework/plugin_lifecycle_operations.go
@@ -114,7 +114,21 @@ func (po *pluginCmdOps) SearchPlugins(filter string) ([]*PluginInfo, error) {
 	if len(strings.TrimSpace(filter)) > 0 {
 		searchPluginCmdWithOptions = searchPluginCmdWithOptions + " " + strings.TrimSpace(filter)
 	}
-	return ExecuteCmdAndBuildJSONOutput[PluginInfo](po.cmdExe, searchPluginCmdWithOptions+JSONOutput)
+	result, err := ExecuteCmdAndBuildJSONOutput[PluginSearch](po.cmdExe, searchPluginCmdWithOptions+JSONOutput)
+	if err != nil {
+		return nil, err
+	}
+	// Convert from PluginSearch to PluginInfo
+	var plugins []*PluginInfo
+	for _, p := range result {
+		plugins = append(plugins, &PluginInfo{
+			Name:        p.Name,
+			Description: p.Description,
+			Target:      p.Target,
+			Version:     p.Latest,
+		})
+	}
+	return plugins, nil
 }
 
 func (po *pluginCmdOps) SearchPluginGroups(flagsWithValues string) ([]*PluginGroup, error) {


### PR DESCRIPTION
### What this PR does / why we need it

After discussion, we have decided that "plugin search" should:
- not show the status or the context
- only show plugins found in the central repo (not ones discovered from a context

So the columns should be :
```
NAME
DESCRIPTION
TARGET
LATEST VERSION. (I have changed this to just LATEST for the sake of space)
```
So this commit makes the "plugin search" command no longer show context-scope plugins which are not part of the central repositories.
Also the "plugin search" command no longer shows status or context information, which is the responsibility of the "plugin list" command.

### Describe testing done for PR

```
# Reset first
$ rm ~/.config/tanzu/config*
$ tz plugin clean
[ok] successfully cleaned up all plugins
$
$ tz config set env.TANZU_CLI_PRE_RELEASE_REPO_IMAGE localhost:9876/tanzu-cli/plugins/central:small
$ make start-test-central-repo
[...]

# Notice the new output
$ tz plugin search
  NAME                DESCRIPTION                  TARGET           LATEST
  isolated-cluster    Desc for isolated-cluster    global           v9.9.9
  pinniped-auth       Desc for pinniped-auth       global           v9.9.9
[...]
  secret              Desc for secret              mission-control  v9.9.9
  tanzupackage        Desc for tanzupackage        mission-control  v9.9.9
  workspace           Desc for workspace           mission-control  v9.9.9

# Create a context which installs plugins with version v0.0.1
$ tz context create --name k3d --kubecontext k3d --kubeconfig /Users/kmarc/.kube/config.k3d
[ok] successfully created a kubernetes context using the kubeconfig /Users/kmarc/.kube/config.k3d
[i] Checking for required plugins...
[i] Installing plugin 'cluster:v0.0.1' with target 'kubernetes'
[i] Installing plugin 'feature:v0.0.1' with target 'kubernetes'
[i] Installing plugin 'kubernetes-release:v0.0.1' with target 'kubernetes'
[i] Installing plugin 'package:v0.0.1' with target 'kubernetes'
[i] Successfully installed all required plugins

# Notice that the LATEST version column shows the content of the central repo
# not what is installed
tz plugin search
  NAME                DESCRIPTION                  TARGET           LATEST
  isolated-cluster    Desc for isolated-cluster    global           v9.9.9
  pinniped-auth       Desc for pinniped-auth       global           v9.9.9
  cluster             Desc for cluster             kubernetes       v9.9.9
  feature             Desc for feature             kubernetes       v9.9.9
  kubernetes-release  Desc for kubernetes-release  kubernetes       v9.9.9
  management-cluster  Desc for management-cluster  kubernetes       v9.9.9
  package             Desc for package             kubernetes       v9.9.9
  secret              Desc for secret              kubernetes       v9.9.9
  telemetry           Desc for telemetry           kubernetes       v9.9.9
  account             Desc for account             mission-control  v9.9.9
  apply               Desc for apply               mission-control  v9.9.9
[...]
  workspace           Desc for workspace           mission-control  v9.9.9

# Add a test repo that contains newer v11.11.11 versions
$ tz config set env.TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY localhost:9876/tanzu-cli/plugins/sandbox1:small

# Notice the output show the latest available version
$ tz plugin search
  NAME                DESCRIPTION                  TARGET           LATEST
  isolated-cluster    Desc for isolated-cluster    global           v9.9.9
  pinniped-auth       Desc for pinniped-auth       global           v9.9.9
  cluster             Desc for cluster             kubernetes       v11.11.11
  feature             Desc for feature             kubernetes       v11.11.11
  kubernetes-release  Desc for kubernetes-release  kubernetes       v11.11.11
  management-cluster  Desc for management-cluster  kubernetes       v11.11.11
  package             Desc for package             kubernetes       v11.11.11
  secret              Desc for secret              kubernetes       v11.11.11
  telemetry           Desc for telemetry           kubernetes       v11.11.11
  account             Desc for account             mission-control  v11.11.11
  apply               Desc for apply               mission-control  v11.11.11
[...]
  tanzupackage        Desc for tanzupackage        mission-control  v11.11.11
  workspace           Desc for workspace           mission-control  v11.11.11

# Add two test repos that contains newer v11.11.11 and v22.22.22 versions
$ tz config set env.TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY localhost:9876/tanzu-cli/plugins/sandbox1:small,localhost:9876/tanzu-cli/plugins/sandbox2:small

# Notice the v22.22.22 now showing since it is the latest
$ tz plugin search
  NAME                DESCRIPTION                  TARGET           LATEST
  isolated-cluster    Desc for isolated-cluster    global           v9.9.9
  pinniped-auth       Desc for pinniped-auth       global           v9.9.9
  cluster             Desc for cluster             kubernetes       v22.22.22
  feature             Desc for feature             kubernetes       v22.22.22
  kubernetes-release  Desc for kubernetes-release  kubernetes       v22.22.22
  management-cluster  Desc for management-cluster  kubernetes       v22.22.22
  package             Desc for package             kubernetes       v22.22.22
  secret              Desc for secret              kubernetes       v22.22.22
  telemetry           Desc for telemetry           kubernetes       v22.22.22
  account             Desc for account             mission-control  v22.22.22
[...]
  tanzupackage        Desc for tanzupackage        mission-control  v22.22.22
  workspace           Desc for workspace           mission-control  v22.22.22

$ tz plugin search -o yaml
- description: Desc for isolated-cluster
  latest: v9.9.9
  name: isolated-cluster
  target: global
- description: Desc for pinniped-auth
  latest: v9.9.9
  name: pinniped-auth
  target: global
- description: Desc for cluster
  latest: v9.9.9
  name: cluster
  target: kubernetes
- description: Desc for feature
  latest: v9.9.9
  name: feature
  target: kubernetes
- description: Desc for kubernetes-release
  latest: v9.9.9
  name: kubernetes-release
  target: kubernetes
- description: Desc for management-cluster
  latest: v9.9.9
  name: management-cluster
  target: kubernetes
- description: Desc for package
  latest: v9.9.9
  name: package
  target: kubernetes
- description: Desc for secret
  latest: v9.9.9
  name: secret
  target: kubernetes
- description: Desc for telemetry
  latest: v9.9.9
  name: telemetry
  target: kubernetes
- description: Desc for account
  latest: v9.9.9
  name: account
  target: mission-control
[...]
- description: Desc for tanzupackage
  latest: v9.9.9
  name: tanzupackage
  target: mission-control
- description: Desc for workspace
  latest: v9.9.9
  name: workspace
  target: mission-control

# Use plugin search with a local repo
# Notice that only what is discovered is shown, not what is installed (compared to plugin list below)
$ tz plugin search --local ~/.config/tanzu-plugins/
  NAME                DESCRIPTION                                                        TARGET      LATEST
  builder             Build Tanzu components                                                         v0.29.0-dev
  codegen             Tanzu code generation tool                                                     v0.29.0-dev
  isolated-cluster    Prepopulating images/bundle for internet-restricted environments               v0.29.0-dev
  login               Login to the platform                                                          v0.29.0-dev
  pinniped-auth       Pinniped authentication operations (usually not directly invoked)              v0.29.0-dev
  test                Test the CLI                                                                   v0.29.0-dev
  cluster             Kubernetes cluster operations                                      kubernetes  v0.29.0-dev
  feature             Operate on features and featuregates                               kubernetes  v0.29.0-dev
  kubernetes-release  Kubernetes release operations                                      kubernetes  v0.29.0-dev
  management-cluster  Kubernetes management cluster operations                           kubernetes  v0.29.0-dev
  package             Tanzu package management                                           kubernetes  v0.29.0-dev
  secret              Tanzu secret management                                            kubernetes  v0.29.0-dev
  telemetry           configure cluster-wide settings for vmware tanzu telemetry         kubernetes  v0.29.0-dev
$ tz plugin list
Standalone Plugins
  NAME  DESCRIPTION  TARGET  VERSION  STATUS

Plugins from Context:  k3d
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v0.0.1   installed
  feature             Operate on features and featuregates  kubernetes  v0.0.1   installed
  kubernetes-release  Kubernetes release operations         kubernetes  v0.0.1   installed
  package             Operate on packages                   kubernetes  v0.0.1   installed

$ tz plugin search --local ~/.config/tanzu-plugins/ -o json
[
  {
    "description": "Build Tanzu components",
    "latest": "v0.29.0-dev",
    "name": "builder",
    "target": ""
  },
  {
    "description": "Tanzu code generation tool",
    "latest": "v0.29.0-dev",
    "name": "codegen",
    "target": ""
  },
  {
    "description": "Prepopulating images/bundle for internet-restricted environments",
    "latest": "v0.29.0-dev",
    "name": "isolated-cluster",
    "target": ""
  },
  {
    "description": "Login to the platform",
    "latest": "v0.29.0-dev",
    "name": "login",
    "target": ""
  },
  {
    "description": "Pinniped authentication operations (usually not directly invoked)",
    "latest": "v0.29.0-dev",
    "name": "pinniped-auth",
    "target": ""
  },
  {
    "description": "Test the CLI",
    "latest": "v0.29.0-dev",
    "name": "test",
    "target": ""
  },
  {
    "description": "Kubernetes cluster operations",
    "latest": "v0.29.0-dev",
    "name": "cluster",
    "target": "kubernetes"
  },
  {
    "description": "Operate on features and featuregates",
    "latest": "v0.29.0-dev",
    "name": "feature",
    "target": "kubernetes"
  },
  {
    "description": "Kubernetes release operations",
    "latest": "v0.29.0-dev",
    "name": "kubernetes-release",
    "target": "kubernetes"
  },
  {
    "description": "Kubernetes management cluster operations",
    "latest": "v0.29.0-dev",
    "name": "management-cluster",
    "target": "kubernetes"
  },
  {
    "description": "Tanzu package management",
    "latest": "v0.29.0-dev",
    "name": "package",
    "target": "kubernetes"
  },
  {
    "description": "Tanzu secret management",
    "latest": "v0.29.0-dev",
    "name": "secret",
    "target": "kubernetes"
  },
  {
    "description": "configure cluster-wide settings for vmware tanzu telemetry",
    "latest": "v0.29.0-dev",
    "name": "telemetry",
    "target": "kubernetes"
  }
]
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The "tanzu plugin search" command no longer shows installation status or context information; the "tanzu plugin list" command should be used to obtain such information"
```

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
