### PR TITLE
Disable CEIP prompt for tanzu 'version', 'ceip set' and 'config set' commands

### DIFF
--- a/pkg/command/ceip_participation.go
+++ b/pkg/command/ceip_participation.go
@@ -27,9 +27,10 @@ const (
 
 func newCEIPParticipationCmd() *cobra.Command {
 	var ceipParticipationCmd = &cobra.Command{
-		Use:     "ceip-participation",
-		Short:   "Manage CEIP Participation",
-		Long:    "Manage CEIP Participation",
+		Use:   "ceip-participation",
+		Short: "Manage VMware's Customer Experience Improvement Program (CEIP) Participation",
+		Long: "Manage VMware's Customer Experience Improvement Program (CEIP) participation which provides VMware with " +
+			"information that enables VMware to improve its products and services and fix problems",
 		Aliases: []string{"ceip"},
 		Annotations: map[string]string{
 			"group": string(plugin.SystemCmdGroup),


### PR DESCRIPTION
- Disable CEIP prompt for `tanzu version`, 'tanzu ceip set' and 'tanzu config set'
- Also updated the short/long description for CEIP command

### What this PR does / why we need it
This PR would disable the CEIP prompt for "tanzu version", "tanzu config set" and "tanzu ceip set" 

We need it for the below reasons:

 - 'tanzu version'(common first command to run),
 - 'ceip set' (not a good UX to prompt user who is trying to set the CEIP configuration)
 - 'config set' (would be a chicken and egg issue if user tries to set CEIP configuration using "tanzu config set env.TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER yes")
 
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #189  

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #189  

### Describe testing done for PR

Tested 
1. `tanzu version command`
2. `tanzu config set`
3. `tanzu ceip set`
All the above commands doesn't show the CEIP prompt 
```
❯ ./bin/tanzu version
Warning, Masking commands for plugins "login" because a core command or other plugin with that name already exists.
version: v0.0.2-dev
buildDate: 2023-04-06
sha: 83540128-dirty

❯ ./bin/tanzu config set env.TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER yes
Warning, Masking commands for plugins "login" because a core command or other plugin with that name already exists.
❯ vim ~/.config/tanzu/config.yaml

❯ vim ~/.config/tanzu/config-ng.yaml

❯ ./bin/tanzu ceip set false
Warning, Masking commands for plugins "login" because a core command or other plugin with that name already exists.
❯ ./bin/tanzu ceip get
Warning, Masking commands for plugins "login" because a core command or other plugin with that name already exists.
  CEIP-STATUS
  Opt-out
```
Then, removed the CEIP opt-in config from the configuration and tested `tanzu config init` and could see the ceip prompt showing up
```
❯ ./bin/tanzu config init
Warning, Masking commands for plugins "login" because a core command or other plugin with that name already exists.
?
VMware's Customer Experience Improvement Program ("CEIP") provides VMware with information that enables VMware to improve its products and services and fix problems. By choosing to participate in CEIP, you agree that VMware may collect technical information about your use of VMware products and services on a regular basis. This information does not personally identify you.
For more details about the Program, please see http://www.vmware.com/trustvmware/ceip.html

Do you agree to Participate in the Customer Experience Improvement Program?
  [Use arrows to move, type to filter]
> Yes
  No
```

Tested the `tanzu ceip-participation` command help to show the details description for the command

```
❯ ./bin/tanzu ceip-participation
Warning, Masking commands for plugins "login" because a core command or other plugin with that name already exists.
Manage VMware's Customer Experience Improvement Program (CEIP) participation which provides VMware with information that enables VMware to improve its products and services and fix problems

Usage:
  tanzu ceip-participation [command]

Aliases:
  ceip-participation, ceip

Available Commands:
  get         Get the current CEIP opt-in status
  set         Set the opt-in preference for CEIP

Flags:
  -h, --help   help for ceip-participation

Use "tanzu ceip-participation [command] --help" for more information about a command.
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Disabled the CEIP participation prompt for tanzu 'version', 'ceip set' and 'config set' commands
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
