### PR TITLE
Add signature verification of the inventory image before downloading plugin bundle

### DIFF
--- a/pkg/airgapped/plugin_bundle_download.go
+++ b/pkg/airgapped/plugin_bundle_download.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/carvelhelpers"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/cosignhelper/sigverifier"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/plugininventory"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
@@ -227,6 +228,13 @@ func (o *DownloadPluginBundleOptions) validateOptions() error {
 	if err != nil {
 		return errors.Wrapf(err, "invalid path for %q", o.ToTar)
 	}
+
+	// Verify the inventory image signature before downloading the plugin inventory database
+	err = sigverifier.VerifyInventoryImageSignature(o.PluginInventoryImage)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/airgapped/plugin_bundle_test.go
+++ b/pkg/airgapped/plugin_bundle_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/verybluebot/tarinator-go"
 	"gopkg.in/yaml.v3"
 
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/distribution"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/fakes"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/plugininventory"
@@ -148,6 +149,7 @@ imagesToCopy:
 			Tar:             filepath.Join(tempTestDir, "plugin_bundle.tar"),
 			ImageProcessor:  fakeImageOperations,
 		}
+		os.Setenv(constants.PluginDiscoveryImageSignatureVerificationSkipList, dpbo.PluginInventoryImage)
 	})
 	AfterEach(func() {
 		defer os.RemoveAll(tempTestDir)

--- a/pkg/cosignhelper/sigverifier/signature_verification.go
+++ b/pkg/cosignhelper/sigverifier/signature_verification.go
@@ -1,0 +1,95 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package sigverifier implements helper functions to verify inventory image signature
+package sigverifier
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/cosignhelper"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/registry"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
+)
+
+func VerifyInventoryImageSignature(image string) error {
+	cosignVerifier, err := getCosignVerifier(image)
+	if err != nil {
+		return errors.Wrapf(err, "failed to initialize the cosign verifier")
+	}
+
+	if sigVerifyErr := verifyInventoryImageSignature(image, cosignVerifier); sigVerifyErr != nil {
+		log.Warningf("Unable to verify the plugins discovery image signature: %v", sigVerifyErr)
+		// TODO(pkalle): Update the message to convey user to check if they could use the latest public key after we get details of the well known location of the public key
+		errMsg := fmt.Sprintf("Fatal, plugins discovery image signature verification failed. The `tanzu` CLI can not ensure the integrity of the plugins to be installed. To ignore this validation please append %q to the comma-separated list in the environment variable %q.  This is NOT RECOMMENDED and could put your environment at risk!",
+			image, constants.PluginDiscoveryImageSignatureVerificationSkipList)
+		log.Fatal(nil, errMsg)
+	}
+	return nil
+}
+
+func getCosignVerifier(image string) (cosignhelper.Cosignhelper, error) {
+	// Get the custom public key path and prepare cosign verifier, if empty, cosign verifier would use embedded public key for verification
+	customPublicKeyPath := os.Getenv(constants.PublicKeyPathForPluginDiscoveryImageSignature)
+
+	registryOptions, err := getCosignVerifierRegistryOptions(image)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to prepare the registry options for cosign verification")
+	}
+	return cosignhelper.NewCosignVerifier(customPublicKeyPath, registryOptions), nil
+}
+
+// getCosignVerifierRegistryOptions prepares the registry options by including the custom certificate configuration if any
+func getCosignVerifierRegistryOptions(image string) (*cosignhelper.RegistryOptions, error) {
+	registryOpts := &cosignhelper.RegistryOptions{}
+	registryName, err := registry.GetRegistryName(strings.TrimSpace(image))
+	if err != nil {
+		return nil, err
+	}
+	// get the certificate configuration and update the registry options
+	regCertOptions, err := registry.GetRegistryCertOptions(registryName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to get the registry certificate configuration")
+	}
+	registryOpts.CACertPaths = regCertOptions.CACertPaths
+	registryOpts.SkipCertVerify = regCertOptions.SkipCertVerify
+	registryOpts.AllowInsecure = regCertOptions.Insecure
+
+	return registryOpts, nil
+}
+
+func verifyInventoryImageSignature(image string, verifier cosignhelper.Cosignhelper) error {
+	signatureVerificationSkipSet := getPluginDiscoveryImagesSkippedForSignatureVerification()
+	if _, exists := signatureVerificationSkipSet[strings.TrimSpace(image)]; exists {
+		// log warning message iff user had not chosen to skip warning message for signature verification
+		if skip, _ := strconv.ParseBool(os.Getenv(constants.SuppressSkipSignatureVerificationWarning)); !skip {
+			log.Warningf("Skipping the plugins discovery image signature verification for %q\n ", image)
+		}
+		return nil
+	}
+
+	err := verifier.Verify(context.Background(), []string{image})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func getPluginDiscoveryImagesSkippedForSignatureVerification() map[string]struct{} {
+	discoveryImages := map[string]struct{}{}
+	discoveryImagesList := strings.Split(os.Getenv(constants.PluginDiscoveryImageSignatureVerificationSkipList), ",")
+	for _, image := range discoveryImagesList {
+		image = strings.TrimSpace(image)
+		if image != "" {
+			discoveryImages[image] = struct{}{}
+		}
+	}
+	return discoveryImages
+}

--- a/pkg/cosignhelper/sigverifier/signature_verification_test.go
+++ b/pkg/cosignhelper/sigverifier/signature_verification_test.go
@@ -1,0 +1,161 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package sigverifier
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/configpaths"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/cosignhelper"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/fakes"
+	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
+	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
+)
+
+func TestSigVerifierSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "sigverifier package Suite")
+}
+
+var _ = Describe("Unit tests for discovery image signature verification", func() {
+	var (
+		err          error
+		configFile   *os.File
+		configFileNG *os.File
+	)
+
+	Describe("Verify inventory image signature", func() {
+		var (
+			cosignVerifier *fakes.Cosignhelperfake
+			image          string
+		)
+		BeforeEach(func() {
+			configFile, err = os.CreateTemp("", "config")
+			Expect(err).To(BeNil())
+			os.Setenv("TANZU_CONFIG", configFile.Name())
+
+			configFileNG, err = os.CreateTemp("", "config_ng")
+			Expect(err).To(BeNil())
+			os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
+
+			image = "test-image:latest"
+		})
+		AfterEach(func() {
+			os.Unsetenv(constants.PluginDiscoveryImageSignatureVerificationSkipList)
+			os.Unsetenv("TANZU_CONFIG")
+			os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
+			os.RemoveAll(configFile.Name())
+			os.RemoveAll(configFileNG.Name())
+		})
+		Context("Cosign signature verification is success", func() {
+			It("should return success", func() {
+				cosignVerifier = &fakes.Cosignhelperfake{}
+				cosignVerifier.VerifyReturns(nil)
+				err = verifyInventoryImageSignature(image, cosignVerifier)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+		Context("When Cosign signature verification failed and TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST environment variable is set", func() {
+			It("should skip signature verification and return success", func() {
+				cosignVerifier = &fakes.Cosignhelperfake{}
+				cosignVerifier.VerifyReturns(fmt.Errorf("signature verification fake error"))
+				os.Setenv(constants.PluginDiscoveryImageSignatureVerificationSkipList, image)
+				err = verifyInventoryImageSignature(image, cosignVerifier)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+		Context("Cosign signature verification failed", func() {
+			It("should return error", func() {
+				cosignVerifier = &fakes.Cosignhelperfake{}
+				cosignVerifier.VerifyReturns(fmt.Errorf("signature verification fake error"))
+				err = verifyInventoryImageSignature(image, cosignVerifier)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("signature verification fake error"))
+			})
+		})
+	})
+
+	Describe("getCosignVerifier tests", func() {
+		var (
+			cosignVerifier cosignhelper.Cosignhelper
+		)
+		const (
+			fakeCACertData = "fake ca cert data"
+			testHost       = "test.vmware.com"
+			image          = "test.vmware.com/tanzu/test-image:latest"
+		)
+		BeforeEach(func() {
+			configFile, err = os.CreateTemp("", "config")
+			Expect(err).To(BeNil())
+			os.Setenv("TANZU_CONFIG", configFile.Name())
+
+			configFileNG, err = os.CreateTemp("", "config_ng")
+			Expect(err).To(BeNil())
+			os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
+		})
+		AfterEach(func() {
+			os.Unsetenv("TANZU_CONFIG")
+			os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
+			os.Unsetenv(constants.PublicKeyPathForPluginDiscoveryImageSignature)
+			os.RemoveAll(configFile.Name())
+			os.RemoveAll(configFileNG.Name())
+		})
+		Context("When no custom cert data is provided for registry endpoint/host", func() {
+			BeforeEach(func() {
+				cert := &configtypes.Cert{
+					Host:           testHost,
+					CACertData:     base64.StdEncoding.EncodeToString([]byte(fakeCACertData)),
+					SkipCertVerify: "true",
+					Insecure:       "true",
+				}
+				err := configlib.SetCert(cert)
+				Expect(err).To(BeNil())
+			})
+			It("should create cosign verifier successfully with registryOptions updated with configured custom cert data", func() {
+				cosignVerifier, err = getCosignVerifier(image)
+				Expect(err).ToNot(HaveOccurred())
+				cvo, ok := cosignVerifier.(*cosignhelper.CosignVerifyOptions)
+				Expect(ok).To(BeTrue())
+
+				regFilePath, err := configpaths.GetRegistryCertFile()
+				Expect(err).To(BeNil())
+				Expect(cvo.RegistryOpts.CACertPaths).To(ContainElement(regFilePath))
+				Expect(cvo.RegistryOpts.SkipCertVerify).To(BeTrue())
+				Expect(cvo.RegistryOpts.AllowInsecure).To(BeTrue())
+			})
+			It("should create cosign verifier successfully with Image signature custom public key path if provided using the environment variable", func() {
+				keyPath := "fake/path/to/publickey"
+				os.Setenv(constants.PublicKeyPathForPluginDiscoveryImageSignature, keyPath)
+				cosignVerifier, err = getCosignVerifier(image)
+				Expect(err).ToNot(HaveOccurred())
+				cvo, ok := cosignVerifier.(*cosignhelper.CosignVerifyOptions)
+				Expect(ok).To(BeTrue())
+
+				Expect(cvo.PublicKeyPath).To(Equal(keyPath))
+
+			})
+		})
+		Context("When custom cert data is not provided for registry endpoint/host in the config file", func() {
+			It("cosign verifier should be created successfully with default registryOptions", func() {
+				cosignVerifier, err = getCosignVerifier(image)
+				Expect(err).ToNot(HaveOccurred())
+				cvo, ok := cosignVerifier.(*cosignhelper.CosignVerifyOptions)
+				Expect(ok).To(BeTrue())
+
+				regFilePath, err := configpaths.GetRegistryCertFile()
+				Expect(err).To(BeNil())
+				Expect(cvo.RegistryOpts.CACertPaths).ToNot(ContainElement(regFilePath))
+				Expect(cvo.RegistryOpts.SkipCertVerify).To(BeFalse())
+				Expect(cvo.RegistryOpts.AllowInsecure).To(BeFalse())
+			})
+		})
+	})
+})

--- a/pkg/discovery/oci_dbbacked.go
+++ b/pkg/discovery/oci_dbbacked.go
@@ -4,12 +4,10 @@
 package discovery
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 
 	"github.com/pkg/errors"
 
@@ -17,9 +15,8 @@ import (
 	"github.com/vmware-tanzu/tanzu-cli/pkg/carvelhelpers"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
-	"github.com/vmware-tanzu/tanzu-cli/pkg/cosignhelper"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/cosignhelper/sigverifier"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/plugininventory"
-	"github.com/vmware-tanzu/tanzu-cli/pkg/registry"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/utils"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
@@ -160,17 +157,10 @@ func (od *DBBackedOCIDiscovery) fetchInventoryImage() error {
 	// The DB has changed and needs to be updated in the cache.
 	log.Infof("Reading plugin inventory for %q, this will take a few seconds.", od.image)
 
-	cosignVerifier, err := od.getCosignVerifier()
+	// Verify the inventory image signature before downloading the plugin inventory database
+	err := sigverifier.VerifyInventoryImageSignature(od.image)
 	if err != nil {
-		return errors.Wrapf(err, "failed to initialize the cosign verifier")
-	}
-
-	if sigVerifyErr := od.verifyInventoryImageSignature(cosignVerifier); sigVerifyErr != nil {
-		log.Warningf("Unable to verify the plugins discovery image signature: %v", sigVerifyErr)
-		// TODO(pkalle): Update the message to convey user to check if they could use the latest public key after we get details of the well known location of the public key
-		errMsg := fmt.Sprintf("Fatal, plugins discovery image signature verification failed. The `tanzu` CLI can not ensure the integrity of the plugins to be installed. To ignore this validation please append %q to the comma-separated list in the environment variable %q.  This is NOT RECOMMENDED and could put your environment at risk!",
-			od.image, constants.PluginDiscoveryImageSignatureVerificationSkipList)
-		log.Fatal(nil, errMsg)
+		return err
 	}
 
 	// download plugin inventory image to get the 'plugin_inventory.db'
@@ -297,63 +287,4 @@ func (od *DBBackedOCIDiscovery) checkDigestFileExistence(hashHexVal, digestPrefi
 		os.Remove(matches[0])
 	}
 	return correctHashFile
-}
-
-func (od *DBBackedOCIDiscovery) verifyInventoryImageSignature(verifier cosignhelper.Cosignhelper) error {
-	signatureVerificationSkipSet := getPluginDiscoveryImagesSkippedForSignatureVerification()
-	if _, exists := signatureVerificationSkipSet[strings.TrimSpace(od.image)]; exists {
-		// log warning message iff user had not chosen to skip warning message for signature verification
-		if skip, _ := strconv.ParseBool(os.Getenv(constants.SuppressSkipSignatureVerificationWarning)); !skip {
-			log.Warningf("Skipping the plugins discovery image signature verification for %q\n ", od.image)
-		}
-		return nil
-	}
-
-	err := verifier.Verify(context.Background(), []string{od.image})
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (od *DBBackedOCIDiscovery) getCosignVerifier() (cosignhelper.Cosignhelper, error) {
-	// Get the custom public key path and prepare cosign verifier, if empty, cosign verifier would use embedded public key for verification
-	customPublicKeyPath := os.Getenv(constants.PublicKeyPathForPluginDiscoveryImageSignature)
-
-	registryOptions, err := od.getCosignVerifierRegistryOptions()
-	if err != nil {
-		return nil, errors.Wrapf(err, "unable to prepare the registry options for cosign verification")
-	}
-	return cosignhelper.NewCosignVerifier(customPublicKeyPath, registryOptions), nil
-}
-
-// getCosignVerifierRegistryOptions prepares the registry options by including the custom certificate configuration if any
-func (od *DBBackedOCIDiscovery) getCosignVerifierRegistryOptions() (*cosignhelper.RegistryOptions, error) {
-	registryOpts := &cosignhelper.RegistryOptions{}
-	registryName, err := registry.GetRegistryName(strings.TrimSpace(od.image))
-	if err != nil {
-		return nil, err
-	}
-	// get the certificate configuration and update the registry options
-	regCertOptions, err := registry.GetRegistryCertOptions(registryName)
-	if err != nil {
-		return nil, errors.Wrapf(err, "unable to get the registry certificate configuration")
-	}
-	registryOpts.CACertPaths = regCertOptions.CACertPaths
-	registryOpts.SkipCertVerify = regCertOptions.SkipCertVerify
-	registryOpts.AllowInsecure = regCertOptions.Insecure
-
-	return registryOpts, nil
-}
-
-func getPluginDiscoveryImagesSkippedForSignatureVerification() map[string]struct{} {
-	discoveryImages := map[string]struct{}{}
-	discoveryImagesList := strings.Split(os.Getenv(constants.PluginDiscoveryImageSignatureVerificationSkipList), ",")
-	for _, image := range discoveryImagesList {
-		image = strings.TrimSpace(image)
-		if image != "" {
-			discoveryImages[image] = struct{}{}
-		}
-	}
-	return discoveryImages
 }

--- a/pkg/discovery/oci_dbbacked_test.go
+++ b/pkg/discovery/oci_dbbacked_test.go
@@ -4,19 +4,13 @@
 package discovery
 
 import (
-	"encoding/base64"
-	"fmt"
 	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/vmware-tanzu/tanzu-cli/pkg/configpaths"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
-	"github.com/vmware-tanzu/tanzu-cli/pkg/cosignhelper"
-	"github.com/vmware-tanzu/tanzu-cli/pkg/fakes"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/plugininventory"
-	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
 
@@ -273,143 +267,6 @@ var _ = Describe("Unit tests for DB-backed OCI discovery", func() {
 			Expect(*filterInErr.groupFilter).To(Equal(plugininventory.PluginGroupFilter{
 				IncludeHidden: true,
 			}))
-		})
-	})
-
-	Describe("Verify inventory image signature", func() {
-		var (
-			cosignVerifier *fakes.Cosignhelperfake
-			dbDiscovery    *DBBackedOCIDiscovery
-			ok             bool
-		)
-		BeforeEach(func() {
-			configFile, err = os.CreateTemp("", "config")
-			Expect(err).To(BeNil())
-			os.Setenv("TANZU_CONFIG", configFile.Name())
-
-			configFileNG, err = os.CreateTemp("", "config_ng")
-			Expect(err).To(BeNil())
-			os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
-
-			discovery = NewOCIDiscovery("test-discovery", "test-image:latest", nil)
-			Expect(err).To(BeNil(), "unable to create discovery")
-			dbDiscovery, ok = discovery.(*DBBackedOCIDiscovery)
-			Expect(ok).To(BeTrue(), "oci discovery is not of type DBBackedOCIDiscovery")
-		})
-		AfterEach(func() {
-			os.Unsetenv(constants.PluginDiscoveryImageSignatureVerificationSkipList)
-			os.Unsetenv("TANZU_CONFIG")
-			os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
-			os.RemoveAll(configFile.Name())
-			os.RemoveAll(configFileNG.Name())
-		})
-		Context("Cosign signature verification is success", func() {
-			It("should return success", func() {
-				cosignVerifier = &fakes.Cosignhelperfake{}
-				cosignVerifier.VerifyReturns(nil)
-				err = dbDiscovery.verifyInventoryImageSignature(cosignVerifier)
-				Expect(err).ToNot(HaveOccurred())
-			})
-		})
-		Context("When Cosign signature verification failed and TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST environment variable is set", func() {
-			It("should skip signature verification and return success", func() {
-				cosignVerifier = &fakes.Cosignhelperfake{}
-				cosignVerifier.VerifyReturns(fmt.Errorf("signature verification fake error"))
-				os.Setenv(constants.PluginDiscoveryImageSignatureVerificationSkipList, dbDiscovery.image)
-				err = dbDiscovery.verifyInventoryImageSignature(cosignVerifier)
-				Expect(err).ToNot(HaveOccurred())
-			})
-		})
-		Context("Cosign signature verification failed", func() {
-			It("should return error", func() {
-				cosignVerifier = &fakes.Cosignhelperfake{}
-				cosignVerifier.VerifyReturns(fmt.Errorf("signature verification fake error"))
-				err = dbDiscovery.verifyInventoryImageSignature(cosignVerifier)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("signature verification fake error"))
-			})
-		})
-	})
-
-	Describe("getCosignVerifier tests", func() {
-		var (
-			cosignVerifier cosignhelper.Cosignhelper
-			dbDiscovery    *DBBackedOCIDiscovery
-			ok             bool
-		)
-		const (
-			fakeCACertData = "fake ca cert data"
-			testHost       = "test.vmware.com"
-		)
-		BeforeEach(func() {
-			configFile, err = os.CreateTemp("", "config")
-			Expect(err).To(BeNil())
-			os.Setenv("TANZU_CONFIG", configFile.Name())
-
-			configFileNG, err = os.CreateTemp("", "config_ng")
-			Expect(err).To(BeNil())
-			os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
-
-			discovery = NewOCIDiscovery("test-discovery", testHost+"/tanzu/test-image:latest", nil)
-			Expect(err).To(BeNil(), "unable to create discovery")
-			dbDiscovery, ok = discovery.(*DBBackedOCIDiscovery)
-			Expect(ok).To(BeTrue(), "oci discovery is not of type DBBackedOCIDiscovery")
-		})
-		AfterEach(func() {
-			os.Unsetenv("TANZU_CONFIG")
-			os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
-			os.Unsetenv(constants.PublicKeyPathForPluginDiscoveryImageSignature)
-			os.RemoveAll(configFile.Name())
-			os.RemoveAll(configFileNG.Name())
-		})
-		Context("When no custom cert data is provided for registry endpoint/host", func() {
-			BeforeEach(func() {
-				cert := &configtypes.Cert{
-					Host:           testHost,
-					CACertData:     base64.StdEncoding.EncodeToString([]byte(fakeCACertData)),
-					SkipCertVerify: "true",
-					Insecure:       "true",
-				}
-				err := configlib.SetCert(cert)
-				Expect(err).To(BeNil())
-			})
-			It("should create cosign verifier successfully with registryOptions updated with configured custom cert data", func() {
-				cosignVerifier, err = dbDiscovery.getCosignVerifier()
-				Expect(err).ToNot(HaveOccurred())
-				cvo, ok := cosignVerifier.(*cosignhelper.CosignVerifyOptions)
-				Expect(ok).To(BeTrue())
-
-				regFilePath, err := configpaths.GetRegistryCertFile()
-				Expect(err).To(BeNil())
-				Expect(cvo.RegistryOpts.CACertPaths).To(ContainElement(regFilePath))
-				Expect(cvo.RegistryOpts.SkipCertVerify).To(BeTrue())
-				Expect(cvo.RegistryOpts.AllowInsecure).To(BeTrue())
-			})
-			It("should create cosign verifier successfully with Image signature custom public key path if provided using the environment variable", func() {
-				keyPath := "fake/path/to/publickey"
-				os.Setenv(constants.PublicKeyPathForPluginDiscoveryImageSignature, keyPath)
-				cosignVerifier, err = dbDiscovery.getCosignVerifier()
-				Expect(err).ToNot(HaveOccurred())
-				cvo, ok := cosignVerifier.(*cosignhelper.CosignVerifyOptions)
-				Expect(ok).To(BeTrue())
-
-				Expect(cvo.PublicKeyPath).To(Equal(keyPath))
-
-			})
-		})
-		Context("When custom cert data is not provided for registry endpoint/host in the config file", func() {
-			It("cosign verifier should be created successfully with default registryOptions", func() {
-				cosignVerifier, err = dbDiscovery.getCosignVerifier()
-				Expect(err).ToNot(HaveOccurred())
-				cvo, ok := cosignVerifier.(*cosignhelper.CosignVerifyOptions)
-				Expect(ok).To(BeTrue())
-
-				regFilePath, err := configpaths.GetRegistryCertFile()
-				Expect(err).To(BeNil())
-				Expect(cvo.RegistryOpts.CACertPaths).ToNot(ContainElement(regFilePath))
-				Expect(cvo.RegistryOpts.SkipCertVerify).To(BeFalse())
-				Expect(cvo.RegistryOpts.AllowInsecure).To(BeFalse())
-			})
 		})
 	})
 })


### PR DESCRIPTION
### What this PR does / why we need it
- Verify the signature of the inventory image before downloading the plugin bundle with the `tanzu plugin download-bundle` command.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Related to #223

### Describe testing done for PR

```
### => Trying to download plugin bundle from inventory image which can be verified with default public key
$ tz plugin download-bundle --image harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest --to-tar /tmp/4/plugin_bundle_tkg_001.tar.gz
[i] downloading image "harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest"
[i] copy | exporting 2 images...
...
```

```
### => Trying to download plugin bundle from inventory image which is not signed with cosign and running command without setting skip validation environment variable
$tz plugin download-bundle --image localhost:9876/tanzu-cli/plugins/airgapped:small --to-tar /tmp/4/plugin_bundle_tkg_001.tar.gz --group vmware-tkg/v0.0.1
[!] Unable to verify the plugins discovery image signature: failed validating the signature of the image localhost:9876/tanzu-cli/plugins/airgapped:small :no matching signatures:
[x] Fatal, plugins discovery image signature verification failed. The `tanzu` CLI can not ensure the integrity of the plugins to be installed. To ignore this validation please append "localhost:9876/tanzu-cli/plugins/airgapped:small" to the comma-separated list in the environment variable "TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST".  This is NOT RECOMMENDED and could put your environment at risk!
```

```
### => Set environment variable to skip the verification
$ export TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST=localhost:9876/tanzu-cli/plugins/airgapped:small
$ tz plugin download-bundle --image localhost:9876/tanzu-cli/plugins/airgapped:small --to-tar /tmp/4/plugin_bundle_tkg_001.tar.gz --group vmware-tkg/v0.0.1
[!] Skipping the plugins discovery image signature verification for "localhost:9876/tanzu-cli/plugins/airgapped:small"

[i] downloading image "localhost:9876/tanzu-cli/plugins/airgapped:small"
[i] copy | exporting 1 images...
...
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add signature verification of the inventory image before downloading plugin bundle
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
