### PR TITLE
Do not show command masked warning for `login` plugin

### DIFF
--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -106,7 +106,10 @@ func NewRootCmd() (*cobra.Command, error) {
 				maskedPlugins = append(maskedPlugins, matchedCmd.Name())
 				rootCmd.RemoveCommand(matchedCmd)
 				rootCmd.AddCommand(cmd)
-			} else {
+			} else if plugins[i].Name != "login" {
+				// As the `login` plugin is now part of the core Tanzu CLI command and not a plugin
+				// anymore, skip the `login` plugin from adding it to the maskedPlugins array to avoid
+				// the warning message from getting shown to the user on each command invocation.
 				maskedPlugins = append(maskedPlugins, plugins[i].Name)
 			}
 		}


### PR DESCRIPTION
### What this PR does / why we need it

- Do not show command masked warning for the `login` plugin
- As the `login` plugin is now part of the core Tanzu CLI command and not a plugin anymore, skip the `login` plugin from adding it to the maskedPlugins array to avoid the warning message from getting shown to the user on each command invocation.


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #191

### Describe testing done for PR

- Install plugins with old CLI
```
/t/4 $ tanzu-0.28.0 plugin sync
ℹ  Checking for required plugins...
ℹ  Installing plugin 'management-cluster:v0.28.0' with target 'kubernetes'
ℹ  Installing plugin 'package:v0.28.0' with target 'kubernetes'
ℹ  Installing plugin 'pinniped-auth:v0.28.0'

ℹ  Installing plugin 'secret:v0.28.0' with target 'kubernetes'
ℹ  Installing plugin 'telemetry:v0.28.0' with target 'kubernetes'
ℹ  Installing plugin 'isolated-cluster:v0.28.0'
ℹ  Installing plugin 'login:v0.28.0'
ℹ  Successfully installed all required plugins
✔  Done
```

- Run a command with a new CLI WITHOUT bug fix
```
$ tz version
Warning, Masking commands for plugins "login" because a core command or other plugin with that name already exists.
version: v0.81.1
buildDate: 2023-04-06
sha: 73a4c10d-dirty
```

- Run a command with a new CLI WITH bug fix
```
$ tz version
version: v0.81.1
buildDate: 2023-04-06
sha: d3580d4e
```



<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
