### PR TITLE
Remove unit test that was no longer relevant

### DIFF
--- a/pkg/config/defaults_test.go
+++ b/pkg/config/defaults_test.go
@@ -4,7 +4,6 @@
 package config
 
 import (
-	"net/url"
 	"os"
 	"strings"
 
@@ -109,15 +108,6 @@ var _ = Describe("defaults test cases", func() {
 
 			err = os.Setenv(constants.ConfigVariableAdditionalDiscoveryForTesting, oldValue)
 			Expect(err).To(BeNil())
-		})
-		It("trusted registries should include hostname of default central discovery", func() {
-			u, err := url.ParseRequestURI("https://" + constants.TanzuCLIDefaultCentralPluginDiscoveryImage)
-			Expect(err).To(BeNil())
-			Expect(u).NotTo(BeNil())
-
-			trustedRegis := GetTrustedRegistries()
-			Expect(trustedRegis).NotTo(BeNil())
-			Expect(trustedRegis).Should(ContainElement(u.Hostname()))
 		})
 	})
 })


### PR DESCRIPTION
### What this PR does / why we need it

With PR #232 the trusted registries include the configured plugin source. The default central repo URI is no longer automatically trusted but only if it is configure as a plugin source (which happens by default).

Therefore, the unit test is superceded by the unit tests of the same file that verifies the trusted registries for configured plugin source.

Furthermore, the test that this commit removes would fail locally when the plugin source configured is not the default central repo.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Before the PR change the plugin source to cause the test to fail:
```
tz plugin source update default -u localhost:9876/tanzu-cli/plugins/central:small
[ok] updated discovery source default
$ go test -timeout 30s -run ^TestCliCorePkgConfigSuite$ github.com/vmware-tanzu/tanzu-cli/pkg/config
Running Suite: pkg/config Suite - /Users/kmarc/git/tanzu-cli/pkg/config
=======================================================================
Random Seed: 1682564513

Will run 18 of 18 specs
•••••••••••••••
------------------------------
• [FAILED] [0.001 seconds]
defaults test cases default locations and repositories [It] trusted registries should include hostname of default central discovery
/Users/kmarc/git/tanzu-cli/pkg/config/defaults_test.go:113

  [FAILED] Expected
      <[]string | len:1, cap:1>: ["localhost"]
  to contain element matching
      <string>: projects.registry.vmware.com
  In [It] at: /Users/kmarc/git/tanzu-cli/pkg/config/defaults_test.go:120 @ 04/26/23 23:01:53.881
------------------------------
••

Summarizing 1 Failure:
  [FAIL] defaults test cases default locations and repositories [It] trusted registries should include hostname of default central discovery
  /Users/kmarc/git/tanzu-cli/pkg/config/defaults_test.go:120

Ran 18 of 18 Specs in 0.097 seconds
FAIL! -- 17 Passed | 1 Failed | 0 Pending | 0 Skipped
--- FAIL: TestCliCorePkgConfigSuite (0.10s)
FAIL
FAIL	github.com/vmware-tanzu/tanzu-cli/pkg/config	1.702s
FAIL
```

Then I repeated the test with this PR:

$ go test -timeout 30s -run ^TestCliCorePkgConfigSuite$ github.com/vmware-tanzu/tanzu-cli/pkg/config
ok  	github.com/vmware-tanzu/tanzu-cli/pkg/config	1.854s
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
