### PR TITLE
Fix e2e random failures and add stress tests to context use cases

### DIFF
--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -1,0 +1,77 @@
+# Copyright 2023 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+E2E_TEST_OUTPUT ?= e2e-test-output.txt
+E2E_TEST_TIMEOUT ?= 60m
+GOTEST_VERBOSE ?= -v
+ROOT_DIR := $(shell git rev-parse --show-toplevel)
+
+ifndef TANZU_API_TOKEN
+TANZU_API_TOKEN = ""
+endif
+
+ifndef TANZU_CLI_TMC_UNSTABLE_URL
+TANZU_CLI_TMC_UNSTABLE_URL = ""
+endif
+
+ifndef TANZU_CLI_E2E_TEST_CENTRAL_REPO_URL
+TANZU_CLI_E2E_TEST_CENTRAL_REPO_URL = gcr.io/eminent-nation-87317/tanzu-cli/test/v1/plugins/plugin-inventory:latest
+endif
+
+ifndef TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL
+TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL = localhost:9876/tanzu-cli/plugins/central:small
+endif
+
+
+.PHONY: e2e-cli-core-all ## Execute all CLI Core E2E Tests
+e2e-cli-core-all: e2e-cli-lifecycle e2e-cli-config e2e-cli-plugin-compatibility-test e2e-context-k8s-tests e2e-context-tmc-test e2e-cli-plugin-lifecycle-sync-test
+
+
+.PHONY: e2e-cli-lifecycle ## Execute CLI life cycle specific e2e tests
+e2e-cli-lifecycle:
+	export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="Yes" ; \
+	${GO} test ${ROOT_DIR}/test/e2e/cli_lifecycle -timeout ${E2E_TEST_TIMEOUT} -race -coverprofile ${E2E_TEST_OUTPUT} ${GOTEST_VERBOSE} ; \
+
+.PHONY: e2e-cli-config ## Execute CLI config life cycle specific e2e tests
+e2e-cli-config:
+	export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="Yes" ; \
+	${GO} test ${ROOT_DIR}/test/e2e/config -timeout ${E2E_TEST_TIMEOUT} -race -coverprofile ${E2E_TEST_OUTPUT} ${GOTEST_VERBOSE} ; \
+
+.PHONY: e2e-cli-plugin-compatibility-test ## Execute CLI Core Plugin Compatibility E2E test cases
+e2e-cli-plugin-compatibility-test:
+	@if [ "${TANZU_CLI_E2E_TEST_CENTRAL_REPO_URL}" = "" ]; then \
+		echo "***Skipping Plugin Compatibility test cases because environment variables TANZU_CLI_E2E_TEST_CENTRAL_REPO_URL is not set***" ; \
+	else \
+		export TANZU_CLI_PRE_RELEASE_REPO_IMAGE=$(TANZU_CLI_E2E_TEST_CENTRAL_REPO_URL) ; \
+		export TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST=$(TANZU_CLI_E2E_TEST_CENTRAL_REPO_URL) ; \
+		export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="Yes" ; \
+		${GO} test ${ROOT_DIR}/test/e2e/plugins_compatibility -timeout ${E2E_TEST_TIMEOUT} -race -coverprofile ${E2E_TEST_OUTPUT} ${GOTEST_VERBOSE} ; \
+	fi 
+
+.PHONY: e2e-cli-plugin-lifecycle-sync-test ## Execute CLI Core Plugin life cycle E2E test cases
+e2e-cli-plugin-lifecycle-sync-test:
+	@if [ "${TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL}" = "" ]; then \
+		echo "***Skipping Plugin life cycle test cases because environment variables TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL is not set***" ; \
+	else \
+		export TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL=$(TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL) ; \
+		export TANZU_CLI_PRE_RELEASE_REPO_IMAGE=$(TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL) ; \
+		export TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST=$(TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL) ; \
+		export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="Yes" ; \
+		${GO} test ${ROOT_DIR}/test/e2e/plugin_lifecycle -timeout ${E2E_TEST_TIMEOUT} -race -coverprofile ${E2E_TEST_OUTPUT} ${GOTEST_VERBOSE} ; \
+		${GO} test ${ROOT_DIR}/test/e2e/plugin_sync -timeout ${E2E_TEST_TIMEOUT} -race -coverprofile ${E2E_TEST_OUTPUT} ${GOTEST_VERBOSE} ; \
+	fi
+
+.PHONY: e2e-context-k8s-tests ## Execute CLI context life cycle e2e tests for k8s target
+e2e-context-k8s-tests:
+	export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="Yes" ; \
+	${GO} test `go list ${ROOT_DIR}/test/e2e/context/... | grep -v test/e2e/context/tmc` -timeout ${E2E_TEST_TIMEOUT} -race -coverprofile ${E2E_TEST_OUTPUT} ${GOTEST_VERBOSE}
+
+## To run TMC tests, we need to set environment variables TANZU_API_TOKEN and TANZU_CLI_TMC_UNSTABLE_URL, in case of github workflow, these are set as github environment variables
+.PHONY: e2e-context-tmc-test ## Execute CLI context life cycle e2e tests for tmc target
+e2e-context-tmc-test:
+	@if [ "${TANZU_API_TOKEN}" = "" ] && [ "$(TANZU_CLI_TMC_UNSTABLE_URL)" = "" ]; then \
+		echo "***Skipping TMC specific e2e tests cases because environment variables TANZU_API_TOKEN and TANZU_CLI_TMC_UNSTABLE_URL are not set***" ; \
+	else \
+	    export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="Yes" ; \
+		${GO} test ${ROOT_DIR}/test/e2e/context/tmc -timeout ${E2E_TEST_TIMEOUT} -race -coverprofile ${E2E_TEST_OUTPUT} ${GOTEST_VERBOSE} ; \
+	fi

--- a/test/e2e/context/context_k8s_lifecycle_stress_test.go
+++ b/test/e2e/context/context_k8s_lifecycle_stress_test.go
@@ -1,0 +1,98 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// context provides context command specific E2E test cases
+package context
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware-tanzu/tanzu-cli/test/e2e/framework"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
+)
+
+// This suite adds stress test cases for context life cycle tests (for the k8s target)
+// Here are sequence of tests:
+// a. delete config files and initialize config
+// b. list and delete contexts if any exists already, before running test cases
+// c. create multiple contexts with kubeconfig and context
+// d. test 'tanzu context use' command with the specific context name (not the recently created one),test for multiple contexts continuously
+// e. test 'tanzu context list' command, should list all contexts created
+// f. test 'tanzu context delete' command, make sure to delete all contexts created in previous test cases
+var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-lifecycle-stress-tests-k8s]", func() {
+	Context("Context lifecycle stress tests for k8s target", func() {
+		// Test case: a. delete config files and initialize config
+		It("should initialize configuration successfully", func() {
+			// delete config files
+			err := tf.Config.DeleteCLIConfigurationFiles()
+			Expect(err).To(BeNil())
+			// call init
+			err = tf.Config.ConfigInit()
+			Expect(err).To(BeNil())
+			// should create config files
+			Expect(tf.Config.IsCLIConfigurationFilesExists()).To(BeTrue())
+		})
+		// Test case: b. list and delete contexts if any exists already, before running test cases
+		It("list and delete contexts if any exists already", func() {
+			By("list and delete contexts if any exists already before running test cases")
+			list, err := tf.ContextCmd.ListContext()
+			Expect(err).To(BeNil(), "list context should not return any error")
+			for _, ctx := range list {
+				err := tf.ContextCmd.DeleteContext(ctx.Name)
+				Expect(err).To(BeNil(), "delete context should delete context without any error")
+				Expect(framework.IsContextExists(tf, ctx.Name)).To(BeFalse(), fmt.Sprintf(framework.ContextShouldNotExists, ctx.Name))
+			}
+			list, err = tf.ContextCmd.ListContext()
+			Expect(err).To(BeNil(), "list context should not return any error")
+			Expect(len(list)).To(Equal(0), "all contexts should be deleted")
+		})
+		// Test case: c. create multiple contexts with kubeconfig and context
+		It("create multiple contexts with kubeconfig and context", func() {
+			By("create multiple contexts with kubeconfig and context")
+			for i := 0; i < ContextCreateLimit; i++ {
+				ctxName := ContextNameConfigPrefix + framework.RandomString(4)
+				err := tf.ContextCmd.CreateContextWithKubeconfig(ctxName, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
+				Expect(err).To(BeNil(), "context should create without any error")
+				log.Info("context: " + ctxName + " added")
+				Expect(framework.IsContextExists(tf, ctxName)).To(BeTrue(), fmt.Sprintf(framework.ContextShouldExistsAsCreated, ctxName))
+				contextNamesStress = append(contextNamesStress, ctxName)
+			}
+		})
+		// Test case: d. test 'tanzu context use' command with the specific context name
+		// 				(not the recently created one), test for multiple contexts continuously
+		It("use context command", func() {
+			By("use context command")
+			for i := 0; i < len(contextNamesStress); i++ {
+				err := tf.ContextCmd.UseContext(contextNamesStress[i])
+				log.Info("set the corrent context as:" + contextNamesStress[i])
+				Expect(err).To(BeNil(), "use context should set context without any error")
+				active, err := tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
+				Expect(err).To(BeNil(), "there should be a active context")
+				Expect(active).To(Equal(contextNamesStress[i]), "the active context should be recently set context")
+			}
+
+		})
+		// Test case: e. test 'tanzu context list' command, should list all contexts created
+		It("list context should have all added contexts", func() {
+			By("list context should have all added contexts")
+			list := GetAvailableContexts(tf, contextNamesStress)
+			Expect(len(list)).To(Equal(len(contextNamesStress)), "list context should have all contexts added in previous tests")
+		})
+		// Test case: f. test 'tanzu context delete' command, make sure to delete all contexts created in previous test cases
+		It("delete context command", func() {
+			By("delete all contexts created in previous tests")
+			for _, ctx := range contextNamesStress {
+				err := tf.ContextCmd.DeleteContext(ctx)
+				log.Infof("context: %s deleted", ctx)
+				Expect(framework.IsContextExists(tf, ctx)).To(BeFalse(), fmt.Sprintf(framework.ContextShouldNotExists, ctx))
+				Expect(err).To(BeNil(), "delete context should delete context without any error")
+			}
+			list := GetAvailableContexts(tf, contextNamesStress)
+			Expect(len(list)).To(Equal(0), "delete context should have deleted all given contexts")
+		})
+	})
+})

--- a/test/e2e/context/context_k8s_lifecycle_test.go
+++ b/test/e2e/context/context_k8s_lifecycle_test.go
@@ -13,12 +13,14 @@ import (
 
 	"github.com/vmware-tanzu/tanzu-cli/test/e2e/framework"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
 
 const ContextNameConfigPrefix = "context-config-k8s-"
 
 // Test suite tests the context life cycle use cases for the k8s target
 var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-lifecycle-k8s]", func() {
+	var active string
 	Context("Context lifecycle tests for k8s target", func() {
 		// Test case: delete config files and initialize config
 		It("should initialize configuration successfully", func() {
@@ -36,10 +38,11 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-lifecycle-k8s]", 
 			By("list and delete contexts if any exists already before running test cases")
 			list, err := tf.ContextCmd.ListContext()
 			Expect(err).To(BeNil(), "list context should not return any error")
-			for _, ctx := range list {
-				err := tf.ContextCmd.DeleteContext(ctx.Name)
+			for i := 0; i < len(list); i++ {
+				err = tf.ContextCmd.DeleteContext(list[i].Name)
 				Expect(err).To(BeNil(), "delete context should delete context without any error")
-				Expect(framework.IsContextExists(tf, ctx.Name)).To(BeFalse(), fmt.Sprintf(framework.ContextShouldNotExists, ctx.Name))
+				log.Infof("context: %s deleted", list[i].Name)
+				Expect(framework.IsContextExists(tf, list[i].Name)).To(BeFalse(), fmt.Sprintf(framework.ContextShouldNotExists, list[i].Name))
 			}
 			list, err = tf.ContextCmd.ListContext()
 			Expect(err).To(BeNil(), "list context should not return any error")
@@ -51,6 +54,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-lifecycle-k8s]", 
 			ctxName := ContextNameConfigPrefix + framework.RandomString(4)
 			err := tf.ContextCmd.CreateContextWithKubeconfig(ctxName, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
 			Expect(err).To(BeNil(), "context should create without any error")
+			log.Infof("context: %s added", ctxName)
 			Expect(framework.IsContextExists(tf, ctxName)).To(BeTrue(), fmt.Sprintf(framework.ContextShouldExistsAsCreated, ctxName))
 			contextNames = append(contextNames, ctxName)
 		})
@@ -78,18 +82,19 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-lifecycle-k8s]", 
 			ctxName := "context-defaultConfig-" + framework.RandomString(4)
 			err := tf.ContextCmd.CreateContextWithDefaultKubeconfig(ctxName, clusterInfo.ClusterKubeContext)
 			Expect(err).To(BeNil(), "context should create without any error")
+			log.Infof("context: %s added", ctxName)
 			Expect(framework.IsContextExists(tf, ctxName)).To(BeTrue(), fmt.Sprintf(framework.ContextShouldExistsAsCreated, ctxName))
 			contextNames = append(contextNames, ctxName)
-			active, err := tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
+			active, err = tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
 			Expect(err).To(BeNil(), "there should be a active context")
 			Expect(active).To(Equal(ctxName), "the active context should be recently added context")
 		})
 		// Test case: test 'tanzu context use' command with the specific context name (not the recently created one)
 		It("use context command", func() {
 			By("use context command")
-			err := tf.ContextCmd.UseContext(contextNames[0])
+			err = tf.ContextCmd.UseContext(contextNames[0])
 			Expect(err).To(BeNil(), "use context should set context without any error")
-			active, err := tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
+			active, err = tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
 			Expect(err).To(BeNil(), "there should be a active context")
 			Expect(active).To(Equal(contextNames[0]), "the active context should be recently set context")
 		})

--- a/test/e2e/context/context_suite_test.go
+++ b/test/e2e/context/context_suite_test.go
@@ -17,11 +17,14 @@ func TestContext(t *testing.T) {
 }
 
 var (
-	tf           *framework.Framework
-	clusterInfo  *framework.ClusterInfo
-	contextNames []string
-	err          error
+	tf                 *framework.Framework
+	clusterInfo        *framework.ClusterInfo
+	contextNames       []string
+	contextNamesStress []string
+	err                error
 )
+
+const ContextCreateLimit = 100
 
 // BeforeSuite created KIND cluster
 var _ = BeforeSuite(func() {
@@ -30,6 +33,7 @@ var _ = BeforeSuite(func() {
 	clusterInfo, err = framework.CreateKindCluster(tf, "context-e2e-"+framework.RandomNumber(4))
 	Expect(err).To(BeNil(), "should not get any error for KIND cluster creation")
 	contextNames = make([]string, 0)
+	contextNamesStress = make([]string, 0)
 })
 
 // AfterSuite deletes the KIND cluster created in BeforeSuite

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -93,6 +93,7 @@ const (
 
 	// log info
 	ExecutingCommand = "Executing command: %s"
+	FileContent      = "file: %s , content: %s"
 
 	// Error messages
 	UnableToFindPluginForTarget                   = "unable to find plugin '%s' for target '%s'"
@@ -124,6 +125,12 @@ const TestPluginsDir = ".e2e-test-plugins"
 // TempDirInTestDirPath is the directory under $HOME/$TestDir, to create temporary files (if any) for E2E test execution
 const TempDirInTestDirPath = "temp"
 
+const ConfigFolder = ".config"
+const TanzuFolder = "tanzu"
+const TanzuPluginsFolder = "tanzu-plugins"
+const ConfigFile = "config.yaml"
+const ConfigNGFile = "config-ng.yaml"
+
 var (
 	// TestDirPath is the absolute directory path for the E2E test execution uses to create all Tanzu CLI specific files (config, local plugins etc)
 	TestDirPath               string
@@ -131,6 +138,12 @@ var (
 	TestStandalonePluginsPath string
 	// FullPathForTempDir is the absolute path for the temp directory under $TestDir
 	FullPathForTempDir string
+
+	// ConfigFilePath represents config.yaml file path which under $HOME/.tanzu-cli-e2e/.config/tanzu
+	ConfigFilePath string
+	// ConfigFilePath represents config-ng.yaml file path which under $HOME/.tanzu-cli-e2e/.config/tanzu
+	ConfigNGFilePath string
+	TanzuFolderPath  string
 )
 
 // PluginsForLifeCycleTests is list of plugins (which are published in local central repo) used in plugin life cycle test cases
@@ -177,8 +190,11 @@ func init() {
 	// Update $HOME as $HOME/.tanzu-cli-e2e
 	os.Setenv("HOME", TestDirPath)
 	TestPluginsDirPath = filepath.Join(TestDirPath, TestPluginsDir)
+	TanzuFolderPath = filepath.Join(filepath.Join(TestDirPath, ConfigFolder), TanzuFolder)
+	ConfigFilePath = filepath.Join(TanzuFolderPath, ConfigFile)
+	ConfigNGFilePath = filepath.Join(TanzuFolderPath, ConfigNGFile)
 	// Create a directory (if not exists) $HOME/.tanzu-cli-e2e/.config/tanzu-plugins/discovery/standalone
-	TestStandalonePluginsPath = filepath.Join(filepath.Join(filepath.Join(filepath.Join(TestDirPath, ".config"), "tanzu-plugins"), "discovery"), "standalone")
+	TestStandalonePluginsPath = filepath.Join(filepath.Join(filepath.Join(filepath.Join(TestDirPath, ConfigFolder), TanzuPluginsFolder), "discovery"), "standalone")
 	_ = CreateDir(TestStandalonePluginsPath)
 	// Create a directory (if not exists) $HOME/.tanzu-cli-e2e/test
 	_ = CreateDir(FullPathForTempDir)

--- a/test/e2e/framework/framework_helper.go
+++ b/test/e2e/framework/framework_helper.go
@@ -290,3 +290,27 @@ func GetGivenPluginFromTheGivenPluginList(pluginList []*PluginInfo, requiredPlug
 	superSet := PluginListToMap(pluginList)
 	return superSet[GetMapKeyForPlugin(requiredPlugin)]
 }
+
+// LogConfigFiles logs info level, contents of files config.yaml and config-ng.yaml
+func LogConfigFiles() error {
+	err := LogFile(ConfigFilePath)
+	if err != nil {
+		return err
+	}
+	err = LogFile(ConfigNGFilePath)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// LogFile logs in info level, the given file content
+func LogFile(file string) error {
+	dat, err := os.ReadFile(file)
+	if err != nil {
+		log.Infof("error while reading file: %s error:%s", file, err.Error())
+		return err
+	}
+	log.Infof(FileContent, ConfigFilePath, string(dat))
+	return err
+}

--- a/test/e2e/plugin_lifecycle/plugin_lifecycle_test.go
+++ b/test/e2e/plugin_lifecycle/plugin_lifecycle_test.go
@@ -23,6 +23,13 @@ import (
 // 1. plugin search, install, delete, describe, list (with negative use cases)
 // 2. plugin source add/update/list/delete (with negative use cases)
 var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-lifecycle]", func() {
+	// use case: tanzu plugin source add, list, update, delete
+	// add plugin source
+	// a. list plugin sources and validate plugin source created in previous step
+	// b. update plugin source URL
+	// c. (negative test) update plugin source URL with incorrect type (--type)
+	// d. (negative test) delete plugin source which is not exists
+	// e. delete plugin source which was created in previous test case
 	Context("plugin source use cases: tanzu plugin source add, list, update, delete", func() {
 		// Test case: add plugin source
 		It("add plugin source", func() {
@@ -60,6 +67,13 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-lifecycle]", func(
 			Expect(framework.IsPluginSourceExists(list, pluginSourceName)).To(BeFalse())
 		})
 	})
+	// use case: tanzu plugin clean, install and describe, list, delete
+	// a. clean plugins if any installed already
+	// b. install all plugins from framework.PluginsForLifeCycleTests, and validate the installation by running describe command on each plugin
+	// c. (negative) describe plugin with incorrect target type
+	// d. (negative) describe plugin with incorrect plugin name
+	// e. list plugins and validate the list plugins output has all plugins which are installed in previous steps
+	// f. delete all plugins which are installed, and validate by running list plugin command
 	Context("plugin use cases: tanzu plugin clean, install and describe, list, delete", func() {
 		// Test case: clean plugins if any installed already
 		It("clean plugins if any installed already", func() {
@@ -115,6 +129,10 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-lifecycle]", func(
 			Expect(len(pluginsList)).Should(Equal(0), "there should not be any plugins available after uninstall all")
 		})
 	})
+	// use case: tanzu plugin clean, install, clean and list
+	// a. clean plugins if any installed already
+	// b. install all plugin
+	// c. run clean plugin command and validate with list plugin command
 	Context("plugin use cases: tanzu plugin clean, install, clean and list", func() {
 		// Test case: clean plugins if any installed already
 		It("clean plugins", func() {
@@ -148,19 +166,23 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-lifecycle]", func(
 			Expect(len(pluginsList)).Should(Equal(0), "there should not be any plugins available after uninstall all")
 		})
 	})
+	// use case: negative test cases for plugin install and plugin delete commands
+	// a. install plugin with incorrect value target flag
+	// b. install plugin with incorrect plugin name
+	// c. install plugin with incorrect value for flag --version
 	Context("plugin use cases: negative test cases for plugin install and plugin delete commands", func() {
-		// Test case: install plugin with incorrect value target flag
+		// Test case: a. install plugin with incorrect value target flag
 		It("install plugin with random string for target flag", func() {
 			err := tf.PluginCmd.InstallPlugin(framework.PluginsForLifeCycleTests[0].Name, framework.RandomString(5), framework.PluginsForLifeCycleTests[0].Version)
 			Expect(err.Error()).To(ContainSubstring(framework.InvalidTargetSpecified))
 		})
-		// Test case: install plugin with incorrect plugin name
+		// Test case: b. install plugin with incorrect plugin name
 		It("install plugin with random string for target flag", func() {
 			name := framework.RandomString(5)
 			err := tf.PluginCmd.InstallPlugin(name, "", "")
 			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(framework.UnableToFindPlugin, name)))
 		})
-		// Test case: install plugin with incorrect value for flag --version
+		// Test case: c. install plugin with incorrect value for flag --version
 		It("install plugin with incorrect version", func() {
 			for _, plugin := range framework.PluginsForLifeCycleTests {
 				if !(plugin.Target == framework.GlobalTarget) {

--- a/test/e2e/plugins_compatibility/plugins_compatibility_test.go
+++ b/test/e2e/plugins_compatibility/plugins_compatibility_test.go
@@ -21,6 +21,14 @@ import (
 // Below test suite, searches for test plugins (plugin name prefix with "test-plugin-") in the test central repository and
 // installs all test plugins, executes basic commands on all installed test plugins, and finally uninstalls all test plugins.
 // Each test plugin built using specific Tanzu CLI Runtime library versions.
+// Here are sequence of test cases in below suite:
+// a. Before installing test plugins, uninstall test plugins (if any installed already) and verify status using plugin list
+// b. install all test plugins from repo gcr.io/eminent-nation-87317/tanzu-cli/test/v1/plugins/plugin-inventory:latest
+// c. list all plugins and make sure all above installed test plugins are listed with status "installed"
+// d. run basic commands on installed test plugins, to make sure works/co-exists with other plugins build with different runtime version
+// e. run hello-world commands on installed test plugins, to make sure works/co-exists with other plugins build with different runtime version
+// f. uninstall all installed compatibility test-plugins
+// g. list all plugins and make sure all above uninstalled test plugins should not be listed in the output
 var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Compatibility]", func() {
 	var (
 		tf      *framework.Framework
@@ -34,7 +42,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Compatibility]", f
 		Expect(len(plugins)).NotTo(BeZero(), fmt.Sprintf("there are no test-plugin-'s in test central repo:%s , make sure its valid test central repo with test-plugins", os.Getenv(framework.TanzuCliE2ETestCentralRepositoryURL)))
 	})
 	Context("Uninstall test plugins and verify status using plugin list", func() {
-		// Test case: Before installing test plugins, uninstall test plugins (if any installed already) and verify status using plugin list
+		// Test case: a. Before installing test plugins, uninstall test plugins (if any installed already) and verify status using plugin list
 		It("Uninstall test plugins (if any test plugin installed already) and verify status using plugin list", func() {
 			UninstallPlugins(tf, plugins)
 			ok := IsAllPluginsUnInstalled(tf, plugins)
@@ -42,7 +50,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Compatibility]", f
 		})
 	})
 	Context("Install plugins for plugins compatibility", func() {
-		// Test case: install all test plugins
+		// Test case: b. install all test plugins from repo TANZU_CLI_E2E_TEST_CENTRAL_REPO_URL
 		It("Install all test plugins", func() {
 			for _, plugin := range plugins {
 				log.Infof("Installing test plugin:%s", plugin)
@@ -50,14 +58,14 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Compatibility]", f
 				Expect(err).To(BeNil(), fmt.Sprintf("should not occur any error while installing the test plugin: %s", plugin))
 			}
 		})
-		// Test case: list all plugins and make sure all above installed test plugins are listed with status "installed"
+		// Test case: c. list all plugins and make sure all above installed test plugins are listed with status "installed"
 		It("List plugins and make sure installed plugins are listed", func() {
 			ok := IsAllPluginsInstalled(tf, plugins)
 			Expect(ok).To(BeTrue(), "All test plugins should be installed and listed in plugin list output as installed")
 		})
 	})
 	Context("Test installed compatibility test-plugins", func() {
-		// Test case: run basic commands on installed test plugins, to make sure works/co-exists with other plugins build with different runtime version
+		// Test case: d. run basic commands on installed test plugins, to make sure works/co-exists with other plugins build with different runtime version
 		It("run basic commands on the installed test-plugins", func() {
 			for _, plugin := range plugins {
 				info, err := tf.PluginCmd.ExecuteSubCommand(plugin.Name + " info")
@@ -67,7 +75,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Compatibility]", f
 		})
 	})
 	Context("Test installed compatibility test-plugins with hello-world command", func() {
-		// Test case: run hello-world commands on installed test plugins, to make sure works/co-exists with other plugins build with different runtime version
+		// Test case: e. run hello-world commands on installed test plugins, to make sure works/co-exists with other plugins build with different runtime version
 		It("run hello-world commands on the installed test-plugins", func() {
 			for _, plugin := range plugins {
 				output, err := tf.PluginCmd.ExecuteSubCommand(plugin.Name + " hello-world")
@@ -77,7 +85,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Compatibility]", f
 		})
 	})
 	Context("Uninstall all installed compatibility test-plugins", func() {
-		// Test case: uninstall all installed compatibility test-plugins
+		// Test case: f. uninstall all installed compatibility test-plugins
 		It("uninstall all test-plugins", func() {
 			for _, plugin := range plugins {
 				log.Infof("Uninstalling test plugin: %s", plugin)
@@ -85,7 +93,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Compatibility]", f
 				Expect(err).To(BeNil(), fmt.Sprintf("should not occur any error while uninstalling the test plugin: %s", plugin))
 			}
 		})
-		// Test case: list all plugins and make sure all above uninstalled test plugins should not be listed in the output
+		// Test case: g. list all plugins and make sure all above uninstalled test plugins should not be listed in the output
 		It("List plugins and check uninstalled plugins exists", func() {
 			ok := IsAllPluginsUnInstalled(tf, plugins)
 			Expect(ok).To(BeTrue(), "All test plugins should be uninstalled")


### PR DESCRIPTION
### What this PR does / why we need it
This PR fixes the E2E random failures issue and adds stress tests to context life cycle use cases.
Before this PR, we execute simultaneously more than one suite of E2E tests which was causing issue to fail E2E tests, because they are trying to change the same config file.
In this PR we have updated the make file target `e2e-cli-core` to run only one E2E test suite at a time.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
[Tanzu CLI Core E2E Tests](https://github.com/vmware-tanzu/tanzu-cli/actions/runs/4693107509/jobs/8319654928?pr=209) executed multiple times in this PR
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
