### PR TITLE
Add filtering to the inventory for plugin groups and ignore hidden/deactivated groups

### DIFF
--- a/cmd/plugin/builder/inventory/inventory_plugin_group_test.go
+++ b/cmd/plugin/builder/inventory/inventory_plugin_group_test.go
@@ -182,7 +182,7 @@ var _ = Describe("Unit tests for inventory plugin-group add", func() {
 
 			// verify that the local db file was updated correctly before publishing the database to remote repository
 			db := plugininventory.NewSQLiteInventory(referencedDBFile, "")
-			pgEntries, err := db.GetAllGroups()
+			pgEntries, err := db.GetPluginGroups(plugininventory.PluginGroupFilter{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pgEntries).NotTo(BeNil())
 			Expect(len(pgEntries)).To(Equal(1))
@@ -211,13 +211,13 @@ var _ = Describe("Unit tests for inventory plugin-group add", func() {
 			fakeImgpkgWrapper.PullImageCalls(pullDBImageStubWithPluginGroups)
 
 			ipgu.Override = true
-			ipgu.DeactivatePluginGroup = true
+			ipgu.DeactivatePluginGroup = false
 			err := ipgu.PluginGroupAdd()
 			Expect(err).NotTo(HaveOccurred())
 
 			// verify that the local db file was updated correctly before publishing the database to remote repository
 			db := plugininventory.NewSQLiteInventory(referencedDBFile, "")
-			pgEntries, err := db.GetAllGroups()
+			pgEntries, err := db.GetPluginGroups(plugininventory.PluginGroupFilter{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pgEntries).NotTo(BeNil())
 			Expect(len(pgEntries)).To(Equal(1))
@@ -287,7 +287,7 @@ var _ = Describe("Unit tests for inventory plugin-group add", func() {
 
 			// verify that the local db file was updated correctly before publishing the database to remote repository
 			db := plugininventory.NewSQLiteInventory(referencedDBFile, "")
-			pgEntries, err := db.GetAllGroups()
+			pgEntries, err := db.GetPluginGroups(plugininventory.PluginGroupFilter{IncludeHidden: true})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pgEntries).NotTo(BeNil())
 			Expect(len(pgEntries)).To(Equal(1))
@@ -309,7 +309,7 @@ var _ = Describe("Unit tests for inventory plugin-group add", func() {
 
 			// verify that the local db file was updated correctly before publishing the database to remote repository
 			db := plugininventory.NewSQLiteInventory(referencedDBFile, "")
-			pgEntries, err := db.GetAllGroups()
+			pgEntries, err := db.GetPluginGroups(plugininventory.PluginGroupFilter{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pgEntries).NotTo(BeNil())
 			Expect(len(pgEntries)).To(Equal(1))

--- a/pkg/discovery/oci_dbbacked.go
+++ b/pkg/discovery/oci_dbbacked.go
@@ -133,7 +133,7 @@ func (od *DBBackedOCIDiscovery) listPluginsFromInventory() ([]Discovered, error)
 }
 
 func (od *DBBackedOCIDiscovery) listGroupsFromInventory() ([]*plugininventory.PluginGroup, error) {
-	return od.getInventory().GetAllGroups()
+	return od.getInventory().GetPluginGroups(plugininventory.PluginGroupFilter{})
 }
 
 // fetchInventoryImage downloads the OCI image containing the information about the

--- a/pkg/discovery/oci_dbbacked_test.go
+++ b/pkg/discovery/oci_dbbacked_test.go
@@ -362,7 +362,7 @@ func (stub *stubInventory) GetPlugins(filter *plugininventory.PluginInventoryFil
 	return matchingEntries, nil
 }
 
-func (stub *stubInventory) GetAllGroups() ([]*plugininventory.PluginGroup, error) {
+func (stub *stubInventory) GetPluginGroups(plugininventory.PluginGroupFilter) ([]*plugininventory.PluginGroup, error) {
 	return groupEntries, nil
 }
 func (stub *stubInventory) CreateSchema() error {

--- a/pkg/plugininventory/plugin_inventory.go
+++ b/pkg/plugininventory/plugin_inventory.go
@@ -22,8 +22,8 @@ type PluginInventory interface {
 	// GetPlugins returns the plugins found in the inventory that match the provided filter.
 	GetPlugins(*PluginInventoryFilter) ([]*PluginInventoryEntry, error)
 
-	// GetAllGroups returns all plugin groups found in the inventory.
-	GetAllGroups() ([]*PluginGroup, error)
+	// GetPluginGroups returns the plugin groups found in the inventory that match the provided filter.
+	GetPluginGroups(PluginGroupFilter) ([]*PluginGroup, error)
 
 	// CreateSchema creates table schemas to the provided database.
 	// returns error if table creation fails for any reason
@@ -121,4 +121,17 @@ type PluginGroup struct {
 	Hidden bool
 	// The list of plugins specified by this group
 	Plugins []*PluginGroupPluginEntry
+}
+
+// PluginGroupFilter allows to specify different criteria for
+// looking up plugin group entries.
+type PluginGroupFilter struct {
+	// Vendor of the group to look for
+	Vendor string
+	// Publisher of the group to look for
+	Publisher string
+	// Name of the group to look for
+	Name string
+	// IncludeHidden indicates if hidden plugin groups should be included
+	IncludeHidden bool
 }


### PR DESCRIPTION
### What this PR does / why we need it

This PR is a step towards properly handling hidden/deactivated plugin groups and improving "plugin group search".
Instead of posting a big PR doing everything, I'm going incrementally to make the review process easier.

So, this PR adds support for filtering plugin group when querying the plugin inventory database.

Thanks to this filtering mechanism, hidden plugin groups are no longer returned by the plugin inventory. 
In a follow-up PR I will provide a configuration option to toggle this behaviour.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

First publish some plugins and plugin groups to the local test DB:
```
$ make plugin-build-and-publish-packages
$ make inventory-init
$ make inventory-plugin-add
$ make inventory-plugin-group-add PLUGIN_GROUP_NAME_VERSION=test:v0.0.1

# Configure the CLI to use the local test repository
$ tz config set env.TANZU_CLI_PRE_RELEASE_REPO_IMAGE localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest
$ tz config set env.TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest

# Make sure we can see the plugin group
$ tz plugin group search
[i] Reading plugin inventory for "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest", this will take a few seconds.
[!] Skipping the plugins discovery image signature verification for "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"

  GROUP
  vmware-tzcli/test:v0.0.1
```

Now we deactivate the group and check that is not shown anymore:
```
$ make inventory-plugin-group-deactivate PLUGIN_GROUP_NAME_VERSION=test:v0.0.1
$ tz plugin group search
  GROUP
$ tz plugin install --group vmware-tzcli/test:v0.0.1
[x] : could not find group 'vmware-tzcli/test:v0.0.1'
```

Reactivate the group and see that it can be used again:
```
$ make inventory-plugin-group-activate PLUGIN_GROUP_NAME_VERSION=test:v0.0.1

$ tz plugin group search
[i] Reading plugin inventory for "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest", this will take a few seconds.
[!] Skipping the plugins discovery image signature verification for "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"

  GROUP
  vmware-tzcli/test:v0.0.1

$ tz plugin install --group vmware-tzcli/test:v0.0.1
[i] Installing plugin 'builder:v0.90.0-alpha.0' with target 'global'
[i] Installing plugin 'test:v0.90.0-alpha.0' with target 'global'
[ok] successfully installed all plugins from group 'vmware-tzcli/test:v0.0.1'
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Plugin groups that are marked as "deactivated" in the repository of plugins are now ignored by the CLI.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
