### PR TITLE
Use a plugin source to find the central plugin discovery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/lithammer/dedent v1.1.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/onsi/ginkgo/v2 v2.9.2
-	github.com/onsi/gomega v1.27.4
+	github.com/onsi/gomega v1.27.6
 	github.com/otiai10/copy v1.4.2
 	github.com/pkg/errors v0.9.1
 	github.com/sigstore/cosign v1.13.1
@@ -32,7 +32,7 @@ require (
 	github.com/vmware-tanzu/carvel-imgpkg v0.36.1
 	github.com/vmware-tanzu/carvel-ytt v0.40.0
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230415084831-9331f55d2999
-	github.com/vmware-tanzu/tanzu-plugin-runtime v0.90.0-alpha.0
+	github.com/vmware-tanzu/tanzu-plugin-runtime v0.90.0-alpha.0.0.20230425191535-014e58e69078
 	go.pinniped.dev v0.20.0
 	go.uber.org/multierr v1.8.0
 	golang.org/x/mod v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -1004,8 +1004,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
-github.com/onsi/gomega v1.27.4 h1:Z2AnStgsdSayCMDiCU42qIz+HLqEPcgiOCXjAU/w+8E=
-github.com/onsi/gomega v1.27.4/go.mod h1:riYq/GJKh8hhoM01HN6Vmuy93AarCXCBGpvFDK3q3fQ=
+github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
+github.com/onsi/gomega v1.27.6/go.mod h1:PIQNjfQwkP3aQAH7lf7j87O/5FiNr+ZR8+ipb+qQlhg=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
@@ -1287,8 +1287,8 @@ github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20221207131309-7323ca04b
 github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20221207131309-7323ca04b86c/go.mod h1:ukZpKQ0hf5bjWdJLjn2M6qXP+9giZWQPxt8nOfrCR+o=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230415084831-9331f55d2999 h1:WITDH+wpdl/clw1hwy+2jtq4Pt//i/Mq9lQXGwg3q4c=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230415084831-9331f55d2999/go.mod h1:umFZBUfJ8VI3p0VO/xocuE+4fO9s9QbytEiOqFcH/Tw=
-github.com/vmware-tanzu/tanzu-plugin-runtime v0.90.0-alpha.0 h1:7HOxIB70moCj8b39/kezbJbzF2XqoCihGS7bIPhqTAA=
-github.com/vmware-tanzu/tanzu-plugin-runtime v0.90.0-alpha.0/go.mod h1:y70TLdev7MX8K6CkAA7h92qVUDyjbX8y9/J5q4UmhRs=
+github.com/vmware-tanzu/tanzu-plugin-runtime v0.90.0-alpha.0.0.20230425191535-014e58e69078 h1:FnqG7kCmltbUgnGJiDcokvQT1Bbvs38IrmVIUFj4P34=
+github.com/vmware-tanzu/tanzu-plugin-runtime v0.90.0-alpha.0.0.20230425191535-014e58e69078/go.mod h1:FlvOcF26rX4EA+ADjYTJdFh6WVur6O4jh25FDP9Lp7E=
 github.com/xanzy/go-gitlab v0.31.0/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
 github.com/xanzy/go-gitlab v0.73.1 h1:UMagqUZLJdjss1SovIC+kJCH4k2AZWXl58gJd38Y/hI=
 github.com/xanzy/go-gitlab v0.73.1/go.mod h1:d/a0vswScO7Agg1CZNz15Ic6SSvBG9vfw8egL99t4kA=

--- a/hack/central-repo/README.md
+++ b/hack/central-repo/README.md
@@ -24,7 +24,7 @@ For the `sandbox2:small` image, the `v22.22.22` of the plugins can be installed.
 The steps to follow to use the test central repo are:
 
 1. Start the test repo with `make start-test-central-repo`.
-1. Configure the plugin source for the test central repo: `tz config set env.TANZU_CLI_PRE_RELEASE_REPO_IMAGE localhost:9876/tanzu-cli/plugins/central:small`
+1. Configure the plugin source for the test central repo: `tz plugin source update default -u localhost:9876/tanzu-cli/plugins/central:small`
 
 Here are the exact commands:
 
@@ -33,7 +33,7 @@ cd tanzu-cli
 make build
 make start-test-central-repo
 alias tz=$(pwd)/bin/tanzu
-tz config set env.TANZU_CLI_PRE_RELEASE_REPO_IMAGE localhost:9876/tanzu-cli/plugins/central:small
+tz plugin source update default -u localhost:9876/tanzu-cli/plugins/central:small
 
 tz plugin search
 tz plugin install cluster --target tmc
@@ -52,7 +52,7 @@ TMC context (`v0.0.1`), but will install them from the test Central Repository.
 To use the large test central repo instead:
 
 ```bash
-tz config set env.TANZU_CLI_PRE_RELEASE_REPO_IMAGE localhost:9876/tanzu-cli/plugins/central:large
+tz plugin source update default -u localhost:9876/tanzu-cli/plugins/central:large
 ```
 
 To stop the central repos: `make stop-test-central-repo`.

--- a/pkg/command/discovery_source.go
+++ b/pkg/command/discovery_source.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/config"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 
 	"github.com/pkg/errors"
@@ -27,40 +28,47 @@ var (
 
 func newDiscoverySourceCmd() *cobra.Command {
 	var discoverySourceCmd = &cobra.Command{
-		Use: "source",
-		// TODO(khouzam): not to be used for the alpha.0 release, but will be re-added after
-		Hidden: true,
-		Short:  "Manage plugin discovery sources",
-		Long:   "Manage plugin discovery sources. Discovery source provides metadata about the list of available plugins, their supported versions and how to download them.",
+		Use:   "source",
+		Short: "Manage plugin discovery sources",
+		Long:  "Manage plugin discovery sources. Discovery source provides metadata about the list of available plugins, their supported versions and how to download them.",
 	}
 	discoverySourceCmd.SetUsageFunc(cli.SubCmdUsageFunc)
 
 	listDiscoverySourceCmd := newListDiscoverySourceCmd()
-	addDiscoverySourceCmd := newAddDiscoverySourceCmd()
 	updateDiscoverySourceCmd := newUpdateDiscoverySourceCmd()
 	deleteDiscoverySourceCmd := newDeleteDiscoverySourceCmd()
-
-	addDiscoverySourceCmd.Flags().StringVarP(&discoverySourceName, "name", "n", "", "name of discovery source")
-	addDiscoverySourceCmd.Flags().StringVarP(&discoverySourceType, "type", "t", "", "type of discovery source")
-	addDiscoverySourceCmd.Flags().StringVarP(&uri, "uri", "u", "", "URI for discovery source. URI format might be different based on the type of discovery source")
-
-	// Not handling errors below because cobra handles the error when flag user doesn't provide these required flags
-	_ = cobra.MarkFlagRequired(addDiscoverySourceCmd.Flags(), "name")
-	_ = cobra.MarkFlagRequired(addDiscoverySourceCmd.Flags(), "type")
-	_ = cobra.MarkFlagRequired(addDiscoverySourceCmd.Flags(), "uri")
-
-	updateDiscoverySourceCmd.Flags().StringVarP(&discoverySourceType, "type", "t", "", "type of discovery source")
-	updateDiscoverySourceCmd.Flags().StringVarP(&uri, "uri", "u", "", "URI for discovery source. URI format might be different based on the type of discovery source")
 
 	listDiscoverySourceCmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format (yaml|json|table)")
 
 	discoverySourceCmd.AddCommand(
 		listDiscoverySourceCmd,
-		addDiscoverySourceCmd,
 		updateDiscoverySourceCmd,
 		deleteDiscoverySourceCmd,
 	)
 
+	if !configlib.IsFeatureActivated(constants.FeatureDisableCentralRepositoryForTesting) {
+		discoverySourceCmd.AddCommand(newInitDiscoverySourceCmd())
+		updateDiscoverySourceCmd.Flags().StringVarP(&uri, "uri", "u", "", "URI for discovery source. The URI must be of an OCI image")
+	} else {
+		updateDiscoverySourceCmd.Flags().StringVarP(&discoverySourceType, "type", "t", "", "type of discovery source")
+		updateDiscoverySourceCmd.Flags().StringVarP(&uri, "uri", "u", "", "URI for discovery source. The URI format might be different based on the type of discovery source")
+
+		// The "add" and "delete" plugin source commands are not needed for the central repo
+		addDiscoverySourceCmd := newAddDiscoverySourceCmd()
+
+		addDiscoverySourceCmd.Flags().StringVarP(&discoverySourceName, "name", "n", "", "name of discovery source")
+		addDiscoverySourceCmd.Flags().StringVarP(&discoverySourceType, "type", "t", "", "type of discovery source")
+		addDiscoverySourceCmd.Flags().StringVarP(&uri, "uri", "u", "", "URI for discovery source. The URI format might be different based on the type of discovery source")
+
+		// Not handling errors below because cobra handles the error when flag user doesn't provide these required flags
+		_ = cobra.MarkFlagRequired(addDiscoverySourceCmd.Flags(), "name")
+		_ = cobra.MarkFlagRequired(addDiscoverySourceCmd.Flags(), "type")
+		_ = cobra.MarkFlagRequired(addDiscoverySourceCmd.Flags(), "uri")
+
+		discoverySourceCmd.AddCommand(
+			addDiscoverySourceCmd,
+		)
+	}
 	return discoverySourceCmd
 }
 
@@ -69,6 +77,19 @@ func newListDiscoverySourceCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List available discovery sources",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if !configlib.IsFeatureActivated(constants.FeatureDisableCentralRepositoryForTesting) {
+				output := component.NewOutputWriter(cmd.OutOrStdout(), outputFormat, "name", "image")
+				discoverySources, _ := configlib.GetCLIDiscoverySources()
+				for _, ds := range discoverySources {
+					if ds.OCI != nil {
+						output.AddRow(ds.OCI.Name, ds.OCI.Image)
+					}
+				}
+
+				output.Render()
+				return nil
+			}
+
 			output := component.NewOutputWriter(cmd.OutOrStdout(), outputFormat, "name", "type", "scope")
 
 			// List standalone scoped discoveries
@@ -143,23 +164,18 @@ func newUpdateDiscoverySourceCmd() *cobra.Command {
 		Use:   "update [name]",
 		Short: "Update a discovery source configuration",
 		Args:  cobra.ExactArgs(1),
-		Example: `
-    # Update a local discovery source. If URI is relative path, 
-    # $HOME/.config/tanzu-plugins will be considered base path
-    tanzu plugin source update standalone-local --type local --uri new/path/to/local/discovery
-
-    # Update an OCI discovery source. URI should be an OCI image.
-    tanzu plugin source update standalone-oci --type oci --uri projects.registry.vmware.com/tkg/tanzu-plugins/standalone:v1.0`,
-
 		RunE: func(cmd *cobra.Command, args []string) error {
 			discoveryName := args[0]
 
-			discoveryNoExistError := fmt.Errorf("discovery %q does not exist", discoveryName)
 			discoverySource, _ := configlib.GetCLIDiscoverySource(discoveryName)
 			if discoverySource == nil {
-				return discoveryNoExistError
+				return fmt.Errorf("discovery %q does not exist", discoveryName)
 			}
 
+			if !configlib.IsFeatureActivated(constants.FeatureDisableCentralRepositoryForTesting) {
+				// With the central discovery, there is no more --type flag
+				discoverySourceType = common.DiscoveryTypeOCI
+			}
 			newDiscoverySource, err := createDiscoverySource(discoverySourceType, discoveryName, uri)
 			if err != nil {
 				return err
@@ -174,6 +190,21 @@ func newUpdateDiscoverySourceCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	if !configlib.IsFeatureActivated(constants.FeatureDisableCentralRepositoryForTesting) {
+		updateDiscoverySourceCmd.Example = `
+    # Update the discovery source for an air-gapped scenario. The URI must be an OCI image.
+    tanzu plugin source update default --uri registry.example.com/tanzu/plugin-inventory:latest`
+	} else {
+		updateDiscoverySourceCmd.Example = `
+    # Update a local discovery source. If URI is relative path,
+    # $HOME/.config/tanzu-plugins will be considered base path
+    tanzu plugin source update standalone-local --type local --uri new/path/to/local/discovery
+
+    # Update an OCI discovery source. URI should be an OCI image.
+    tanzu plugin source update standalone-oci --type oci --uri projects.registry.vmware.com/tkg/tanzu-plugins/standalone:v1.0`
+	}
+
 	return updateDiscoverySourceCmd
 }
 
@@ -184,9 +215,14 @@ func newDeleteDiscoverySourceCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Example: `
     # Delete a discovery source
-    tanzu plugin discovery delete standalone-oci`,
+    tanzu plugin discovery delete default`,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			discoveryName := args[0]
+
+			discoverySource, _ := configlib.GetCLIDiscoverySource(discoveryName)
+			if discoverySource == nil {
+				return fmt.Errorf("discovery %q does not exist", discoveryName)
+			}
 
 			err = configlib.DeleteCLIDiscoverySource(discoveryName)
 			if err != nil {
@@ -198,6 +234,25 @@ func newDeleteDiscoverySourceCmd() *cobra.Command {
 	}
 	return deleteDiscoverySourceCmd
 }
+
+func newInitDiscoverySourceCmd() *cobra.Command {
+	var initDiscoverySourceCmd = &cobra.Command{
+		Use:   "init",
+		Short: "Initialize the discovery source to its default value",
+		Args:  cobra.MaximumNArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := config.PopulateDefaultCentralDiscovery(true)
+			if err != nil {
+				return err
+			}
+
+			log.Successf("successfully initialized discovery source")
+			return nil
+		},
+	}
+	return initDiscoverySourceCmd
+}
+
 func createDiscoverySource(dsType, dsName, uri string) (configtypes.PluginDiscovery, error) {
 	pluginDiscoverySource := configtypes.PluginDiscovery{}
 	if dsType == "" {

--- a/pkg/command/plugin_search_test.go
+++ b/pkg/command/plugin_search_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
-	"github.com/vmware-tanzu/tanzu-cli/pkg/pluginmanager"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 )
 
@@ -67,10 +66,6 @@ func TestPluginSearch(t *testing.T) {
 	assert.Nil(err)
 	os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
 	os.Setenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER", "No")
-
-	// Bypass the environment variable for testing
-	err = os.Setenv(constants.ConfigVariablePreReleasePluginRepoImage, pluginmanager.PreReleasePluginRepoImageBypass)
-	assert.Nil(err)
 
 	featureArray := strings.Split(constants.FeatureContextCommand, ".")
 	err = config.SetFeature(featureArray[1], featureArray[2], "true")

--- a/pkg/command/plugin_test.go
+++ b/pkg/command/plugin_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
-	"github.com/vmware-tanzu/tanzu-cli/pkg/pluginmanager"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/plugin"
@@ -359,10 +358,6 @@ func TestInstallPlugin(t *testing.T) {
 	assert.Nil(err)
 	os.Setenv("TANZU_CONFIG_NEXT_GEN", tkgConfigFileNG.Name())
 	os.Setenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER", "No")
-
-	// Bypass the environment variable for testing
-	err = os.Setenv(constants.ConfigVariablePreReleasePluginRepoImage, pluginmanager.PreReleasePluginRepoImageBypass)
-	assert.Nil(err)
 
 	featureArray := strings.Split(constants.FeatureContextCommand, ".")
 	err = config.SetFeature(featureArray[1], featureArray[2], "true")

--- a/pkg/config/defaults_test.go
+++ b/pkg/config/defaults_test.go
@@ -6,11 +6,14 @@ package config
 import (
 	"net/url"
 	"os"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
+	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
 
 var _ = Describe("defaults test cases", func() {
@@ -25,18 +28,71 @@ var _ = Describe("defaults test cases", func() {
 			Expect(trustedRegis).NotTo(BeNil())
 			DefaultAllowedPluginRepositories = ""
 		})
-		It("trusted registries should include hostname of env var", func() {
-			testHost := "example.com"
-			oldValue := os.Getenv(constants.ConfigVariablePreReleasePluginRepoImage)
-			err := os.Setenv(constants.ConfigVariablePreReleasePluginRepoImage, testHost+"/test/path")
-			Expect(err).To(BeNil())
+		Context("with config files", func() {
+			var (
+				configFile   *os.File
+				configFileNG *os.File
+				err          error
+			)
+			BeforeEach(func() {
+				configFile, err = os.CreateTemp("", "config")
+				Expect(err).To(BeNil())
+				os.Setenv("TANZU_CONFIG", configFile.Name())
 
-			trustedRegis := GetTrustedRegistries()
-			Expect(trustedRegis).NotTo(BeNil())
-			Expect(trustedRegis).Should(ContainElement(testHost))
+				configFileNG, err = os.CreateTemp("", "config_ng")
+				Expect(err).To(BeNil())
+				os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
 
-			err = os.Setenv(constants.ConfigVariablePreReleasePluginRepoImage, oldValue)
-			Expect(err).To(BeNil())
+				featureArray := strings.Split(constants.FeatureContextCommand, ".")
+				err = configlib.SetFeature(featureArray[1], featureArray[2], "true")
+				Expect(err).To(BeNil())
+			})
+			AfterEach(func() {
+				os.Unsetenv("TANZU_CONFIG")
+				os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
+				os.RemoveAll(configFile.Name())
+				os.RemoveAll(configFileNG.Name())
+			})
+			It("trusted registries should include hostname of each configured central discovery source", func() {
+				testHost1 := "example.com"
+				testImage1 := testHost1 + "/the/path/to/an/image:tag"
+				testImage2 := testHost1 + ":12345/the/path/to/another/image:latest"
+				testHost2 := "another.com"
+				testImage3 := testHost2 + "/the/path/to/an/image:tag"
+				testImage4 := testHost2 + ":12345/the/path/to/another/image:latest"
+
+				err = configlib.SetCLIDiscoverySources([]types.PluginDiscovery{
+					{
+						OCI: &types.OCIDiscovery{
+							Name:  "default1",
+							Image: testImage1,
+						},
+					},
+					{
+						OCI: &types.OCIDiscovery{
+							Name:  "default2",
+							Image: testImage2,
+						},
+					},
+					{
+						OCI: &types.OCIDiscovery{
+							Name:  "default3",
+							Image: testImage3,
+						},
+					}, {
+						OCI: &types.OCIDiscovery{
+							Name:  "default4",
+							Image: testImage4,
+						},
+					},
+				})
+				Expect(err).To(BeNil())
+
+				trustedRegis := GetTrustedRegistries()
+				Expect(trustedRegis).NotTo(BeNil())
+				Expect(trustedRegis).Should(ContainElement(testHost1))
+				Expect(trustedRegis).Should(ContainElement(testHost2))
+			})
 		})
 		It("trusted registries should include hostname of additional discoveries", func() {
 			testHost1 := "registry1.vmware.com"
@@ -51,7 +107,7 @@ var _ = Describe("defaults test cases", func() {
 			Expect(trustedRegis).Should(ContainElement(testHost1))
 			Expect(trustedRegis).Should(ContainElement(testHost2))
 
-			err = os.Setenv(constants.ConfigVariablePreReleasePluginRepoImage, oldValue)
+			err = os.Setenv(constants.ConfigVariableAdditionalDiscoveryForTesting, oldValue)
 			Expect(err).To(BeNil())
 		})
 		It("trusted registries should include hostname of default central discovery", func() {

--- a/pkg/constants/env_variables.go
+++ b/pkg/constants/env_variables.go
@@ -10,7 +10,6 @@ const (
 
 const (
 	AllowedRegistries                                 = "ALLOWED_REGISTRY"
-	ConfigVariablePreReleasePluginRepoImage           = "TANZU_CLI_PRE_RELEASE_REPO_IMAGE"
 	ConfigVariableAdditionalDiscoveryForTesting       = "TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY"
 	ConfigVariableIncludeDeactivatedPluginsForTesting = "TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY"
 	// PluginDiscoveryImageSignatureVerificationSkipList is a comma separated list of discovery image urls

--- a/pkg/pluginmanager/manager_helper_test.go
+++ b/pkg/pluginmanager/manager_helper_test.go
@@ -57,10 +57,10 @@ func setupLocalDistroForTesting() func() {
 	common.DefaultLocalPluginDistroDir = filepath.Join(tmpDir, "distro")
 	common.DefaultCacheDir = filepath.Join(tmpDir, "cache")
 
-	tkgConfigFile := filepath.Join(tmpDir, "tanzu_config.yaml")
-	tkgConfigNextGenFile := filepath.Join(tmpDir, "tanzu_config_ng.yaml")
-	os.Setenv("TANZU_CONFIG", tkgConfigFile)
-	os.Setenv("TANZU_CONFIG_NEXT_GEN", tkgConfigNextGenFile)
+	configFile := filepath.Join(tmpDir, "tanzu_config.yaml")
+	configNextGenFile := filepath.Join(tmpDir, "tanzu_config_ng.yaml")
+	os.Setenv("TANZU_CONFIG", configFile)
+	os.Setenv("TANZU_CONFIG_NEXT_GEN", configNextGenFile)
 	os.Setenv("HOME", tmpHomeDir)
 
 	err = copy.Copy(filepath.Join("test", "local"), common.DefaultLocalPluginDistroDir)
@@ -68,12 +68,12 @@ func setupLocalDistroForTesting() func() {
 		log.Fatal(err, "Error while setting local distro for testing")
 	}
 
-	err = copy.Copy(filepath.Join("test", "config.yaml"), tkgConfigFile)
+	err = copy.Copy(filepath.Join("test", "config.yaml"), configFile)
 	if err != nil {
 		log.Fatal(err, "Error while coping tanzu config file for testing")
 	}
 
-	err = copy.Copy(filepath.Join("test", "config-ng.yaml"), tkgConfigNextGenFile)
+	err = copy.Copy(filepath.Join("test", "config-ng.yaml"), configNextGenFile)
 	if err != nil {
 		log.Fatal(err, "Error while coping tanzu config next gen file for testing")
 	}

--- a/pkg/pluginmanager/manager_test.go
+++ b/pkg/pluginmanager/manager_test.go
@@ -91,8 +91,6 @@ func Test_DiscoverPlugins(t *testing.T) {
 	assertions := assert.New(t)
 
 	defer setupLocalDistroForTesting()()
-	err := os.Setenv(constants.ConfigVariablePreReleasePluginRepoImage, PreReleasePluginRepoImageBypass)
-	assertions.Nil(err)
 
 	serverPlugins, standalonePlugins := DiscoverPlugins()
 	assertions.Equal(len(expectedDiscoveredContextPlugins), len(serverPlugins))
@@ -109,7 +107,7 @@ func Test_DiscoverPlugins(t *testing.T) {
 		assertions.Equal(expectedDiscoveredPlugins[i].Target, p.Target)
 	}
 
-	err = configlib.SetFeature("global", "context-target-v2", "false")
+	err := configlib.SetFeature("global", "context-target-v2", "false")
 	assertions.Nil(err)
 
 	serverPlugins, standalonePlugins = DiscoverPlugins()
@@ -227,16 +225,12 @@ func Test_InstallPlugin_InstalledPlugins_No_Central_Repo(t *testing.T) {
 func Test_InstallPlugin_InstalledPlugins_Central_Repo(t *testing.T) {
 	assertions := assert.New(t)
 
-	// Bypass the environment variable for testing
-	err := os.Setenv(constants.ConfigVariablePreReleasePluginRepoImage, PreReleasePluginRepoImageBypass)
-	assertions.Nil(err)
-
 	defer setupLocalDistroForTesting()()
 	execCommand = fakeInfoExecCommand
 	defer func() { execCommand = exec.Command }()
 
 	// Try installing nonexistent plugin
-	err = InstallStandalonePlugin("not-exists", "v0.2.0", configtypes.TargetUnknown)
+	err := InstallStandalonePlugin("not-exists", "v0.2.0", configtypes.TargetUnknown)
 	assertions.NotNil(err)
 	assertions.Contains(err.Error(), "unable to find plugin 'not-exists'")
 
@@ -321,10 +315,6 @@ func Test_InstallPlugin_InstalledPlugins_Central_Repo(t *testing.T) {
 func Test_InstallPluginFromGroup(t *testing.T) {
 	assertions := assert.New(t)
 
-	// Bypass the environment variable for testing
-	err := os.Setenv(constants.ConfigVariablePreReleasePluginRepoImage, PreReleasePluginRepoImageBypass)
-	assertions.Nil(err)
-
 	defer setupLocalDistroForTesting()()
 	execCommand = fakeInfoExecCommand
 	defer func() { execCommand = exec.Command }()
@@ -332,17 +322,13 @@ func Test_InstallPluginFromGroup(t *testing.T) {
 	// A local discovery currently does not support groups, but we can
 	// at least do negative testing
 	groupID := "vmware-tkg/v2.1.0"
-	err = InstallPluginsFromGroup("cluster", groupID)
+	err := InstallPluginsFromGroup("cluster", groupID)
 	assertions.NotNil(err)
 	assertions.Contains(err.Error(), fmt.Sprintf("could not find group '%s'", groupID))
 }
 
 func Test_DiscoverPluginGroups(t *testing.T) {
 	assertions := assert.New(t)
-
-	// Bypass the environment variable for testing
-	err := os.Setenv(constants.ConfigVariablePreReleasePluginRepoImage, PreReleasePluginRepoImageBypass)
-	assertions.Nil(err)
 
 	defer setupLocalDistroForTesting()()
 	execCommand = fakeInfoExecCommand
@@ -359,9 +345,6 @@ func Test_AvailablePlugins(t *testing.T) {
 	assertions := assert.New(t)
 
 	defer setupLocalDistroForTesting()()
-	// Bypass the environment variable for testing
-	err := os.Setenv(constants.ConfigVariablePreReleasePluginRepoImage, PreReleasePluginRepoImageBypass)
-	assertions.Nil(err)
 
 	expectedDiscoveredPlugins := append(expectedDiscoveredContextPlugins, expectedDiscoveredStandalonePlugins...)
 	discoveredPlugins, err := AvailablePlugins()
@@ -463,9 +446,6 @@ func Test_AvailablePlugins_With_K8s_None_Target_Plugin_Name_Conflict_With_One_In
 	assertions := assert.New(t)
 
 	defer setupLocalDistroForTesting()()
-	// Bypass the environment variable for testing
-	err := os.Setenv(constants.ConfigVariablePreReleasePluginRepoImage, PreReleasePluginRepoImageBypass)
-	assertions.Nil(err)
 
 	expectedDiscoveredPlugins := append(expectedDiscoveredContextPlugins, expectedDiscoveredStandalonePlugins...)
 	discoveredPlugins, err := AvailablePlugins()
@@ -519,9 +499,6 @@ func Test_AvailablePlugins_With_K8s_None_Target_Plugin_Name_Conflict_With_Plugin
 	assertions := assert.New(t)
 
 	defer setupLocalDistroForTesting()()
-	// Bypass the environment variable for testing
-	err := os.Setenv(constants.ConfigVariablePreReleasePluginRepoImage, PreReleasePluginRepoImageBypass)
-	assertions.Nil(err)
 
 	expectedDiscoveredPlugins := append(expectedDiscoveredContextPlugins, expectedDiscoveredStandalonePlugins...)
 	discoveredPlugins, err := AvailablePlugins()
@@ -689,12 +666,9 @@ func Test_DescribePlugin(t *testing.T) {
 	assertions := assert.New(t)
 
 	defer setupLocalDistroForTesting()()
-	// Bypass the environment variable for testing
-	err := os.Setenv(constants.ConfigVariablePreReleasePluginRepoImage, PreReleasePluginRepoImageBypass)
-	assertions.Nil(err)
 
 	// Try to describe plugin when plugin is not installed
-	_, err = DescribePlugin("login", configtypes.TargetUnknown)
+	_, err := DescribePlugin("login", configtypes.TargetUnknown)
 	assertions.NotNil(err)
 	assertions.Contains(err.Error(), "unable to find plugin 'login'")
 
@@ -733,12 +707,9 @@ func Test_DeletePlugin(t *testing.T) {
 	assertions := assert.New(t)
 
 	defer setupLocalDistroForTesting()()
-	// Bypass the environment variable for testing
-	err := os.Setenv(constants.ConfigVariablePreReleasePluginRepoImage, PreReleasePluginRepoImageBypass)
-	assertions.Nil(err)
 
 	// Try to delete plugin when plugin is not installed
-	err = DeletePlugin(DeletePluginOptions{PluginName: "cluster", Target: configtypes.TargetTMC, ForceDelete: true})
+	err := DeletePlugin(DeletePluginOptions{PluginName: "cluster", Target: configtypes.TargetTMC, ForceDelete: true})
 	assertions.NotNil(err)
 	assertions.Contains(err.Error(), "unable to find plugin 'cluster'")
 
@@ -1364,11 +1335,6 @@ func TestGetPluginDiscoveries(t *testing.T) {
 
 	// Start with no additional discoveries
 	err := os.Setenv(constants.ConfigVariableAdditionalDiscoveryForTesting, "")
-	assertions.Nil(err)
-
-	// Bypass the temporary pre-release variable
-	err = os.Setenv(constants.ConfigVariablePreReleasePluginRepoImage,
-		PreReleasePluginRepoImageBypass)
 	assertions.Nil(err)
 
 	discoveries, err := getPluginDiscoveries()

--- a/pkg/pluginmanager/test/config-ng.yaml
+++ b/pkg/pluginmanager/test/config-ng.yaml
@@ -1,3 +1,11 @@
+cli:
+  discoverySources:
+    - local:
+        name: default-local
+        path: default
+    - local:
+        name: fake
+        path: standalone
 currentContext:
   kubernetes: mgmt
   mission-control: tmc-fake

--- a/pkg/pluginmanager/test/config.yaml
+++ b/pkg/pluginmanager/test/config.yaml
@@ -1,14 +1,4 @@
 apiVersion: config.tanzu.vmware.com/v1alpha1
-clientOptions:
-  cli:
-    discoverySources:
-      - local:
-          name: default-local
-          path: default
-      - local:
-          name: fake
-          path: standalone
-    useContextAwareDiscovery: true
 current: mgmt
 currentContext:
   kubernetes: mgmt

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -42,7 +42,7 @@ e2e-cli-plugin-compatibility-test:
 	@if [ "${TANZU_CLI_E2E_TEST_CENTRAL_REPO_URL}" = "" ]; then \
 		echo "***Skipping Plugin Compatibility test cases because environment variables TANZU_CLI_E2E_TEST_CENTRAL_REPO_URL is not set***" ; \
 	else \
-		export TANZU_CLI_PRE_RELEASE_REPO_IMAGE=$(TANZU_CLI_E2E_TEST_CENTRAL_REPO_URL) ; \
+		export TANZU_CLI_E2E_TEST_CENTRAL_REPO_URL=$(TANZU_CLI_E2E_TEST_CENTRAL_REPO_URL) ; \
 		export TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST=$(TANZU_CLI_E2E_TEST_CENTRAL_REPO_URL) ; \
 		export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="Yes" ; \
 		${GO} test ${ROOT_DIR}/test/e2e/plugins_compatibility -timeout ${E2E_TEST_TIMEOUT} -race -coverprofile ${E2E_TEST_OUTPUT} ${GOTEST_VERBOSE} ; \
@@ -54,7 +54,6 @@ e2e-cli-plugin-lifecycle-sync-test:
 		echo "***Skipping Plugin life cycle test cases because environment variables TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL is not set***" ; \
 	else \
 		export TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL=$(TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL) ; \
-		export TANZU_CLI_PRE_RELEASE_REPO_IMAGE=$(TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL) ; \
 		export TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST=$(TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL) ; \
 		export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="Yes" ; \
 		${GO} test ${ROOT_DIR}/test/e2e/plugin_lifecycle -timeout ${E2E_TEST_TIMEOUT} -race -coverprofile ${E2E_TEST_OUTPUT} ${GOTEST_VERBOSE} ; \

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -109,9 +109,6 @@ type PluginBasicOps interface {
 }
 // PluginSourceOps helps 'plugin source' commands
 type PluginSourceOps interface {
-    // AddPluginDiscoverySource adds plugin discovery source, and returns stdOut and error info
-    AddPluginDiscoverySource(discoveryOpts *DiscoveryOptions) (string, error)
-
     // UpdatePluginDiscoverySource updates plugin discovery source, and returns stdOut and error info
     UpdatePluginDiscoverySource(discoveryOpts *DiscoveryOptions) (string, error)
 
@@ -120,6 +117,9 @@ type PluginSourceOps interface {
 
     // ListPluginSources returns all available plugin discovery sources
     ListPluginSources() ([]*PluginSourceInfo, error)
+
+    // InitPluginDiscoverySource initializes the plugin source to its default value, and returns stdOut and error info
+    InitPluginDiscoverySource(opts ...E2EOption) (string, error)
 }
 type PluginGroupOps interface {
     // SearchPluginGroups performs plugin group search

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -28,10 +28,10 @@ const (
 	ConfigServerDelete = "%s config server delete %s -y"
 
 	// Plugin commands
-	AddPluginSource                     = "%s plugin source add --name %s --type %s --uri %s"
-	UpdatePluginSource                  = "%s plugin source update %s --type %s --uri %s"
+	UpdatePluginSource                  = "%s plugin source update %s --uri %s"
 	ListPluginSourcesWithJSONOutputFlag = "%s plugin source list -o json"
 	DeletePluginSource                  = "%s plugin source delete %s"
+	InitPluginDiscoverySource           = "%s plugin source init"
 	ListPluginsCmdWithJSONOutputFlag    = "%s plugin list -o json"
 	SearchPluginsCmd                    = "%s plugin search"
 	SearchPluginGroupsCmd               = "%s plugin group search"
@@ -48,7 +48,6 @@ const (
 	PluginKey                           = "%s_%s_%s" // Plugins - Name_Target_Versions
 
 	// Central repository
-	CentralRepositoryPreReleaseRepoImage     = "TANZU_CLI_PRE_RELEASE_REPO_IMAGE"
 	TanzuCliE2ETestCentralRepositoryURL      = "TANZU_CLI_E2E_TEST_CENTRAL_REPO_URL"
 	TanzuCliE2ETestLocalCentralRepositoryURL = "TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL"
 
@@ -102,8 +101,7 @@ const (
 	UnableToFindPlugin                            = "unable to find plugin '%s'"
 	InvalidTargetSpecified                        = "invalid target specified. Please specify correct value of `--target` or `-t` flag from 'global/kubernetes/k8s/mission-control/tmc'"
 	InvalidTargetGlobal                           = "invalid target for plugin: global"
-	UnknownDiscoverySourceType                    = "unknown discovery source type"
-	DiscoverySourceNotFound                       = "cli discovery source not found"
+	DiscoverySourceNotFound                       = "discovery %q does not exist"
 	ErrorLogForCommandWithErrStdErrAndStdOut      = "error while executing command:'%s', error:'%s' stdErr:'%s' stdOut: '%s'"
 	FailedToConstructJSONNodeFromOutputAndErrInfo = "failed to construct json node from output:'%s' error:'%s' "
 	FailedToConstructJSONNodeFromOutput           = "failed to construct json node from output:'%s'"

--- a/test/e2e/framework/output_handling.go
+++ b/test/e2e/framework/output_handling.go
@@ -27,8 +27,7 @@ type PluginGroup struct {
 
 type PluginSourceInfo struct {
 	Name  string `json:"name"`
-	Scope string `json:"scope"`
-	Type  string `json:"type"`
+	Image string `json:"image"`
 }
 
 type ContextListInfo struct {

--- a/test/e2e/framework/plugin_lifecycle_operations.go
+++ b/test/e2e/framework/plugin_lifecycle_operations.go
@@ -40,9 +40,6 @@ type PluginBasicOps interface {
 
 // PluginSourceOps helps 'plugin source' commands
 type PluginSourceOps interface {
-	// AddPluginDiscoverySource adds plugin discovery source, and returns stdOut and error info
-	AddPluginDiscoverySource(discoveryOpts *DiscoveryOptions, opts ...E2EOption) (string, error)
-
 	// UpdatePluginDiscoverySource updates plugin discovery source, and returns stdOut and error info
 	UpdatePluginDiscoverySource(discoveryOpts *DiscoveryOptions, opts ...E2EOption) (string, error)
 
@@ -51,6 +48,9 @@ type PluginSourceOps interface {
 
 	// ListPluginSources returns all available plugin discovery sources
 	ListPluginSources(opts ...E2EOption) ([]*PluginSourceInfo, error)
+
+	// InitPluginDiscoverySource initializes the plugin source to its default value, and returns stdOut and error info
+	InitPluginDiscoverySource(opts ...E2EOption) (string, error)
 }
 
 type PluginGroupOps interface {
@@ -86,15 +86,9 @@ func NewPluginLifecycleOps() PluginCmdOps {
 	}
 }
 
-func (po *pluginCmdOps) AddPluginDiscoverySource(discoveryOpts *DiscoveryOptions, opts ...E2EOption) (string, error) {
-	addCmd := fmt.Sprintf(AddPluginSource, "%s", discoveryOpts.Name, discoveryOpts.SourceType, discoveryOpts.URI)
-	out, _, err := po.cmdExe.TanzuCmdExec(addCmd, opts...)
-	return out.String(), err
-}
-
 func (po *pluginCmdOps) UpdatePluginDiscoverySource(discoveryOpts *DiscoveryOptions, opts ...E2EOption) (string, error) {
-	addCmd := fmt.Sprintf(UpdatePluginSource, "%s", discoveryOpts.Name, discoveryOpts.SourceType, discoveryOpts.URI)
-	out, _, err := po.cmdExe.TanzuCmdExec(addCmd, opts...)
+	updateCmd := fmt.Sprintf(UpdatePluginSource, "%s", discoveryOpts.Name, discoveryOpts.URI)
+	out, _, err := po.cmdExe.TanzuCmdExec(updateCmd, opts...)
 	return out.String(), err
 }
 
@@ -107,6 +101,15 @@ func (po *pluginCmdOps) DeletePluginDiscoverySource(pluginSourceName string, opt
 	out, stdErr, err := po.cmdExe.TanzuCmdExec(deleteCmd, opts...)
 	if err != nil {
 		log.Errorf(ErrorLogForCommandWithErrStdErrAndStdOut, deleteCmd, err.Error(), stdErr.String(), out.String())
+	}
+	return out.String(), err
+}
+
+func (po *pluginCmdOps) InitPluginDiscoverySource(opts ...E2EOption) (string, error) {
+	initCmd := fmt.Sprintf(InitPluginDiscoverySource, "%s")
+	out, stdErr, err := po.cmdExe.TanzuCmdExec(initCmd, opts...)
+	if err != nil {
+		log.Errorf(ErrorLogForCommandWithErrStdErrAndStdOut, initCmd, err.Error(), stdErr.String(), out.String())
 	}
 	return out.String(), err
 }

--- a/test/e2e/plugin_lifecycle/plugin_lifecycle_suite_test.go
+++ b/test/e2e/plugin_lifecycle/plugin_lifecycle_suite_test.go
@@ -26,7 +26,6 @@ var (
 	pluginsSearchList          []*framework.PluginInfo
 	pluginGroups               []*framework.PluginGroup
 	pluginGroupToPluginListMap map[string][]*framework.PluginInfo
-	pluginSourceName           string
 )
 
 // BeforeSuite initializes and set up the environment to execute the plugin life cycle and plugin group life cycle end-to-end test cases
@@ -35,8 +34,10 @@ var _ = BeforeSuite(func() {
 	// check E2E test central repo URL (TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL)
 	e2eTestLocalCentralRepoURL = os.Getenv(framework.TanzuCliE2ETestLocalCentralRepositoryURL)
 	Expect(e2eTestLocalCentralRepoURL).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with local central repository URL", framework.TanzuCliE2ETestLocalCentralRepositoryURL))
-	// set E2E test central repo URL to TANZU_CLI_PRE_RELEASE_REPO_IMAGE
-	os.Setenv(framework.CentralRepositoryPreReleaseRepoImage, e2eTestLocalCentralRepoURL)
+
+	// setup the test central repo
+	_, err := tf.PluginCmd.UpdatePluginDiscoverySource(&framework.DiscoveryOptions{Name: "default", SourceType: framework.SourceType, URI: e2eTestLocalCentralRepoURL})
+	Expect(err).To(BeNil(), "should not get any error for plugin source update")
 
 	// search plugin groups and make sure there plugin groups available
 	pluginGroups = SearchAllPluginGroups(tf)

--- a/test/e2e/plugin_sync/plugin_sync_lifecycle_suite_test.go
+++ b/test/e2e/plugin_sync/plugin_sync_lifecycle_suite_test.go
@@ -36,11 +36,14 @@ const numberOfPluginsToInstall = 3
 // BeforeSuite initializes and set up the environment to execute the plugin life cycle and plugin group life cycle end-to-end test cases
 var _ = BeforeSuite(func() {
 	tf = framework.NewFramework()
+
 	// check E2E test central repo URL (TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL)
 	e2eTestLocalCentralRepoURL = os.Getenv(framework.TanzuCliE2ETestLocalCentralRepositoryURL)
 	Expect(e2eTestLocalCentralRepoURL).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with local central repository URL", framework.TanzuCliE2ETestLocalCentralRepositoryURL))
-	// set E2E test central repo URL to TANZU_CLI_PRE_RELEASE_REPO_IMAGE
-	os.Setenv(framework.CentralRepositoryPreReleaseRepoImage, e2eTestLocalCentralRepoURL)
+
+	// setup the test central repo
+	_, err := tf.PluginCmd.UpdatePluginDiscoverySource(&framework.DiscoveryOptions{Name: "default", SourceType: framework.SourceType, URI: e2eTestLocalCentralRepoURL})
+	Expect(err).To(BeNil(), "should not get any error for plugin source update")
 
 	// search plugin groups and make sure there plugin groups available
 	pluginGroups = helper.SearchAllPluginGroups(tf)

--- a/test/e2e/plugins_compatibility/plugins_compatibility_suite_test.go
+++ b/test/e2e/plugins_compatibility/plugins_compatibility_suite_test.go
@@ -30,7 +30,13 @@ var (
 // In the BeforeSuite search for the test-plugin-'s from the TANZU_CLI_E2E_TEST_CENTRAL_REPO_URL test central repository
 var _ = BeforeSuite(func() {
 	tf = framework.NewFramework()
+
+	// setup the test central repo
+	centralURI := os.Getenv(framework.TanzuCliE2ETestCentralRepositoryURL)
+	_, err := tf.PluginCmd.UpdatePluginDiscoverySource(&framework.DiscoveryOptions{Name: "default", SourceType: framework.SourceType, URI: centralURI})
+	Expect(err).To(BeNil(), "should not get any error for plugin source update")
+
 	// get all plugins with name prefix "test-plugin-"
 	plugins = plugincompatibility.PluginsForCompatibilityTesting(tf)
-	Expect(len(plugins)).NotTo(BeZero(), fmt.Sprintf("there are no test-plugin-'s in test central repo:%s , make sure its valid test central repo with test-plugins", os.Getenv(framework.TanzuCliE2ETestCentralRepositoryURL)))
+	Expect(len(plugins)).NotTo(BeZero(), fmt.Sprintf("there are no test-plugin-'s in test central repo:%s , make sure its valid test central repo with test-plugins", centralURI))
 })


### PR DESCRIPTION
### What this PR does / why we need it

This PR removes the use of `TANZU_CLI_PRE_RELEASE_REPO_IMAGE` which was a temporary approach.

Instead, the central discovery is automatically created in the config file as a "discoverySource" and "tanzu plugin source update" can be used to override this default value.

This commit also updates the "tanzu plugin source" family of commands.
With the central discovery feature enabled:
1. "tanzu plugin source add" is removed
2. "tanzu plugin source update" no longer has a "--type/-t" flag
3. "tanzu plugin source init" is added

Please see the additional notes at the end of this PR's description to see how "tanzu plugin source delete" is handled.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

I confirm that `make e2e-context-tmc-test` passes locally.

```
# Cleanup
$ rm ~/.cache/tanzu/plugin_inventory
$ rm ~/.config/tanzu/config*
$ unset TANZU_CLI_PRE_RELEASE_REPO_IMAGE
$ tz ceip-participation set true

# Notice the default central discovery is automatically set
$ tz plugin source list
  NAME     IMAGE
  default  projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest
$ tz plugin search
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest", this will take a few seconds.
  NAME     DESCRIPTION             TARGET  LATEST
  builder  Build Tanzu components  global  v0.90.0-alpha.0
  test     Test the CLI            global  v0.90.0-alpha.0

# Update the default plugin source (meant for air-gapped)
$ tz plugin source update default -u localhost:9876/tanzu-cli/plugins/central:small
[ok] updated discovery source default
$ tz config set env.TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST localhost:9876/tanzu-cli/plugins/central:small
$ tz plugin source list
  NAME     IMAGE
  default  localhost:9876/tanzu-cli/plugins/central:small
$ tz plugin search
[i] Reading plugin inventory for "localhost:9876/tanzu-cli/plugins/central:small", this will take a few seconds.
[!] Skipping the plugins discovery image signature verification for "localhost:9876/tanzu-cli/plugins/central:small"

  NAME                DESCRIPTION                  TARGET           LATEST
  isolated-cluster    Desc for isolated-cluster    global           v9.9.9
  pinniped-auth       Desc for pinniped-auth       global           v9.9.9
  cluster             Desc for cluster             kubernetes       v9.9.9
[...]

# Reset the default plugin source
$ tz plugin source init
[ok] successfully initialized discovery source
$ tz plugin source list
  NAME     IMAGE
  default  projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest

# Remove the config files and see that the default source is re-created automatically
$ rm ~/.config/tanzu/config*
$ tz ceip-participation set true
$ tz plugin source list
  NAME     IMAGE
  default  projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest
```

Now lets test the special "plugin source delete" handling which allows to remove the default central discovery:
```
$ tz plugin source delete default
[ok] deleted discovery source default

# Notice that the plugin source remains deleted (not added back automatically)
$ tz plugin source list
  NAME  IMAGE
$ tz plugin search
  NAME  DESCRIPTION  TARGET  LATEST

# Notice that we can easily restore the default central discovery
$ tz plugin source init
[ok] successfully initialized discovery source
$ tz plugin source list
  NAME     IMAGE
  default  projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The temporary `TANZU_CLI_PRE_RELEASE_REPO_IMAGE` has been removed.  Instead, the use of `tanzu plugin source update` can be used to override the default central discovery location.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

There is an important behaviour I'd like to get opinions on:
I decided to keep `tanzu plugin source delete`.  The idea is that I've always been a bit uncomfortable with the fact there was no way to remove the default discovery.  By keeping the `tanzu plugin source delete` command it allows us to remove the default central repo and not have the CLI add it back automatically; instead, if a user does a `tanzu plugin source delete default` they can add back the central repo by doing `tanzu plugin source init`.

Note that on first use or removal of the config file, the CLI will notice the config file has no top-level entry for discoverySources and will create the default discovery source; but after a `tanzu plugin source delete`, the CLI will see the discoverySources section exist but is empty, in which case it will not add back the central discovery source.

If this is not desirable, we can easily remove the `tanzu plugin source delete` command as was originally planned.