### PR TITLE
Provide a means to list all versions of a plugin

### DIFF
--- a/pkg/command/plugin_search_test.go
+++ b/pkg/command/plugin_search_test.go
@@ -1,0 +1,116 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package command
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/pluginmanager"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
+)
+
+func TestPluginSearch(t *testing.T) {
+	tests := []struct {
+		test                string
+		centralRepoDisabled string
+		args                []string
+		expected            string
+		expectedFailure     bool
+	}{
+		{
+			test:                "no 'plugin search' without central repo",
+			centralRepoDisabled: "true",
+			args:                []string{"plugin", "search"},
+			expected:            "Manage CLI plugins",
+		},
+		{
+			test:            "invalid target",
+			args:            []string{"plugin", "search", "--target", "invalid"},
+			expectedFailure: true,
+			expected:        "invalid target specified. Please specify correct value of `--target` or `-t` flag from 'global/kubernetes/k8s/mission-control/tmc'",
+		},
+		{
+			test:            "no --local and --name together",
+			args:            []string{"plugin", "search", "--local", "./", "--name", "myplugin"},
+			expectedFailure: true,
+			expected:        "if any flags in the group [local name] are set none of the others can be",
+		},
+		{
+			test:            "no --local and --target together",
+			args:            []string{"plugin", "search", "--local", "./", "--target", "tmc"},
+			expectedFailure: true,
+			expected:        "if any flags in the group [local target] are set none of the others can be",
+		},
+		{
+			test:            "no --local and --show-details together",
+			args:            []string{"plugin", "search", "--local", "./", "--show-details"},
+			expectedFailure: true,
+			expected:        "if any flags in the group [local show-details] are set none of the others can be",
+		},
+	}
+
+	assert := assert.New(t)
+
+	configFile, err := os.CreateTemp("", "config")
+	assert.Nil(err)
+	os.Setenv("TANZU_CONFIG", configFile.Name())
+
+	configFileNG, err := os.CreateTemp("", "config_ng")
+	assert.Nil(err)
+	os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
+	os.Setenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER", "No")
+
+	// Bypass the environment variable for testing
+	err = os.Setenv(constants.ConfigVariablePreReleasePluginRepoImage, pluginmanager.PreReleasePluginRepoImageBypass)
+	assert.Nil(err)
+
+	featureArray := strings.Split(constants.FeatureContextCommand, ".")
+	err = config.SetFeature(featureArray[1], featureArray[2], "true")
+	assert.Nil(err)
+
+	defer func() {
+		os.Unsetenv("TANZU_CONFIG")
+		os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
+		os.Unsetenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER")
+		os.RemoveAll(configFile.Name())
+		os.RemoveAll(configFileNG.Name())
+	}()
+
+	for _, spec := range tests {
+		t.Run(spec.test, func(t *testing.T) {
+			// Disable the Central Repository feature if needed
+			featureArray := strings.Split(constants.FeatureDisableCentralRepositoryForTesting, ".")
+			err := config.SetFeature(featureArray[1], featureArray[2], spec.centralRepoDisabled)
+			assert.Nil(err)
+
+			rootCmd, err := NewRootCmd()
+			assert.Nil(err)
+			rootCmd.SetArgs(spec.args)
+
+			b := bytes.NewBufferString("")
+			rootCmd.SetOut(b)
+
+			err = rootCmd.Execute()
+			assert.Equal(err != nil, spec.expectedFailure)
+			if spec.expected != "" {
+				if spec.expectedFailure {
+					assert.Contains(err.Error(), spec.expected)
+				} else {
+					got, err := io.ReadAll(b)
+					assert.Nil(err)
+
+					// whitespace-agnostic match
+					assert.Contains(strings.Join(strings.Fields(string(got)), " "), spec.expected)
+				}
+			}
+		})
+	}
+}

--- a/pkg/pluginmanager/manager.go
+++ b/pkg/pluginmanager/manager.go
@@ -171,13 +171,13 @@ func discoverPluginGroup(pd []configtypes.PluginDiscovery, groupID string) (*plu
 }
 
 // DiscoverStandalonePlugins returns the available standalone plugins
-func DiscoverStandalonePlugins() ([]discovery.Discovered, error) {
+func DiscoverStandalonePlugins(criteria *discovery.PluginDiscoveryCriteria) ([]discovery.Discovered, error) {
 	discoveries, err := getPluginDiscoveries()
 	if err != nil {
 		return nil, err
 	}
 
-	plugins, err := discoverPlugins(discoveries)
+	plugins, err := discoverSpecificPlugins(discoveries, criteria)
 	if err != nil {
 		return plugins, err
 	}
@@ -326,7 +326,7 @@ func DiscoverPlugins() ([]discovery.Discovered, []discovery.Discovered) {
 		log.Warningf("unable to discover server plugins, %v", err.Error())
 	}
 
-	standalonePlugins, err := DiscoverStandalonePlugins()
+	standalonePlugins, err := DiscoverStandalonePlugins(nil)
 	if err != nil {
 		log.Warningf("unable to discover standalone plugins, %v", err.Error())
 	}


### PR DESCRIPTION
### What this PR does / why we need it

This commit introduces a "--name" flag to "plugin search".  Using this flag it is possible to limit the search to plugins with a specific name.

This commit also adds a "--show-details" flag to "plugin search" (instead of the orignally intended "--list-versions").  Using the "--show-details" flag, it is possible to get more information about each plugin, including all versions that are available.

This commit also adds a "--target" flag to "plugin search".  Using this flag, it is possible to limit the search to plugins of the specified target.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #134

### Describe testing done for PR

```
# Unchanged
$ tz plugin search
  NAME                DESCRIPTION                                                        TARGET           LATEST
  builder             Build Tanzu components                                             global           v0.90.0-alpha.0
  isolated-cluster    Prepopulating images/bundle for internet-restricted environments   global           v0.28.1
  pinniped-auth       Pinniped authentication operations (usually not directly invoked)  global           v0.28.1
  test                Test the CLI                                                       global           v0.90.0-alpha.0
  accelerator         Manage accelerators in a Kubernetes cluster                        kubernetes       v1.4.0
  apps                Applications on Kubernetes                                         kubernetes       v0.10.0
  cluster             Kubernetes cluster operations                                      kubernetes       v0.28.1
  feature             Operate on features and featuregates                               kubernetes       v0.28.1
  insight             Post & query image, package, source, and vulnerability data        kubernetes       v1.4.2
  kubernetes-release  Kubernetes release operations                                      kubernetes       v0.28.1
  management-cluster  Kubernetes management cluster operations                           kubernetes       v0.28.1
  package             Tanzu package management                                           kubernetes       v0.28.1
  secret              Tanzu secret management                                            kubernetes       v0.28.1
  services            Commands for working with service instances, classes and claims    kubernetes       v0.5.0
  telemetry           configure cluster-wide settings for vmware tanzu telemetry         kubernetes       v0.28.1
  account             Account for tmc resources                                          mission-control  v0.0.1
  apply               Create/Update a resource with a resource file                      mission-control  v0.0.1
[...]

# Unchanged
$ tz plugin search --local ~/.config/tanzu-plugins/
  NAME                DESCRIPTION                                                        TARGET      LATEST
  builder             Build Tanzu components                                                         v0.29.0-dev
  codegen             Tanzu code generation tool                                                     v0.29.0-dev
  isolated-cluster    Prepopulating images/bundle for internet-restricted environments               v0.29.0-dev
  login               Login to the platform                                                          v0.29.0-dev
  pinniped-auth       Pinniped authentication operations (usually not directly invoked)              v0.29.0-dev
  test                Test the CLI                                                                   v0.29.0-dev
  cluster             Kubernetes cluster operations                                      kubernetes  v0.29.0-dev
  feature             Operate on features and featuregates                               kubernetes  v0.29.0-dev
  kubernetes-release  Kubernetes release operations                                      kubernetes  v0.29.0-dev
  management-cluster  Kubernetes management cluster operations                           kubernetes  v0.29.0-dev
  package             Tanzu package management                                           kubernetes  v0.29.0-dev
  secret              Tanzu secret management                                            kubernetes  v0.29.0-dev
  telemetry           configure cluster-wide settings for vmware tanzu telemetry         kubernetes  v0.29.0-dev

# The new flags don't apply when using --local
$ tz plugin search --local ~/.config/tanzu-plugins/ --name a
[x] : if any flags in the group [local name] are set none of the others can be; [local name] were all set
$ tz plugin search --local ~/.config/tanzu-plugins/ --target tmc
[x] : if any flags in the group [local target] are set none of the others can be; [local target] were all set
$ tz plugin search --local ~/.config/tanzu-plugins/ --show-details
[x] : if any flags in the group [local show-details] are set none of the others can be; [local show-details] were all set

# Limit search to plugin name
$ tz plugin search --name cluster
  NAME     DESCRIPTION                    TARGET           LATEST
  cluster  Kubernetes cluster operations  kubernetes       v0.28.1
  cluster  cluster plugin                 mission-control  v0.0.1

$ tz plugin search --name cluster -o yaml
- description: Kubernetes cluster operations
  latest: v0.28.1
  name: cluster
  target: kubernetes
- description: cluster plugin
  latest: v0.0.1
  name: cluster
  target: mission-control

$ tz plugin search --name cluster --show-details
name: cluster
description: Kubernetes cluster operations
target: kubernetes
latest: v0.28.1
versions:
    - v0.25.0
    - v0.25.4
    - v0.28.0
    - v0.28.1

name: cluster
description: cluster plugin
target: mission-control
latest: v0.0.1
versions:
    - v0.0.1

$ tz plugin search --name cluster --show-details -o yaml
- name: cluster
  description: Kubernetes cluster operations
  target: kubernetes
  latest: v0.28.1
  versions:
    - v0.25.0
    - v0.25.4
    - v0.28.0
    - v0.28.1
- name: cluster
  description: cluster plugin
  target: mission-control
  latest: v0.0.1
  versions:
    - v0.0.1

# Limit search to a target
$ tz plugin search --target k8s
  NAME                DESCRIPTION                                                      TARGET      LATEST
  accelerator         Manage accelerators in a Kubernetes cluster                      kubernetes  v1.4.0
  apps                Applications on Kubernetes                                       kubernetes  v0.10.0
  cluster             Kubernetes cluster operations                                    kubernetes  v0.28.1
  feature             Operate on features and featuregates                             kubernetes  v0.28.1
  insight             Post & query image, package, source, and vulnerability data      kubernetes  v1.4.2
  kubernetes-release  Kubernetes release operations                                    kubernetes  v0.28.1
  management-cluster  Kubernetes management cluster operations                         kubernetes  v0.28.1
  package             Tanzu package management                                         kubernetes  v0.28.1
  secret              Tanzu secret management                                          kubernetes  v0.28.1
  services            Commands for working with service instances, classes and claims  kubernetes  v0.5.0
  telemetry           configure cluster-wide settings for vmware tanzu telemetry       kubernetes  v0.28.1

$ tz plugin search --name cluster --target tmc
  NAME     DESCRIPTION     TARGET           LATEST
  cluster  cluster plugin  mission-control  v0.0.1

$ tz plugin search --name cluster --target k8s --show-details
name: cluster
description: Kubernetes cluster operations
target: kubernetes
latest: v0.28.1
versions:
    - v0.25.0
    - v0.25.4
    - v0.28.0
    - v0.28.1
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The "tanzu plugin search" command now accepts a "--name" flag to limit the breadth of the search.  That command also accepts a "--show-details" flag which allows to get details about available plugins, including the list of supported versions.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

Please pay attention to the output formatting.  I used an `objectWriter` for details and used the `yaml` format which I felt was best for readability.  So, when showing details, we don't use a table, as was suggested in #134.

Some decisions I made that are up for discussion:
1. We support `tanzu plugin search --show-details`, which will show the long version for all plugins
2. For `--local` we don't support the new flags (`--target`, `--name`, `--show-details`), although I don't think it would be too hard to support, I wanted feedback first.  Searching a local discovery will normally yield a very small amount of plugins, and therefore limiting the search by name or target seemed unnecessary.  As for `--show-details`, I was thinking that a local discovery would normally only contain a single version, so there would be no point in showing details.  Of course this can all be changed in the future if appropriate use cases present themselves.
