### PR TITLE
Additional discoveries are automatically trusted

### DIFF
--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -133,9 +133,17 @@ func GetTrustedRegistries() []string {
 		}
 	}
 
-	// Add default central plugin discovery image to trusted registries
+	// Add default central plugin discovery image to the trusted registries
 	if u, err := url.ParseRequestURI("https://" + constants.TanzuCLIDefaultCentralPluginDiscoveryImage); err == nil {
 		trustedRegistries = append(trustedRegistries, u.Hostname())
+	}
+
+	// Add any additional test central plugin discovery images to the trusted registries
+	testDiscoveryImages := GetAdditionalTestDiscoveryImages()
+	for _, image := range testDiscoveryImages {
+		if u, err := url.ParseRequestURI("https://" + image); err == nil {
+			trustedRegistries = append(trustedRegistries, u.Hostname())
+		}
 	}
 
 	// If ALLOWED_REGISTRY environment variable is specified, allow those registries as well
@@ -146,6 +154,18 @@ func GetTrustedRegistries() []string {
 	}
 
 	return trustedRegistries
+}
+
+func GetAdditionalTestDiscoveryImages() []string {
+	var additionalImages []string
+	testDiscoveryImages := strings.Split(os.Getenv(constants.ConfigVariableAdditionalDiscoveryForTesting), ",")
+	for _, image := range testDiscoveryImages {
+		image = strings.TrimSpace(image)
+		if image != "" {
+			additionalImages = append(additionalImages, image)
+		}
+	}
+	return additionalImages
 }
 
 func getHTTPURIForGCPPluginRepository(repo configtypes.GCPPluginRepository) string { // nolint:staticcheck // Deprecated

--- a/pkg/config/defaults_test.go
+++ b/pkg/config/defaults_test.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"net/url"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -36,6 +37,31 @@ var _ = Describe("defaults test cases", func() {
 
 			err = os.Setenv(constants.ConfigVariablePreReleasePluginRepoImage, oldValue)
 			Expect(err).To(BeNil())
+		})
+		It("trusted registries should include hostname of additional discoveries", func() {
+			testHost1 := "registry1.vmware.com"
+			testHost2 := "registry2.vmware.com"
+			oldValue := os.Getenv(constants.ConfigVariableAdditionalDiscoveryForTesting)
+			err := os.Setenv(constants.ConfigVariableAdditionalDiscoveryForTesting,
+				testHost1+"/test/path, "+testHost2+"/another/test/image")
+			Expect(err).To(BeNil())
+
+			trustedRegis := GetTrustedRegistries()
+			Expect(trustedRegis).NotTo(BeNil())
+			Expect(trustedRegis).Should(ContainElement(testHost1))
+			Expect(trustedRegis).Should(ContainElement(testHost2))
+
+			err = os.Setenv(constants.ConfigVariablePreReleasePluginRepoImage, oldValue)
+			Expect(err).To(BeNil())
+		})
+		It("trusted registries should include hostname of default central discovery", func() {
+			u, err := url.ParseRequestURI("https://" + constants.TanzuCLIDefaultCentralPluginDiscoveryImage)
+			Expect(err).To(BeNil())
+			Expect(u).NotTo(BeNil())
+
+			trustedRegis := GetTrustedRegistries()
+			Expect(trustedRegis).NotTo(BeNil())
+			Expect(trustedRegis).Should(ContainElement(u.Hostname()))
 		})
 	})
 })

--- a/pkg/pluginmanager/manager.go
+++ b/pkg/pluginmanager/manager.go
@@ -232,19 +232,14 @@ func getPreReleasePluginDiscovery() ([]configtypes.PluginDiscovery, error) {
 // discovery in question.
 func getAdditionalTestPluginDiscoveries() []configtypes.PluginDiscovery {
 	var testDiscoveries []configtypes.PluginDiscovery
-	testDiscoveryImages := strings.Split(os.Getenv(constants.ConfigVariableAdditionalDiscoveryForTesting), ",")
-	count := 0
-	for _, image := range testDiscoveryImages {
-		image = strings.TrimSpace(image)
-		if image != "" {
-			testDiscoveries = append(testDiscoveries, configtypes.PluginDiscovery{
-				OCI: &configtypes.OCIDiscovery{
-					Name:  fmt.Sprintf("test_%d", count),
-					Image: image,
-				},
-			})
-			count++
-		}
+	testDiscoveryImages := config.GetAdditionalTestDiscoveryImages()
+	for idx, image := range testDiscoveryImages {
+		testDiscoveries = append(testDiscoveries, configtypes.PluginDiscovery{
+			OCI: &configtypes.OCIDiscovery{
+				Name:  fmt.Sprintf("test_%d", idx),
+				Image: image,
+			},
+		})
 	}
 	return testDiscoveries
 }


### PR DESCRIPTION
### What this PR does / why we need it

This PR automatically adds to the trusted repositories any central discovery image added through the variable `TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY`.

This allows users to add test repos using that variable without having to also set them in ALLOW_REGISTRY.

Unit tests are added.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Before the PR:
```
$ rm ~/.config/tanzu/config*
$ unset ALLOWED_REGISTRY
$ unset ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY
$ git checkout main
$ make build
$ tz config set env.TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY <REDACTED>
$ tz plugin install cluster --target k8s
[i] Installing plugin 'cluster:v0.28.0' with target 'kubernetes'
[x] : "cluster" plugin pre-download verification failed: untrusted registry detected with image "<REDACTED>". Allowed registries are [projects.registry.vmware.com]
```

With this PR, notice that the plugin installation no longer fails although I did not set the ALLOWED_REGISTRY variable:
```
git checkout -
make build
$ tz plugin install cluster --target k8s
[i] Installing plugin 'cluster:v0.28.0' with target 'kubernetes'
[ok] successfully installed 'cluster' plugin
```
