### PR TITLE
Bug fix: Add Validators for prompts to not allow bad data into context and login commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 replace cloud.google.com/go => cloud.google.com/go v0.102.1
 
 require (
+	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/Masterminds/semver v1.5.0
 	github.com/adrg/xdg v0.4.0
 	github.com/cppforlife/go-cli-ui v0.0.0-20220425131040-94f26b16bc14
@@ -33,7 +34,7 @@ require (
 	github.com/vmware-tanzu/carvel-imgpkg v0.36.1
 	github.com/vmware-tanzu/carvel-ytt v0.40.0
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230415084831-9331f55d2999
-	github.com/vmware-tanzu/tanzu-plugin-runtime v0.90.0-alpha.1
+	github.com/vmware-tanzu/tanzu-plugin-runtime v1.0.0-dev
 	go.pinniped.dev v0.20.0
 	go.uber.org/multierr v1.8.0
 	golang.org/x/mod v0.9.0
@@ -53,7 +54,6 @@ require (
 	bitbucket.org/creachadair/shell v0.0.7 // indirect
 	cloud.google.com/go/compute v1.18.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
-	github.com/AlecAivazis/survey/v2 v2.3.6 // indirect
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest v0.11.28 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1289,8 +1289,8 @@ github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20221207131309-7323ca04b
 github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20221207131309-7323ca04b86c/go.mod h1:ukZpKQ0hf5bjWdJLjn2M6qXP+9giZWQPxt8nOfrCR+o=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230415084831-9331f55d2999 h1:WITDH+wpdl/clw1hwy+2jtq4Pt//i/Mq9lQXGwg3q4c=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230415084831-9331f55d2999/go.mod h1:umFZBUfJ8VI3p0VO/xocuE+4fO9s9QbytEiOqFcH/Tw=
-github.com/vmware-tanzu/tanzu-plugin-runtime v0.90.0-alpha.1 h1:kwMMBJAxtJ3324O1fMt7jR77xKXU3u25dO/QT76cC9M=
-github.com/vmware-tanzu/tanzu-plugin-runtime v0.90.0-alpha.1/go.mod h1:FlvOcF26rX4EA+ADjYTJdFh6WVur6O4jh25FDP9Lp7E=
+github.com/vmware-tanzu/tanzu-plugin-runtime v1.0.0-dev h1:AcjgTGDTwdl7I3uurnTOH1WofwHUSl/rzGNXwvocMpU=
+github.com/vmware-tanzu/tanzu-plugin-runtime v1.0.0-dev/go.mod h1:FlvOcF26rX4EA+ADjYTJdFh6WVur6O4jh25FDP9Lp7E=
 github.com/xanzy/go-gitlab v0.31.0/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
 github.com/xanzy/go-gitlab v0.73.1 h1:UMagqUZLJdjss1SovIC+kJCH4k2AZWXl58gJd38Y/hI=
 github.com/xanzy/go-gitlab v0.73.1/go.mod h1:d/a0vswScO7Agg1CZNz15Ic6SSvBG9vfw8egL99t4kA=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,8 +1,12 @@
 cloud.google.com/go v0.102.1 h1:vpK6iQWv/2uUeFJth4/cBHsQAGjn1iIE6AAlxipRaA0=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
+github.com/chzyer/logex v1.2.0/go.mod h1:9+9sk7u7pGNWYMkh0hdiL++6OeibzJccyQU4p4MedaY=
+github.com/chzyer/readline v1.5.0/go.mod h1:x22KAscuvRqlLoK9CsoYsmxoXZMMFVyOl86cAH8qUic=
+github.com/chzyer/test v0.0.0-20210722231415-061457976a23/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/emicklei/go-restful v2.16.0+incompatible h1:rgqiKNjTnFQA6kkhFe16D8epTksy9HQ1MyrbDXSdYhM=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
+github.com/ianlancetaylor/demangle v0.0.0-20220319035150-800ac71e25c2/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
-github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
+golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=

--- a/pkg/command/ceip_participation.go
+++ b/pkg/command/ceip_participation.go
@@ -53,10 +53,10 @@ func newCEIPParticipationSetCmd() *cobra.Command {
 		Long:  "Set the opt-in preference for CEIP (subject to change)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !strings.EqualFold(args[0], "true") && !strings.EqualFold(args[0], "false") {
+			if !strings.EqualFold(args[0], True) && !strings.EqualFold(args[0], "false") {
 				return errors.Errorf("incorrect boolean argument: %q", args[0])
 			}
-			err := configlib.SetCEIPOptIn(strconv.FormatBool(strings.EqualFold(args[0], "true")))
+			err := configlib.SetCEIPOptIn(strconv.FormatBool(strings.EqualFold(args[0], True)))
 			if err != nil {
 				return errors.Wrapf(err, "failed to update the configuration")
 			}
@@ -78,7 +78,7 @@ func newCEIPParticipationGetCmd() *cobra.Command {
 				return errors.Wrapf(err, "failed to get the CEIP opt-in status")
 			}
 			ceipStatus := ""
-			if optInVal == "true" {
+			if optInVal == True {
 				ceipStatus = CeipOptInStatus
 			} else {
 				ceipStatus = CeipOptOutStatus

--- a/pkg/command/ceip_participation.go
+++ b/pkg/command/ceip_participation.go
@@ -49,14 +49,14 @@ func newCEIPParticipationCmd() *cobra.Command {
 func newCEIPParticipationSetCmd() *cobra.Command {
 	var setCmd = &cobra.Command{
 		Use:   "set OPT_IN_BOOL",
-		Short: "Set the opt-in preference for CEIP (subject to change)",
+		Short: "Set the opt-in preference for CEIP45 (subject to change)",
 		Long:  "Set the opt-in preference for CEIP (subject to change)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !strings.EqualFold(args[0], True) && !strings.EqualFold(args[0], "false") {
+			if !strings.EqualFold(args[0], "true") && !strings.EqualFold(args[0], "false") {
 				return errors.Errorf("incorrect boolean argument: %q", args[0])
 			}
-			err := configlib.SetCEIPOptIn(strconv.FormatBool(strings.EqualFold(args[0], True)))
+			err := configlib.SetCEIPOptIn(strconv.FormatBool(strings.EqualFold(args[0], "true")))
 			if err != nil {
 				return errors.Wrapf(err, "failed to update the configuration")
 			}
@@ -78,7 +78,7 @@ func newCEIPParticipationGetCmd() *cobra.Command {
 				return errors.Wrapf(err, "failed to get the CEIP opt-in status")
 			}
 			ceipStatus := ""
-			if optInVal == True {
+			if strings.EqualFold(optInVal, "true") {
 				ceipStatus = CeipOptInStatus
 			} else {
 				ceipStatus = CeipOptOutStatus

--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/AlecAivazis/survey/v2"
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -163,6 +164,9 @@ func getPromptOpts() []component.PromptOpt {
 		// This uses stderr because it needs to work inside the kubectl exec plugin flow where stdout is reserved.
 		promptOpts = append(promptOpts, component.WithStdio(os.Stdin, os.Stderr, os.Stderr))
 	}
+	// Add default validations, required
+	promptOpts = append(promptOpts, component.WithValidator(survey.Required), component.WithValidator(component.NoOnlySpaces))
+
 	return promptOpts
 }
 

--- a/pkg/command/plugin_search_test.go
+++ b/pkg/command/plugin_search_test.go
@@ -82,7 +82,7 @@ func TestPluginSearch(t *testing.T) {
 	for _, spec := range tests {
 		t.Run(spec.test, func(t *testing.T) {
 			// Disable the Central Repository feature if needed
-			if spec.centralRepoDisabled == "true" {
+			if strings.EqualFold(spec.centralRepoDisabled, "true") {
 				featureArray := strings.Split(constants.FeatureDisableCentralRepositoryForTesting, ".")
 				err := config.SetFeature(featureArray[1], featureArray[2], spec.centralRepoDisabled)
 				assert.Nil(err)

--- a/pkg/command/plugin_search_test.go
+++ b/pkg/command/plugin_search_test.go
@@ -34,25 +34,25 @@ func TestPluginSearch(t *testing.T) {
 			test:            "invalid target",
 			args:            []string{"plugin", "search", "--target", "invalid"},
 			expectedFailure: true,
-			expected:        "invalid target specified. Please specify correct value of `--target` or `-t` flag from 'global/kubernetes/k8s/mission-control/tmc'",
+			expected:        "unknown flag: --target",
 		},
 		{
 			test:            "no --local and --name together",
 			args:            []string{"plugin", "search", "--local", "./", "--name", "myplugin"},
 			expectedFailure: true,
-			expected:        "if any flags in the group [local name] are set none of the others can be",
+			expected:        "unknown flag: --local",
 		},
 		{
 			test:            "no --local and --target together",
 			args:            []string{"plugin", "search", "--local", "./", "--target", "tmc"},
 			expectedFailure: true,
-			expected:        "if any flags in the group [local target] are set none of the others can be",
+			expected:        "unknown flag: --local",
 		},
 		{
 			test:            "no --local and --show-details together",
 			args:            []string{"plugin", "search", "--local", "./", "--show-details"},
 			expectedFailure: true,
-			expected:        "if any flags in the group [local show-details] are set none of the others can be",
+			expected:        "unknown flag: --local",
 		},
 	}
 
@@ -82,9 +82,11 @@ func TestPluginSearch(t *testing.T) {
 	for _, spec := range tests {
 		t.Run(spec.test, func(t *testing.T) {
 			// Disable the Central Repository feature if needed
-			featureArray := strings.Split(constants.FeatureDisableCentralRepositoryForTesting, ".")
-			err := config.SetFeature(featureArray[1], featureArray[2], spec.centralRepoDisabled)
-			assert.Nil(err)
+			if spec.centralRepoDisabled == "true" {
+				featureArray := strings.Split(constants.FeatureDisableCentralRepositoryForTesting, ".")
+				err := config.SetFeature(featureArray[1], featureArray[2], spec.centralRepoDisabled)
+				assert.Nil(err)
+			}
 
 			rootCmd, err := NewRootCmd()
 			assert.Nil(err)

--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -23,6 +23,7 @@ import (
 )
 
 const cmdNameSet = "set"
+const True = "true"
 
 // NewRootCmd creates a root command.
 func NewRootCmd() (*cobra.Command, error) {

--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -23,7 +23,6 @@ import (
 )
 
 const cmdNameSet = "set"
-const True = "true"
 
 // NewRootCmd creates a root command.
 func NewRootCmd() (*cobra.Command, error) {


### PR DESCRIPTION
### What this PR does / why we need it

-  Added required and no empty spaces validators to prompts in tanzu context and tanzu login commands to avoid having bad data in the config yaml files.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR


Below testing show Required and no only spaces validators in action

```
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix-do-not-allow-empty-context-names)> tanzu context create
? Select context creation type Control plane endpoint
X Sorry, your reply was invalid: value contains only spaces
? Enter control plane endpoint test
X Sorry, your reply was invalid: value contains only spaces
? Give the context a name test
[i] Failed to test for vSphere supervisor: Get "test/wcp/loginbanner": unsupported protocol scheme ""
[x] : error creating kubeconfig with tanzu pinniped-auth login plugin: Get "test/wcp/loginbanner": unsupported protocol scheme ""
[x] : error creating kubeconfig with tanzu pinniped-auth login plugin: Get "test/wcp/loginbanner": unsupported protocol scheme ""
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix-do-not-allow-empty-context-names) [1]> tanzu context create
? Select context creation type Local kubeconfig
X Sorry, your reply was invalid: Value is required
? Enter path to kubeconfig (if any) test
X Sorry, your reply was invalid: Value is required
? Enter kube context to use test
X Sorry, your reply was invalid: Value is required
? Give the context a name test
```


```
mpanchajanya@mpanchajanF09MK tanzu-cli % tanzu login  
Command "login" is deprecated, will be removed in version "1.2.0". Use "context" instead.
? Select login type Server endpoint
X Sorry, your reply was invalid: Value is required
? Enter server endpoint test
X Sorry, your reply was invalid: Value is required
? Give the server a name test
[i] Failed to test for vSphere supervisor: Get "test/wcp/loginbanner": unsupported protocol scheme ""
[x] : error creating kubeconfig with tanzu pinniped-auth login plugin: Get "test/wcp/loginbanner": unsupported protocol scheme ""
[x] : error creating kubeconfig with tanzu pinniped-auth login plugin: Get "test/wcp/loginbanner": unsupported protocol scheme ""
mpanchajanya@mpanchajanF09MK tanzu-cli % 


```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Added validators to tanzu context and tanzu login to prevent bad data to persist into config
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
