### PR TITLE
E2E framework: Setup dynamic tanzu prefix commands

### DIFF
--- a/test/e2e/framework/cli_lifecycle_operations.go
+++ b/test/e2e/framework/cli_lifecycle_operations.go
@@ -5,8 +5,8 @@ package framework
 
 // CliOps performs basic cli operations
 type CliOps interface {
-	CliInit() error
-	CliVersion() (string, error)
+	CliInit(opts ...E2EOption) error
+	CliVersion(opts ...E2EOption) (string, error)
 	InstallCLI(version string) error
 	UninstallCLI(version string) error
 }
@@ -22,14 +22,14 @@ func NewCliOps() CliOps {
 }
 
 // Init() initializes the CLI
-func (co *cliOps) CliInit() error {
-	_, _, err := co.Exec(TanzuInit)
+func (co *cliOps) CliInit(opts ...E2EOption) error {
+	_, _, err := co.Exec(TanzuInit, opts...)
 	return err
 }
 
 // Version returns the CLI version info
-func (co *cliOps) CliVersion() (string, error) {
-	stdOut, _, err := co.Exec(TanzuVersion)
+func (co *cliOps) CliVersion(opts ...E2EOption) (string, error) {
+	stdOut, _, err := co.Exec(TanzuVersion, opts...)
 	return stdOut.String(), err
 }
 

--- a/test/e2e/framework/cli_lifecycle_operations.go
+++ b/test/e2e/framework/cli_lifecycle_operations.go
@@ -21,15 +21,15 @@ func NewCliOps() CliOps {
 	}
 }
 
-// Init() initializes the CLI
+// CliInit() initializes the CLI
 func (co *cliOps) CliInit(opts ...E2EOption) error {
-	_, _, err := co.Exec(TanzuInit, opts...)
+	_, _, err := co.TanzuCmdExec(TanzuInit, opts...)
 	return err
 }
 
-// Version returns the CLI version info
+// CliVersion returns the CLI version info
 func (co *cliOps) CliVersion(opts ...E2EOption) (string, error) {
-	stdOut, _, err := co.Exec(TanzuVersion, opts...)
+	stdOut, _, err := co.TanzuCmdExec(TanzuInit, opts...)
 	return stdOut.String(), err
 }
 

--- a/test/e2e/framework/cmd_exec_operations.go
+++ b/test/e2e/framework/cmd_exec_operations.go
@@ -14,12 +14,12 @@ import (
 
 // CmdOps performs the Command line exec operations
 type CmdOps interface {
-	Exec(command string) (stdOut, stdErr *bytes.Buffer, err error)
-	ExecContainsString(command, contains string) error
-	ExecContainsAnyString(command string, contains []string) error
-	ExecContainsErrorString(command, contains string) error
-	ExecNotContainsStdErrorString(command, contains string) error
-	ExecNotContainsString(command, contains string) error
+	Exec(command string, opts ...E2EOption) (stdOut, stdErr *bytes.Buffer, err error)
+	ExecContainsString(command, contains string, opts ...E2EOption) error
+	ExecContainsAnyString(command string, contains []string, opts ...E2EOption) error
+	ExecContainsErrorString(command, contains string, opts ...E2EOption) error
+	ExecNotContainsStdErrorString(command, contains string, opts ...E2EOption) error
+	ExecNotContainsString(command, contains string, opts ...E2EOption) error
 }
 
 // cmdOps is the implementation of CmdOps
@@ -32,8 +32,24 @@ func NewCmdOps() CmdOps {
 }
 
 // Exec the command, exit on error
-func (co *cmdOps) Exec(command string) (stdOut, stdErr *bytes.Buffer, err error) {
+func (co *cmdOps) Exec(command string, opts ...E2EOption) (stdOut, stdErr *bytes.Buffer, err error) {
+	// Default options
+	options := &E2EOptions{
+		TanzuCommandPrefix: TanzuPrefix,
+	}
+
+	// Apply provided options
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	// Verify if the tanzu prefix is set if not set it with default tanzu prefix value
+	if strings.Index(command, "%s") == 0 {
+		command = fmt.Sprintf(command, options.TanzuCommandPrefix)
+	}
+
 	log.Infof(ExecutingCommand, command)
+
 	cmdInput := strings.Split(command, " ")
 	cmdName := cmdInput[0]
 	cmdArgs := cmdInput[1:]
@@ -49,8 +65,8 @@ func (co *cmdOps) Exec(command string) (stdOut, stdErr *bytes.Buffer, err error)
 }
 
 // ExecContainsString checks that the given command output contains the string.
-func (co *cmdOps) ExecContainsString(command, contains string) error {
-	stdOut, _, err := co.Exec(command)
+func (co *cmdOps) ExecContainsString(command, contains string, opts ...E2EOption) error {
+	stdOut, _, err := co.Exec(command, opts...)
 	if err != nil {
 		return err
 	}
@@ -58,8 +74,8 @@ func (co *cmdOps) ExecContainsString(command, contains string) error {
 }
 
 // ExecContainsAnyString checks that the given command output contains any of the given set of strings.
-func (co *cmdOps) ExecContainsAnyString(command string, contains []string) error {
-	stdOut, _, err := co.Exec(command)
+func (co *cmdOps) ExecContainsAnyString(command string, contains []string, opts ...E2EOption) error {
+	stdOut, _, err := co.Exec(command, opts...)
 	if err != nil {
 		return err
 	}
@@ -67,8 +83,8 @@ func (co *cmdOps) ExecContainsAnyString(command string, contains []string) error
 }
 
 // ExecContainsErrorString checks that the given command stdErr output contains the string
-func (co *cmdOps) ExecContainsErrorString(command, contains string) error {
-	_, stdErr, err := co.Exec(command)
+func (co *cmdOps) ExecContainsErrorString(command, contains string, opts ...E2EOption) error {
+	_, stdErr, err := co.Exec(command, opts...)
 	if err != nil {
 		return err
 	}
@@ -76,8 +92,8 @@ func (co *cmdOps) ExecContainsErrorString(command, contains string) error {
 }
 
 // ExecNotContainsStdErrorString checks that the given command stdErr output contains the string
-func (co *cmdOps) ExecNotContainsStdErrorString(command, contains string) error {
-	_, stdErr, err := co.Exec(command)
+func (co *cmdOps) ExecNotContainsStdErrorString(command, contains string, opts ...E2EOption) error {
+	_, stdErr, err := co.Exec(command, opts...)
 	if err != nil && stdErr == nil {
 		return err
 	}
@@ -118,8 +134,8 @@ func ContainsAnyString(stdOut *bytes.Buffer, contains []string) error {
 }
 
 // ExecNotContainsString checks that the given command output not contains the string.
-func (co *cmdOps) ExecNotContainsString(command, contains string) error {
-	stdOut, _, err := co.Exec(command)
+func (co *cmdOps) ExecNotContainsString(command, contains string, opts ...E2EOption) error {
+	stdOut, _, err := co.Exec(command, opts...)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/framework/config_lifecycle_operations.go
+++ b/test/e2e/framework/config_lifecycle_operations.go
@@ -58,7 +58,7 @@ func NewConfOps() ConfigLifecycleOps {
 
 // GetConfig gets the tanzu config
 func (co *configOps) GetConfig(opts ...E2EOption) (*configapi.ClientConfig, error) {
-	out, _, err := co.cmdExe.Exec(ConfigGet, opts...)
+	out, _, err := co.cmdExe.TanzuCmdExec(ConfigGet, opts...)
 	var cnf *configapi.ClientConfig
 	if err != nil {
 		return cnf, err
@@ -73,7 +73,7 @@ func (co *configOps) GetConfig(opts ...E2EOption) (*configapi.ClientConfig, erro
 // ConfigSetFeatureFlag sets the given tanzu config feature flag
 func (co *configOps) ConfigSetFeatureFlag(path, value string, opts ...E2EOption) (err error) {
 	confSetCmd := ConfigSet + path + " " + value
-	_, _, err = co.cmdExe.Exec(confSetCmd, opts...)
+	_, _, err = co.cmdExe.TanzuCmdExec(confSetCmd, opts...)
 	return err
 }
 
@@ -94,13 +94,13 @@ func (co *configOps) ConfigGetFeatureFlag(path string, opts ...E2EOption) (strin
 // ConfigUnsetFeature un-sets the tanzu config feature flag
 func (co *configOps) ConfigUnsetFeature(path string, opts ...E2EOption) (err error) {
 	unsetFeatureCmd := ConfigUnset + path
-	_, _, err = co.cmdExe.Exec(unsetFeatureCmd, opts...)
+	_, _, err = co.cmdExe.TanzuCmdExec(unsetFeatureCmd, opts...)
 	return
 }
 
 // ConfigInit performs "tanzu config init"
 func (co *configOps) ConfigInit(opts ...E2EOption) (err error) {
-	_, _, err = co.cmdExe.Exec(ConfigInit, opts...)
+	_, _, err = co.cmdExe.TanzuCmdExec(ConfigInit, opts...)
 	return
 }
 
@@ -113,7 +113,7 @@ func (co *configOps) ConfigServerList(opts ...E2EOption) ([]*Server, error) {
 // ConfigServerDelete deletes a server from tanzu config
 func (co *configOps) ConfigServerDelete(serverName string, opts ...E2EOption) error {
 	configDelCmd := fmt.Sprintf(ConfigServerDelete, "%s", serverName)
-	_, _, err := co.cmdExe.Exec(configDelCmd, opts...)
+	_, _, err := co.cmdExe.TanzuCmdExec(configDelCmd, opts...)
 	if err != nil {
 		log.Infof("failed to delete config server: %s", serverName)
 		log.Error(err, "error while running: "+configDelCmd)

--- a/test/e2e/framework/config_lifecycle_operations.go
+++ b/test/e2e/framework/config_lifecycle_operations.go
@@ -26,19 +26,19 @@ const (
 // ConfigLifecycleOps performs "tanzu config" command operations
 type ConfigLifecycleOps interface {
 	// ConfigSetFeatureFlag sets the tanzu config feature flag
-	ConfigSetFeatureFlag(path, value string) error
+	ConfigSetFeatureFlag(path, value string, opts ...E2EOption) error
 	// ConfigGetFeatureFlag gets the tanzu config feature flag
-	ConfigGetFeatureFlag(path string) (string, error)
+	ConfigGetFeatureFlag(path string, opts ...E2EOption) (string, error)
 	// ConfigUnsetFeature un-sets the tanzu config feature flag
-	ConfigUnsetFeature(path string) error
+	ConfigUnsetFeature(path string, opts ...E2EOption) error
 	// ConfigInit performs "tanzu config init"
-	ConfigInit() error
+	ConfigInit(opts ...E2EOption) error
 	// GetConfig gets the tanzu config
-	GetConfig() (*configapi.ClientConfig, error)
+	GetConfig(opts ...E2EOption) (*configapi.ClientConfig, error)
 	// ConfigServerList returns the server list
-	ConfigServerList() ([]*Server, error)
+	ConfigServerList(opts ...E2EOption) ([]*Server, error)
 	// ConfigServerDelete deletes given server from tanzu config
-	ConfigServerDelete(serverName string) error
+	ConfigServerDelete(serverName string, opts ...E2EOption) error
 	// DeleteCLIConfigurationFiles deletes cli configuration files
 	DeleteCLIConfigurationFiles() error
 	// IsCLIConfigurationFilesExists checks the existence of cli configuration files
@@ -57,8 +57,8 @@ func NewConfOps() ConfigLifecycleOps {
 }
 
 // GetConfig gets the tanzu config
-func (co *configOps) GetConfig() (*configapi.ClientConfig, error) {
-	out, _, err := co.cmdExe.Exec(ConfigGet)
+func (co *configOps) GetConfig(opts ...E2EOption) (*configapi.ClientConfig, error) {
+	out, _, err := co.cmdExe.Exec(ConfigGet, opts...)
 	var cnf *configapi.ClientConfig
 	if err != nil {
 		return cnf, err
@@ -71,15 +71,15 @@ func (co *configOps) GetConfig() (*configapi.ClientConfig, error) {
 }
 
 // ConfigSetFeatureFlag sets the given tanzu config feature flag
-func (co *configOps) ConfigSetFeatureFlag(path, value string) (err error) {
+func (co *configOps) ConfigSetFeatureFlag(path, value string, opts ...E2EOption) (err error) {
 	confSetCmd := ConfigSet + path + " " + value
-	_, _, err = co.cmdExe.Exec(confSetCmd)
+	_, _, err = co.cmdExe.Exec(confSetCmd, opts...)
 	return err
 }
 
 // ConfigGetFeatureFlag gets the given tanzu config feature flag
-func (co *configOps) ConfigGetFeatureFlag(path string) (string, error) {
-	cnf, err := co.GetConfig()
+func (co *configOps) ConfigGetFeatureFlag(path string, opts ...E2EOption) (string, error) {
+	cnf, err := co.GetConfig(opts...)
 	if err != nil {
 		return "", err
 	}
@@ -92,28 +92,28 @@ func (co *configOps) ConfigGetFeatureFlag(path string) (string, error) {
 }
 
 // ConfigUnsetFeature un-sets the tanzu config feature flag
-func (co *configOps) ConfigUnsetFeature(path string) (err error) {
+func (co *configOps) ConfigUnsetFeature(path string, opts ...E2EOption) (err error) {
 	unsetFeatureCmd := ConfigUnset + path
-	_, _, err = co.cmdExe.Exec(unsetFeatureCmd)
+	_, _, err = co.cmdExe.Exec(unsetFeatureCmd, opts...)
 	return
 }
 
 // ConfigInit performs "tanzu config init"
-func (co *configOps) ConfigInit() (err error) {
-	_, _, err = co.cmdExe.Exec(ConfigInit)
+func (co *configOps) ConfigInit(opts ...E2EOption) (err error) {
+	_, _, err = co.cmdExe.Exec(ConfigInit, opts...)
 	return
 }
 
 // ConfigServerList returns the server list
-func (co *configOps) ConfigServerList() ([]*Server, error) {
+func (co *configOps) ConfigServerList(opts ...E2EOption) ([]*Server, error) {
 	ConfigServerListWithJSONOutput := ConfigServerList + JSONOutput
-	return ExecuteCmdAndBuildJSONOutput[Server](co.cmdExe, ConfigServerListWithJSONOutput)
+	return ExecuteCmdAndBuildJSONOutput[Server](co.cmdExe, ConfigServerListWithJSONOutput, opts...)
 }
 
 // ConfigServerDelete deletes a server from tanzu config
-func (co *configOps) ConfigServerDelete(serverName string) error {
-	configDelCmd := fmt.Sprintf(ConfigServerDelete, serverName)
-	_, _, err := co.cmdExe.Exec(configDelCmd)
+func (co *configOps) ConfigServerDelete(serverName string, opts ...E2EOption) error {
+	configDelCmd := fmt.Sprintf(ConfigServerDelete, "%s", serverName)
+	_, _, err := co.cmdExe.Exec(configDelCmd, opts...)
 	if err != nil {
 		log.Infof("failed to delete config server: %s", serverName)
 		log.Error(err, "error while running: "+configDelCmd)

--- a/test/e2e/framework/context_create_operations.go
+++ b/test/e2e/framework/context_create_operations.go
@@ -14,13 +14,13 @@ import (
 // ContextCreateOps helps to run context create command
 type ContextCreateOps interface {
 	// CreateContextWithEndPoint creates a context with a given endpoint URL
-	CreateContextWithEndPoint(contextName, endpoint string) error
+	CreateContextWithEndPoint(contextName, endpoint string, opts ...E2EOption) error
 	// CreateContextWithEndPointStaging creates a context with a given endpoint URL for staging
-	CreateContextWithEndPointStaging(contextName, endpoint string) error
+	CreateContextWithEndPointStaging(contextName, endpoint string, opts ...E2EOption) error
 	// CreateContextWithKubeconfig creates a context with the given kubeconfig file path and a context from the kubeconfig file
-	CreateContextWithKubeconfig(contextName, kubeconfigPath, kubeContext string) error
+	CreateContextWithKubeconfig(contextName, kubeconfigPath, kubeContext string, opts ...E2EOption) error
 	// CreateContextWithDefaultKubeconfig creates a context with the default kubeconfig file and a given input context name if it exists in the default kubeconfig file
-	CreateContextWithDefaultKubeconfig(contextName, kubeContext string) error
+	CreateContextWithDefaultKubeconfig(contextName, kubeContext string, opts ...E2EOption) error
 }
 
 type contextCreateOps struct {
@@ -34,9 +34,9 @@ func NewContextCreateOps() ContextCreateOps {
 	}
 }
 
-func (cc *contextCreateOps) CreateContextWithEndPoint(contextName, endpoint string) error {
-	createContextCmd := fmt.Sprintf(CreateContextWithEndPoint, endpoint, contextName)
-	out, _, err := cc.cmdExe.Exec(createContextCmd)
+func (cc *contextCreateOps) CreateContextWithEndPoint(contextName, endpoint string, opts ...E2EOption) error {
+	createContextCmd := fmt.Sprintf(CreateContextWithEndPoint, "%s", endpoint, contextName)
+	out, _, err := cc.cmdExe.Exec(createContextCmd, opts...)
 	if err != nil {
 		log.Info(fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
 		return errors.Wrap(err, fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
@@ -45,9 +45,9 @@ func (cc *contextCreateOps) CreateContextWithEndPoint(contextName, endpoint stri
 	return err
 }
 
-func (cc *contextCreateOps) CreateContextWithEndPointStaging(contextName, endpoint string) error {
-	createContextCmd := fmt.Sprintf(CreateContextWithEndPointStaging, endpoint, contextName)
-	out, _, err := cc.cmdExe.Exec(createContextCmd)
+func (cc *contextCreateOps) CreateContextWithEndPointStaging(contextName, endpoint string, opts ...E2EOption) error {
+	createContextCmd := fmt.Sprintf(CreateContextWithEndPointStaging, "%s", endpoint, contextName)
+	out, _, err := cc.cmdExe.Exec(createContextCmd, opts...)
 	if err != nil {
 		log.Info(fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
 		return errors.Wrap(err, fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
@@ -56,9 +56,9 @@ func (cc *contextCreateOps) CreateContextWithEndPointStaging(contextName, endpoi
 	return err
 }
 
-func (cc *contextCreateOps) CreateContextWithKubeconfig(contextName, kubeconfigPath, kubeContext string) error {
-	createContextCmd := fmt.Sprintf(CreateContextWithKubeconfigFile, kubeconfigPath, kubeContext, contextName)
-	out, _, err := cc.cmdExe.Exec(createContextCmd)
+func (cc *contextCreateOps) CreateContextWithKubeconfig(contextName, kubeconfigPath, kubeContext string, opts ...E2EOption) error {
+	createContextCmd := fmt.Sprintf(CreateContextWithKubeconfigFile, "%s", kubeconfigPath, kubeContext, contextName)
+	out, _, err := cc.cmdExe.Exec(createContextCmd, opts...)
 	if err != nil {
 		log.Info(fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
 		return errors.Wrap(err, fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
@@ -67,9 +67,9 @@ func (cc *contextCreateOps) CreateContextWithKubeconfig(contextName, kubeconfigP
 	return err
 }
 
-func (cc *contextCreateOps) CreateContextWithDefaultKubeconfig(contextName, kubeContext string) error {
-	createContextCmd := fmt.Sprintf(CreateContextWithDefaultKubeconfigFile, kubeContext, contextName)
-	out, _, err := cc.cmdExe.Exec(createContextCmd)
+func (cc *contextCreateOps) CreateContextWithDefaultKubeconfig(contextName, kubeContext string, opts ...E2EOption) error {
+	createContextCmd := fmt.Sprintf(CreateContextWithDefaultKubeconfigFile, "%s", kubeContext, contextName)
+	out, _, err := cc.cmdExe.Exec(createContextCmd, opts...)
 	if err != nil {
 		log.Info(fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
 		return errors.Wrap(err, fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))

--- a/test/e2e/framework/context_create_operations.go
+++ b/test/e2e/framework/context_create_operations.go
@@ -36,7 +36,7 @@ func NewContextCreateOps() ContextCreateOps {
 
 func (cc *contextCreateOps) CreateContextWithEndPoint(contextName, endpoint string, opts ...E2EOption) error {
 	createContextCmd := fmt.Sprintf(CreateContextWithEndPoint, "%s", endpoint, contextName)
-	out, _, err := cc.cmdExe.Exec(createContextCmd, opts...)
+	out, _, err := cc.cmdExe.TanzuCmdExec(createContextCmd, opts...)
 	if err != nil {
 		log.Info(fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
 		return errors.Wrap(err, fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
@@ -47,7 +47,7 @@ func (cc *contextCreateOps) CreateContextWithEndPoint(contextName, endpoint stri
 
 func (cc *contextCreateOps) CreateContextWithEndPointStaging(contextName, endpoint string, opts ...E2EOption) error {
 	createContextCmd := fmt.Sprintf(CreateContextWithEndPointStaging, "%s", endpoint, contextName)
-	out, _, err := cc.cmdExe.Exec(createContextCmd, opts...)
+	out, _, err := cc.cmdExe.TanzuCmdExec(createContextCmd, opts...)
 	if err != nil {
 		log.Info(fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
 		return errors.Wrap(err, fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
@@ -58,7 +58,7 @@ func (cc *contextCreateOps) CreateContextWithEndPointStaging(contextName, endpoi
 
 func (cc *contextCreateOps) CreateContextWithKubeconfig(contextName, kubeconfigPath, kubeContext string, opts ...E2EOption) error {
 	createContextCmd := fmt.Sprintf(CreateContextWithKubeconfigFile, "%s", kubeconfigPath, kubeContext, contextName)
-	out, _, err := cc.cmdExe.Exec(createContextCmd, opts...)
+	out, _, err := cc.cmdExe.TanzuCmdExec(createContextCmd, opts...)
 	if err != nil {
 		log.Info(fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
 		return errors.Wrap(err, fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
@@ -69,7 +69,7 @@ func (cc *contextCreateOps) CreateContextWithKubeconfig(contextName, kubeconfigP
 
 func (cc *contextCreateOps) CreateContextWithDefaultKubeconfig(contextName, kubeContext string, opts ...E2EOption) error {
 	createContextCmd := fmt.Sprintf(CreateContextWithDefaultKubeconfigFile, "%s", kubeContext, contextName)
-	out, _, err := cc.cmdExe.Exec(createContextCmd, opts...)
+	out, _, err := cc.cmdExe.TanzuCmdExec(createContextCmd, opts...)
 	if err != nil {
 		log.Info(fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
 		return errors.Wrap(err, fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))

--- a/test/e2e/framework/context_lifecycle_operations.go
+++ b/test/e2e/framework/context_lifecycle_operations.go
@@ -17,15 +17,15 @@ type ContextCmdOps interface {
 	// ContextCreateOps helps context create operations
 	ContextCreateOps
 	// UseContext helps to run 'context use' command
-	UseContext(contextName string) error
+	UseContext(contextName string, opts ...E2EOption) error
 	// GetContext helps to run `context get` command
-	GetContext(contextName string) (ContextInfo, error)
+	GetContext(contextName string, opts ...E2EOption) (ContextInfo, error)
 	// ListContext helps to run `context list` command
-	ListContext() ([]*ContextListInfo, error)
+	ListContext(opts ...E2EOption) ([]*ContextListInfo, error)
 	// DeleteContext helps to run `context delete` command
-	DeleteContext(contextName string) error
+	DeleteContext(contextName string, opts ...E2EOption) error
 	// GetActiveContext returns current active context
-	GetActiveContext(targetType string) (string, error)
+	GetActiveContext(targetType string, opts ...E2EOption) (string, error)
 }
 
 // contextCmdOps implements the interface ContextCmdOps
@@ -41,15 +41,15 @@ func NewContextCmdOps() ContextCmdOps {
 	}
 }
 
-func (cc *contextCmdOps) UseContext(contextName string) error {
-	useContextCmd := fmt.Sprintf(UseContext, contextName)
-	_, _, err := cc.cmdExe.Exec(useContextCmd)
+func (cc *contextCmdOps) UseContext(contextName string, opts ...E2EOption) error {
+	useContextCmd := fmt.Sprintf(UseContext, "%s", contextName)
+	_, _, err := cc.cmdExe.Exec(useContextCmd, opts...)
 	return err
 }
 
-func (cc *contextCmdOps) GetContext(contextName string) (ContextInfo, error) {
-	getContextCmd := fmt.Sprintf(GetContext, contextName)
-	out, _, err := cc.cmdExe.Exec(getContextCmd)
+func (cc *contextCmdOps) GetContext(contextName string, opts ...E2EOption) (ContextInfo, error) {
+	getContextCmd := fmt.Sprintf(GetContext, "%s", contextName)
+	out, _, err := cc.cmdExe.Exec(getContextCmd, opts...)
 	if err != nil {
 		return ContextInfo{}, err
 	}
@@ -62,12 +62,12 @@ func (cc *contextCmdOps) GetContext(contextName string) (ContextInfo, error) {
 	return contextInfo, nil
 }
 
-func (cc *contextCmdOps) ListContext() ([]*ContextListInfo, error) {
-	return ExecuteCmdAndBuildJSONOutput[ContextListInfo](cc.cmdExe, ListContextOutputInJSON)
+func (cc *contextCmdOps) ListContext(opts ...E2EOption) ([]*ContextListInfo, error) {
+	return ExecuteCmdAndBuildJSONOutput[ContextListInfo](cc.cmdExe, ListContextOutputInJSON, opts...)
 }
 
-func (cc *contextCmdOps) GetActiveContext(targetType string) (string, error) {
-	list, err := cc.ListContext()
+func (cc *contextCmdOps) GetActiveContext(targetType string, opts ...E2EOption) (string, error) {
+	list, err := cc.ListContext(opts...)
 	if err != nil {
 		return "", err
 	}
@@ -83,9 +83,9 @@ func (cc *contextCmdOps) GetActiveContext(targetType string) (string, error) {
 	return activeCtx, nil
 }
 
-func (cc *contextCmdOps) DeleteContext(contextName string) error {
-	deleteContextCmd := fmt.Sprintf(DeleteContext, contextName)
-	stdOut, stdErr, err := cc.cmdExe.Exec(deleteContextCmd)
+func (cc *contextCmdOps) DeleteContext(contextName string, opts ...E2EOption) error {
+	deleteContextCmd := fmt.Sprintf(DeleteContext, "%s", contextName)
+	stdOut, stdErr, err := cc.cmdExe.Exec(deleteContextCmd, opts...)
 	if err != nil {
 		log.Infof("failed to delete context:%s", contextName)
 		return errors.Wrapf(err, FailedToDeleteContext+", stderr:%s stdout:%s , ", stdErr.String(), stdOut.String())

--- a/test/e2e/framework/context_lifecycle_operations.go
+++ b/test/e2e/framework/context_lifecycle_operations.go
@@ -43,13 +43,13 @@ func NewContextCmdOps() ContextCmdOps {
 
 func (cc *contextCmdOps) UseContext(contextName string, opts ...E2EOption) error {
 	useContextCmd := fmt.Sprintf(UseContext, "%s", contextName)
-	_, _, err := cc.cmdExe.Exec(useContextCmd, opts...)
+	_, _, err := cc.cmdExe.TanzuCmdExec(useContextCmd, opts...)
 	return err
 }
 
 func (cc *contextCmdOps) GetContext(contextName string, opts ...E2EOption) (ContextInfo, error) {
 	getContextCmd := fmt.Sprintf(GetContext, "%s", contextName)
-	out, _, err := cc.cmdExe.Exec(getContextCmd, opts...)
+	out, _, err := cc.cmdExe.TanzuCmdExec(getContextCmd, opts...)
 	if err != nil {
 		return ContextInfo{}, err
 	}
@@ -85,7 +85,7 @@ func (cc *contextCmdOps) GetActiveContext(targetType string, opts ...E2EOption) 
 
 func (cc *contextCmdOps) DeleteContext(contextName string, opts ...E2EOption) error {
 	deleteContextCmd := fmt.Sprintf(DeleteContext, "%s", contextName)
-	stdOut, stdErr, err := cc.cmdExe.Exec(deleteContextCmd, opts...)
+	stdOut, stdErr, err := cc.cmdExe.TanzuCmdExec(deleteContextCmd, opts...)
 	if err != nil {
 		log.Infof("failed to delete context:%s", contextName)
 		return errors.Wrapf(err, FailedToDeleteContext+", stderr:%s stdout:%s , ", stdErr.String(), stdOut.String())

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -180,6 +180,14 @@ type E2EOptions struct {
 	TanzuCommandPrefix string
 }
 
+func NewE2EOptions(options ...E2EOption) *E2EOptions {
+	e := &E2EOptions{}
+	for _, option := range options {
+		option(e)
+	}
+	return e
+}
+
 type E2EOption func(*E2EOptions)
 
 // WithTanzuCommandPrefix is to set the tanzu command prefix; default is tanzu

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -14,35 +14,37 @@ import (
 const (
 	CliCore = "[CLI-Core]"
 
-	TanzuInit    = "tanzu init"
-	TanzuVersion = "tanzu version"
+	TanzuInit    = "%s init"
+	TanzuVersion = "%s version"
+	TanzuPrefix  = "tanzu"
+	TzPrefix     = "tz"
 
 	// Config commands
-	ConfigSet          = "tanzu config set "
-	ConfigGet          = "tanzu config get "
-	ConfigUnset        = "tanzu config unset "
-	ConfigInit         = "tanzu config init"
-	ConfigServerList   = "tanzu config server list"
-	ConfigServerDelete = "tanzu config server delete %s -y"
+	ConfigSet          = "%s config set "
+	ConfigGet          = "%s config get "
+	ConfigUnset        = "%s config unset "
+	ConfigInit         = "%s config init"
+	ConfigServerList   = "%s config server list"
+	ConfigServerDelete = "%s config server delete %s -y"
 
 	// Plugin commands
-	AddPluginSource                     = "tanzu plugin source add --name %s --type %s --uri %s"
-	UpdatePluginSource                  = "tanzu plugin source update %s --type %s --uri %s"
-	ListPluginSourcesWithJSONOutputFlag = "tanzu plugin source list -o json"
-	DeletePluginSource                  = "tanzu plugin source delete %s"
-	ListPluginsCmdWithJSONOutputFlag    = "tanzu plugin list -o json"
-	SearchPluginsCmd                    = "tanzu plugin search"
-	SearchPluginGroupsCmd               = "tanzu plugin group search"
-	InstallPluginCmd                    = "tanzu plugin install %s"
-	InstallPluginFromGroupCmd           = "tanzu plugin install %s --group %s"
-	InstallAllPluginsFromGroupCmd       = "tanzu plugin install --group %s"
-	DescribePluginCmd                   = "tanzu plugin describe %s"
-	UninstallPLuginCmd                  = "tanzu plugin delete %s --yes"
-	CleanPluginsCmd                     = "tanzu plugin clean"
-	pluginSyncCmd                       = "tanzu plugin sync"
+	AddPluginSource                     = "%s plugin source add --name %s --type %s --uri %s"
+	UpdatePluginSource                  = "%s plugin source update %s --type %s --uri %s"
+	ListPluginSourcesWithJSONOutputFlag = "%s plugin source list -o json"
+	DeletePluginSource                  = "%s plugin source delete %s"
+	ListPluginsCmdWithJSONOutputFlag    = "%s plugin list -o json"
+	SearchPluginsCmd                    = "%s plugin search"
+	SearchPluginGroupsCmd               = "%s plugin group search"
+	InstallPluginCmd                    = "%s plugin install %s"
+	InstallPluginFromGroupCmd           = "%s plugin install %s --group %s"
+	InstallAllPluginsFromGroupCmd       = "%s plugin install --group %s"
+	DescribePluginCmd                   = "%s plugin describe %s"
+	UninstallPLuginCmd                  = "%s plugin delete %s --yes"
+	CleanPluginsCmd                     = "%s plugin clean"
+	pluginSyncCmd                       = "%s plugin sync"
 	JSONOutput                          = " -o json"
 	TestPluginsPrefix                   = "test-plugin-"
-	PluginSubCommand                    = "tanzu %s"
+	PluginSubCommand                    = "%s %s"
 	PluginKey                           = "%s_%s_%s" // Plugins - Name_Target_Versions
 
 	// Central repository
@@ -56,14 +58,14 @@ const (
 	NotInstalled = "not installed"
 
 	// Context commands
-	CreateContextWithEndPoint              = "tanzu context create --endpoint %s --name %s"
-	CreateContextWithEndPointStaging       = "tanzu context create --endpoint %s --name %s --staging"
-	CreateContextWithKubeconfigFile        = "tanzu context create --kubeconfig %s --kubecontext %s --name %s"
-	CreateContextWithDefaultKubeconfigFile = "tanzu context create --kubecontext %s --name %s"
-	UseContext                             = "tanzu context use %s"
-	GetContext                             = "tanzu context get %s"
-	ListContextOutputInJSON                = "tanzu context list -o json"
-	DeleteContext                          = "tanzu context delete %s --yes"
+	CreateContextWithEndPoint              = "%s context create --endpoint %s --name %s"
+	CreateContextWithEndPointStaging       = "%s context create --endpoint %s --name %s --staging"
+	CreateContextWithKubeconfigFile        = "%s context create --kubeconfig %s --kubecontext %s --name %s"
+	CreateContextWithDefaultKubeconfigFile = "%s context create --kubecontext %s --name %s"
+	UseContext                             = "%s context use %s"
+	GetContext                             = "%s context get %s"
+	ListContextOutputInJSON                = "%s context list -o json"
+	DeleteContext                          = "%s context delete %s --yes"
 	TanzuAPIToken                          = "TANZU_API_TOKEN" //nolint:gosec
 	TanzuCliTmcUnstableURL                 = "TANZU_CLI_TMC_UNSTABLE_URL"
 
@@ -170,6 +172,21 @@ type Framework struct {
 	PluginCmd    PluginCmdOps    // performs plugin command operations
 	PluginHelper PluginHelperOps // helper (pre-setup) for plugin cmd operations
 	ContextCmd   ContextCmdOps
+}
+
+// E2EOptions used to configure certain options to customize the E2E framework
+// TanzuCommandPrefix should be set to customize the tanzu command prefix; default is tanzu
+type E2EOptions struct {
+	TanzuCommandPrefix string
+}
+
+type E2EOption func(*E2EOptions)
+
+// WithTanzuCommandPrefix is to set the tanzu command prefix; default is tanzu
+func WithTanzuCommandPrefix(prefix string) E2EOption {
+	return func(opts *E2EOptions) {
+		opts.TanzuCommandPrefix = prefix
+	}
 }
 
 func NewFramework() *Framework {

--- a/test/e2e/framework/framework_helper.go
+++ b/test/e2e/framework/framework_helper.go
@@ -93,15 +93,14 @@ func GetHomeDir() string {
 }
 
 // ExecuteCmdAndBuildJSONOutput is generic function to execute given command and build JSON output and return
-func ExecuteCmdAndBuildJSONOutput[T PluginInfo | PluginSearch | PluginGroup | PluginSourceInfo | types.ClientConfig | Server | ContextListInfo](cmdExe CmdOps, cmd string) ([]*T, error) {
-	out, stdErr, err := cmdExe.Exec(cmd)
+func ExecuteCmdAndBuildJSONOutput[T PluginInfo | PluginSearch | PluginGroup | PluginSourceInfo | types.ClientConfig | Server | ContextListInfo](cmdExe CmdOps, cmd string, opts ...E2EOption) ([]*T, error) {
+	out, stdErr, err := cmdExe.Exec(cmd, opts...)
 
 	if err != nil {
 		log.Errorf(ErrorLogForCommandWithErrStdErrAndStdOut, cmd, err.Error(), stdErr.String(), out.String())
 		return nil, err
 	}
 	jsonStr := out.String()
-	log.Info(jsonStr)
 	var list []*T
 	err = json.Unmarshal([]byte(jsonStr), &list)
 	if err != nil {

--- a/test/e2e/framework/framework_helper.go
+++ b/test/e2e/framework/framework_helper.go
@@ -94,7 +94,7 @@ func GetHomeDir() string {
 
 // ExecuteCmdAndBuildJSONOutput is generic function to execute given command and build JSON output and return
 func ExecuteCmdAndBuildJSONOutput[T PluginInfo | PluginSearch | PluginGroup | PluginSourceInfo | types.ClientConfig | Server | ContextListInfo](cmdExe CmdOps, cmd string, opts ...E2EOption) ([]*T, error) {
-	out, stdErr, err := cmdExe.Exec(cmd, opts...)
+	out, stdErr, err := cmdExe.TanzuCmdExec(cmd, opts...)
 
 	if err != nil {
 		log.Errorf(ErrorLogForCommandWithErrStdErrAndStdOut, cmd, err.Error(), stdErr.String(), out.String())

--- a/test/e2e/framework/plugin_lifecycle_operations.go
+++ b/test/e2e/framework/plugin_lifecycle_operations.go
@@ -15,51 +15,51 @@ import (
 // PluginBasicOps helps to perform the plugin command operations
 type PluginBasicOps interface {
 	// ListPlugins lists all plugins by running 'tanzu plugin list' command
-	ListPlugins() ([]*PluginInfo, error)
+	ListPlugins(opts ...E2EOption) ([]*PluginInfo, error)
 	// ListInstalledPlugins lists all installed plugins
-	ListInstalledPlugins() ([]*PluginInfo, error)
+	ListInstalledPlugins(opts ...E2EOption) ([]*PluginInfo, error)
 	// ListPluginsForGivenContext lists all plugins for a given context and either installed only or all
-	ListPluginsForGivenContext(context string, installedOnly bool) ([]*PluginInfo, error)
+	ListPluginsForGivenContext(context string, installedOnly bool, opts ...E2EOption) ([]*PluginInfo, error)
 	// SearchPlugins searches all plugins for given filter (keyword|regex) by running 'tanzu plugin search' command
-	SearchPlugins(filter string) ([]*PluginInfo, error)
+	SearchPlugins(filter string, opts ...E2EOption) ([]*PluginInfo, error)
 	// InstallPlugin installs given plugin and flags
-	InstallPlugin(pluginName, target, versions string) error
+	InstallPlugin(pluginName, target, versions string, opts ...E2EOption) error
 	// Sync performs sync operation
-	Sync() (string, error)
+	Sync(opts ...E2EOption) (string, error)
 	// DescribePlugin describes given plugin and flags
-	DescribePlugin(pluginName, target string) (string, error)
+	DescribePlugin(pluginName, target string, opts ...E2EOption) (string, error)
 	// UninstallPlugin uninstalls/deletes given plugin
-	UninstallPlugin(pluginName, target string) error
+	UninstallPlugin(pluginName, target string, opts ...E2EOption) error
 	// DeletePlugin deletes/uninstalls given plugin
-	DeletePlugin(pluginName, target string) error
+	DeletePlugin(pluginName, target string, opts ...E2EOption) error
 	// ExecuteSubCommand executes specific plugin sub-command
-	ExecuteSubCommand(pluginWithSubCommand string) (string, error)
+	ExecuteSubCommand(pluginWithSubCommand string, opts ...E2EOption) (string, error)
 	// CleanPlugins executes the plugin clean command to delete all existing plugins
-	CleanPlugins() error
+	CleanPlugins(opts ...E2EOption) error
 }
 
 // PluginSourceOps helps 'plugin source' commands
 type PluginSourceOps interface {
 	// AddPluginDiscoverySource adds plugin discovery source, and returns stdOut and error info
-	AddPluginDiscoverySource(discoveryOpts *DiscoveryOptions) (string, error)
+	AddPluginDiscoverySource(discoveryOpts *DiscoveryOptions, opts ...E2EOption) (string, error)
 
 	// UpdatePluginDiscoverySource updates plugin discovery source, and returns stdOut and error info
-	UpdatePluginDiscoverySource(discoveryOpts *DiscoveryOptions) (string, error)
+	UpdatePluginDiscoverySource(discoveryOpts *DiscoveryOptions, opts ...E2EOption) (string, error)
 
 	// DeletePluginDiscoverySource removes the plugin discovery source, and returns stdOut and error info
-	DeletePluginDiscoverySource(pluginSourceName string) (string, error)
+	DeletePluginDiscoverySource(pluginSourceName string, opts ...E2EOption) (string, error)
 
 	// ListPluginSources returns all available plugin discovery sources
-	ListPluginSources() ([]*PluginSourceInfo, error)
+	ListPluginSources(opts ...E2EOption) ([]*PluginSourceInfo, error)
 }
 
 type PluginGroupOps interface {
 	// SearchPluginGroups performs plugin group search
 	// input: flagsWithValues - flags and values if any
-	SearchPluginGroups(flagsWithValues string) ([]*PluginGroup, error)
+	SearchPluginGroups(flagsWithValues string, opts ...E2EOption) ([]*PluginGroup, error)
 
 	// InstallPluginsFromGroup a plugin or all plugins from the given plugin group
-	InstallPluginsFromGroup(pluginNameORAll, groupName string) error
+	InstallPluginsFromGroup(pluginNameORAll, groupName string, opts ...E2EOption) error
 }
 
 // PluginCmdOps helps to perform the plugin and its sub-commands lifecycle operations
@@ -86,37 +86,37 @@ func NewPluginLifecycleOps() PluginCmdOps {
 	}
 }
 
-func (po *pluginCmdOps) AddPluginDiscoverySource(discoveryOpts *DiscoveryOptions) (string, error) {
-	addCmd := fmt.Sprintf(AddPluginSource, discoveryOpts.Name, discoveryOpts.SourceType, discoveryOpts.URI)
-	out, _, err := po.cmdExe.Exec(addCmd)
+func (po *pluginCmdOps) AddPluginDiscoverySource(discoveryOpts *DiscoveryOptions, opts ...E2EOption) (string, error) {
+	addCmd := fmt.Sprintf(AddPluginSource, "%s", discoveryOpts.Name, discoveryOpts.SourceType, discoveryOpts.URI)
+	out, _, err := po.cmdExe.Exec(addCmd, opts...)
 	return out.String(), err
 }
 
-func (po *pluginCmdOps) UpdatePluginDiscoverySource(discoveryOpts *DiscoveryOptions) (string, error) {
-	addCmd := fmt.Sprintf(UpdatePluginSource, discoveryOpts.Name, discoveryOpts.SourceType, discoveryOpts.URI)
-	out, _, err := po.cmdExe.Exec(addCmd)
+func (po *pluginCmdOps) UpdatePluginDiscoverySource(discoveryOpts *DiscoveryOptions, opts ...E2EOption) (string, error) {
+	addCmd := fmt.Sprintf(UpdatePluginSource, "%s", discoveryOpts.Name, discoveryOpts.SourceType, discoveryOpts.URI)
+	out, _, err := po.cmdExe.Exec(addCmd, opts...)
 	return out.String(), err
 }
 
-func (po *pluginCmdOps) ListPluginSources() ([]*PluginSourceInfo, error) {
-	return ExecuteCmdAndBuildJSONOutput[PluginSourceInfo](po.cmdExe, ListPluginSourcesWithJSONOutputFlag)
+func (po *pluginCmdOps) ListPluginSources(opts ...E2EOption) ([]*PluginSourceInfo, error) {
+	return ExecuteCmdAndBuildJSONOutput[PluginSourceInfo](po.cmdExe, ListPluginSourcesWithJSONOutputFlag, opts...)
 }
 
-func (po *pluginCmdOps) DeletePluginDiscoverySource(pluginSourceName string) (string, error) {
-	deleteCmd := fmt.Sprintf(DeletePluginSource, pluginSourceName)
-	out, stdErr, err := po.cmdExe.Exec(deleteCmd)
+func (po *pluginCmdOps) DeletePluginDiscoverySource(pluginSourceName string, opts ...E2EOption) (string, error) {
+	deleteCmd := fmt.Sprintf(DeletePluginSource, "%s", pluginSourceName)
+	out, stdErr, err := po.cmdExe.Exec(deleteCmd, opts...)
 	if err != nil {
 		log.Errorf(ErrorLogForCommandWithErrStdErrAndStdOut, deleteCmd, err.Error(), stdErr.String(), out.String())
 	}
 	return out.String(), err
 }
 
-func (po *pluginCmdOps) ListPlugins() ([]*PluginInfo, error) {
-	return ExecuteCmdAndBuildJSONOutput[PluginInfo](po.cmdExe, ListPluginsCmdWithJSONOutputFlag)
+func (po *pluginCmdOps) ListPlugins(opts ...E2EOption) ([]*PluginInfo, error) {
+	return ExecuteCmdAndBuildJSONOutput[PluginInfo](po.cmdExe, ListPluginsCmdWithJSONOutputFlag, opts...)
 }
 
-func (po *pluginCmdOps) ListInstalledPlugins() ([]*PluginInfo, error) {
-	plugins, err := ExecuteCmdAndBuildJSONOutput[PluginInfo](po.cmdExe, ListPluginsCmdWithJSONOutputFlag)
+func (po *pluginCmdOps) ListInstalledPlugins(opts ...E2EOption) ([]*PluginInfo, error) {
+	plugins, err := ExecuteCmdAndBuildJSONOutput[PluginInfo](po.cmdExe, ListPluginsCmdWithJSONOutputFlag, opts...)
 	installedPlugins := make([]*PluginInfo, 0)
 	for i := range plugins {
 		if plugins[i].Status == Installed {
@@ -126,8 +126,8 @@ func (po *pluginCmdOps) ListInstalledPlugins() ([]*PluginInfo, error) {
 	return installedPlugins, err
 }
 
-func (po *pluginCmdOps) ListPluginsForGivenContext(context string, installedOnly bool) ([]*PluginInfo, error) {
-	plugins, err := ExecuteCmdAndBuildJSONOutput[PluginInfo](po.cmdExe, ListPluginsCmdWithJSONOutputFlag)
+func (po *pluginCmdOps) ListPluginsForGivenContext(context string, installedOnly bool, opts ...E2EOption) ([]*PluginInfo, error) {
+	plugins, err := ExecuteCmdAndBuildJSONOutput[PluginInfo](po.cmdExe, ListPluginsCmdWithJSONOutputFlag, opts...)
 	contextSpecificPlugins := make([]*PluginInfo, 0)
 	for i := range plugins {
 		if plugins[i].Context == context {
@@ -143,20 +143,20 @@ func (po *pluginCmdOps) ListPluginsForGivenContext(context string, installedOnly
 	return contextSpecificPlugins, err
 }
 
-func (po *pluginCmdOps) Sync() (string, error) {
-	out, stdErr, err := po.cmdExe.Exec(pluginSyncCmd)
+func (po *pluginCmdOps) Sync(opts ...E2EOption) (string, error) {
+	out, stdErr, err := po.cmdExe.Exec(pluginSyncCmd, opts...)
 	if err != nil {
 		log.Errorf(ErrorLogForCommandWithErrStdErrAndStdOut, pluginSyncCmd, err.Error(), stdErr.String(), out.String())
 	}
 	return out.String(), err
 }
 
-func (po *pluginCmdOps) SearchPlugins(filter string) ([]*PluginInfo, error) {
+func (po *pluginCmdOps) SearchPlugins(filter string, opts ...E2EOption) ([]*PluginInfo, error) {
 	searchPluginCmdWithOptions := SearchPluginsCmd
 	if len(strings.TrimSpace(filter)) > 0 {
 		searchPluginCmdWithOptions = searchPluginCmdWithOptions + " " + strings.TrimSpace(filter)
 	}
-	result, err := ExecuteCmdAndBuildJSONOutput[PluginSearch](po.cmdExe, searchPluginCmdWithOptions+JSONOutput)
+	result, err := ExecuteCmdAndBuildJSONOutput[PluginSearch](po.cmdExe, searchPluginCmdWithOptions+JSONOutput, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -173,75 +173,75 @@ func (po *pluginCmdOps) SearchPlugins(filter string) ([]*PluginInfo, error) {
 	return plugins, nil
 }
 
-func (po *pluginCmdOps) SearchPluginGroups(flagsWithValues string) ([]*PluginGroup, error) {
+func (po *pluginCmdOps) SearchPluginGroups(flagsWithValues string, opts ...E2EOption) ([]*PluginGroup, error) {
 	searchPluginGroupCmdWithOptions := SearchPluginGroupsCmd
 	if len(strings.TrimSpace(flagsWithValues)) > 0 {
 		searchPluginGroupCmdWithOptions = searchPluginGroupCmdWithOptions + " " + strings.TrimSpace(flagsWithValues)
 	}
-	return ExecuteCmdAndBuildJSONOutput[PluginGroup](po.cmdExe, searchPluginGroupCmdWithOptions+JSONOutput)
+	return ExecuteCmdAndBuildJSONOutput[PluginGroup](po.cmdExe, searchPluginGroupCmdWithOptions+JSONOutput, opts...)
 }
 
-func (po *pluginCmdOps) InstallPlugin(pluginName, target, versions string) error {
-	installPluginCmd := fmt.Sprintf(InstallPluginCmd, pluginName)
+func (po *pluginCmdOps) InstallPlugin(pluginName, target, versions string, opts ...E2EOption) error {
+	installPluginCmd := fmt.Sprintf(InstallPluginCmd, "%s", pluginName)
 	if len(strings.TrimSpace(target)) > 0 {
 		installPluginCmd += " --target " + target
 	}
 	if len(strings.TrimSpace(versions)) > 0 {
 		installPluginCmd += " --version " + versions
 	}
-	out, stdErr, err := po.cmdExe.Exec(installPluginCmd)
+	out, stdErr, err := po.cmdExe.Exec(installPluginCmd, opts...)
 	if err != nil {
 		log.Errorf(ErrorLogForCommandWithErrStdErrAndStdOut, installPluginCmd, err.Error(), stdErr.String(), out.String())
 	}
 	return err
 }
 
-func (po *pluginCmdOps) InstallPluginsFromGroup(pluginNameORAll, groupName string) error {
+func (po *pluginCmdOps) InstallPluginsFromGroup(pluginNameORAll, groupName string, opts ...E2EOption) error {
 	var installPluginCmd string
 	if len(pluginNameORAll) > 0 {
-		installPluginCmd = fmt.Sprintf(InstallPluginFromGroupCmd, pluginNameORAll, groupName)
+		installPluginCmd = fmt.Sprintf(InstallPluginFromGroupCmd, "%s", pluginNameORAll, groupName)
 	} else {
-		installPluginCmd = fmt.Sprintf(InstallAllPluginsFromGroupCmd, groupName)
+		installPluginCmd = fmt.Sprintf(InstallAllPluginsFromGroupCmd, "%s", groupName)
 	}
-	out, stdErr, err := po.cmdExe.Exec(installPluginCmd)
+	out, stdErr, err := po.cmdExe.Exec(installPluginCmd, opts...)
 	if err != nil {
 		log.Errorf(ErrorLogForCommandWithErrStdErrAndStdOut, installPluginCmd, err.Error(), stdErr.String(), out.String())
 	}
 	return err
 }
 
-func (po *pluginCmdOps) DescribePlugin(pluginName, target string) (string, error) {
-	installPluginCmd := fmt.Sprintf(DescribePluginCmd, pluginName)
+func (po *pluginCmdOps) DescribePlugin(pluginName, target string, opts ...E2EOption) (string, error) {
+	installPluginCmd := fmt.Sprintf(DescribePluginCmd, "%s", pluginName)
 	if len(strings.TrimSpace(target)) > 0 {
 		installPluginCmd += " --target " + target
 	}
 
-	stdOut, stdErr, err := po.cmdExe.Exec(installPluginCmd)
+	stdOut, stdErr, err := po.cmdExe.Exec(installPluginCmd, opts...)
 	if err != nil {
 		log.Errorf(ErrorLogForCommandWithErrStdErrAndStdOut, installPluginCmd, err.Error(), stdErr.String(), stdOut.String())
 	}
 	return stdOut.String(), err
 }
 
-func (po *pluginCmdOps) DeletePlugin(pluginName, target string) error {
-	return po.UninstallPlugin(pluginName, target)
+func (po *pluginCmdOps) DeletePlugin(pluginName, target string, opts ...E2EOption) error {
+	return po.UninstallPlugin(pluginName, target, opts...)
 }
 
-func (po *pluginCmdOps) UninstallPlugin(pluginName, target string) error {
-	uninstallPluginCmd := fmt.Sprintf(UninstallPLuginCmd, pluginName)
+func (po *pluginCmdOps) UninstallPlugin(pluginName, target string, opts ...E2EOption) error {
+	uninstallPluginCmd := fmt.Sprintf(UninstallPLuginCmd, "%s", pluginName)
 	if len(strings.TrimSpace(target)) > 0 {
 		uninstallPluginCmd += " --target " + target
 	}
-	out, stdErr, err := po.cmdExe.Exec(uninstallPluginCmd)
+	out, stdErr, err := po.cmdExe.Exec(uninstallPluginCmd, opts...)
 	if err != nil {
 		log.Errorf(ErrorLogForCommandWithErrStdErrAndStdOut, uninstallPluginCmd, err.Error(), stdErr.String(), out.String())
 	}
 	return err
 }
 
-func (po *pluginCmdOps) ExecuteSubCommand(pluginWithSubCommand string) (string, error) {
-	pluginCmdWithSubCommand := fmt.Sprintf(PluginSubCommand, pluginWithSubCommand)
-	stdOut, stdErr, err := po.cmdExe.Exec(pluginCmdWithSubCommand)
+func (po *pluginCmdOps) ExecuteSubCommand(pluginWithSubCommand string, opts ...E2EOption) (string, error) {
+	pluginCmdWithSubCommand := fmt.Sprintf(PluginSubCommand, "%s", pluginWithSubCommand)
+	stdOut, stdErr, err := po.cmdExe.Exec(pluginCmdWithSubCommand, opts...)
 	if err != nil {
 		log.Errorf(ErrorLogForCommandWithErrStdErrAndStdOut, pluginCmdWithSubCommand, err.Error(), stdErr.String(), stdOut.String())
 		return stdOut.String(), errors.Wrap(err, stdErr.String())
@@ -249,8 +249,8 @@ func (po *pluginCmdOps) ExecuteSubCommand(pluginWithSubCommand string) (string, 
 	return stdOut.String(), nil
 }
 
-func (po *pluginCmdOps) CleanPlugins() error {
-	out, stdErr, err := po.cmdExe.Exec(CleanPluginsCmd)
+func (po *pluginCmdOps) CleanPlugins(opts ...E2EOption) error {
+	out, stdErr, err := po.cmdExe.Exec(CleanPluginsCmd, opts...)
 	if err != nil {
 		log.Errorf(ErrorLogForCommandWithErrStdErrAndStdOut, CleanPluginsCmd, err.Error(), stdErr.String(), out.String())
 	}

--- a/test/e2e/framework/plugin_lifecycle_operations.go
+++ b/test/e2e/framework/plugin_lifecycle_operations.go
@@ -88,13 +88,13 @@ func NewPluginLifecycleOps() PluginCmdOps {
 
 func (po *pluginCmdOps) AddPluginDiscoverySource(discoveryOpts *DiscoveryOptions, opts ...E2EOption) (string, error) {
 	addCmd := fmt.Sprintf(AddPluginSource, "%s", discoveryOpts.Name, discoveryOpts.SourceType, discoveryOpts.URI)
-	out, _, err := po.cmdExe.Exec(addCmd, opts...)
+	out, _, err := po.cmdExe.TanzuCmdExec(addCmd, opts...)
 	return out.String(), err
 }
 
 func (po *pluginCmdOps) UpdatePluginDiscoverySource(discoveryOpts *DiscoveryOptions, opts ...E2EOption) (string, error) {
 	addCmd := fmt.Sprintf(UpdatePluginSource, "%s", discoveryOpts.Name, discoveryOpts.SourceType, discoveryOpts.URI)
-	out, _, err := po.cmdExe.Exec(addCmd, opts...)
+	out, _, err := po.cmdExe.TanzuCmdExec(addCmd, opts...)
 	return out.String(), err
 }
 
@@ -104,7 +104,7 @@ func (po *pluginCmdOps) ListPluginSources(opts ...E2EOption) ([]*PluginSourceInf
 
 func (po *pluginCmdOps) DeletePluginDiscoverySource(pluginSourceName string, opts ...E2EOption) (string, error) {
 	deleteCmd := fmt.Sprintf(DeletePluginSource, "%s", pluginSourceName)
-	out, stdErr, err := po.cmdExe.Exec(deleteCmd, opts...)
+	out, stdErr, err := po.cmdExe.TanzuCmdExec(deleteCmd, opts...)
 	if err != nil {
 		log.Errorf(ErrorLogForCommandWithErrStdErrAndStdOut, deleteCmd, err.Error(), stdErr.String(), out.String())
 	}
@@ -144,7 +144,7 @@ func (po *pluginCmdOps) ListPluginsForGivenContext(context string, installedOnly
 }
 
 func (po *pluginCmdOps) Sync(opts ...E2EOption) (string, error) {
-	out, stdErr, err := po.cmdExe.Exec(pluginSyncCmd, opts...)
+	out, stdErr, err := po.cmdExe.TanzuCmdExec(pluginSyncCmd, opts...)
 	if err != nil {
 		log.Errorf(ErrorLogForCommandWithErrStdErrAndStdOut, pluginSyncCmd, err.Error(), stdErr.String(), out.String())
 	}
@@ -189,7 +189,7 @@ func (po *pluginCmdOps) InstallPlugin(pluginName, target, versions string, opts 
 	if len(strings.TrimSpace(versions)) > 0 {
 		installPluginCmd += " --version " + versions
 	}
-	out, stdErr, err := po.cmdExe.Exec(installPluginCmd, opts...)
+	out, stdErr, err := po.cmdExe.TanzuCmdExec(installPluginCmd, opts...)
 	if err != nil {
 		log.Errorf(ErrorLogForCommandWithErrStdErrAndStdOut, installPluginCmd, err.Error(), stdErr.String(), out.String())
 	}
@@ -203,7 +203,7 @@ func (po *pluginCmdOps) InstallPluginsFromGroup(pluginNameORAll, groupName strin
 	} else {
 		installPluginCmd = fmt.Sprintf(InstallAllPluginsFromGroupCmd, "%s", groupName)
 	}
-	out, stdErr, err := po.cmdExe.Exec(installPluginCmd, opts...)
+	out, stdErr, err := po.cmdExe.TanzuCmdExec(installPluginCmd, opts...)
 	if err != nil {
 		log.Errorf(ErrorLogForCommandWithErrStdErrAndStdOut, installPluginCmd, err.Error(), stdErr.String(), out.String())
 	}
@@ -216,7 +216,7 @@ func (po *pluginCmdOps) DescribePlugin(pluginName, target string, opts ...E2EOpt
 		installPluginCmd += " --target " + target
 	}
 
-	stdOut, stdErr, err := po.cmdExe.Exec(installPluginCmd, opts...)
+	stdOut, stdErr, err := po.cmdExe.TanzuCmdExec(installPluginCmd, opts...)
 	if err != nil {
 		log.Errorf(ErrorLogForCommandWithErrStdErrAndStdOut, installPluginCmd, err.Error(), stdErr.String(), stdOut.String())
 	}
@@ -232,7 +232,7 @@ func (po *pluginCmdOps) UninstallPlugin(pluginName, target string, opts ...E2EOp
 	if len(strings.TrimSpace(target)) > 0 {
 		uninstallPluginCmd += " --target " + target
 	}
-	out, stdErr, err := po.cmdExe.Exec(uninstallPluginCmd, opts...)
+	out, stdErr, err := po.cmdExe.TanzuCmdExec(uninstallPluginCmd, opts...)
 	if err != nil {
 		log.Errorf(ErrorLogForCommandWithErrStdErrAndStdOut, uninstallPluginCmd, err.Error(), stdErr.String(), out.String())
 	}
@@ -241,7 +241,7 @@ func (po *pluginCmdOps) UninstallPlugin(pluginName, target string, opts ...E2EOp
 
 func (po *pluginCmdOps) ExecuteSubCommand(pluginWithSubCommand string, opts ...E2EOption) (string, error) {
 	pluginCmdWithSubCommand := fmt.Sprintf(PluginSubCommand, "%s", pluginWithSubCommand)
-	stdOut, stdErr, err := po.cmdExe.Exec(pluginCmdWithSubCommand, opts...)
+	stdOut, stdErr, err := po.cmdExe.TanzuCmdExec(pluginCmdWithSubCommand, opts...)
 	if err != nil {
 		log.Errorf(ErrorLogForCommandWithErrStdErrAndStdOut, pluginCmdWithSubCommand, err.Error(), stdErr.String(), stdOut.String())
 		return stdOut.String(), errors.Wrap(err, stdErr.String())
@@ -250,7 +250,7 @@ func (po *pluginCmdOps) ExecuteSubCommand(pluginWithSubCommand string, opts ...E
 }
 
 func (po *pluginCmdOps) CleanPlugins(opts ...E2EOption) error {
-	out, stdErr, err := po.cmdExe.Exec(CleanPluginsCmd, opts...)
+	out, stdErr, err := po.cmdExe.TanzuCmdExec(CleanPluginsCmd, opts...)
 	if err != nil {
 		log.Errorf(ErrorLogForCommandWithErrStdErrAndStdOut, CleanPluginsCmd, err.Error(), stdErr.String(), out.String())
 	}


### PR DESCRIPTION
### What this PR does / why we need it

- Refactored E2E framework methods to support dynamic tanzu command prefix that is required for coexistence tests
- Introduced E2EOptions struct to configure tanzu prefix for commands execution this struct can be extended as needed.
- Introduced TanzuCmdExec() to run tanzu related commands

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

make lint to verify the refactored changes are good
Tested e2e tests on local


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
