### PR TITLE
Provide configuration variable to access deactivated plugins/groups

### DIFF
--- a/cmd/plugin/builder/README.md
+++ b/cmd/plugin/builder/README.md
@@ -252,9 +252,14 @@ Below are the examples:
 
 ### Inventory-plugin-activate-deactivate
 
-Once the plugins are added to the inventory database, there might be a scenario where publisher need to mark the plugin as hidden or in deactive state so that users do not discover these plugins from the central repository. To support this scenario builder plugin implements `tanzu builder inventory plugin activate` and `tanzu builder inventory plugin deactivate` commands.
+Once the plugins are added to the inventory database, there might be scenarios where publishers want to mark
+the plugins as deactivated (hidden) so that users do not discover them from the central repository.  For
+example, when publishers want to prepare for the release of their plugins by publishing them to the central
+repository but want to wait for the actual release date to make them accessible to users, they would publish
+such plugins as _deactivated_. To support this scenario the builder plugin implements the
+`tanzu builder inventory plugin activate` and `tanzu builder inventory plugin deactivate` commands.
 
-Below are the flags available with `tanzu builder inventory plugin activate` and `tanzu builder inventory plugin deactivate` commands:
+Below are the flags available with `tanzu builder inventory plugin activate` and `tanzu builder inventory plugin deactivate`:
 
 ```txt
   -h, --help                                help for activate/deactivate
@@ -265,7 +270,7 @@ Below are the flags available with `tanzu builder inventory plugin activate` and
       --vendor string                       name of the vendor
 ```
 
-Below are the examples:
+Below are some examples:
 
 ```shell
   # Activate plugins in the inventory database based on the specified manifest file
@@ -273,6 +278,19 @@ Below are the examples:
 
   # Deactivate plugins in the inventory database based on the specified manifest file
   tanzu builder inventory plugin deactivate --repository localhost:5002/test/v1/tanzu-cli/plugins --vendor vmware --publisher tkg1 --manifest ./artifacts/packages/plugin_manifest.yaml
+```
+
+When plugins are published as _deactivated_, the CLI will completely ignore them, as if they were not
+present in the central repository.  For testing purposes, publishers can use the environment variable
+`TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY` to instruct the CLI to treat deactivated plugins as
+if they were _active_.  For example:
+
+```shell
+export TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY=1
+tanzu plugin search
+
+# Or for a single command
+TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY=1 tanzu plugin search
 ```
 
 ### Inventory-plugin-group-add
@@ -305,6 +323,21 @@ Here the `--manifest` flag is used to provide metadata about the plugin-group in
 ### Inventory-plugin-group-activate-deactivate
 
 In some scenarios, such as preparing for a new product release, a plugin-group may need to be created and added to the inventory database but kept "deactivated".  A "deactivated" plugin-group is not visible to the Tanzu CLI and therefore will not be discovered by users before the official product release, however testers can configure the CLI to discover "deactivated" plugins. To support this scenario the `builder` plugin implements the `tanzu builder inventory plugin-group activate` and `tanzu builder inventory plugin-group deactivate` commands.
+
+To configure the CLI to discover "deactivated" plugin-groups (and plugins) as if they were active,
+testers should use the environment variable `TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY`.
+For example:
+
+```shell
+export TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY=1
+tanzu plugin group search
+
+# Or for a single command
+TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY=1 tanzu plugin group search
+```
+
+*Note*: When using the builder plugin to create a plugin-group that contains _deactivated_ plugins,
+the `TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY=1` environment variable must first be set.
 
 Below are the flags available with `tanzu builder inventory plugin-group activate` and `tanzu builder inventory plugin-group deactivate` commands:
 

--- a/pkg/constants/env_variables.go
+++ b/pkg/constants/env_variables.go
@@ -9,9 +9,10 @@ const (
 )
 
 const (
-	AllowedRegistries                           = "ALLOWED_REGISTRY"
-	ConfigVariablePreReleasePluginRepoImage     = "TANZU_CLI_PRE_RELEASE_REPO_IMAGE"
-	ConfigVariableAdditionalDiscoveryForTesting = "TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY"
+	AllowedRegistries                                 = "ALLOWED_REGISTRY"
+	ConfigVariablePreReleasePluginRepoImage           = "TANZU_CLI_PRE_RELEASE_REPO_IMAGE"
+	ConfigVariableAdditionalDiscoveryForTesting       = "TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY"
+	ConfigVariableIncludeDeactivatedPluginsForTesting = "TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY"
 	// PluginDiscoveryImageSignatureVerificationSkipList is a comma separated list of discovery image urls
 	PluginDiscoveryImageSignatureVerificationSkipList = "TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST"
 	PublicKeyPathForPluginDiscoveryImageSignature     = "TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_PUBLIC_KEY_PATH"

--- a/pkg/discovery/oci_dbbacked.go
+++ b/pkg/discovery/oci_dbbacked.go
@@ -83,18 +83,23 @@ func (od *DBBackedOCIDiscovery) GetAllGroups() ([]*plugininventory.PluginGroup, 
 func (od *DBBackedOCIDiscovery) listPluginsFromInventory() ([]Discovered, error) {
 	var pluginEntries []*plugininventory.PluginInventoryEntry
 	var err error
+
+	shouldIncludeHidden, _ := strconv.ParseBool(os.Getenv(constants.ConfigVariableIncludeDeactivatedPluginsForTesting))
 	if od.criteria == nil {
-		pluginEntries, err = od.getInventory().GetAllPlugins()
+		pluginEntries, err = od.getInventory().GetPlugins(&plugininventory.PluginInventoryFilter{
+			IncludeHidden: shouldIncludeHidden,
+		})
 		if err != nil {
 			return nil, err
 		}
 	} else {
 		pluginEntries, err = od.getInventory().GetPlugins(&plugininventory.PluginInventoryFilter{
-			Name:    od.criteria.Name,
-			Target:  od.criteria.Target,
-			Version: od.criteria.Version,
-			OS:      od.criteria.OS,
-			Arch:    od.criteria.Arch,
+			Name:          od.criteria.Name,
+			Target:        od.criteria.Target,
+			Version:       od.criteria.Version,
+			OS:            od.criteria.OS,
+			Arch:          od.criteria.Arch,
+			IncludeHidden: shouldIncludeHidden,
 		})
 		if err != nil {
 			return nil, err
@@ -133,7 +138,10 @@ func (od *DBBackedOCIDiscovery) listPluginsFromInventory() ([]Discovered, error)
 }
 
 func (od *DBBackedOCIDiscovery) listGroupsFromInventory() ([]*plugininventory.PluginGroup, error) {
-	return od.getInventory().GetPluginGroups(plugininventory.PluginGroupFilter{})
+	shouldIncludeHidden, _ := strconv.ParseBool(os.Getenv(constants.ConfigVariableIncludeDeactivatedPluginsForTesting))
+	return od.getInventory().GetPluginGroups(plugininventory.PluginGroupFilter{
+		IncludeHidden: shouldIncludeHidden,
+	})
 }
 
 // fetchInventoryImage downloads the OCI image containing the information about the

--- a/pkg/discovery/oci_dbbacked_test.go
+++ b/pkg/discovery/oci_dbbacked_test.go
@@ -10,360 +10,33 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
-	"github.com/vmware-tanzu/tanzu-cli/pkg/distribution"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/fakes"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/plugininventory"
-	"github.com/vmware-tanzu/tanzu-cli/pkg/utils"
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
 
-var pluginEntries = []*plugininventory.PluginInventoryEntry{
-	{
-		Name:               "cluster",
-		Target:             configtypes.TargetK8s,
-		Description:        "cluster plugin for k8s",
-		Publisher:          "tkg",
-		Vendor:             "vmware",
-		RecommendedVersion: "v0.28.0",
-		Artifacts: distribution.Artifacts{
-			"v0.26.0": []distribution.Artifact{
-				{
-					Image:  "darwin/amd64/k8s/cluster:v0.26.0",
-					URI:    "",
-					Digest: "1a11111",
-					OS:     "darwin",
-					Arch:   "amd64",
-				},
-				{
-					Image:  "linux/amd64/k8s/cluster:v0.26.0",
-					URI:    "",
-					Digest: "1a22222",
-					OS:     "linux",
-					Arch:   "amd64",
-				},
-				{
-					Image:  "windows/amd64/k8s/cluster:v0.26.0",
-					URI:    "",
-					Digest: "1a33333",
-					OS:     "windows",
-					Arch:   "amd64",
-				},
-				{
-					Image:  "darwin/arm64/k8s/cluster:v0.26.0",
-					URI:    "",
-					Digest: "1a44444",
-					OS:     "darwin",
-					Arch:   "arm64",
-				},
-			},
-			"v0.28.0": []distribution.Artifact{
-				{
-					Image:  "darwin/amd64/k8s/cluster:v0.28.0",
-					URI:    "",
-					Digest: "1b11111",
-					OS:     "darwin",
-					Arch:   "amd64",
-				},
-				{
-					Image:  "linux/amd64/k8s/cluster:v0.28.0",
-					URI:    "",
-					Digest: "1b22222",
-					OS:     "linux",
-					Arch:   "amd64",
-				},
-				{
-					Image:  "windows/amd64/k8s/cluster:v0.28.0",
-					URI:    "",
-					Digest: "1b33333",
-					OS:     "windows",
-					Arch:   "amd64",
-				},
-				{
-					Image:  "darwin/arm64/k8s/cluster:v0.28.0",
-					URI:    "",
-					Digest: "1b44444",
-					OS:     "darwin",
-					Arch:   "arm64",
-				},
-			},
-		},
-	},
-	{
-		Name:               "cluster",
-		Target:             configtypes.TargetTMC,
-		Description:        "Cluster plugin for tmc",
-		Publisher:          "tmc",
-		Vendor:             "vmware",
-		RecommendedVersion: "v0.2.0",
-		Artifacts: distribution.Artifacts{
-			"v0.0.1": []distribution.Artifact{
-				{
-					Image:  "darwin/amd64/k8s/cluster:v0.0.1",
-					URI:    "",
-					Digest: "2a11111",
-					OS:     "darwin",
-					Arch:   "amd64",
-				},
-				{
-					Image:  "linux/amd64/k8s/cluster:v0.0.1",
-					URI:    "",
-					Digest: "2a22222",
-					OS:     "linux",
-					Arch:   "amd64",
-				},
-				{
-					Image:  "windows/amd64/k8s/cluster:v0.0.1",
-					URI:    "",
-					Digest: "2a33333",
-					OS:     "windows",
-					Arch:   "amd64",
-				},
-			},
-			"v0.2.0": []distribution.Artifact{
-				{
-					Image:  "darwin/amd64/k8s/cluster:v0.2.0",
-					URI:    "",
-					Digest: "2b11111",
-					OS:     "darwin",
-					Arch:   "amd64",
-				},
-				{
-					Image:  "linux/amd64/k8s/cluster:v0.2.0",
-					URI:    "",
-					Digest: "2b22222",
-					OS:     "linux",
-					Arch:   "amd64",
-				},
-				{
-					Image:  "windows/amd64/k8s/cluster:v0.2.0",
-					URI:    "",
-					Digest: "2b33333",
-					OS:     "windows",
-					Arch:   "amd64",
-				},
-			},
-		},
-	},
-	{
-		Name:               "telemetry",
-		Target:             configtypes.TargetK8s,
-		Description:        "telemetry plugin for k8s",
-		Publisher:          "tkg",
-		Vendor:             "vmware",
-		RecommendedVersion: "v0.28.0",
-		Artifacts: distribution.Artifacts{
-			"v0.26.0": []distribution.Artifact{
-				{
-					Image:  "darwin/amd64/k8s/telemetry:v0.26.0",
-					URI:    "",
-					Digest: "3a11111",
-					OS:     "darwin",
-					Arch:   "amd64",
-				},
-				{
-					Image:  "linux/amd64/k8s/telemetry:v0.26.0",
-					URI:    "",
-					Digest: "3a22222",
-					OS:     "linux",
-					Arch:   "amd64",
-				},
-				{
-					Image:  "windows/amd64/k8s/telemetry:v0.26.0",
-					URI:    "",
-					Digest: "3a33333",
-					OS:     "windows",
-					Arch:   "amd64",
-				},
-			},
-			"v0.28.0": []distribution.Artifact{
-				{
-					Image:  "darwin/amd64/k8s/telemetry:v0.28.0",
-					URI:    "",
-					Digest: "3b11111",
-					OS:     "darwin",
-					Arch:   "amd64",
-				},
-				{
-					Image:  "linux/amd64/k8s/telemetry:v0.28.0",
-					URI:    "",
-					Digest: "3b22222",
-					OS:     "linux",
-					Arch:   "amd64",
-				},
-				{
-					Image:  "windows/amd64/k8s/telemetry:v0.28.0",
-					URI:    "",
-					Digest: "3b33333",
-					OS:     "windows",
-					Arch:   "amd64",
-				},
-			},
-		},
-	},
+type inventoryFilterInError struct {
+	pluginFilter *plugininventory.PluginInventoryFilter
+	groupFilter  *plugininventory.PluginGroupFilter
 }
 
-var groupEntries = []*plugininventory.PluginGroup{
-	{
-		Vendor:    "vmware",
-		Publisher: "tkg",
-		Name:      "2.1.0",
-		Plugins: []*plugininventory.PluginGroupPluginEntry{
-			{
-				PluginIdentifier: plugininventory.PluginIdentifier{
-					Name:    "management-cluster",
-					Target:  configtypes.TargetK8s,
-					Version: "v0.28.0",
-				},
-			},
-			{
-				PluginIdentifier: plugininventory.PluginIdentifier{
-					Name:    "package",
-					Target:  configtypes.TargetK8s,
-					Version: "v0.28.0",
-				},
-			},
-			{
-				PluginIdentifier: plugininventory.PluginIdentifier{
-					Name:    "feature",
-					Target:  configtypes.TargetK8s,
-					Version: "v0.28.0",
-				},
-			},
-			{
-				PluginIdentifier: plugininventory.PluginIdentifier{
-					Name:    "kubernetes-release",
-					Target:  configtypes.TargetK8s,
-					Version: "v0.28.0",
-				},
-			},
-			{
-				PluginIdentifier: plugininventory.PluginIdentifier{
-					Name:    "isolated-cluster",
-					Target:  configtypes.TargetK8s,
-					Version: "v0.28.0",
-				},
-			},
-		},
-	},
-	{
-		Vendor:    "vmware",
-		Publisher: "tkg",
-		Name:      "1.6.0",
-		Plugins: []*plugininventory.PluginGroupPluginEntry{
-			{
-				PluginIdentifier: plugininventory.PluginIdentifier{
-					Name:    "management-cluster",
-					Target:  configtypes.TargetK8s,
-					Version: "v0.26.0",
-				},
-			},
-			{
-				PluginIdentifier: plugininventory.PluginIdentifier{
-					Name:    "package",
-					Target:  configtypes.TargetK8s,
-					Version: "v0.26.0",
-				},
-			},
-			{
-				PluginIdentifier: plugininventory.PluginIdentifier{
-					Name:    "feature",
-					Target:  configtypes.TargetK8s,
-					Version: "v0.26.0",
-				},
-			},
-			{
-				PluginIdentifier: plugininventory.PluginIdentifier{
-					Name:    "kubernetes-release",
-					Target:  configtypes.TargetK8s,
-					Version: "v0.26.0",
-				},
-			},
-		},
-	},
-	{
-		Vendor:    "independent",
-		Publisher: "other",
-		Name:      "mygroup",
-		Plugins: []*plugininventory.PluginGroupPluginEntry{
-			{
-				PluginIdentifier: plugininventory.PluginIdentifier{
-					Name:    "plugin1",
-					Target:  configtypes.TargetK8s,
-					Version: "v0.1.0",
-				},
-			},
-			{
-				PluginIdentifier: plugininventory.PluginIdentifier{
-					Name:    "plugin2",
-					Target:  configtypes.TargetTMC,
-					Version: "v0.2.0",
-				},
-			},
-		},
-	},
+func (i inventoryFilterInError) Error() string {
+	return ""
 }
 
 type stubInventory struct{}
 
 func (stub *stubInventory) GetAllPlugins() ([]*plugininventory.PluginInventoryEntry, error) {
-	return pluginEntries, nil
+	return stub.GetPlugins(&plugininventory.PluginInventoryFilter{})
 }
-
-// nolint: gocyclo
 func (stub *stubInventory) GetPlugins(filter *plugininventory.PluginInventoryFilter) ([]*plugininventory.PluginInventoryEntry, error) {
-	var matchingEntries []*plugininventory.PluginInventoryEntry
-	// First find the matching plugins
-	for _, entry := range pluginEntries {
-		if filter.Name != "" && entry.Name != filter.Name {
-			continue
-		}
-		if filter.Target != "" && entry.Target != filter.Target {
-			continue
-		}
-		if filter.Publisher != "" && entry.Publisher != filter.Publisher {
-			continue
-		}
-		if filter.Vendor != "" && entry.Vendor != filter.Vendor {
-			continue
-		}
-		matchingEntries = append(matchingEntries, entry)
-	}
-
-	// Now only keep the matching artifacts
-	for _, entry := range matchingEntries {
-		if filter.Version != "" {
-			if _, found := entry.Artifacts[filter.Version]; found {
-				// Only keep the matching version
-				filteredArtifacts := make(distribution.Artifacts, 0)
-				filteredArtifacts[filter.Version] = entry.Artifacts[filter.Version]
-				entry.Artifacts = filteredArtifacts
-			} else {
-				// Couldn't find the version.  Remove all artifacts.
-				entry.Artifacts = distribution.Artifacts{}
-				continue
-			}
-		}
-
-		if filter.OS != "" || filter.Arch != "" {
-			var filteredArtifactList distribution.ArtifactList
-			for version, artifactList := range entry.Artifacts {
-				for _, artifact := range artifactList {
-					if (filter.OS == "" || artifact.OS == filter.OS) &&
-						(filter.Arch == "" || artifact.Arch == filter.Arch) {
-						filteredArtifactList = append(filteredArtifactList, artifact)
-					}
-				}
-				entry.Artifacts[version] = filteredArtifactList
-			}
-		}
-	}
-	return matchingEntries, nil
+	// Return the plugin filter so the tests can verify if it is correct
+	return nil, inventoryFilterInError{pluginFilter: filter}
 }
-
-func (stub *stubInventory) GetPluginGroups(plugininventory.PluginGroupFilter) ([]*plugininventory.PluginGroup, error) {
-	return groupEntries, nil
+func (stub *stubInventory) GetPluginGroups(filter plugininventory.PluginGroupFilter) ([]*plugininventory.PluginGroup, error) {
+	// Return the group filter so the tests can verify if it is correct
+	return nil, inventoryFilterInError{groupFilter: &filter}
 }
 func (stub *stubInventory) CreateSchema() error {
 	return nil
@@ -383,11 +56,11 @@ func (stub *stubInventory) UpdatePluginGroupActivationState(pg *plugininventory.
 
 var _ = Describe("Unit tests for DB-backed OCI discovery", func() {
 	var (
-		err             error
-		tmpDir          string
-		discovery       Discovery
-		tkgConfigFile   *os.File
-		tkgConfigFileNG *os.File
+		err          error
+		tmpDir       string
+		discovery    Discovery
+		configFile   *os.File
+		configFileNG *os.File
 	)
 
 	Describe("List plugins from inventory", func() {
@@ -395,23 +68,24 @@ var _ = Describe("Unit tests for DB-backed OCI discovery", func() {
 			tmpDir, err = os.MkdirTemp(os.TempDir(), "")
 			Expect(err).To(BeNil(), "unable to create temporary directory")
 
-			tkgConfigFile, err = os.CreateTemp("", "config")
+			configFile, err = os.CreateTemp("", "config")
 			Expect(err).To(BeNil())
-			os.Setenv("TANZU_CONFIG", tkgConfigFile.Name())
+			os.Setenv("TANZU_CONFIG", configFile.Name())
 
-			tkgConfigFileNG, err = os.CreateTemp("", "config_ng")
+			configFileNG, err = os.CreateTemp("", "config_ng")
 			Expect(err).To(BeNil())
-			os.Setenv("TANZU_CONFIG_NEXT_GEN", tkgConfigFileNG.Name())
+			os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
 		})
 		AfterEach(func() {
 			os.Unsetenv("TANZU_CONFIG")
 			os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
-			os.RemoveAll(tkgConfigFile.Name())
-			os.RemoveAll(tkgConfigFileNG.Name())
+			os.Unsetenv(constants.ConfigVariableIncludeDeactivatedPluginsForTesting)
+			os.RemoveAll(configFile.Name())
+			os.RemoveAll(configFileNG.Name())
 			os.RemoveAll(tmpDir)
 		})
 		Context("Without any criteria", func() {
-			It("should list all plugins", func() {
+			It("should have a filter that only ignore hidden plugins", func() {
 				discovery = NewOCIDiscovery("test-discovery", "test-image:latest", nil)
 				Expect(err).To(BeNil(), "unable to create discovery")
 				dbDiscovery, ok := discovery.(*DBBackedOCIDiscovery)
@@ -422,27 +96,76 @@ var _ = Describe("Unit tests for DB-backed OCI discovery", func() {
 				dbDiscovery.inventory = &stubInventory{}
 
 				plugins, err := dbDiscovery.listPluginsFromInventory()
+				Expect(plugins).To(BeNil())
+				Expect(err).ToNot(BeNil())
+				filterInErr, ok := err.(inventoryFilterInError)
+				Expect(ok).To(BeTrue())
+				Expect(*filterInErr.pluginFilter).To(Equal(plugininventory.PluginInventoryFilter{
+					IncludeHidden: false,
+				}))
+			})
+			It("with TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY=1 the filter should include hidden plugins", func() {
+				discovery = NewOCIDiscovery("test-discovery", "test-image:latest", nil)
+				Expect(err).To(BeNil(), "unable to create discovery")
+				dbDiscovery, ok := discovery.(*DBBackedOCIDiscovery)
+				Expect(ok).To(BeTrue(), "oci discovery is not of type DBBackedOCIDiscovery")
+
+				// Inject the stub inventory and data dir
+				dbDiscovery.pluginDataDir = tmpDir
+				dbDiscovery.inventory = &stubInventory{}
+
+				err = os.Setenv(constants.ConfigVariableIncludeDeactivatedPluginsForTesting, "true")
+				defer os.Unsetenv(constants.ConfigVariableIncludeDeactivatedPluginsForTesting)
 				Expect(err).To(BeNil())
-				Expect(plugins).ToNot(BeNil())
-				Expect(len(plugins)).To(Equal(len(pluginEntries)))
 
-				for _, p := range plugins {
-					entry := findMatchingPluginEntry(pluginEntries, p.Name, p.Target)
-
-					Expect(p.Description).To(Equal(entry.Description))
-					Expect(p.RecommendedVersion).To(Equal(entry.RecommendedVersion))
-					Expect(p.InstalledVersion).To(Equal(""))
-					Expect(p.SupportedVersions).To(Equal(getSupportedVersions(entry.Artifacts)))
-					Expect(p.Distribution).To(Equal(entry.Artifacts))
-					Expect(p.Optional).To(Equal(false))
-					Expect(p.Scope).To(Equal(common.PluginScopeStandalone))
-					Expect(p.Source).To(Equal("test-discovery"))
-					Expect(p.DiscoveryType).To(Equal(common.DiscoveryTypeOCI))
-				}
+				plugins, err := dbDiscovery.listPluginsFromInventory()
+				Expect(plugins).To(BeNil())
+				Expect(err).ToNot(BeNil())
+				filterInErr, ok := err.(inventoryFilterInError)
+				Expect(ok).To(BeTrue())
+				Expect(*filterInErr.pluginFilter).To(Equal(plugininventory.PluginInventoryFilter{
+					IncludeHidden: true,
+				}))
 			})
 		})
 		Context("With a criteria", func() {
-			It("should list only matching info", func() {
+			It("should have a filter that matches the criteria and ignore hidden plugins", func() {
+				filteredName := "cluster" // nolint:goconst
+				filteredTarget := configtypes.TargetK8s
+				filteredVersion := "v0.26.0" // nolint:goconst
+				filteredOS := "darwin"       // nolint:goconst
+				filteredArch := "amd64"      // nolint:goconst
+
+				discovery = NewOCIDiscovery("test-discovery", "test-image:latest", &PluginDiscoveryCriteria{
+					Name:    filteredName,
+					Target:  filteredTarget,
+					Version: filteredVersion,
+					OS:      filteredOS,
+					Arch:    filteredArch,
+				})
+				Expect(err).To(BeNil(), "unable to create discovery")
+				dbDiscovery, ok := discovery.(*DBBackedOCIDiscovery)
+				Expect(ok).To(BeTrue(), "oci discovery is not of type DBBackedOCIDiscovery")
+
+				// Inject the stub inventory and data dir
+				dbDiscovery.pluginDataDir = tmpDir
+				dbDiscovery.inventory = &stubInventory{}
+
+				plugins, err := dbDiscovery.listPluginsFromInventory()
+				Expect(plugins).To(BeNil())
+				Expect(err).ToNot(BeNil())
+				filterInErr, ok := err.(inventoryFilterInError)
+				Expect(ok).To(BeTrue())
+				Expect(*filterInErr.pluginFilter).To(Equal(plugininventory.PluginInventoryFilter{
+					Name:          filteredName,
+					Target:        filteredTarget,
+					Version:       filteredVersion,
+					OS:            filteredOS,
+					Arch:          filteredArch,
+					IncludeHidden: false,
+				}))
+			})
+			It("with TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY=1 the filter should include hidden plugin", func() {
 				filteredName := "cluster"
 				filteredTarget := configtypes.TargetK8s
 				filteredVersion := "v0.26.0"
@@ -464,41 +187,23 @@ var _ = Describe("Unit tests for DB-backed OCI discovery", func() {
 				dbDiscovery.pluginDataDir = tmpDir
 				dbDiscovery.inventory = &stubInventory{}
 
-				plugins, err := dbDiscovery.listPluginsFromInventory()
+				err = os.Setenv(constants.ConfigVariableIncludeDeactivatedPluginsForTesting, "true")
+				defer os.Unsetenv(constants.ConfigVariableIncludeDeactivatedPluginsForTesting)
 				Expect(err).To(BeNil())
-				Expect(plugins).ToNot(BeNil())
-				// Only the "cluster" plugin should be returned
-				Expect(len(plugins)).To(Equal(1))
 
-				p := plugins[0]
-				Expect(p.Name).To(Equal(filteredName))
-				Expect(p.Target).To(Equal(filteredTarget))
-
-				entry := findMatchingPluginEntry(pluginEntries, p.Name, p.Target)
-
-				Expect(p.Description).To(Equal(entry.Description))
-				Expect(p.RecommendedVersion).To(Equal(entry.RecommendedVersion))
-				Expect(p.InstalledVersion).To(Equal(""))
-				// We only asked for a single version
-				Expect(p.SupportedVersions).To(Equal([]string{filteredVersion}))
-				Expect(p.Optional).To(Equal(false))
-				Expect(p.Scope).To(Equal(common.PluginScopeStandalone))
-				Expect(p.Source).To(Equal("test-discovery"))
-				Expect(p.DiscoveryType).To(Equal(common.DiscoveryTypeOCI))
-
-				Expect(p.Distribution).ToNot(BeNil())
-				artifacts, ok := p.Distribution.(distribution.Artifacts)
-				Expect(ok).To(BeTrue(), "distribution is not of type Artifacts")
-				// We only asked for a single version
-				Expect(len(artifacts)).To(Equal(1))
-				artifactList, ok := artifacts[filteredVersion]
-				Expect(ok).To(BeTrue(), "artifacts don't contain the requested version")
-
-				// We only asked for a single os/arch combination
-				Expect(len(artifactList)).To(Equal(1))
-				artifact := artifactList[0]
-				Expect(artifact.Arch).To(Equal(filteredArch))
-				Expect(artifact.OS).To(Equal(filteredOS))
+				plugins, err := dbDiscovery.listPluginsFromInventory()
+				Expect(plugins).To(BeNil())
+				Expect(err).ToNot(BeNil())
+				filterInErr, ok := err.(inventoryFilterInError)
+				Expect(ok).To(BeTrue())
+				Expect(*filterInErr.pluginFilter).To(Equal(plugininventory.PluginInventoryFilter{
+					Name:          filteredName,
+					Target:        filteredTarget,
+					Version:       filteredVersion,
+					OS:            filteredOS,
+					Arch:          filteredArch,
+					IncludeHidden: true,
+				}))
 			})
 		})
 	})
@@ -508,22 +213,22 @@ var _ = Describe("Unit tests for DB-backed OCI discovery", func() {
 			tmpDir, err = os.MkdirTemp(os.TempDir(), "")
 			Expect(err).To(BeNil(), "unable to create temporary directory")
 
-			tkgConfigFile, err = os.CreateTemp("", "config")
+			configFile, err = os.CreateTemp("", "config")
 			Expect(err).To(BeNil())
-			os.Setenv("TANZU_CONFIG", tkgConfigFile.Name())
+			os.Setenv("TANZU_CONFIG", configFile.Name())
 
-			tkgConfigFileNG, err = os.CreateTemp("", "config_ng")
+			configFileNG, err = os.CreateTemp("", "config_ng")
 			Expect(err).To(BeNil())
-			os.Setenv("TANZU_CONFIG_NEXT_GEN", tkgConfigFileNG.Name())
+			os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
 		})
 		AfterEach(func() {
 			os.Unsetenv("TANZU_CONFIG")
 			os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
-			os.RemoveAll(tkgConfigFile.Name())
-			os.RemoveAll(tkgConfigFileNG.Name())
+			os.RemoveAll(configFile.Name())
+			os.RemoveAll(configFileNG.Name())
 			os.RemoveAll(tmpDir)
 		})
-		It("should list three plugin groups", func() {
+		It("should use a filter that ignores hidden groups", func() {
 			discovery = NewOCIDiscovery("test-discovery", "test-image:latest", nil)
 			Expect(err).To(BeNil(), "unable to create discovery")
 			dbDiscovery, ok := discovery.(*DBBackedOCIDiscovery)
@@ -534,10 +239,36 @@ var _ = Describe("Unit tests for DB-backed OCI discovery", func() {
 			dbDiscovery.inventory = &stubInventory{}
 
 			groups, err := dbDiscovery.listGroupsFromInventory()
+			Expect(groups).To(BeNil())
+			Expect(err).ToNot(BeNil())
+			filterInErr, ok := err.(inventoryFilterInError)
+			Expect(ok).To(BeTrue())
+			Expect(*filterInErr.groupFilter).To(Equal(plugininventory.PluginGroupFilter{
+				IncludeHidden: false,
+			}))
+		})
+		It("with TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY=1 the filter should include hidden groups", func() {
+			discovery = NewOCIDiscovery("test-discovery", "test-image:latest", nil)
+			Expect(err).To(BeNil(), "unable to create discovery")
+			dbDiscovery, ok := discovery.(*DBBackedOCIDiscovery)
+			Expect(ok).To(BeTrue(), "oci discovery is not of type DBBackedOCIDiscovery")
+
+			// Inject the stub inventory and data dir
+			dbDiscovery.pluginDataDir = tmpDir
+			dbDiscovery.inventory = &stubInventory{}
+
+			err = os.Setenv(constants.ConfigVariableIncludeDeactivatedPluginsForTesting, "true")
+			defer os.Unsetenv(constants.ConfigVariableIncludeDeactivatedPluginsForTesting)
 			Expect(err).To(BeNil())
-			Expect(groups).ToNot(BeNil())
-			Expect(len(groups)).To(Equal(len(groupEntries)))
-			Expect(groups).To(Equal(groupEntries))
+
+			groups, err := dbDiscovery.listGroupsFromInventory()
+			Expect(groups).To(BeNil())
+			Expect(err).ToNot(BeNil())
+			filterInErr, ok := err.(inventoryFilterInError)
+			Expect(ok).To(BeTrue())
+			Expect(*filterInErr.groupFilter).To(Equal(plugininventory.PluginGroupFilter{
+				IncludeHidden: true,
+			}))
 		})
 	})
 
@@ -551,13 +282,13 @@ var _ = Describe("Unit tests for DB-backed OCI discovery", func() {
 			tmpDir, err = os.MkdirTemp(os.TempDir(), "")
 			Expect(err).To(BeNil(), "unable to create temporary directory")
 
-			tkgConfigFile, err = os.CreateTemp("", "config")
+			configFile, err = os.CreateTemp("", "config")
 			Expect(err).To(BeNil())
-			os.Setenv("TANZU_CONFIG", tkgConfigFile.Name())
+			os.Setenv("TANZU_CONFIG", configFile.Name())
 
-			tkgConfigFileNG, err = os.CreateTemp("", "config_ng")
+			configFileNG, err = os.CreateTemp("", "config_ng")
 			Expect(err).To(BeNil())
-			os.Setenv("TANZU_CONFIG_NEXT_GEN", tkgConfigFileNG.Name())
+			os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
 
 			discovery = NewOCIDiscovery("test-discovery", "test-image:latest", nil)
 			Expect(err).To(BeNil(), "unable to create discovery")
@@ -568,8 +299,8 @@ var _ = Describe("Unit tests for DB-backed OCI discovery", func() {
 			os.Unsetenv(constants.PluginDiscoveryImageSignatureVerificationSkipList)
 			os.Unsetenv("TANZU_CONFIG")
 			os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
-			os.RemoveAll(tkgConfigFile.Name())
-			os.RemoveAll(tkgConfigFileNG.Name())
+			os.RemoveAll(configFile.Name())
+			os.RemoveAll(configFileNG.Name())
 			os.RemoveAll(tmpDir)
 		})
 		Context("Cosign signature verification is success", func() {
@@ -600,24 +331,3 @@ var _ = Describe("Unit tests for DB-backed OCI discovery", func() {
 		})
 	})
 })
-
-func getSupportedVersions(artifacts distribution.Artifacts) []string {
-	var versions []string
-	for v := range artifacts {
-		versions = append(versions, v)
-	}
-	err := utils.SortVersions(versions)
-	Expect(err).To(BeNil(), "error parsing versions for plugin")
-
-	return versions
-}
-
-// findMatchingPluginEntry returns the pluginInventoryEntry that matches the specified name and target.
-func findMatchingPluginEntry(entries []*plugininventory.PluginInventoryEntry, pluginName string, target configtypes.Target) *plugininventory.PluginInventoryEntry {
-	for _, entry := range entries {
-		if pluginName == entry.Name && target == entry.Target {
-			return entry
-		}
-	}
-	return nil
-}

--- a/pkg/plugininventory/sqlite_inventory.go
+++ b/pkg/plugininventory/sqlite_inventory.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/catalog"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/distribution"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/utils"
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
@@ -532,10 +533,11 @@ func (b *SQLiteInventory) InsertPluginGroup(pg *PluginGroup, override bool) erro
 		}
 	}
 
+	allowHiddenPlugins, _ := strconv.ParseBool(os.Getenv(constants.ConfigVariableIncludeDeactivatedPluginsForTesting))
 	for _, pi := range pg.Plugins {
 		// Verify that the plugin exists in the database before inserting it to the PluginGroup table.
-		// Allow including hidden plugins.
-		pie, err := b.GetPlugins(&PluginInventoryFilter{Name: pi.Name, Target: pi.Target, Version: pi.Version, IncludeHidden: true})
+		// Allow including hidden plugins if the TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY is properly set.
+		pie, err := b.GetPlugins(&PluginInventoryFilter{Name: pi.Name, Target: pi.Target, Version: pi.Version, IncludeHidden: allowHiddenPlugins})
 		if err != nil {
 			return errors.Wrap(err, "error while verifying existence of the plugin in the database")
 		} else if len(pie) == 0 {


### PR DESCRIPTION
### What this PR does / why we need it

To test their plugins before activating them in the central repo, publishers can now set the environment variable `TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY=true`

This variable tells the CLI to include any deactivated plugins and groups as if they were active.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

I confirm that `make e2e-context-tmc-test` passes locally.

Then I did the following:
```
$ make plugin-build-and-publish-packages
$ make inventory-init
$ make inventory-plugin-add
$ make inventory-plugin-group-add PLUGIN_GROUP_NAME_VERSION=test:v0.0.1

# Configure the CLI to use the local test repository
$ tz config set env.TANZU_CLI_PRE_RELEASE_REPO_IMAGE localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest
$ tz config set env.TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest

# Make sure we can see the plugins and plugin group
$ tz plugin search
[i] Reading plugin inventory for "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest", this will take a few seconds.
[!] Skipping the plugins discovery image signature verification for "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"

  NAME     DESCRIPTION             TARGET  LATEST
  builder  Build Tanzu components  global  v0.90.0-alpha.0
  test     Test the CLI            global  v0.90.0-alpha.0
$ tz plugin group search
  GROUP
  vmware-tzcli/test:v0.0.1

# Deactivate plugins
$ make inventory-plugin-deactivate
$ tz plugin search
[i] Reading plugin inventory for "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest", this will take a few seconds.
[!] Skipping the plugins discovery image signature verification for "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"

  NAME  DESCRIPTION  TARGET  LATEST

# => test that we can see the hidden plugin with the new env var
$ TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY=1 tz plugin search
  NAME     DESCRIPTION             TARGET  LATEST
  builder  Build Tanzu components  global  v0.90.0-alpha.0
  test     Test the CLI            global  v0.90.0-alpha.0

# => check that using 'false' will be respected
$ TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY=false tz plugin search
  NAME  DESCRIPTION  TARGET  LATEST

# Test installing an active group that contains hidden plugins
$ tz plugin install --group vmware-tzcli/test:v0.0.1
[!] unable to install plugin 'builder': unable to find plugin 'builder' for target 'global'
[!] unable to install plugin 'test': unable to find plugin 'test' for target 'global'
[x] : could not install 2 plugin(s) from group 'vmware-tzcli/test:v0.0.1'

# => Try installing using the group and enabling deactivated plugins
$ TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY=true tz plugin install --group vmware-tzcli/test:v0.0.1
[i] Installing plugin 'builder:v0.90.0-alpha.0' with target 'global'
[i] Installing plugin 'test:v0.90.0-alpha.0' with target 'global'
[ok] successfully installed all plugins from group 'vmware-tzcli/test:v0.0.1'

# Hide the group
$ make inventory-plugin-group-deactivate PLUGIN_GROUP_NAME_VERSION=test:v0.0.1
$ tz plugin group search
[i] Reading plugin inventory for "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest", this will take a few seconds.
[!] Skipping the plugins discovery image signature verification for "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"

  GROUP

# => test that we can see the hidden plugin with the new env var
$ TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY=1 tz plugin group search
  GROUP
  vmware-tzcli/test:v0.0.1

# => check that using '0' will be respected
$ TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY=0 tz plugin group search
  GROUP

# => Try installing using the hidden group
$ tz plugin install --group vmware-tzcli/test:v0.0.1
[x] : could not find group 'vmware-tzcli/test:v0.0.1'

# => Try installing using the group and enabling deactivated plugins and groups
$ TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY=true tz plugin install --group vmware-tzcli/test:v0.0.1
[i] Installing plugin 'builder:v0.90.0-alpha.0' with target 'global'
[i] Installing plugin 'test:v0.90.0-alpha.0' with target 'global'
[ok] successfully installed all plugins from group 'vmware-tzcli/test:v0.0.1'
```
Test publishing a group containing hidden plugins:
```
$ make inventory-plugin-group-add PLUGIN_GROUP_NAME_VERSION=withhidden:v0.0.1
/Users/kmarc/git/tanzu-cli/bin/builder inventory plugin-group add \
		--repository localhost:5001/test/v1/tanzu-cli/plugins \
		--plugin-inventory-image-tag latest \
		--publisher tzcli \
		--vendor vmware \
		--manifest /Users/kmarc/git/tanzu-cli/artifacts/plugins/plugin_group_manifest.yaml \
		--name withhidden:v0.0.1 \

2023-04-20T16:07:26-04:00 [i] pulling plugin inventory database from: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
2023-04-20T16:07:28-04:00 [i] updating plugin inventory database with plugin group entry
Error: error while inserting plugin group 'withhidden:v0.0.1': specified plugin 'name:builder', 'target:global', 'version:v0.90.0-alpha.0' is not present in the database
2023-04-20T16:07:28-04:00 [x] : error while inserting plugin group 'withhidden:v0.0.1': specified plugin 'name:builder', 'target:global', 'version:v0.90.0-alpha.0' is not present in the database
make: *** [inventory-plugin-group-add] Error 1
$ TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY=true make inventory-plugin-group-add PLUGIN_GROUP_NAME_VERSION=withhidden:v0.0.1
/Users/kmarc/git/tanzu-cli/bin/builder inventory plugin-group add \
		--repository localhost:5001/test/v1/tanzu-cli/plugins \
		--plugin-inventory-image-tag latest \
		--publisher tzcli \
		--vendor vmware \
		--manifest /Users/kmarc/git/tanzu-cli/artifacts/plugins/plugin_group_manifest.yaml \
		--name withhidden:v0.0.1 \

2023-04-20T16:07:49-04:00 [i] pulling plugin inventory database from: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
2023-04-20T16:07:52-04:00 [i] updating plugin inventory database with plugin group entry
2023-04-20T16:07:52-04:00 [i] publishing plugin inventory database
2023-04-20T16:07:54-04:00 [i] successfully published plugin inventory database at: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
$ tz plugin group search
[i] Reading plugin inventory for "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest", this will take a few seconds.
[!] Skipping the plugins discovery image signature verification for "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"

  GROUP
  vmware-tzcli/withhidden:v0.0.1

$ tz plugin install --group vmware-tzcli/withhidden:v0.0.1
[!] unable to install plugin 'builder': unable to find plugin 'builder' for target 'global'
[!] unable to install plugin 'test': unable to find plugin 'test' for target 'global'
[x] : could not install 2 plugin(s) from group 'vmware-tzcli/withhidden:v0.0.1'

$ TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY=true  tz plugin install --group vmware-tzcli/withhidden:v0.0.1
[i] Installing plugin 'builder:v0.90.0-alpha.0' with target 'global'
[i] Installing plugin 'test:v0.90.0-alpha.0' with target 'global'
[ok] successfully installed all plugins from group 'vmware-tzcli/withhidden:v0.0.1'
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The `TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY=1` variable can now be used to ask the CLI to include deactivated plugins and groups.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

**Note 1**
I did something kind of special to simplify the unit tests.

It was becoming increasingly difficult to test `listPluginsFromInventory()` and `listGroupsFromInventory()` now that we had to consider hidden plugins.  The stubbed inventory logic would have to be pretty advanced to be able to properly filter out hidden plugins when needed.

The top commit takes a different approach to testing the `oci_dbbacked.go`file.  We use the fact that we don't need to test the logic implemented by the inventory stub but only the fact that the stub should be called with the correct plugin filter. Instead of returning a filtered list of plugins, the stub returns the plugin/group filter by using the error object; the test can then verify that the filter is appropriate to provide the type of plugins/groups that is expected.

I feel this type of testing is sufficient since there are other tests for the real plugin inventory code which is its own package.

**Note 2**
If a publisher creates an active plugin group containing some deactivated plugins to prepare the group with the idea of activating some plugins later on, the user will see an error that some plugins (the deactivated ones) are missing.  This is not a good UX but since it is a rare case which is not obvious to fix, I will open an separate issue if this PR gets merged as is. 