### PR TITLE
Bug fix : Add version in the error messages for plugin lifecycle methods

### DIFF
--- a/pkg/pluginmanager/manager.go
+++ b/pkg/pluginmanager/manager.go
@@ -690,9 +690,9 @@ func installPlugin(pluginName, version string, target configtypes.Target, contex
 
 	if len(availablePlugins) == 0 {
 		if target != configtypes.TargetUnknown {
-			return errors.Errorf("unable to find plugin '%v' for target '%s'", pluginName, string(target))
+			return errors.Errorf("unable to find plugin '%v' with version '%v' for target '%s'", pluginName, version, string(target))
 		}
-		return errors.Errorf("unable to find plugin '%v'", pluginName)
+		return errors.Errorf("unable to find plugin '%v' with version '%v'", pluginName, version)
 	}
 
 	// Deal with duplicates from different plugin discovery sources
@@ -711,9 +711,9 @@ func installPlugin(pluginName, version string, target configtypes.Target, contex
 	}
 	if len(matchedPlugins) == 0 {
 		if target != configtypes.TargetUnknown {
-			return errors.Errorf("unable to find plugin '%v' for target '%s'", pluginName, string(target))
+			return errors.Errorf("unable to find plugin '%v' with version '%v' for target '%s'", pluginName, version, string(target))
 		}
-		return errors.Errorf("unable to find plugin '%v'", pluginName)
+		return errors.Errorf("unable to find plugin '%v' with version '%v'", pluginName, version)
 	}
 
 	if len(matchedPlugins) == 1 {
@@ -755,9 +755,9 @@ func legacyPluginInstall(pluginName, version string, target configtypes.Target) 
 	}
 	if len(matchedPlugins) == 0 {
 		if target != configtypes.TargetUnknown {
-			return errors.Errorf("unable to find plugin '%v' for target '%s'", pluginName, string(target))
+			return errors.Errorf("unable to find plugin '%v' with version '%v' for target '%s'", pluginName, version, string(target))
 		}
-		return errors.Errorf("unable to find plugin '%v'", pluginName)
+		return errors.Errorf("unable to find plugin '%v' with version '%v'", pluginName, version)
 	}
 
 	if len(matchedPlugins) == 1 {
@@ -1159,9 +1159,9 @@ func InstallPluginsFromLocalSource(pluginName, version string, target configtype
 		}
 
 		if target != configtypes.TargetUnknown {
-			return errors.Errorf("unable to find plugin '%v' for target '%s'", pluginName, string(target))
+			return errors.Errorf("unable to find plugin '%v' with version '%v' for target '%s'", pluginName, version, string(target))
 		}
-		return errors.Errorf("unable to find plugin '%v'", pluginName)
+		return errors.Errorf("unable to find plugin '%v' with version '%v'", pluginName, version)
 	}
 
 	if len(matchedPlugins) == 1 {

--- a/pkg/pluginmanager/manager_test.go
+++ b/pkg/pluginmanager/manager_test.go
@@ -171,7 +171,7 @@ func Test_InstallPlugin_InstalledPlugins_No_Central_Repo(t *testing.T) {
 	// Try installing the feature plugin which is targeted for k8s but requesting the TMC target
 	err = InstallStandalonePlugin("feature", "v0.2.0", configtypes.TargetTMC)
 	assertions.NotNil(err)
-	assertions.Contains(err.Error(), "unable to find plugin 'feature' for target 'mission-control'")
+	assertions.Contains(err.Error(), "unable to find plugin 'feature' with version 'v0.2.0' for target 'mission-control'")
 
 	// Verify installed plugins
 	installedStandalonePlugins, err := pluginsupplier.GetInstalledStandalonePlugins()
@@ -268,7 +268,7 @@ func Test_InstallPlugin_InstalledPlugins_Central_Repo(t *testing.T) {
 	// Try installing the feature plugin which is targeted for k8s but requesting the TMC target
 	err = InstallStandalonePlugin("feature", "v0.2.0", configtypes.TargetTMC)
 	assertions.NotNil(err)
-	assertions.Contains(err.Error(), "unable to find plugin 'feature' for target 'mission-control'")
+	assertions.Contains(err.Error(), "unable to find plugin 'feature' with version 'v0.2.0' for target 'mission-control'")
 
 	// Verify installed plugins
 	installedStandalonePlugins, err := pluginsupplier.GetInstalledStandalonePlugins()
@@ -635,7 +635,7 @@ func Test_InstallPlugin_InstalledPlugins_From_LocalSource(t *testing.T) {
 	// Try installing the feature plugin which is targeted for k8s but requesting the TMC target
 	err = InstallPluginsFromLocalSource("feature", "v0.2.0", configtypes.TargetTMC, localPluginSourceDir, false)
 	assertions.NotNil(err)
-	assertions.Contains(err.Error(), "unable to find plugin 'feature' for target 'mission-control'")
+	assertions.Contains(err.Error(), "unable to find plugin 'feature' with version 'v0.2.0' for target 'mission-control'")
 
 	// Install login from local source directory
 	err = InstallPluginsFromLocalSource("login", "v0.2.0", configtypes.TargetUnknown, localPluginSourceDir, false)

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -98,6 +98,7 @@ const (
 
 	// Error messages
 	UnableToFindPluginForTarget                   = "unable to find plugin '%s' for target '%s'"
+	UnableToFindPluginWithVersionForTarget        = "unable to find plugin '%s' with version '%s' for target '%s'"
 	UnableToFindPlugin                            = "unable to find plugin '%s'"
 	InvalidTargetSpecified                        = "invalid target specified. Please specify correct value of `--target` or `-t` flag from 'global/kubernetes/k8s/mission-control/tmc'"
 	InvalidTargetGlobal                           = "invalid target for plugin: global"

--- a/test/e2e/plugin_sync/plugin_sync_lifecycle_test.go
+++ b/test/e2e/plugin_sync/plugin_sync_lifecycle_test.go
@@ -198,7 +198,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", 
 		// Test case: e. run plugin sync and validate the plugin list
 		It("Uninstall one of the installed plugin", func() {
 			_, err = tf.PluginCmd.Sync()
-			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(framework.UnableToFindPluginForTarget, pluginsWithIncorrectVer[0].Name, pluginsWithIncorrectVer[0].Target)))
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(framework.UnableToFindPluginWithVersionForTarget, pluginsWithIncorrectVer[0].Name, pluginsWithIncorrectVer[0].Version, pluginsWithIncorrectVer[0].Target)))
 
 			pluginsList, err = tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")


### PR DESCRIPTION
### What this PR does / why we need it

- Improve the error message of the `tanzu plugin sync` command to mention the version of the plugin if the plugin is not found.

*Previously*

```
~ $ tanzu plugin list
Standalone Plugins
  NAME     DESCRIPTION                 TARGET      VERSION                 STATUS
  builder  Build Tanzu components      global      v0.1.0-dev-8-g6087ea00  installed
  apps     Applications on Kubernetes  kubernetes  v0.10.0                 installed

Plugins from Context:  k8s-cluster-1
  NAME                DESCRIPTION                    TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations  kubernetes  v0.28.0  installed
  kubernetes-release  Kubernetes release operations  kubernetes  v0.28.1  not installed

[!] As shown above, some recommended plugins have not been installed. To install them please run 'tanzu plugin sync'.

``` 

```
~ $ tanzu plugin sync
[i] Checking for required plugins...
[x] : unable to find plugin 'kubernetes-release' for target 'kubernetes'

```

*After the improvement with this fix*

Improve the error message to include the plugin version as well. Example:

```
[x] : unable to find plugin 'kubernetes-release' with version 'v0.28.1' for target 'kubernetes'

```

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

- Updated Unit tests to verify the error message to include plugin version
-  E2E test to verify the new error message that includes plugin version

```
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (fix_plugin_sync_err_msg)> tanzu plugin search
  NAME                DESCRIPTION                  TARGET           LATEST
  isolated-cluster    Desc for isolated-cluster    global           v9.9.9
  pinniped-auth       Desc for pinniped-auth       global           v9.9.9
  cluster             Desc for cluster             kubernetes       v9.9.9
  feature             Desc for feature             kubernetes       v9.9.9
  kubernetes-release  Desc for kubernetes-release  kubernetes       v9.9.9
  management-cluster  Desc for management-cluster  kubernetes       v9.9.9
  package             Desc for package             kubernetes       v9.9.9
  secret              Desc for secret              kubernetes       v9.9.9
  telemetry           Desc for telemetry           kubernetes       v9.9.9
  account             Desc for account             mission-control  v9.9.9
  apply               Desc for apply               mission-control  v9.9.9
  audit               Desc for audit               mission-control  v9.9.9
  cluster             Desc for cluster             mission-control  v9.9.9
  clustergroup        Desc for clustergroup        mission-control  v9.9.9
  continuousdelivery  Desc for continuousdelivery  mission-control  v9.9.9
  data-protection     Desc for data-protection     mission-control  v9.9.9
  ekscluster          Desc for ekscluster          mission-control  v9.9.9
  events              Desc for events              mission-control  v9.9.9
  helm                Desc for helm                mission-control  v9.9.9
  iam                 Desc for iam                 mission-control  v9.9.9
  inspection          Desc for inspection          mission-control  v9.9.9
  integration         Desc for integration         mission-control  v9.9.9
  management-cluster  Desc for management-cluster  mission-control  v9.9.9
  policy              Desc for policy              mission-control  v9.9.9
  secret              Desc for secret              mission-control  v9.9.9
  tanzupackage        Desc for tanzupackage        mission-control  v9.9.9
  workspace           Desc for workspace           mission-control  v9.9.9
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (fix_plugin_sync_err_msg)> tanzu plugin install kubernetes-release -v 1.1.1
[x] : unable to find plugin 'kubernetes-release' with version '1.1.1'
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (fix_plugin_sync_err_msg) [1]> tanzu plugin install kubernetes-release -v 1.1.1 -t k8s
[x] : unable to find plugin 'kubernetes-release' with version '1.1.1' for target 'kubernetes'
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (fix_plugin_sync_err_msg) [1]> tanzu plugin install kubernetes-release -v 1.1.1 -t tmc
[x] : unable to find plugin 'kubernetes-release' with version '1.1.1' for target 'mission-control'
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (fix_plugin_sync_err_msg) [1]>
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
 plugin install/sync error message now include version of plugin it failed to install
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
