### PR TITLE
Add CEIP Opt-In support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,7 @@ test: fmt ## Run Tests
 
 .PHONY: e2e-cli-core ## Execute all CLI Core E2E Tests
 e2e-cli-core: e2e-cli-plugin-compatibility-test e2e-cli-tmc-test e2e-cli-plugin-lifecycle-test
+	export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="Yes" ; \
 	${GO} test `go list ./test/e2e/... | grep -v test/e2e/context/tmc | grep -v test/e2e/plugins_compatibility | grep -v test/e2e/plugin_lifecycle` -timeout 60m -race -coverprofile coverage.txt ${GOTEST_VERBOSE}
 
 .PHONY: e2e-cli-plugin-compatibility-test ## Execute CLI Core Plugin Compatibility E2E test cases
@@ -204,6 +205,7 @@ e2e-cli-plugin-compatibility-test:
 	else \
 		export TANZU_CLI_PRE_RELEASE_REPO_IMAGE=$(TANZU_CLI_E2E_TEST_CENTRAL_REPO_URL) ; \
 		export TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST=$(TANZU_CLI_E2E_TEST_CENTRAL_REPO_URL) ; \
+		export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="Yes" ; \
 		${GO} test ./test/e2e/plugins_compatibility -timeout 60m -race -coverprofile coverage.txt ${GOTEST_VERBOSE} ; \
 	fi 
 
@@ -215,6 +217,7 @@ e2e-cli-plugin-lifecycle-test:
 		export TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL=$(TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL) ; \
 		export TANZU_CLI_PRE_RELEASE_REPO_IMAGE=$(TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL) ; \
 		export TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST=$(TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL) ; \
+		export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="Yes" ; \
 		${GO} test ./test/e2e/plugin_lifecycle -timeout 60m -race -coverprofile coverage.txt ${GOTEST_VERBOSE} ; \
 	fi
 
@@ -223,6 +226,7 @@ e2e-cli-tmc-test:
 	@if [ "${TANZU_API_TOKEN}" = "" ] && [ "$(TANZU_CLI_TMC_UNSTABLE_URL)" = "" ]; then \
 		echo "***Skipping TMC specific e2e tests cases because environment variables TANZU_API_TOKEN and TANZU_CLI_TMC_UNSTABLE_URL are not set***" ; \
 	else \
+	    export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="Yes" ; \
 		${GO} test ./test/e2e/context/tmc -timeout 60m -race -coverprofile coverage.txt ${GOTEST_VERBOSE} ; \
 	fi
 

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/tj/assert v0.0.3
 	github.com/vmware-tanzu/carvel-ytt v0.40.0
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230130173350-eeda69d80a24
-	github.com/vmware-tanzu/tanzu-plugin-runtime v0.0.2-0.20230321210330-330c29284da6
+	github.com/vmware-tanzu/tanzu-plugin-runtime v0.0.2-0.20230403161015-4575b79c9655
 	go.pinniped.dev v0.20.0
 	go.uber.org/multierr v1.8.0
 	golang.org/x/mod v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -1286,8 +1286,8 @@ github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20221207131309-7323ca04b
 github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20221207131309-7323ca04b86c/go.mod h1:ukZpKQ0hf5bjWdJLjn2M6qXP+9giZWQPxt8nOfrCR+o=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230130173350-eeda69d80a24 h1:zz3XDCLPqvhtx8OMMRNjSn/krxhqkYnuw9Z9DBh6ruA=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230130173350-eeda69d80a24/go.mod h1:rcIfoGpdav3evsyEMMzYH0xhGZOkIy+Ra3koypM8Aco=
-github.com/vmware-tanzu/tanzu-plugin-runtime v0.0.2-0.20230321210330-330c29284da6 h1:w+lpvLqFtRr0NpmAHtRnMi7hLOG8x0DZ8sE+iVX+RRs=
-github.com/vmware-tanzu/tanzu-plugin-runtime v0.0.2-0.20230321210330-330c29284da6/go.mod h1:y70TLdev7MX8K6CkAA7h92qVUDyjbX8y9/J5q4UmhRs=
+github.com/vmware-tanzu/tanzu-plugin-runtime v0.0.2-0.20230403161015-4575b79c9655 h1:ZAkEx5/PIwVuapIJ1IH4QJCjLX2TXGXOu1CaO9is4t4=
+github.com/vmware-tanzu/tanzu-plugin-runtime v0.0.2-0.20230403161015-4575b79c9655/go.mod h1:y70TLdev7MX8K6CkAA7h92qVUDyjbX8y9/J5q4UmhRs=
 github.com/xanzy/go-gitlab v0.31.0/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
 github.com/xanzy/go-gitlab v0.73.1 h1:UMagqUZLJdjss1SovIC+kJCH4k2AZWXl58gJd38Y/hI=
 github.com/xanzy/go-gitlab v0.73.1/go.mod h1:d/a0vswScO7Agg1CZNz15Ic6SSvBG9vfw8egL99t4kA=

--- a/pkg/command/ceip_participation.go
+++ b/pkg/command/ceip_participation.go
@@ -1,0 +1,93 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package command
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/component"
+	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/plugin"
+)
+
+// CeipOptOutStatus and CeipOptInStatus are constants for the CEIP opt-in/out verbiage
+const (
+	CeipOptInStatus  = "Opt-in"
+	CeipOptOutStatus = "Opt-out"
+)
+
+// Note(TODO:prkalle): The below ceip-participation command(experimental) added may be removed in the next release,
+//       If we decide to fold this functionality into existing 'tanzu telemetry' plugin
+
+func newCEIPParticipationCmd() *cobra.Command {
+	var ceipParticipationCmd = &cobra.Command{
+		Use:     "ceip-participation",
+		Short:   "Manage CEIP Participation",
+		Long:    "Manage CEIP Participation",
+		Aliases: []string{"ceip"},
+		Annotations: map[string]string{
+			"group": string(plugin.SystemCmdGroup),
+		},
+	}
+	ceipParticipationCmd.SetUsageFunc(cli.SubCmdUsageFunc)
+
+	ceipParticipationCmd.AddCommand(
+		newCEIPParticipationSetCmd(),
+		newCEIPParticipationGetCmd(),
+	)
+
+	return ceipParticipationCmd
+}
+
+func newCEIPParticipationSetCmd() *cobra.Command {
+	var setCmd = &cobra.Command{
+		Use:   "set OPT_IN_BOOL",
+		Short: "Set the opt-in preference for CEIP",
+		Long:  "Set the opt-in preference for CEIP",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !strings.EqualFold(args[0], "true") && !strings.EqualFold(args[0], "false") {
+				return errors.Errorf("incorrect boolean argument: %q", args[0])
+			}
+			err := configlib.SetCEIPOptIn(strconv.FormatBool(strings.EqualFold(args[0], "true")))
+			if err != nil {
+				return errors.Wrapf(err, "failed to update the configuration")
+			}
+			return nil
+		},
+	}
+
+	return setCmd
+}
+
+func newCEIPParticipationGetCmd() *cobra.Command {
+	var getCmd = &cobra.Command{
+		Use:   "get",
+		Short: "Get the current CEIP opt-in status",
+		Long:  "Get the current CEIP opt-in status",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			optInVal, err := configlib.GetCEIPOptIn()
+			if err != nil {
+				return errors.Wrapf(err, "failed to get the CEIP opt-in status")
+			}
+			ceipStatus := ""
+			if optInVal == "true" {
+				ceipStatus = CeipOptInStatus
+			} else {
+				ceipStatus = CeipOptOutStatus
+			}
+			t := component.NewOutputWriter(cmd.OutOrStdout(), outputFormat, "CEIP-Status")
+			t.AddRow(ceipStatus)
+			t.Render()
+			return nil
+		},
+	}
+
+	return getCmd
+}

--- a/pkg/command/ceip_participation_test.go
+++ b/pkg/command/ceip_participation_test.go
@@ -1,0 +1,117 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package command
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/otiai10/copy"
+)
+
+var _ = Describe("ceip-participation command tests", func() {
+
+	Describe("ceip-participation command set/get tests", func() {
+		var (
+			tkgConfigFile   *os.File
+			tkgConfigFileNG *os.File
+			err             error
+		)
+
+		BeforeEach(func() {
+			tkgConfigFile, err = os.CreateTemp("", "config")
+			Expect(err).To(BeNil())
+			err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config.yaml"), tkgConfigFile.Name())
+			Expect(err).To(BeNil(), "Error while copying tanzu config file for testing")
+			os.Setenv("TANZU_CONFIG", tkgConfigFile.Name())
+
+			tkgConfigFileNG, err = os.CreateTemp("", "config_ng")
+			Expect(err).To(BeNil())
+			os.Setenv("TANZU_CONFIG_NEXT_GEN", tkgConfigFileNG.Name())
+			err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config_ng.yaml"), tkgConfigFileNG.Name())
+			Expect(err).To(BeNil(), "Error while copying tanzu config_ng.yaml file for testing")
+		})
+		AfterEach(func() {
+			os.Unsetenv("TANZU_CONFIG")
+			os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
+			os.RemoveAll(tkgConfigFile.Name())
+			os.RemoveAll(tkgConfigFileNG.Name())
+			resetLoginCommandFlags()
+		})
+		Context("ceip-participation set to true", func() {
+			It("ceip-participation set should be successful and get should return status as 'Opt-in' status", func() {
+				ceipSetCmd := newCEIPParticipationSetCmd()
+				ceipSetCmd.SetArgs([]string{"true"})
+				err = ceipSetCmd.Execute()
+				Expect(err).To(BeNil())
+
+				ceipGetCmd := newCEIPParticipationGetCmd()
+				var out bytes.Buffer
+				ceipGetCmd.SetOut(&out)
+				err = ceipGetCmd.Execute()
+				Expect(err).To(BeNil())
+				Expect(out.String()).To(ContainSubstring("Opt-in"))
+
+				ceipSetCmd = newCEIPParticipationSetCmd()
+				ceipSetCmd.SetArgs([]string{"True"})
+				err = ceipSetCmd.Execute()
+				Expect(err).To(BeNil())
+
+				ceipGetCmd = newCEIPParticipationGetCmd()
+				out.Reset()
+				ceipGetCmd.SetOut(&out)
+				err = ceipGetCmd.Execute()
+				Expect(err).To(BeNil())
+				Expect(out.String()).To(ContainSubstring("Opt-in"))
+
+			})
+		})
+		Context("ceip-participation set to false", func() {
+			It("ceip-participation set should be successful and get should return status as 'Opt-out' status", func() {
+				ceipSetCmd := newCEIPParticipationSetCmd()
+				ceipSetCmd.SetArgs([]string{"false"})
+				err = ceipSetCmd.Execute()
+				Expect(err).To(BeNil())
+
+				ceipGetCmd := newCEIPParticipationGetCmd()
+				var out bytes.Buffer
+				ceipGetCmd.SetOut(&out)
+				err = ceipGetCmd.Execute()
+				Expect(err).To(BeNil())
+				Expect(out.String()).To(ContainSubstring("Opt-out"))
+
+				ceipSetCmd = newCEIPParticipationSetCmd()
+				ceipSetCmd.SetArgs([]string{"False"})
+				err = ceipSetCmd.Execute()
+				Expect(err).To(BeNil())
+
+				ceipGetCmd = newCEIPParticipationGetCmd()
+				out.Reset()
+				ceipGetCmd.SetOut(&out)
+				err = ceipGetCmd.Execute()
+				Expect(err).To(BeNil())
+				Expect(out.String()).To(ContainSubstring("Opt-out"))
+			})
+		})
+		Context("ceip-participation set to invalid boolean argument", func() {
+			It("ceip-participation set should fail", func() {
+				ceipSetCmd := newCEIPParticipationSetCmd()
+				ceipSetCmd.SetArgs([]string{"fakebool"})
+				err = ceipSetCmd.Execute()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("incorrect boolean argument:"))
+			})
+		})
+		Context("ceip-participation set without argument", func() {
+			It("ceip-participation set should fail", func() {
+				ceipSetCmd := newCEIPParticipationSetCmd()
+				err = ceipSetCmd.Execute()
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+})

--- a/pkg/command/plugin_test.go
+++ b/pkg/command/plugin_test.go
@@ -148,6 +148,7 @@ func TestPluginList(t *testing.T) {
 		assert.Nil(t, err)
 		defer os.RemoveAll(dir)
 		os.Setenv("TEST_CUSTOM_CATALOG_CACHE_DIR", dir)
+		os.Setenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER", "No")
 
 		// Always turn on the context feature
 		featureArray := strings.Split(constants.FeatureContextCommand, ".")
@@ -209,6 +210,7 @@ func TestPluginList(t *testing.T) {
 		os.Unsetenv("TEST_CUSTOM_CATALOG_CACHE_DIR")
 		os.Unsetenv("TANZU_CONFIG")
 		os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
+		os.Unsetenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER")
 	}
 }
 
@@ -245,7 +247,7 @@ func TestDeletePlugin(t *testing.T) {
 		assert.Nil(t, err)
 		defer os.RemoveAll(dir)
 		os.Setenv("TEST_CUSTOM_CATALOG_CACHE_DIR", dir)
-
+		os.Setenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER", "No")
 		var completionType uint8
 		t.Run(spec.test, func(t *testing.T) {
 			assert := assert.New(t)
@@ -284,6 +286,7 @@ func TestDeletePlugin(t *testing.T) {
 			}
 		})
 		os.Unsetenv("TEST_CUSTOM_CATALOG_CACHE_DIR")
+		os.Unsetenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER")
 	}
 }
 
@@ -355,6 +358,7 @@ func TestInstallPlugin(t *testing.T) {
 	tkgConfigFileNG, err := os.CreateTemp("", "config_ng")
 	assert.Nil(err)
 	os.Setenv("TANZU_CONFIG_NEXT_GEN", tkgConfigFileNG.Name())
+	os.Setenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER", "No")
 
 	// Bypass the environment variable for testing
 	err = os.Setenv(constants.ConfigVariablePreReleasePluginRepoImage, pluginmanager.PreReleasePluginRepoImageBypass)
@@ -367,6 +371,7 @@ func TestInstallPlugin(t *testing.T) {
 	defer func() {
 		os.Unsetenv("TANZU_CONFIG")
 		os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
+		os.Unsetenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER")
 		os.RemoveAll(tkgConfigFile.Name())
 		os.RemoveAll(tkgConfigFileNG.Name())
 	}()
@@ -415,6 +420,7 @@ func TestUpgradePlugin(t *testing.T) {
 	tkgConfigFileNG, err := os.CreateTemp("", "config_ng")
 	assert.Nil(err)
 	os.Setenv("TANZU_CONFIG_NEXT_GEN", tkgConfigFileNG.Name())
+	os.Setenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER", "No")
 
 	featureArray := strings.Split(constants.FeatureContextCommand, ".")
 	err = config.SetFeature(featureArray[1], featureArray[2], "true")
@@ -423,6 +429,7 @@ func TestUpgradePlugin(t *testing.T) {
 	defer func() {
 		os.Unsetenv("TANZU_CONFIG")
 		os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
+		os.Unsetenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER")
 		os.RemoveAll(tkgConfigFile.Name())
 		os.RemoveAll(tkgConfigFileNG.Name())
 	}()

--- a/pkg/command/root_test.go
+++ b/pkg/command/root_test.go
@@ -318,6 +318,7 @@ func TestEnvVarsSet(t *testing.T) {
 	defer os.RemoveAll(configFile.Name())
 	configFileNG, _ := os.CreateTemp("", "config_ng")
 	os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
+	os.Setenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER", "No")
 	defer os.RemoveAll(configFileNG.Name())
 
 	// Setup default feature flags since we have created new config files
@@ -353,6 +354,7 @@ func TestEnvVarsSet(t *testing.T) {
 	// Cleanup
 	os.Unsetenv("TANZU_CONFIG")
 	os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
+	os.Unsetenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER")
 	os.Unsetenv(envVarName)
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,12 +6,27 @@ package config
 
 import (
 	"os"
+	"strconv"
+	"strings"
 
+	"github.com/pkg/errors"
+
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/component"
+	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/interfaces"
 )
 
 var (
 	configClient interfaces.ConfigClientWrapper
+	// TODO(prkalle): Update the below CEIP message if necessary
+	ceipPromptMsg = `
+VMware's Customer Experience Improvement Program ("CEIP") provides VMware with information that enables VMware to improve its products and services and fix problems. By choosing to participate in CEIP, you agree that VMware may collect technical information about your use of VMware products and services on a regular basis. This information does not personally identify you.
+For more details about the Program, please see http://www.vmware.com/trustvmware/ceip.html
+
+Do you agree to Participate in the Customer Experience Improvement Program? 
+`
 )
 
 func init() {
@@ -32,4 +47,47 @@ func ConfigureEnvVariables() {
 			os.Setenv(variable, value)
 		}
 	}
+}
+
+// ConfigureCEIPOptIn checks and configures the User CEIP Opt-in choice in the tanzu configuration file
+func ConfigureCEIPOptIn() error {
+	ceipOptInConfigVal, _ := configlib.GetCEIPOptIn()
+	// If CEIP Opt-In config parameter is already set, do nothing
+	if ceipOptInConfigVal != "" {
+		return nil
+	}
+
+	ceipOptInUserVal, err := getCEIPUserOptIn()
+	if err != nil {
+		return errors.Wrapf(err, "failed to get CEIP Opt-In status")
+	}
+
+	err = configlib.SetCEIPOptIn(strconv.FormatBool(ceipOptInUserVal))
+	if err != nil {
+		return errors.Wrapf(err, "failed to update the CEIP Opt-In status")
+	}
+
+	return nil
+}
+
+func getCEIPUserOptIn() (bool, error) {
+	var ceipOptIn string
+	optInPromptChoiceEnvVal := os.Getenv(constants.CEIPOptInUserPromptAnswer)
+	if optInPromptChoiceEnvVal != "" {
+		return strings.EqualFold(optInPromptChoiceEnvVal, "Yes"), nil
+	}
+
+	// prompt user and record their choice
+	err := component.Prompt(
+		&component.PromptConfig{
+			Message: ceipPromptMsg,
+			Options: []string{"Yes", "No"},
+			Default: "Yes",
+		},
+		&ceipOptIn,
+	)
+	if err != nil {
+		return false, err
+	}
+	return (ceipOptIn == "Yes"), nil
 }

--- a/pkg/constants/env_variables.go
+++ b/pkg/constants/env_variables.go
@@ -16,4 +16,5 @@ const (
 	PluginDiscoveryImageSignatureVerificationSkipList = "TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST"
 	PublicKeyPathForPluginDiscoveryImageSignature     = "TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_PUBLIC_KEY_PATH"
 	SuppressSkipSignatureVerificationWarning          = "TANZU_CLI_SUPPRESS_SKIP_SIGNATURE_VERIFICATION_WARNING"
+	CEIPOptInUserPromptAnswer                         = "TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER"
 )


### PR DESCRIPTION
### What this PR does / why we need it

This PR adds support for CEIP(Customer Experience Improvement Program) Opt-In support.

Summary of changes:
- User would be prompted for CEIP Opt-In on any first tanzu command. Users choice would be persisted in the tanzu configuration file. Users can skip the prompt by providing their choice(yes/no) using the environment variable (TANZU_CLI_CEIP_OPT_IN_PROMPT_CHOICE) on the first use
- Also added commands(experimental) "tanzu ceip-participation set" and "tanzu ceip-participation get" to get and set the CEIP Opt-In status. These commands may be deleted in future release if we decide to fold these commands functionality into existing `tanzu telemetry` plugin

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #142 

### Describe testing done for PR
User would be prompted for CEIP opt-in choice on the first use( any tanzu command/plugin comamnd) as shown below.

```
❯ ./bin/tanzu plugin search
?
VMware's Customer Experience Improvement Program ("CEIP") provides VMware with information that enables VMware to improve its products and services and fix problems. By choosing to participate in CEIP, you agree that VMware may collect technical information about your use of VMware products and services on a regular basis. This information does not personally identify you.
For more details about the Program, please see http://www.vmware.com/trustvmware/ceip.html

Do you agree to Participate in the Customer Experience Improvement Program?
  [Use arrows to move, type to filter]
> Yes
  No

```
Based on the users selection, the status would be persisted in tanzu `config-ng.yaml`  configuration file and user wouid not be prompted on subsequent tanzu command executions.

```
❯ ./bin/tanzu plugin search
  NAME                DESCRIPTION                           TARGET           VERSION      STATUS         CONTEXT
  isolated-cluster    Desc for isolated-cluster             global           v9.9.9       not installed
  pinniped-auth       Desc for pinniped-auth                global           v9.9.9       not installed
  cluster             Kubernetes cluster operations         kubernetes       v0.25.0-dev  not installed  tkg-aws-cc-capi115-upg-mc
  feature             Operate on features and featuregates  kubernetes       v0.25.0-dev  not installed  tkg-aws-cc-capi115-upg-mc
  kubernetes-release  Kubernetes release operations         kubernetes       v0.25.0-dev  not installed  tkg-aws-cc-capi115-upg-mc
  management-cluster  Desc for management-cluster           kubernetes       v9.9.9       not installed
  package             Desc for package                      kubernetes       v9.9.9       not installed
  secret              Desc for secret                       kubernetes       v9.9.9       not installed
  telemetry           Desc for telemetry                    kubernetes       v9.9.9       not installed
  account             Desc for account                      mission-control  v9.9.9       not installed
  apply               Desc for apply                        mission-control  v9.9.9       not installed
  audit               Desc for audit                        mission-control  v9.9.9       not installed
  cluster             Desc for cluster                      mission-control  v9.9.9       not installed
  clustergroup        Desc for clustergroup                 mission-control  v9.9.9       not installed
  continuousdelivery  Desc for continuousdelivery           mission-control  v9.9.9       not installed
  data-protection     Desc for data-protection              mission-control  v9.9.9       not installed
  ekscluster          Desc for ekscluster                   mission-control  v9.9.9       not installed
  events              Desc for events                       mission-control  v9.9.9       not installed
  helm                Desc for helm                         mission-control  v9.9.9       not installed
  iam                 Desc for iam                          mission-control  v9.9.9       not installed
  inspection          Desc for inspection                   mission-control  v9.9.9       not installed
  integration         Desc for integration                  mission-control  v9.9.9       not installed
  management-cluster  Desc for management-cluster           mission-control  v9.9.9       not installed
  policy              Desc for policy                       mission-control  v9.9.9       not installed
  secret              Desc for secret                       mission-control  v9.9.9       not installed
  tanzupackage        Desc for tanzupackage                 mission-control  v9.9.9       not installed
  workspace           Desc for workspace                    mission-control  v9.9.9       not installed
```

User can also skip the prompt by setting the environment variable `TANZU_CLI_CEIP_OPT_IN_PROMPT_CHOICE` to `Yes` or `No`
```
❯ export TANZU_CLI_CEIP_OPT_IN_PROMPT_CHOICE=no

❯ ./bin/tanzu plugin search
  NAME                DESCRIPTION                           TARGET           VERSION      STATUS         CONTEXT
  isolated-cluster    Desc for isolated-cluster             global           v9.9.9       not installed
  pinniped-auth       Desc for pinniped-auth                global           v9.9.9       not installed
  cluster             Kubernetes cluster operations         kubernetes       v0.25.0-dev  not installed  tkg-aws-cc-capi115-upg-mc
  feature             Operate on features and featuregates  kubernetes       v0.25.0-dev  not installed  tkg-aws-cc-capi115-upg-mc
  kubernetes-release  Kubernetes release operations         kubernetes       v0.25.0-dev  not installed  tkg-aws-cc-capi115-upg-mc
  management-cluster  Desc for management-cluster           kubernetes       v9.9.9       not installed
  package             Desc for package                      kubernetes       v9.9.9       not installed
  secret              Desc for secret                       kubernetes       v9.9.9       not installed
  telemetry           Desc for telemetry                    kubernetes       v9.9.9       not installed
  account             Desc for account                      mission-control  v9.9.9       not installed
  apply               Desc for apply                        mission-control  v9.9.9       not installed
  audit               Desc for audit                        mission-control  v9.9.9       not installed
  cluster             Desc for cluster                      mission-control  v9.9.9       not installed
  clustergroup        Desc for clustergroup                 mission-control  v9.9.9       not installed
  continuousdelivery  Desc for continuousdelivery           mission-control  v9.9.9       not installed
  data-protection     Desc for data-protection              mission-control  v9.9.9       not installed
  ekscluster          Desc for ekscluster                   mission-control  v9.9.9       not installed
  events              Desc for events                       mission-control  v9.9.9       not installed
  helm                Desc for helm                         mission-control  v9.9.9       not installed
  iam                 Desc for iam                          mission-control  v9.9.9       not installed
  inspection          Desc for inspection                   mission-control  v9.9.9       not installed
  integration         Desc for integration                  mission-control  v9.9.9       not installed
  management-cluster  Desc for management-cluster           mission-control  v9.9.9       not installed
  policy              Desc for policy                       mission-control  v9.9.9       not installed
  secret              Desc for secret                       mission-control  v9.9.9       not installed
  tanzupackage        Desc for tanzupackage                 mission-control  v9.9.9       not installed
  workspace           Desc for workspace                    mission-control  v9.9.9       not installed
```

User can get their current CEIP participation status using `tanzu ceip-participation get` command
```
❯ ./bin/tanzu ceip-participation get
  CEIP-STATUS
  Opt-in
```

User can update their current CEIP participation status using `tanzu ceip-participation set` command
```
❯ ./bin/tanzu ceip-participation set false
❯ ./bin/tanzu ceip-participation get
  CEIP-STATUS
  Opt-out
```



<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add CEIP Opt-In support 
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

This PR is depending on `tanzu-plugin-runtime`  [PR:42](https://github.com/vmware-tanzu/tanzu-plugin-runtime/pull/42). So build and CI jobs would fails.  I will update the PR with tanzu-plugin-runtime dependency in go.mod dependency once the   other PR is merged. However the PR is open for comments and PR.

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
