### PR TITLE
Check that the context-target-v2 flag is enabled

### DIFF
--- a/pkg/command/plugin.go
+++ b/pkg/command/plugin.go
@@ -106,8 +106,9 @@ func newPluginCmd() *cobra.Command {
 	if !config.IsFeatureActivated(constants.FeatureDisableCentralRepositoryForTesting) {
 		installPluginCmd.MarkFlagsMutuallyExclusive("group", "local")
 		installPluginCmd.MarkFlagsMutuallyExclusive("group", "version")
-		installPluginCmd.MarkFlagsMutuallyExclusive("group", "target")
-
+		if config.IsFeatureActivated(constants.FeatureContextCommand) {
+			installPluginCmd.MarkFlagsMutuallyExclusive("group", "target")
+		}
 		pluginCmd.AddCommand(
 			newSearchPluginCmd(),
 			newPluginGroupCmd())


### PR DESCRIPTION
### What this PR does / why we need it

We don't really support turning off the "context-target-v2" anymore but if the user does the CLI crashes for every command.

To reproduce:
```
bin/tanzu version
version: v0.81.1
buildDate: 2023-04-07
sha: 0f8698235
$ grep v2 ~/.config/tanzu/config.yaml
            context-target-v2: "true"
$ mv tmp.txt ~/.config/tanzu/config.yaml
overwrite /Users/kmarc/.config/tanzu/config.yaml? (y/n [n]) y
$ bin/tanzu version
panic: Failed to find flag "target" and mark it as being in a mutually exclusive flag group

goroutine 1 [running]:
github.com/spf13/cobra.(*Command).MarkFlagsMutuallyExclusive(0x101f63873?, {0xc000b5bc88, 0x2, 0x2})
	/Users/kmarc/go/pkg/mod/github.com/spf13/cobra@v1.6.1/flag_groups.go:53 +0x2a9
github.com/vmware-tanzu/tanzu-cli/pkg/command.newPluginCmd()
	/Users/kmarc/git/tanzu-cli/pkg/command/plugin.go:109 +0x6c9
github.com/vmware-tanzu/tanzu-cli/pkg/command.NewRootCmd()
	/Users/kmarc/git/tanzu-cli/pkg/command/root.go:38 +0x7f
github.com/vmware-tanzu/tanzu-cli/pkg/command.Execute()
	/Users/kmarc/git/tanzu-cli/pkg/command/root.go:221 +0x19
main.main()
	/Users/kmarc/git/tanzu-cli/cmd/tanzu/main.go:15 +0x1d
```

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

I repeated the steps to reproduce the problem with this PR and it no longer crashes.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
