### PR TITLE
Update the description of CEIP command with "subject to change"

### DIFF
--- a/pkg/command/ceip_participation.go
+++ b/pkg/command/ceip_participation.go
@@ -28,9 +28,9 @@ const (
 func newCEIPParticipationCmd() *cobra.Command {
 	var ceipParticipationCmd = &cobra.Command{
 		Use:   "ceip-participation",
-		Short: "Manage VMware's Customer Experience Improvement Program (CEIP) Participation",
+		Short: "Manage VMware's Customer Experience Improvement Program (CEIP) Participation (subject to change)",
 		Long: "Manage VMware's Customer Experience Improvement Program (CEIP) participation which provides VMware with " +
-			"information that enables VMware to improve its products and services and fix problems",
+			"information that enables VMware to improve its products and services and fix problems (subject to change)",
 		Aliases: []string{"ceip"},
 		Annotations: map[string]string{
 			"group": string(plugin.SystemCmdGroup),
@@ -49,8 +49,8 @@ func newCEIPParticipationCmd() *cobra.Command {
 func newCEIPParticipationSetCmd() *cobra.Command {
 	var setCmd = &cobra.Command{
 		Use:   "set OPT_IN_BOOL",
-		Short: "Set the opt-in preference for CEIP",
-		Long:  "Set the opt-in preference for CEIP",
+		Short: "Set the opt-in preference for CEIP (subject to change)",
+		Long:  "Set the opt-in preference for CEIP (subject to change)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !strings.EqualFold(args[0], "true") && !strings.EqualFold(args[0], "false") {
@@ -70,8 +70,8 @@ func newCEIPParticipationSetCmd() *cobra.Command {
 func newCEIPParticipationGetCmd() *cobra.Command {
 	var getCmd = &cobra.Command{
 		Use:   "get",
-		Short: "Get the current CEIP opt-in status",
-		Long:  "Get the current CEIP opt-in status",
+		Short: "Get the current CEIP opt-in status (subject to change)",
+		Long:  "Get the current CEIP opt-in status (subject to change)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			optInVal, err := configlib.GetCEIPOptIn()
 			if err != nil {


### PR DESCRIPTION
### What this PR does / why we need it
This PR updates the description of the CEIP commands with "subject to change" to convey that CEIP command is subject to change(as CEIP command may be folded into telemetry plugin).

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

The below is output of `tanzu` and `tanzu ceip` commands

```
❯ ./bin/tanzu
Usage:
  tanzu [command]

Available command groups:

  Admin
    builder                 Build Tanzu components
    codegen                 Tanzu code generation tool
    test                    Test the CLI

  Manage
    pkhellowplugin          prem test helloworld plugin

  Run
    cluster                 Kubernetes cluster operations
    feature                 Operate on features and featuregates
    isolated-cluster        Prepopulating images/bundle for internet-restricted environments
    kubernetes-release      Kubernetes release operations
    management-cluster      Kubernetes management cluster operations
    package                 Tanzu package management
    secret                  Tanzu secret management
    telemetry               configure cluster-wide settings for vmware tanzu telemetry

  System
    ceip-participation      Manage VMware's Customer Experience Improvement Program (CEIP) Participation (subject to change)
    completion              Output shell completion code
    config                  Configuration for the CLI
    context                 Configure and manage contexts for the Tanzu CLI
    init                    Initialize the CLI
    login                   Login to the platform
    plugin                  Manage CLI plugins
    version                 Version information

  Target
    kubernetes              Tanzu CLI plugins that target a Kubernetes cluster
    mission-control         Tanzu CLI plugins that target a Tanzu Mission Control endpoint


Flags:
  -h, --help   help for tanzu

Use "tanzu [command] --help" for more information about a command.

Not logged in
❯ ./bin/tanzu ceip
Manage VMware's Customer Experience Improvement Program (CEIP) participation which provides VMware with information that enables VMware to improve its products and services and fix problems (subject to change)

Usage:
  tanzu ceip-participation [command]

Aliases:
  ceip-participation, ceip

Available Commands:
  get         Get the current CEIP opt-in status (subject to change)
  set         Set the opt-in preference for CEIP (subject to change)

Flags:
  -h, --help   help for ceip-participation

```


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
