### PR TITLE
Update plugin-tooling.mk, Update `tanzu builder init` to include `plugin-tooling.mk` to build and publish plugins

### DIFF
--- a/cmd/plugin/builder/init.go
+++ b/cmd/plugin/builder/init.go
@@ -25,7 +25,7 @@ var (
 // NewInitCmd initializes a repository.
 func NewInitCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "init PLUGIN_NAME",
+		Use:   "init REPO_NAME",
 		Short: "Initialize a new plugin repository",
 		Long:  desc,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/plugin/builder/template/plugintemplates/Makefile.tmpl
+++ b/cmd/plugin/builder/template/plugintemplates/Makefile.tmpl
@@ -1,91 +1,23 @@
 ROOT_DIR_RELATIVE := .
 
 include $(ROOT_DIR_RELATIVE)/common.mk
-
-BUILD_VERSION ?= $(shell cat BUILD_VERSION)
-BUILD_SHA ?= $(shell git rev-parse --short HEAD)
-BUILD_DATE ?= $(shell date -u +"%Y-%m-%d")
-
-GOOS ?= $(shell go env GOOS)
-GOARCH ?= $(shell go env GOARCH)
-GOHOSTOS ?= $(shell go env GOHOSTOS)
-GOHOSTARCH ?= $(shell go env GOHOSTARCH)
-
-LD_FLAGS = -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=$(BUILD_DATE)'
-LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=$(BUILD_SHA)'
-LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=$(BUILD_VERSION)'
+include $(ROOT_DIR_RELATIVE)/plugin-tooling.mk
 
 TOOLS_DIR := tools
 TOOLS_BIN_DIR := $(TOOLS_DIR)/bin
 GOLANGCI_LINT := $(TOOLS_BIN_DIR)/golangci-lint
 GOLANGCI_LINT_VERSION := 1.49.0
 
-GO_SRCS := $(call rwildcard,.,*.go)
-
-ARTIFACTS_DIR ?= ./artifacts
-TANZU_PLUGIN_PUBLISH_PATH ?= $(ARTIFACTS_DIR)/published
-
-# Name of Tanzu CLI binary
-TZBIN ?= tz
-
-# Add list of plugins separated by space
-PLUGINS ?= ""
-
-# Add supported OS-ARCHITECTURE combinations here
-ENVS ?= linux-amd64 windows-amd64 darwin-amd64
-
-BUILD_JOBS := $(addprefix build-,${ENVS})
-PUBLISH_JOBS := $(addprefix publish-,${ENVS})
-
-go.mod go.sum: $(GO_SRCS)
-	go mod download
-	go mod tidy
-
-.PHONY: build-local
-build-local: ## Build the plugin
-	$(TZBIN) builder cli compile --version $(BUILD_VERSION) --ldflags "$(LD_FLAGS)" --path ./cmd/plugin --target local --artifacts artifacts/${GOHOSTOS}/${GOHOSTARCH}/cli
-
-.PHONY: build
-build: $(BUILD_JOBS) $(PUBLISH_JOBS) ## Build the plugin
-
-.PHONY: build-%
-build-%:
-	$(eval ARCH = $(word 2,$(subst -, ,$*)))
-	$(eval OS = $(word 1,$(subst -, ,$*)))
-	$(TZBIN) builder cli compile --version $(BUILD_VERSION) --ldflags "$(LD_FLAGS)" --path ./cmd/plugin --artifacts artifacts/${OS}/${ARCH}/cli --target ${OS}_${ARCH}
-
-publish-local: ## Publish the plugin to generate discovery and distribution directory for local OS_ARCH
-	$(TZBIN) builder publish --type local --plugins "$(PLUGINS)" --version $(BUILD_VERSION) --os-arch "${GOHOSTOS}-${GOHOSTARCH}" --local-output-discovery-dir "$(TANZU_PLUGIN_PUBLISH_PATH)/${GOHOSTOS}-${GOHOSTARCH}/discovery/standalone" --local-output-distribution-dir "$(TANZU_PLUGIN_PUBLISH_PATH)/${GOHOSTOS}-${GOHOSTARCH}/distribution" --input-artifact-dir $(ARTIFACTS_DIR)
-
-.PHONY: publish
-publish: $(PUBLISH_JOBS) ## Publish the plugin to generate discovery and distribution directory
-
-.PHONY: publish-%
-publish-%:
-	$(eval ARCH = $(word 2,$(subst -, ,$*)))
-	$(eval OS = $(word 1,$(subst -, ,$*)))
-	$(TZBIN) builder publish --type local --plugins "$(PLUGINS)" --version $(BUILD_VERSION) --os-arch "${OS}-${ARCH}" --local-output-discovery-dir "$(TANZU_PLUGIN_PUBLISH_PATH)/${OS}-${ARCH}/discovery/standalone" --local-output-distribution-dir "$(TANZU_PLUGIN_PUBLISH_PATH)/${OS}-${ARCH}/distribution" --input-artifact-dir $(ARTIFACTS_DIR)
-
-.PHONY: install-local
-install-local: ## Install the locally built plugins
-	$(TZBIN) plugin install all --local $(TANZU_PLUGIN_PUBLISH_PATH)/${GOHOSTOS}-${GOHOSTARCH}
-
-.PHONY: build-install-local
-build-install-local: build-local publish-local ## Build and Install plugin for local OS-ARCH
-	$(TZBIN) plugin install all --local $(TANZU_PLUGIN_PUBLISH_PATH)/${GOHOSTOS}-${GOHOSTARCH}
-
-.PHONY: release
-release: $(BUILD_JOBS) $(PUBLISH_JOBS) # Generates release directory structure for all plugins under `./artifacts/published` (default)
-
 .PHONY: lint
 lint: $(GOLANGCI_LINT) ## Lint the plugin
 	$(GOLANGCI_LINT) run -v
 
-.PHONY: init
-init:go.mod go.sum  ## Initialise the plugin
+.PHONY: gomod
+gomod: ## Update go module dependencies
+	go mod tidy
 
 .PHONY: test
-test: $(GO_SRCS) go.sum
+test:
 	go test ./...
 
 $(TOOLS_BIN_DIR):

--- a/cmd/plugin/builder/template/plugintemplates/main.go.tmpl
+++ b/cmd/plugin/builder/template/plugintemplates/main.go.tmpl
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
     "github.com/vmware-tanzu/tanzu-plugin-runtime/plugin"
     "github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo"
@@ -11,6 +12,7 @@ import (
 var descriptor = plugin.PluginDescriptor{
 	Name:        "{{ .PluginName | ToLower }}",
 	Description: "{{ .Description | ToLower }}",
+	Target:      types.TargetUnknown,
 	Version:     buildinfo.Version,
 	BuildSHA:    buildinfo.SHA,
 	Group:       plugin.ManageCmdGroup, // set group

--- a/cmd/plugin/builder/template/plugintemplates/main.go.tmpl
+++ b/cmd/plugin/builder/template/plugintemplates/main.go.tmpl
@@ -12,7 +12,7 @@ import (
 var descriptor = plugin.PluginDescriptor{
 	Name:        "{{ .PluginName | ToLower }}",
 	Description: "{{ .Description | ToLower }}",
-	Target:      types.TargetUnknown,
+	Target:      "FIXME<<<", // set the Target of the plugin to types.(one of {TargetGlobal,TargetK8s,TargetTMC})
 	Version:     buildinfo.Version,
 	BuildSHA:    buildinfo.SHA,
 	Group:       plugin.ManageCmdGroup, // set group

--- a/cmd/plugin/builder/template/plugintemplates/plugin-tooling.mk.tmpl
+++ b/cmd/plugin/builder/template/plugintemplates/plugin-tooling.mk.tmpl
@@ -16,7 +16,7 @@ endif
 
 PLUGIN_BUILD_SHA ?= $(shell git describe --match=$(git rev-parse --short HEAD) --always --dirty)
 PLUGIN_BUILD_DATE ?= $(shell date -u +"%Y-%m-%d")
-PLUGIN_BUILD_VERSION ?= $(shell git describe --tags 2>$(NUL))
+PLUGIN_BUILD_VERSION ?= $(shell git describe --tags --abbrev=0 2>$(NUL))
 
 ifeq ($(strip $(PLUGIN_BUILD_VERSION)),)
 PLUGIN_BUILD_VERSION = v0.0.0
@@ -46,7 +46,7 @@ TZBIN ?= tanzu
 BUILDER_PLUGIN ?= $(TZBIN) builder
 PUBLISHER ?= tzcli
 VENDOR ?= vmware
-PLUGIN_PUBLISH_REPOSITORY ?= localhost:$(REGISTRY_PORT)/test/v1/tanzu-cli/plugins
+PLUGIN_PUBLISH_REPOSITORY ?= $(REGISTRY_ENDPOINT)/test/v1/tanzu-cli/plugins
 PLUGIN_INVENTORY_IMAGE_TAG ?= latest
 
 PLUGIN_SCOPE_ASSOCIATION_FILE ?= ""

--- a/cmd/plugin/builder/template/plugintemplates/plugin-tooling.mk.tmpl
+++ b/cmd/plugin/builder/template/plugintemplates/plugin-tooling.mk.tmpl
@@ -42,13 +42,14 @@ REGISTRY_ENDPOINT ?= localhost:$(REGISTRY_PORT)
 PLUGIN_NAME ?= *
 
 # Repository specific configuration
-BUILDER_PLUGIN ?= $(ROOT_DIR)/bin/builder
+TZBIN ?= tanzu
+BUILDER_PLUGIN ?= $(TZBIN) builder
 PUBLISHER ?= tzcli
 VENDOR ?= vmware
 PLUGIN_PUBLISH_REPOSITORY ?= localhost:$(REGISTRY_PORT)/test/v1/tanzu-cli/plugins
 PLUGIN_INVENTORY_IMAGE_TAG ?= latest
 
-PLUGIN_SCOPE_ASSOCIATION_FILE ?= $(PLUGIN_DIR)/plugin-scope-association.yaml
+PLUGIN_SCOPE_ASSOCIATION_FILE ?= ""
 PLUGIN_GROUP_NAME ?= 
 
 # Process configuration and setup additional variables

--- a/cmd/plugin/builder/template/plugintemplates/templates.go
+++ b/cmd/plugin/builder/template/plugintemplates/templates.go
@@ -35,6 +35,11 @@ var Makefile string
 //go:embed common.mk.tmpl
 var CommonMK string
 
+// PluginToolingMK contains the plugin tooling
+//
+//go:embed plugin-tooling.mk.tmpl
+var PluginToolingMK string
+
 // MainGo contains the plugin main.go template
 //
 //go:embed main.go.tmpl

--- a/cmd/plugin/builder/template/root.go
+++ b/cmd/plugin/builder/template/root.go
@@ -59,10 +59,9 @@ var PluginToolingMK = Target{
 }
 
 // Codeowners target
-// TODO (pbarker): replace with the CLI reviewers group
 var Codeowners = Target{
 	Filepath: "CODEOWNERS",
-	Template: `* @vuil`,
+	Template: `* # edit as appropriate`,
 }
 
 // Tools target.

--- a/cmd/plugin/builder/template/root.go
+++ b/cmd/plugin/builder/template/root.go
@@ -52,6 +52,12 @@ var Makefile = Target{
 	Template: plugintemplates.Makefile,
 }
 
+// PluginToolingMK target
+var PluginToolingMK = Target{
+	Filepath: "plugin-tooling.mk",
+	Template: plugintemplates.PluginToolingMK,
+}
+
 // Codeowners target
 // TODO (pbarker): replace with the CLI reviewers group
 var Codeowners = Target{

--- a/cmd/plugin/builder/template/target.go
+++ b/cmd/plugin/builder/template/target.go
@@ -66,6 +66,7 @@ var DefaultInitTargets = []Target{
 	GolangCIConfig,
 	Tools,
 	CommonMK,
+	PluginToolingMK,
 }
 
 // DefaultPluginTargets are the default plugin targets.

--- a/plugin-tooling.mk
+++ b/plugin-tooling.mk
@@ -16,7 +16,7 @@ endif
 
 PLUGIN_BUILD_SHA ?= $(shell git describe --match=$(git rev-parse --short HEAD) --always --dirty)
 PLUGIN_BUILD_DATE ?= $(shell date -u +"%Y-%m-%d")
-PLUGIN_BUILD_VERSION ?= $(shell git describe --tags 2>$(NUL))
+PLUGIN_BUILD_VERSION ?= $(shell git describe --tags --abbrev=0 2>$(NUL))
 
 ifeq ($(strip $(PLUGIN_BUILD_VERSION)),)
 PLUGIN_BUILD_VERSION = v0.0.0
@@ -45,7 +45,7 @@ PLUGIN_NAME ?= *
 BUILDER_PLUGIN ?= $(ROOT_DIR)/bin/builder
 PUBLISHER ?= tzcli
 VENDOR ?= vmware
-PLUGIN_PUBLISH_REPOSITORY ?= localhost:$(REGISTRY_PORT)/test/v1/tanzu-cli/plugins
+PLUGIN_PUBLISH_REPOSITORY ?= $(REGISTRY_ENDPOINT)/test/v1/tanzu-cli/plugins
 PLUGIN_INVENTORY_IMAGE_TAG ?= latest
 
 PLUGIN_SCOPE_ASSOCIATION_FILE ?= $(PLUGIN_DIR)/plugin-scope-association.yaml


### PR DESCRIPTION
### What this PR does / why we need it

- Update `plugin-tooling.mk` within the repo.
- Add a `make plugin-install-local` target to install locally built plugins.
- Update `builder` plugin templates to use the new `plugin-tooling.mk` file to build the plugins.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #86 

### Describe testing done for PR

```
# Initialize a new repository
$ tanzu builder init hello-world --repo-type github
$ cd hello-world

# Add a new plugin with name foo
$ tanzu builder cli add-plugin foo

# Commit the base changes
$ git add -A
$ git commit -m "Initialize plugin repository"

# Go get the latest tanzu-plugin-runtime from the main branch. [NOTE: This step should not be needed once we have an official tag on the `tanzu-plugin-runtime` repository]
$ go get github.com/vmware-tanzu/tanzu-plugin-runtime@main
$ make gomod

# Building Plugin
$ make plugin-build-local

# Installing plugins from a local source
$ make plugin-install-local

# OR Combined Build and Install target is also available
$ make plugin-build-install-local

# Publish the plugin as oci image to the local oci repository
$ make plugin-publish-packages

# Combined target to build and publish plugins
$ make plugin-build-and-publish-packages

# Initialize a local inventory database by running the below command
$ make inventory-plugin-add

# Add plugin to the local inventory database
$ make inventory-plugin-add

# Configure below environment variable to point to the inventory database as discovery image 
$ tanzu config set env.TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest

# Run plugin search
$ tz plugin search
  NAME                DESCRIPTION                                                        TARGET           LATEST
  foo                 foo plugin v2                                                      global           v0.0.0
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Update `tanzu builder init` to include `plugin-tooling.mk` file containing the tooling to build and publish plugins
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
