### PR TITLE
Hide the "plugin source" commands and deprecate "config server"

### DIFF
--- a/pkg/command/config.go
+++ b/pkg/command/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/command"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/component"
 	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
@@ -39,6 +40,7 @@ func init() {
 	)
 	serversCmd.AddCommand(listServersCmd)
 	addDeleteServersCmd()
+	command.DeprecateCommandWithAlternative(serversCmd, "1.2.0", "context")
 }
 
 var unattended bool

--- a/pkg/command/discovery_source.go
+++ b/pkg/command/discovery_source.go
@@ -28,9 +28,11 @@ var (
 
 func newDiscoverySourceCmd() *cobra.Command {
 	var discoverySourceCmd = &cobra.Command{
-		Use:   "source",
-		Short: "Manage plugin discovery sources",
-		Long:  "Manage plugin discovery sources. Discovery source provides metadata about the list of available plugins, their supported versions and how to download them.",
+		Use: "source",
+		// TODO(khouzam): not to be used for the alpha.0 release, but will be re-added after
+		Hidden: true,
+		Short:  "Manage plugin discovery sources",
+		Long:   "Manage plugin discovery sources. Discovery source provides metadata about the list of available plugins, their supported versions and how to download them.",
 	}
 	discoverySourceCmd.SetUsageFunc(cli.SubCmdUsageFunc)
 

--- a/pkg/command/login.go
+++ b/pkg/command/login.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
 
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/command"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/component"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
@@ -54,8 +55,8 @@ func init() {
 	loginCmd.Flags().MarkHidden("force-csp")   // nolint
 	loginCmd.Flags().MarkHidden("staging")     // nolint
 	loginCmd.SetUsageFunc(cli.SubCmdUsageFunc)
-	msg := fmt.Sprintf("will be removed in version %q. Use the %q command instead.", "1.2.0", "context")
-	loginCmd.Deprecated = msg
+	command.DeprecateCommandWithAlternative(loginCmd, "1.2.0", "context")
+
 	loginCmd.Example = `
 	# Login to TKG management cluster using endpoint
 	tanzu login --endpoint "https://login.example.com"  --name mgmt-cluster


### PR DESCRIPTION
### What this PR does / why we need it

For the alpha.0 release of the CLI, plugin discovery sources are not used to configure the Central Repository.

This commit hides the commands to avoid any confusion. These commands were not really used before anyway, so this should not even be noticed by alpha.0 users.

Plugin discovery sources will be enhanced and re-enabled after the alpha.0 release.

Further, the second commit deprecates the "config server" set of commands as they have been replaced with the concept of "context" and the corresponding "context" commands.  Notice that "tanzu login" has already been deprecated in the same fashion.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes N/A

### Describe testing done for PR

Test for `tanzu plugin source`:
```
# Notice the "source" command is no longer shown under "tanzu plugin"
$ tz plugin -h
Manage CLI plugins

Usage:
  tanzu plugin [command]

Available Commands:
  clean       Clean the plugins
  delete      Delete a plugin
  describe    Describe a plugin
  group       Manage plugin groups
  install     Install a plugin
  list        List available plugins
  search      Search for a keyword or regex in the list of available plugins
  sync        Sync the plugins
  upgrade     Upgrade a plugin

Flags:
  -h, --help   help for plugin

Use "tanzu plugin [command] --help" for more information about a command.

# Notice the "plugin source" command is still accessible
$ tz plugin source -h
Manage plugin discovery sources. Discovery source provides metadata about the list of available plugins, their supported versions and how to download them.

Usage:
  tanzu plugin source [command]

Available Commands:
  add         Add a discovery source
  delete      Delete a discovery source
  list        List available discovery sources
  update      Update a discovery source configuration

Flags:
  -h, --help   help for source

Use "tanzu plugin source [command] --help" for more information about a command.

# Notice the "plugin source" subcommand are still functional
$ tz plugin source list
  NAME  TYPE  SCOPE
```

Test for `tanzu config server`:
```
# Command "config server" is hidden
tz config -h
Configuration for the CLI

Usage:
  tanzu config [command]

Available Commands:
  get         Get the current configuration
  init        Initialize config with defaults
  set         Set config values at the given path
  unset       Unset config values at the given path

Flags:
  -h, --help   help for config

Use "tanzu config [command] --help" for more information about a command.

# Command still accessible
$  tz config server
Command "server" is deprecated, will be removed in version "1.2.0". Use the "context" set of commands instead.
Configured servers

Usage:
  tanzu config server [command]

Available Commands:
  delete      Delete a server from the config
  list        List servers

Flags:
  -h, --help   help for server

Use "tanzu config server [command] --help" for more information about a command.

# Command works
$ tz config server list
  NAME  TYPE               ENDPOINT  PATH                                    CONTEXT
  tkg1  managementcluster            /Users/kmarc/.k3d/kubeconfig-tkg1.yaml  tkg1
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The `plugin source` commands are hidden since they have no effect at the moment.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
