### PR TITLE
Unify the tanzu installation locations

### DIFF
--- a/pkg/common/defaults.go
+++ b/pkg/common/defaults.go
@@ -16,12 +16,12 @@ var (
 	// compatibility is achieved.
 
 	// DefaultPluginRoot is the default plugin root.
-	DefaultPluginRoot = filepath.Join(xdg.DataHome, "_tanzu-cli")
+	DefaultPluginRoot = filepath.Join(xdg.DataHome, "tanzu-cli")
 
 	// DefaultCacheDir is the default cache directory
-	DefaultCacheDir = filepath.Join(xdg.Home, ".cache", "_tanzu")
+	DefaultCacheDir = filepath.Join(xdg.Home, ".cache", "tanzu")
 
 	// DefaultLocalPluginDistroDir is the default Local plugin distribution root directory
 	// This directory will be used for local discovery and local distribute of plugins
-	DefaultLocalPluginDistroDir = filepath.Join(xdg.Home, ".config", "_tanzu-plugins")
+	DefaultLocalPluginDistroDir = filepath.Join(xdg.Home, ".config", "tanzu-plugins")
 )


### PR DESCRIPTION
### What this PR does / why we need it

Unifying the installation of Tanzu
The names of the directories for the plugins, catalog cache and local
plugin discovery (<XDG_DATA_HOME>/_tanzu-cli, $HOME/.cache/_tanzu, $HOME/.config/_tanzu-plugins) are all directories prefixed with " _ " previously , so as not to conflict with their nonprefixed counterparts is changed to use the existing CLI installations directories without ' _' prefix

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

As part of testing https://github.com/vmware-tanzu/tanzu-cli/pull/124
- Added cli coexistence go tests using e2e framework.
- Added GitHub workflow to run CLI-Coexistence Tests using docker

Tested the unification and coexistence by writing test using E2E framework for various use cases involving installing plugins, Core CLI commands config set,get,context.

Manual testing in a docker environment to verify the unification and coexistence of new Tanzu CLI and legacy Tanzu CLI- v0.28 are performed.

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Tanzu Installation locations uses the existing CLI installations directories without ' _' prefix 
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
