### PR TITLE
Configure staging central plugin repository as default plugin discovery

### DIFF
--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -133,6 +133,11 @@ func GetTrustedRegistries() []string {
 		}
 	}
 
+	// Add default central plugin discovery image to trusted registries
+	if u, err := url.ParseRequestURI("https://" + constants.TanzuCLIDefaultCentralPluginDiscoveryImage); err == nil {
+		trustedRegistries = append(trustedRegistries, u.Hostname())
+	}
+
 	// If ALLOWED_REGISTRY environment variable is specified, allow those registries as well
 	if allowedRegistry := os.Getenv(constants.AllowedRegistries); allowedRegistry != "" {
 		for _, r := range strings.Split(allowedRegistry, ",") {

--- a/pkg/constants/defaults.go
+++ b/pkg/constants/defaults.go
@@ -15,4 +15,8 @@ const (
 
 	// DefaultBurst is the default maximum burst for throttle for the rest config
 	DefaultBurst = 200
+
+	// TanzuCLIDefaultCentralPluginDiscoveryImage defines the default discovery image
+	// from where the CLI will discover the plugins
+	TanzuCLIDefaultCentralPluginDiscoveryImage = "projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest"
 )

--- a/pkg/pluginmanager/manager.go
+++ b/pkg/pluginmanager/manager.go
@@ -200,16 +200,18 @@ func DiscoverPluginGroups() ([]*discovery.DiscoveredPluginGroups, error) {
 }
 
 // getPreReleasePluginDiscovery
-// For our pre-releases we use an environment variable to point to the
-// repository of plugins.  This is because the configuration
-// cfg.ClientOptions.CLI.DiscoverySources
+// For pre-releases CLI points to a default staging central plugin discovery image
+// from where the CLI will discover plugins.
+// For pre-releases, CLI also allows default discovery image to be overridden by using
+// an environment variable and pointing to the different repository of plugins.
+//
+// This is because the configuration cfg.ClientOptions.CLI.DiscoverySources
 // is read by older CLIs so we don't want to modify it.
 // TODO(khouzam): remove before 1.0
 func getPreReleasePluginDiscovery() ([]configtypes.PluginDiscovery, error) {
 	centralRepoTestImage := os.Getenv(constants.ConfigVariablePreReleasePluginRepoImage)
 	if centralRepoTestImage == "" {
-		// Don't set a default value.  This test repo URI is not meant to be public.
-		return nil, fmt.Errorf("you must set the environment variable %s to the URI of the image of the plugin repository.  Please see the documentation", constants.ConfigVariablePreReleasePluginRepoImage)
+		centralRepoTestImage = constants.TanzuCLIDefaultCentralPluginDiscoveryImage
 	} else if centralRepoTestImage == PreReleasePluginRepoImageBypass {
 		return nil, nil
 	}


### PR DESCRIPTION
### What this PR does / why we need it

This change updates the CLI to use `projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest` as the default central plugin repository.

To override the default central repository, developers can configure `TANZU_CLI_PRE_RELEASE_REPO_IMAGE`. However, this is not an officially supported method.

CLI will by default point to the public staging central repository (projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest).
That means, 
- No need to configure TANZU_CLI_PRE_RELEASE_REPO_IMAGE 
- CLI is still be using this variable for our testing pipelines and unit tests but no external user should need to use it and it will not be documented.
- To get plugins from any additional discovery endpoint, please specify it with the TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY env variable.


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

```
$ tz plugin clean
[ok] successfully cleaned up all plugins

$ tz plugin search
  NAME     DESCRIPTION             TARGET  VERSION                 STATUS         CONTEXT
  builder  Build Tanzu components  global  v0.1.0-dev-8-g6087ea00  not installed
  test     Test the CLI            global  v0.1.0-dev-8-g6087ea00  not installed

$ tz plugin install builder
[i] Installing plugin 'builder:v0.1.0-dev-8-g6087ea00' with target 'global'
t[ok] successfully installed 'builder' plugin

$ tz plugin list
Standalone Plugins
  NAME     DESCRIPTION             TARGET  VERSION                 STATUS
  builder  Build Tanzu components  global  v0.1.0-dev-8-g6087ea00  installed
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Configure staging central plugin repository as default plugin discovery
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
