### PR TITLE
Replace direct access with library config functions for plugin sources

### DIFF
--- a/pkg/command/discovery_source_test.go
+++ b/pkg/command/discovery_source_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
 
 func Test_createDiscoverySource(t *testing.T) {
@@ -69,91 +67,10 @@ func Test_createDiscoverySource(t *testing.T) {
 }
 
 func Test_addDiscoverySource(t *testing.T) {
-	assert := assert.New(t)
-
-	discoverySources := []configtypes.PluginDiscovery{
-		configtypes.PluginDiscovery{
-			Local: &configtypes.LocalDiscovery{
-				Name: "source1",
-				Path: "fakepath1",
-			},
-		},
-	}
-
-	// When discovery source already exists
-	_, err := addDiscoverySource(discoverySources, "source1", "local", "fakepath2")
-	assert.NotNil(err)
-	assert.Contains(err.Error(), "discovery name \"source1\" already exists")
-
-	// When new discovery source gets added
-	updatedDiscoverySources, err := addDiscoverySource(discoverySources, "source2", "local", "fakepath2")
-	assert.Nil(err)
-	assert.Equal(2, len(updatedDiscoverySources))
-	assert.NotNil(updatedDiscoverySources[1].Local)
-	assert.Equal("source2", updatedDiscoverySources[1].Local.Name)
-	assert.Equal("fakepath2", updatedDiscoverySources[1].Local.Path)
 }
 
 func Test_updateDiscoverySources(t *testing.T) {
-	assert := assert.New(t)
-
-	discoverySources := []configtypes.PluginDiscovery{
-		configtypes.PluginDiscovery{
-			Local: &configtypes.LocalDiscovery{
-				Name: "source1",
-				Path: "fakepath1",
-			},
-		},
-	}
-
-	// When discovery source already exists
-	updatedDiscoverySources, err := updateDiscoverySources(discoverySources, "source1", "local", "fakepath2")
-	assert.Nil(err)
-	assert.Equal(1, len(updatedDiscoverySources))
-	assert.NotNil(updatedDiscoverySources[0].Local)
-	assert.Equal("source1", updatedDiscoverySources[0].Local.Name)
-	assert.Equal("fakepath2", updatedDiscoverySources[0].Local.Path)
-
-	// When discovery source does not exist
-	_, err = updateDiscoverySources(discoverySources, "source2", "local", "fakepath2")
-	assert.NotNil(err)
-	assert.Contains(err.Error(), "discovery source \"source2\" does not exist")
 }
 
 func Test_deleteDiscoverySource(t *testing.T) {
-	assert := assert.New(t)
-
-	discoverySources := []configtypes.PluginDiscovery{
-		configtypes.PluginDiscovery{
-			Local: &configtypes.LocalDiscovery{
-				Name: "source1",
-				Path: "fakepath1",
-			},
-		},
-		configtypes.PluginDiscovery{
-			OCI: &configtypes.OCIDiscovery{
-				Name:  "source2",
-				Image: "test.registry.com/test-image:v1.0.0",
-			},
-		},
-	}
-
-	// When discovery source does not exist
-	_, err := deleteDiscoverySource(discoverySources, "source-does-not-exists")
-	assert.NotNil(err)
-	assert.Contains(err.Error(), "discovery source \"source-does-not-exists\" does not exist")
-
-	// When deleting existing discovery source
-	updatedDiscoverySources, err := deleteDiscoverySource(discoverySources, "source1")
-	assert.Nil(err)
-	assert.Equal(1, len(updatedDiscoverySources))
-	assert.Nil(updatedDiscoverySources[0].Local)
-	assert.NotNil(updatedDiscoverySources[0].OCI)
-	assert.Equal("source2", updatedDiscoverySources[0].OCI.Name)
-	assert.Equal("test.registry.com/test-image:v1.0.0", updatedDiscoverySources[0].OCI.Image)
-
-	// When deleting last discovery source
-	updatedDiscoverySources, err = deleteDiscoverySource(updatedDiscoverySources, "source2")
-	assert.Nil(err)
-	assert.Equal(0, len(updatedDiscoverySources))
 }

--- a/pkg/pluginmanager/manager.go
+++ b/pkg/pluginmanager/manager.go
@@ -1520,18 +1520,13 @@ func getPluginDiscoveries() ([]configtypes.PluginDiscovery, error) {
 		}
 	}
 
-	// Look for configured plugin discovery sources
-	cfg, err := configlib.GetClientConfig()
-	if err != nil {
-		return testDiscoveries, errors.Wrapf(err, "unable to get client configuration")
-	}
-
-	if cfg == nil || cfg.ClientOptions == nil || cfg.ClientOptions.CLI == nil {
+	discoverySources, _ := configlib.GetCLIDiscoverySources()
+	if discoverySources == nil {
 		return testDiscoveries, nil
 	}
 	// The configured discoveries should be searched BEFORE the test discoveries.
 	// For example, if the staging central repo is added as a test discovery, it
 	// may contain older versions of a plugin that is now published to the production
 	// central repo; we therefore need to search the test discoveries last.
-	return append(cfg.ClientOptions.CLI.DiscoverySources, testDiscoveries...), nil
+	return append(discoverySources, testDiscoveries...), nil
 }


### PR DESCRIPTION
### What this PR does / why we need it

The configuration support provided by tanzu-plugin-runtime has functions that allow to get and set discovery sources.  The CLI should not access the raw config data but instead use these functions.

This commit replaces direct access with these function calls.  This modification causes no change in behaviour.

Note that unit tests are actually removed with this commit.  Those tests were verifying code that is now provided by the tanzu-plugin-runtime library.  The test functions were not removed as they should be modified to test the actual cobra command logic.  This will be done in a follow-up change.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

I confirm that `make e2e-context-tmc-test` passes locally.

There are no functional changes from this PR, and the below tests just verify that using `tanzu plugin source` continues to behave appropriately.

```
$ rm ~/.config/tanzu/config*
$ tz ceip-participation set true
$ tz config get
clientOptions:
    cli:
        edition: tkg
        bomRepo: projects.registry.vmware.com/tkg
        compatibilityFilePath: tkg-compatibility
    features:
        global:
            context-target-v2: "true"
cli:
    ceipOptIn: "true"

$ tz plugin source list
  NAME  TYPE  SCOPE
$ tz plugin source add -n default -t oci -u localhost:9876/tanzu-cli/plugins/central:large
[ok] successfully added discovery source default
$ tz plugin source list
  NAME     TYPE  SCOPE
  default  oci   Standalone
$ tz config get
clientOptions:
    cli:
        discoverySources:
            - oci:
                name: default
                image: localhost:9876/tanzu-cli/plugins/central:large
        edition: tkg
        bomRepo: projects.registry.vmware.com/tkg
        compatibilityFilePath: tkg-compatibility
    features:
        global:
            context-target-v2: "true"
cli:
    ceipOptIn: "true"

$ tz plugin source add --name admin --type local --uri /Users/kmarc/.config/tanzu-plugins/discovery/admin
[ok] successfully added discovery source admin
$ tz plugin source list
  NAME     TYPE   SCOPE
  default  oci    Standalone
  admin    local  Standalone
$ tz config get
clientOptions:
    cli:
        discoverySources:
            - oci:
                name: default
                image: localhost:9876/tanzu-cli/plugins/central:large
            - local:
                name: admin
                path: /Users/kmarc/.config/tanzu-plugins/discovery/admin
        edition: tkg
        bomRepo: projects.registry.vmware.com/tkg
        compatibilityFilePath: tkg-compatibility
    features:
        global:
            context-target-v2: "true"
cli:
    ceipOptIn: "true"

$ tz plugin source update default -u localhost:9876/bad
[x] : discovery source type cannot be empty
$ tz plugin source update default -u localhost:9876/bad -t oci
[ok] updated discovery source default
$ tz plugin source list
  NAME     TYPE   SCOPE
  default  oci    Standalone
  admin    local  Standalone
$ tz config get
clientOptions:
    cli:
        discoverySources:
            - oci:
                name: default
                image: localhost:9876/bad
            - local:
                name: admin
                path: /Users/kmarc/.config/tanzu-plugins/discovery/admin
        edition: tkg
        bomRepo: projects.registry.vmware.com/tkg
        compatibilityFilePath: tkg-compatibility
    features:
        global:
            context-target-v2: "true"
cli:
    ceipOptIn: "true"

$ tz config init
[ok] successfully initialized the config
$ tz config get
clientOptions:
    cli:
        discoverySources:
            - oci:
                name: default
                image: localhost:9876/bad
            - local:
                name: admin
                path: /Users/kmarc/.config/tanzu-plugins/discovery/admin
        edition: tkg
        bomRepo: projects.registry.vmware.com/tkg
        compatibilityFilePath: tkg-compatibility
    features:
        cluster:
            allow-legacy-cluster: "false"
            custom-nameservers: "false"
            dual-stack-ipv4-primary: "false"
            dual-stack-ipv6-primary: "false"
        global:
            context-target-v2: "true"
            tkr-version-v1alpha3-beta: "false"
        management-cluster:
            aws-instance-types-exclude-arm: "true"
            custom-nameservers: "false"
            deploy-in-cluster-ipam-provider: "true"
            dual-stack-ipv4-primary: "false"
            dual-stack-ipv6-primary: "false"
            export-from-confirm: "true"
            import: "false"
            package-based-cc: "true"
            standalone-cluster-mode: "false"
        package:
            kctrl-command-tree: "true"
cli:
    ceipOptIn: "true"

# Now tests some error cases
$ tz plugin source delete default2
[x] : cli discovery source not found
$ tz plugin source add --name admin --type occ --uri /Users/kmarc/.config/tanzu-plugins/discovery/admin
[x] : unknown discovery source type 'occ'
$ tz plugin source add --name admin --type occ
[x] : required flag(s) "uri" not set
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

Beyond the simplification of the code, this change will make modifying the configuration entry for plugin sources easier.

Please pay attention to the point about removing unit tests in case you disagree.
