### PR TITLE
Use caching for plugin discovery images

### DIFF
--- a/pkg/pluginmanager/manager.go
+++ b/pkg/pluginmanager/manager.go
@@ -218,7 +218,7 @@ func getPreReleasePluginDiscovery() ([]configtypes.PluginDiscovery, error) {
 	return []configtypes.PluginDiscovery{
 		{
 			OCI: &configtypes.OCIDiscovery{
-				Name:  "default_pre_release",
+				Name:  "default",
 				Image: centralRepoTestImage,
 			},
 		}}, nil


### PR DESCRIPTION
### What this PR does / why we need it

This is a draft as I still have the unit tests to work on.

Because of discovery image signature verification which can take a few seconds, the performance of commands such as `tanzu plugin search` has become too slow.  To improve this, we start using caching of the DB images.

The solution chosen has two aspects:
1. Check the cache validity and re-use the image when appropriate.  When re-using the image, there is no need to verify its signature which speeds up the operation significantly.
2. When the cache needs to be updated, we notify the user that the DB is being updated which can take a few seconds. This makes the UX much smoother in itself.

With this commit, the cache directory structure stays the same except that a new file is added in the same location as where the DB image is downloaded.  This file is named "digest.<imageHash>" and is empty. It serves the purpose of indicating the hash value of the cached DB image.  For example, we could have:

```
~/.cache/_tanzu/plugin_inventory
├── default
│   ├── digest.b160d48e089d01b60303e4ff91f8858bd0c81db3d56f3ba0a21aa29091c18c79
│   └── plugin_inventory.db
└── test_0
    ├── digest.89edcfa8a1bf54744dfef48da1b77c82697f278a4170eec9693b0af7f3c7d049
    └── plugin_inventory.db
```

The first directory ("default") represents the default plugin discovery image, while in this example, the second entry represents an additional test image added through the use of the environment variable TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY.

To make sure we don't use a stale cache, whenever we need to use a DB image, we always first download its most recent digest hash and compare its value with the "digest.<imageHash>" file name.  If they match, it means we can re-use the cached DB.  If they don't match, we need to refresh the cache.  In the latter case, we must also remove the old digest file.


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #147

### Describe testing done for PR

First test with a vanilla configuration:
```
# Reset the CLI to a vanilla configuration
$ rm ~/.config/tanzu/config*
$ unset TANZU_CLI_PRE_RELEASE_REPO_IMAGE
$ unset TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY
$ unset TANZU_CLI_SKIP_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION

# Delete the cache
$ rm ~/.cache/_tanzu/plugin_inventory

# The first call needs to fill the cache.
# Notice the new printout that helps the user know to be patient. 
$ time tz plugin search
[i] Updating plugin database cache for projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest, this will take a few seconds.
  NAME     DESCRIPTION             TARGET  LATEST
  builder  Build Tanzu components  global  v0.1.0-dev-8-g6087ea00
  test     Test the CLI            global  v0.1.0-dev-8-g6087ea00
/Users/kmarc/git/tanzu-cli/bin/tanzu plugin search  0.58s user 0.42s system 19% cpu 5.102 total

$ tree ~/.cache/_tanzu/plugin_inventory
/Users/kmarc/.cache/_tanzu/plugin_inventory
└── default
    ├── digest.b160d48e089d01b60303e4ff91f8858bd0c81db3d56f3ba0a21aa29091c18c79
    └── plugin_inventory.db

# Re-run the command immediately to see the effects of the caching.
# Notice the drop from 5 seconds above to 1 second now.
$ time tz plugin search
  NAME     DESCRIPTION             TARGET  LATEST
  builder  Build Tanzu components  global  v0.1.0-dev-8-g6087ea00
  test     Test the CLI            global  v0.1.0-dev-8-g6087ea00
/Users/kmarc/git/tanzu-cli/bin/tanzu plugin search  0.26s user 0.05s system 28% cpu 1.086 total

# Test when the digest is out of date (I do this by changing the digest value to anything else)
# Notice the cache being refreshed and the message to the user
$ mv ~/.cache/_tanzu/plugin_inventory/default/digest.b160d48e089d01b60303e4ff91f8858bd0c81db3d56f3ba0a21aa29091c18c79 ~/.cache/_tanzu/plugin_inventory/default/digest.abba
$ time tz plugin search
[i] Updating plugin database cache for projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest, this will take a few seconds.
  NAME     DESCRIPTION             TARGET  LATEST
  builder  Build Tanzu components  global  v0.1.0-dev-8-g6087ea00
  test     Test the CLI            global  v0.1.0-dev-8-g6087ea00
/Users/kmarc/git/tanzu-cli/bin/tanzu plugin search  0.60s user 0.42s system 20% cpu 5.049 total

$ tree ~/.cache/_tanzu/plugin_inventory
/Users/kmarc/.cache/_tanzu/plugin_inventory
└── default
    ├── digest.b160d48e089d01b60303e4ff91f8858bd0c81db3d56f3ba0a21aa29091c18c79
    └── plugin_inventory.db

# Test if there is no digest file.  The cache is refreshed.
$ rm ~/.cache/_tanzu/plugin_inventory/default/digest.b160d48e089d01b60303e4ff91f8858bd0c81db3d56f3ba0a21aa29091c18c79
$ time tz plugin search
[i] Updating plugin database cache for projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest, this will take a few seconds.
  NAME     DESCRIPTION             TARGET  LATEST
  builder  Build Tanzu components  global  v0.1.0-dev-8-g6087ea00
  test     Test the CLI            global  v0.1.0-dev-8-g6087ea00
/Users/kmarc/git/tanzu-cli/bin/tanzu plugin search  0.61s user 0.42s system 20% cpu 5.026 total

$ tree ~/.cache/_tanzu/plugin_inventory
/Users/kmarc/.cache/_tanzu/plugin_inventory
└── default
    ├── digest.b160d48e089d01b60303e4ff91f8858bd0c81db3d56f3ba0a21aa29091c18c79
    └── plugin_inventory.db

# Test if there are more than one digest file.  This would be a bug in the code of the CLI as it should
# never happen.  However, it is better to protect against such a case to avoid possibly using an invalid
# cache without realizing it.
# To test this I create a second digest file and confirm the cache is refreshed
$ cp ~/.cache/_tanzu/plugin_inventory/default/digest.b160d48e089d01b60303e4ff91f8858bd0c81db3d56f3ba0a21aa29091c18c79 ~/.cache/_tanzu/plugin_inventory/default/digest.abba
$ time tz plugin search
[i] Updating plugin database cache for projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest, this will take a few seconds.
  NAME     DESCRIPTION             TARGET  LATEST
  builder  Build Tanzu components  global  v0.1.0-dev-8-g6087ea00
  test     Test the CLI            global  v0.1.0-dev-8-g6087ea00
/Users/kmarc/git/tanzu-cli/bin/tanzu plugin search  0.59s user 0.41s system 19% cpu 5.078 total

$ tree ~/.cache/_tanzu/plugin_inventory
/Users/kmarc/.cache/_tanzu/plugin_inventory
└── default
    ├── digest.b160d48e089d01b60303e4ff91f8858bd0c81db3d56f3ba0a21aa29091c18c79
    └── plugin_inventory.db
```

Now test with an additional test repository:
```
$ tree ~/.cache/_tanzu/plugin_inventory
/Users/kmarc/.cache/_tanzu/plugin_inventory
└── default
    ├── digest.b160d48e089d01b60303e4ff91f8858bd0c81db3d56f3ba0a21aa29091c18c79
    └── plugin_inventory.db
$ tz config set env.TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY <REDACTED>

# Notice that only the DB for the additional test repo is setup since the default repo is already cached
$ time tz plugin search
[i] Updating plugin database cache for <REDACTED>, this will take a few seconds.
  NAME                DESCRIPTION                                                        TARGET           LATEST
  builder             Build Tanzu components                                             global           v0.1.0-dev-8-g6087ea00
[...]
/Users/kmarc/git/tanzu-cli/bin/tanzu plugin search  0.62s user 0.43s system 10% cpu 10.283 total

$ tree ~/.cache/_tanzu/plugin_inventory
/Users/kmarc/.cache/_tanzu/plugin_inventory
├── default
│   ├── digest.b160d48e089d01b60303e4ff91f8858bd0c81db3d56f3ba0a21aa29091c18c79
│   └── plugin_inventory.db
└── test_0
    ├── digest.89edcfa8a1bf54744dfef48da1b77c82697f278a4170eec9693b0af7f3c7d049
    └── plugin_inventory.db

# Test an outdated manifest for the additional test repo and notice only this DB being refreshed
$ mv ~/.cache/_tanzu/plugin_inventory/test_0/digest.89edcfa8a1bf54744dfef48da1b77c82697f278a4170eec9693b0af7f3c7d049 ~/.cache/_tanzu/plugin_inventory/test_0/digest.abba

$ time tz plugin search
[i] Updating plugin database cache for <REDACTED>, this will take a few seconds.
  NAME                DESCRIPTION                                                        TARGET           LATEST
  builder             Build Tanzu components                                             global           v0.1.0-dev-8-g6087ea00
[...]
/Users/kmarc/git/tanzu-cli/bin/tanzu plugin search  0.64s user 0.44s system 18% cpu 6.020 total

$ tree ~/.cache/_tanzu/plugin_inventory
/Users/kmarc/.cache/_tanzu/plugin_inventory
├── default
│   ├── digest.b160d48e089d01b60303e4ff91f8858bd0c81db3d56f3ba0a21aa29091c18c79
│   └── plugin_inventory.db
└── test_0
    ├── digest.89edcfa8a1bf54744dfef48da1b77c82697f278a4170eec9693b0af7f3c7d049
    └── plugin_inventory.db

# Test if all repos (the default one and the test one) are out of date.
$ mv ~/.cache/_tanzu/plugin_inventory/test_0/digest.89edcfa8a1bf54744dfef48da1b77c82697f278a4170eec9693b0af7f3c7d049 ~/.cache/_tanzu/plugin_inventory/test_0/digest.abba
$ mv ~/.cache/_tanzu/plugin_inventory/default/digest.b160d48e089d01b60303e4ff91f8858bd0c81db3d56f3ba0a21aa29091c18c79 ~/.cache/_tanzu/plugin_inventory/default/digest.abba

# Notice both DB being refreshed.
$ time tz plugin search
[i] Updating plugin database cache for projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest, this will take a few seconds.
[i] Updating plugin database cache for <REDACTED>, this will take a few seconds.
  NAME                DESCRIPTION                                                        TARGET           LATEST
  builder             Build Tanzu components                                             global           v0.1.0-dev-8-g6087ea00
[...]
/Users/kmarc/git/tanzu-cli/bin/tanzu plugin search  0.94s user 0.80s system 14% cpu 12.115 total

$ tree ~/.cache/_tanzu/plugin_inventory
/Users/kmarc/.cache/_tanzu/plugin_inventory
├── default
│   ├── digest.b160d48e089d01b60303e4ff91f8858bd0c81db3d56f3ba0a21aa29091c18c79
│   └── plugin_inventory.db
└── test_0
    ├── digest.89edcfa8a1bf54744dfef48da1b77c82697f278a4170eec9693b0af7f3c7d049
    └── plugin_inventory.db
```

Test with plugin group search and notice the 12 seconds delay with an empty cache and only 2 seconds with the cache:
```
# Remove entire cache (both the default and the test discovery images)
$ rm ~/.cache/_tanzu/plugin_inventory
$ time tz plugin group search
[i] Updating plugin database cache for projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest, this will take a few seconds.
[i] Updating plugin database cache for <REDACTED>, this will take a few seconds.
  GROUP
  vmware-tzcli/admin:v0.0.1
  vmware-tap/v1.4.0
  vmware-tkg/v2.1.0
  vmware-tmc/v0.0.1
/Users/kmarc/git/tanzu-cli/bin/tanzu plugin group search  0.93s user 0.80s system 15% cpu 11.186 total
$ time tz plugin group search
  GROUP
  vmware-tzcli/admin:v0.0.1
  vmware-tap/v1.4.0
  vmware-tkg/v2.1.0
  vmware-tmc/v0.0.1
/Users/kmarc/git/tanzu-cli/bin/tanzu plugin group search  0.26s user 0.05s system 15% cpu 1.951 total
```

Test impact with plugin installation:
```
# First remove the cache
$ rm ~/.cache/_tanzu/plugin_inventory/default

# Now install a plugin and see that the DB is being fetched
$ time tz plugin install builder
[i] Updating plugin database cache for projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest, this will take a few seconds.
[i] Installing plugin 'builder:v0.1.0-dev-8-g6087ea00' with target 'global'
[ok] successfully installed 'builder' plugin
/Users/kmarc/git/tanzu-cli/bin/tanzu plugin install builder  1.62s user 0.80s system 19% cpu 12.492 total

# Try again and see the cache has been re-used
$ time tz plugin install builder
[i] Installing plugin 'builder:v0.1.0-dev-8-g6087ea00' with target 'global'
[ok] successfully installed 'builder' plugin
/Users/kmarc/git/tanzu-cli/bin/tanzu plugin install builder  1.35s user 0.38s system 21% cpu 7.948 total

# Try with plugin groups to see that the cache prevents from refreshing the DB for every plugin
$ rm ~/.cache/_tanzu/plugin_inventory/default

# Notice the DB refresh for the first plugin only
$ time tz plugin install --group vmware-tzcli/admin:v0.0.1
[i] Updating plugin database cache for projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest, this will take a few seconds.
[i] Installing plugin 'builder:v0.1.0-dev-8-g6087ea00' with target 'global'
[i] Installing plugin 'test:v0.1.0-dev-8-g6087ea00' with target 'global'
[ok] successfully installed all plugins from group 'vmware-tzcli/admin:v0.0.1'
/Users/kmarc/git/tanzu-cli/bin/tanzu plugin install --group   3.91s user 1.45s system 19% cpu 26.931 total

# Notice no DB refresh
$ time tz plugin install --group vmware-tzcli/admin:v0.0.1
[i] Installing plugin 'builder:v0.1.0-dev-8-g6087ea00' with target 'global'
[i] Installing plugin 'test:v0.1.0-dev-8-g6087ea00' with target 'global'
[ok] successfully installed all plugins from group 'vmware-tzcli/admin:v0.0.1'
/Users/kmarc/git/tanzu-cli/bin/tanzu plugin install --group   3.23s user 1.15s system 21% cpu 20.343 total
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The Tanzu CLI now uses caching to speed-up plugin search and installation.
```

### Additional information

#### Special notes for your reviewer

The design we originally discussed was going to store the DB file in a directory named after the digest of the DB image.  I started with:

`~/cache/_tanzu/plugin_inventory/b160d48e089d01b60303e4ff91f8858bd0c81db3d56f3ba0a21aa29091c18c79/plugin_inventory.db`

This worked, but had an issue with cleanup.  When downloading a new DB image, we need to delete the old image to avoid the cache constantly growing.  The problem with the above is that when more than one discovery was being used (the default one AND additional test ones) it was not possible to know which old DB image to delete between the different discoveries.  To fix this I re-introduced the discovery name prefix in the path:

`~/cache/_tanzu/plugin_inventory/default/b160d48e089d01b60303e4ff91f8858bd0c81db3d56f3ba0a21aa29091c18c79/plugin_inventory.db`
`~/cache/_tanzu/plugin_inventory/test_0/89edcfa8a1bf54744dfef48da1b77c82697f278a4170eec9693b0af7f3c7d049/plugin_inventory.db`

With this, we know there should only be one directory under each discovery directory and are able to properly cleanup.

However, because the digest hash is part of the path to the `plugin_inventory.db` file in this approach, reading the plugin DB requires to know the hash value.  This required some of the details of the cache to "leak" into other parts of the code.  Basically, the hash value would have to be determined when discovering the latest DB image, but would need to be made available to the parts of the code that needed to read that DB after it had been downloaded.

To avoid this, I decided to keep the path to the `plugin_inventory.db` file unchanged (`~/cache/_tanzu/plugin_inventory/default/plugin_inventory.db`) which allowed readers to access it as before.  And to verify the cache, I added a file `digest.<imageHash` that only the cache handling logic needs to use.



