### PR TITLE
Move "BeforeSuite" to top-level

### DIFF
--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -69,7 +69,7 @@ e2e-context-k8s-tests:
 ## To run TMC tests, we need to set environment variables TANZU_API_TOKEN and TANZU_CLI_TMC_UNSTABLE_URL, in case of github workflow, these are set as github environment variables
 .PHONY: e2e-context-tmc-test ## Execute CLI context life cycle e2e tests for tmc target
 e2e-context-tmc-test:
-	@if [ "${TANZU_API_TOKEN}" = "" ] && [ "$(TANZU_CLI_TMC_UNSTABLE_URL)" = "" ]; then \
+	@if [ "${TANZU_API_TOKEN}" = "" ] || [ "$(TANZU_CLI_TMC_UNSTABLE_URL)" = "" ]; then \
 		echo "***Skipping TMC specific e2e tests cases because environment variables TANZU_API_TOKEN and TANZU_CLI_TMC_UNSTABLE_URL are not set***" ; \
 	else \
 	    export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="Yes" ; \

--- a/test/e2e/context/tmc/context_tmc_lifecycle_test.go
+++ b/test/e2e/context/tmc/context_tmc_lifecycle_test.go
@@ -32,20 +32,23 @@ const ContextShouldExistsAsCreated = "the context %s should exists as its been c
 // g. (negative test) test 'tanzu context use' command with the specific context name (incorrect, which is not exists)
 // h. test 'tanzu context list' command, should list all contexts created
 // i. test 'tanzu context delete' command, make sure to delete all context's created in previous test cases
+var (
+	tf           *framework.Framework
+	clusterInfo  *framework.ClusterInfo
+	contextNames []string
+)
+
+var _ = BeforeSuite(func() {
+	tf = framework.NewFramework()
+	// get TMC TANZU_CLI_TMC_UNSTABLE_URL and TANZU_API_TOKEN from environment variables
+	clusterInfo = context.GetTMCClusterInfo()
+	Expect(clusterInfo.EndPoint).NotTo(Equal(""), "TMC cluster URL is must needed to create TMC context")
+	Expect(clusterInfo.APIKey).NotTo(Equal(""), "TMC API Key is must needed to create TMC context")
+	contextNames = make([]string, 0)
+})
+
 var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-lifecycle-tmc]", func() {
-	var (
-		tf           *framework.Framework
-		clusterInfo  *framework.ClusterInfo
-		contextNames []string
-	)
-	BeforeSuite(func() {
-		tf = framework.NewFramework()
-		// get TMC TANZU_CLI_TMC_UNSTABLE_URL and TANZU_API_TOKEN from environment variables
-		clusterInfo = context.GetTMCClusterInfo()
-		Expect(clusterInfo.EndPoint).NotTo(Equal(""), "TMC cluster URL is must needed to create TMC context")
-		Expect(clusterInfo.APIKey).NotTo(Equal(""), "TMC API Key is must needed to create TMC context")
-		contextNames = make([]string, 0)
-	})
+
 	Context("Context lifecycle tests for TMC target", func() {
 		// Test case: a. list and delete contexts if any exists
 		It("delete context command", func() {

--- a/test/e2e/plugin_sync/plugin_sync_lifecycle_test.go
+++ b/test/e2e/plugin_sync/plugin_sync_lifecycle_test.go
@@ -14,14 +14,14 @@ import (
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
 
-var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Group-lifecycle]", func() {
+var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 
 	// Use case 1: create a KIND cluster, don't apply CRD and CRs, create context, make sure no plugins are installed
 	// a. create k8s context for the KIND cluster
 	// b. create context and validate current active context
 	// c. list plugins and make sure no plugins installed
 	// d. delete current context and KIND cluster
-	Context("plugin install from group: install a plugin from a specific plugin group", func() {
+	Context("Use case: Install KIND Cluster, create context and validate plugin sync", func() {
 		var clusterInfo *framework.ClusterInfo
 		var contextName string
 		var err error


### PR DESCRIPTION
### What this PR does / why we need it

This PR fixes the E2E test that are failing on main.

ginkgo requires the "BeforeSuite" function to be at the top-level. When we upgraded to ginkgo 2, it started throwing an error due to this situation and the E2E tests started failing (only on the main branch because the tests in question don't run in PRs because they need access to secrets).

This commit also does a couple of minor cleanups.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #227 

### Describe testing done for PR

With the main branch checked out I ran the failing tests locally:

```
$ make e2e-context-tmc-test
=== RUN   TestTmc
Ginkgo detected an issue with your spec structure
BeforeSuite(func() {
/Users/kmarc/git/tanzu-cli/test/e2e/context/tmc/context_tmc_lifecycle_test.go:41
  It looks like you are trying to add a [BeforeSuite] node within a container
  node.

  BeforeSuite can only be called at the top level.

  Learn more at:
  http://onsi.github.io/ginkgo/#suite-setup-and-cleanup-beforesuite-and-aftersuite

FAIL	github.com/vmware-tanzu/tanzu-cli/test/e2e/context/tmc	0.902s
FAIL
make: *** [e2e-context-tmc-test] Error 1
```

Then I ran the same tests with this PR and they pass.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

Before merging PRs, I recommend running `make e2e-context-tmc-test` locally after having set the `TANZU_CLI_TMC_UNSTABLE_URL` and `TANZU_API_TOKEN` variables.
