### PR TITLE
Delete entries using unknown target

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -72,7 +72,7 @@ func (c *ContextCatalog) Upsert(plugin *cli.PluginInfo) error {
 	}
 
 	// The "unknown" target was previously used in two scenarios:
-	// 1- to represent the global target (>= v0.28)
+	// 1- to represent the global target (>= v0.28 and < v0.90)
 	// 2- to represent either the global or kubernetes target (< v0.28)
 	// When inserting the "global" or "k8s" target we should remove any similar plugin using
 	// the "unknown" target and vice versa.


### PR DESCRIPTION
### What this PR does / why we need it

Plugins aimed at a "global" target (not "k8s" nor "tmc") use a target named "global", but used to use the unknown/unspecified target which was just the empty string.

If an plugin is installed with the "global" target, it now replaces any installation that uses the unknown target and vice versa.


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #200

### Describe testing done for PR
I repeated the two tests shown in #200 (as shown below) and confirmed only the last installation was shown.
I also verified that the catalog only contained the last installation info.

```
$ tz plugin clean
Warning, Masking commands for plugins "isolated-cluster" because a core command or other plugin with that name already exists.
[ok] successfully cleaned up all plugins
$ tz plugin install isolated-cluster --local ~/.config/tanzu-plugins/
[i] Installing plugin 'isolated-cluster:v0.29.0-dev'
[ok] successfully installed 'isolated-cluster' plugin
$ tz plugin list
Standalone Plugins
  NAME              DESCRIPTION                                                       TARGET  VERSION      STATUS
  isolated-cluster  Prepopulating images/bundle for internet-restricted environments          v0.29.0-dev  installed
$ tz plugin install isolated-cluster
[i] Installing plugin 'isolated-cluster:v9.9.9' with target 'global'
[ok] successfully installed 'isolated-cluster' plugin
$ tz plugin list
Standalone Plugins
  NAME              DESCRIPTION                     TARGET  VERSION  STATUS
  isolated-cluster  isolated-cluster functionality  global  v9.9.9   installed
$ tz plugin install isolated-cluster --local ~/.config/tanzu-plugins/
[i] Installing plugin 'isolated-cluster:v0.29.0-dev'
[ok] successfully installed 'isolated-cluster' plugin
$ tz plugin list
Standalone Plugins
  NAME              DESCRIPTION                                                       TARGET  VERSION      STATUS
  isolated-cluster  Prepopulating images/bundle for internet-restricted environments          v0.29.0-dev  installed
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
