### PR TITLE
Update OS Package recipes for the new repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,10 +152,7 @@ apt-package: ## Build a debian package to use with APT
 		echo "Docker required to build apt package" ;\
 		exit 1 ;\
 	fi
-
-	@# To call this target, the VERSION variable must be set by the caller.  The version must match an existing release
-	@# of the tanzu CLI on Github. E.g., VERSION=v0.26.0 make apt-package
-	docker run --rm -e VERSION=$${VERSION} -v $(ROOT_DIR):$(ROOT_DIR) ubuntu $(ROOT_DIR)/hack/apt/build_package.sh
+	docker run --rm -e VERSION=$(BUILD_VERSION) -v $(ROOT_DIR):$(ROOT_DIR) ubuntu $(ROOT_DIR)/hack/apt/build_package.sh
 
 .PHONY: rpm-package
 rpm-package: ## Build an RPM package
@@ -163,10 +160,7 @@ rpm-package: ## Build an RPM package
 		echo "Docker required to build rpm package" ;\
 		exit 1 ;\
 	fi
-
-	@# To call this target, the VERSION variable must be set by the caller.  The version must match an existing release
-	@# of the tanzu CLI on Github. E.g., VERSION=v0.26.0 make rpm-package
-	docker run --rm -e VERSION=$${VERSION} -v $(ROOT_DIR):$(ROOT_DIR) fedora $(ROOT_DIR)/hack/rpm/build_package.sh
+	docker run --rm -e VERSION=$(BUILD_VERSION) -v $(ROOT_DIR):$(ROOT_DIR) fedora $(ROOT_DIR)/hack/rpm/build_package.sh
 
 .PHONY: choco-package
 choco-package: ## Build a Chocolatey package
@@ -180,10 +174,7 @@ choco-package: ## Build a Chocolatey package
 		echo "Can only build chocolatey package on an amd64 machine at the moment" ;\
 		exit 1 ;\
 	fi
-
-	@# To call this target, the VERSION variable must be set by the caller.  The version must match an existing release
-	@# of the tanzu CLI on Github. E.g., VERSION=v0.26.0 make choco-package
-	docker run --rm -e VERSION=$${VERSION} -v $(ROOT_DIR):$(ROOT_DIR) chocolatey/choco $(ROOT_DIR)/hack/choco/build_package.sh
+	docker run --rm -e VERSION=$(BUILD_VERSION) -v $(ROOT_DIR):$(ROOT_DIR) chocolatey/choco $(ROOT_DIR)/hack/choco/build_package.sh
 
 ## --------------------------------------
 ## Testing

--- a/hack/apt/README.md
+++ b/hack/apt/README.md
@@ -28,7 +28,7 @@ or using a docker container. For example:
 ```bash
 $ cd tanzu-cli
 $ docker run --rm -it -v $(pwd)/hack/apt/_output/apt:/tmp/apt ubuntu
-echo "deb file:///tmp/apt jessie main" | tee /etc/apt/sources.list.d/tanzu.list
+echo "deb file:///tmp/apt tanzu-cli-jessie main" | tee /etc/apt/sources.list.d/tanzu.list
 apt-get update --allow-insecure-repositories
 apt install -y tanzu-cli --allow-unauthenticated
 tanzu
@@ -54,7 +54,7 @@ To install from an insecure repo:
 $ docker run --rm -it ubuntu
 apt update
 apt install -y ca-certificates
-echo "deb https://storage.googleapis.com/tanzu-cli-os-packages/apt jessie main" | tee /etc/apt/sources.list.d/tanzu.list
+echo "deb https://storage.googleapis.com/tanzu-cli-os-packages/apt tanzu-cli-jessie main" | tee /etc/apt/sources.list.d/tanzu.list
 apt update --allow-insecure-repositories
 apt install -y tanzu-cli --allow-unauthenticated
 ```

--- a/hack/apt/build_package.sh
+++ b/hack/apt/build_package.sh
@@ -31,7 +31,7 @@ rm -rf ${OUTPUT_DIR}
 
 # Prepare repository that will be published
 mkdir -p ${OUTPUT_DIR}/apt/conf
-echo "Codename: jessie
+echo "Codename: tanzu-cli-jessie
 Components: main
 Architectures: amd64 arm64" \
    > ${OUTPUT_DIR}/apt/conf/distributions 
@@ -47,12 +47,12 @@ for arch in amd64 arm64; do
    # For now, we don't have an ARM64 build, so we get the AMD64 one and use it for ARM64.
    # This is for Apple M1 machines which normally have an emulator.
    # TODO: Replace all instances of "amd64" with "${arch}"
-   curl -sLo tanzu-cli-linux-${arch}.tar.gz https://github.com/vmware-tanzu/tanzu-framework/releases/download/v${VERSION}/tanzu-cli-linux-amd64.tar.gz
+   curl -sLo tanzu-cli-linux-${arch}.tar.gz https://github.com/vmware-tanzu/tanzu-cli/releases/download/v${VERSION}/tanzu-cli-linux-amd64.tar.gz
 
-   tar xzf tanzu-cli-linux-${arch}.tar.gz --strip-components=1 v${VERSION}/tanzu-core-linux_amd64
-   mv tanzu-core-linux_amd64 ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}/usr/bin/tanzu
+   tar xzf tanzu-cli-linux-${arch}.tar.gz --strip-components=1 v${VERSION}/tanzu-cli-linux_amd64
+   mv tanzu-cli-linux_amd64 ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}/usr/bin/tanzu
 
-# Create the control file
+   # Create the control file
    mkdir -p ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}/DEBIAN
    echo "Package: tanzu-cli
 Version: ${VERSION}
@@ -60,18 +60,22 @@ Maintainer: Tanzu CLI project team
 Architecture: ${arch}
 Section: main
 Priority: optional
-Homepage: https://github.com/vmware-tanzu/tanzu-cli/
-Description: The tanzu CLI" \
+Homepage: https://github.com/vmware-tanzu/tanzu-cli
+Description: The core Tanzu CLI" \
       > ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}/DEBIAN/control
 
    # Create the .deb package
    dpkg-deb --build -Zgzip ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}
 
    # Create repository
-   reprepro -b ${OUTPUT_DIR}/apt includedeb jessie ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}.deb
+   reprepro -b ${OUTPUT_DIR}/apt includedeb tanzu-cli-jessie ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}.deb
 
    # Cleanup
    rm -f tanzu-cli-linux-${arch}.tar.gz
    rm -f ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}.deb
    rm -rf ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}
 done
+
+# Global cleanup
+rm -rf ${OUTPUT_DIR}/apt/conf
+rm -rf ${OUTPUT_DIR}/apt/db

--- a/hack/rpm/README.md
+++ b/hack/rpm/README.md
@@ -32,7 +32,7 @@ docker run --rm -it -v $(pwd)/hack/rpm/_output/rpm:/tmp/rpm fedora
 cat << EOF | sudo tee /etc/yum.repos.d/tanzu-cli.repo
 [tanzu-cli]
 name=Tanzu CLI
-baseurl=file:///tmp/rpm
+baseurl=file:///tmp/rpm/tanzu-cli
 enabled=1
 gpgcheck=0
 EOF
@@ -61,7 +61,7 @@ docker run --rm -it fedora
 cat << EOF | sudo tee /etc/yum.repos.d/tanzu-cli.repo
 [tanzu-cli]
 name=Tanzu CLI
-baseurl=https://storage.googleapis.com/tanzu-cli-os-packages/rpm
+baseurl=https://storage.googleapis.com/tanzu-cli-os-packages/rpm/tanzu-cli
 enabled=1
 gpgcheck=0
 EOF

--- a/hack/rpm/build_package.sh
+++ b/hack/rpm/build_package.sh
@@ -27,7 +27,7 @@ fi
 VERSION=${VERSION#v}
 
 BASE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}"); pwd)
-OUTPUT_DIR=${BASE_DIR}/_output/rpm
+OUTPUT_DIR=${BASE_DIR}/_output/rpm/tanzu-cli
 
 # Install build dependencies
 $DNF install -y rpmdevtools rpmlint createrepo
@@ -40,9 +40,12 @@ mkdir -p ${HOME}/rpmbuild/SOURCES
 # Create the .rpm packages
 rm -rf ${OUTPUT_DIR}
 mkdir -p ${OUTPUT_DIR}
-rpmbuild --define "cli_version ${VERSION}" -bb ${BASE_DIR}/tanzu-cli.spec --target amd64
+# RPM does not like - in the its package version
+PACKAGE_VERSION=${VERSION//-/_}
+rpmbuild --define "package_version ${PACKAGE_VERSION}" --define "release_version ${VERSION}" -bb ${BASE_DIR}/tanzu-cli.spec --target amd64
 mv ${HOME}/rpmbuild/RPMS/amd64/* ${OUTPUT_DIR}/
-rpmbuild --define "cli_version ${VERSION}" -bb ${BASE_DIR}/tanzu-cli.spec --target aarch64
+
+rpmbuild --define "package_version ${PACKAGE_VERSION}" --define "release_version ${VERSION}" -bb ${BASE_DIR}/tanzu-cli.spec --target aarch64
 mv ${HOME}/rpmbuild/RPMS/aarch64/* ${OUTPUT_DIR}/
 
 # Create the repository metadata

--- a/hack/rpm/tanzu-cli.spec
+++ b/hack/rpm/tanzu-cli.spec
@@ -1,12 +1,12 @@
 Name:       tanzu-cli
-Version:    %{cli_version}
+Version:    %{package_version}
 Release:    1
 License:    Apache 2.0
-URL:        https://github.com/vmware-tanzu/tanzu-cli/
+URL:        https://github.com/vmware-tanzu/tanzu-cli
 Vendor:     VMware
-Summary:    The Tanzu CLI
+Summary:    The core Tanzu CLI
 Provides:   tanzu-cli
-Obsoletes:  tanzu-cli  < %{cli_version}
+Obsoletes:  tanzu-cli  < %{package_version}
 
 %ifarch amd64
 %define arch amd64
@@ -18,7 +18,7 @@ Obsoletes:  tanzu-cli  < %{cli_version}
 %endif
 
 %undefine _disable_source_fetch
-Source0:    https://github.com/vmware-tanzu/tanzu-framework/releases/download/v%{version}/tanzu-cli-linux-%{arch}.tar.gz
+Source0:    https://github.com/vmware-tanzu/tanzu-cli/releases/download/v%{release_version}/tanzu-cli-linux-%{arch}.tar.gz
 
 %description
 VMware Tanzu is a modular, cloud native application platform that enables vital DevSecOps outcomes
@@ -32,7 +32,7 @@ in a multi-cloud world.  The Tanzu CLI allows you to control VMware Tanzu from t
 %define debug_package %nil
 
 %prep
-%setup -q -n v%{cli_version}
+%setup -q -n v%{release_version}
 
 %build
 # Nothing to build
@@ -40,7 +40,7 @@ in a multi-cloud world.  The Tanzu CLI allows you to control VMware Tanzu from t
 %install
 rm -rf $RPM_BUILD_ROOT
 mkdir -p $RPM_BUILD_ROOT/%{_bindir}
-mv tanzu-core-linux_%{arch} $RPM_BUILD_ROOT/%{_bindir}/tanzu
+mv tanzu-cli-linux_%{arch} $RPM_BUILD_ROOT/%{_bindir}/tanzu
 
 %files
 %{_bindir}/tanzu


### PR DESCRIPTION
### What this PR does / why we need it

This PR does the last preparations needed to produce `apt` and `rpm` packages for the Tanzu CLI.
This can be merged now.
Once a release is available we will need to produce the the packages and upload them to our GCP location.

The content of the PR covers:

Some updates were missed when we moved the OS Packages recipes to this CLI repo.

Also, handle '-' character for RPM packages in preparation for an alpha pre-release.

Also add an extra directory "tanzu-cli" under the rpm directory; this will allow to include other rpm packages in the same directory structure.

We also prefix the code name "jessie" to be "tanzu-cli-jessie". This will allow to include other apt packages under the same directory structure but using a different name.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes N/A

### Describe testing done for PR

I've created [test releases in my own fork](https://github.com/marckhouzam/tanzu-cli/releases) for a pretend:
1. v0.89.0-pre-alpha.0
2. v0.89.0-pre-alpha.1
3. v0.89.0-pre-beta.1
4. v0.89.0
 
I used `v0.89.0` to avoid any risk of confusion with our upcoming release.

I then tested installation/upgrading from one version of the CLI to another of these pretend releases to mimic what will happen for our real releases.

So, for each release in-turn, I performed the following:

1- build the `apt` and `rpm` packages as follows:
```
cd tanzu-cli
make apt-package
make rpm-package
```
2- upload the resulting packages to our GCP location following the instructions at: 
https://github.com/vmware-tanzu/tanzu-cli/blob/main/hack/rpm/README.md#publishing-the-package-to-gcloud
and
https://github.com/vmware-tanzu/tanzu-cli/tree/main/hack/apt#publishing-the-package-to-gcloud

3- test the installation of the CLI using the GCP repo following the instructions at:
https://github.com/vmware-tanzu/tanzu-cli/blob/main/hack/rpm/README.md#installing-the-tanzu-cli
and
https://github.com/vmware-tanzu/tanzu-cli/tree/main/hack/apt#installing-the-tanzu-cli

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

When trying to upgrade from one version to another e.g., from `v0.89.0-pre-beta.1` to `v0.89.0`, I sometimes struggled with refreshing the content of the package repository and detect the presence of the new package.  This is most probably due to caching and because I was uploading new versions minutes from each other.

I'm not expecting this caching problem to happen when are release are weeks apart.  In fact, I was able to upgrade 2 out of 3 times.  For the 3rd time (moving to `v0.89.0`) I couldn't get the repo to refresh so a workaround was to uninstall the CLI using the package manager, and then the new installation did detect and install the new version.
