### PR TITLE
Add TANZU_CLI_STANDALONE_OVER_CONTEXT_PLUGINS to prioritize standalone over context plugins

### DIFF
--- a/docs/plugindev/README.md
+++ b/docs/plugindev/README.md
@@ -265,12 +265,34 @@ as it would introduce a security risk.
 
 ### Testing the plugins
 
+#### Manual testing
+
+As a plugin developer, you will want to test your plugin manually at some point.
+During the development cycle, you can easily build and install the latest version of your plugin
+as described in the section on [building a plugin](#building-a-plugin).
+
+If you are using "contexts" while doing testing of your plugin and that your plugin is context-scoped
+you may find that your new plugin version is being overwritten with an older version by the CLI.
+When a plugin is context-scoped a context may recommend a specific version of that plugin for the CLI
+to use.  In such a case, if you want to test your new version and prevent the CLI from overwriting it
+with the version recommended by the context you can enable the `TANZU_CLI_STANDALONE_OVER_CONTEXT_PLUGINS`
+variable by doing:
+
+```sh
+tanzu config set env.TANZU_CLI_STANDALONE_OVER_CONTEXT_PLUGINS true
+```
+
+This variable will instruct the CLI that any installation done with `tanzu plugin install <pluginName>`
+should take precedence over any installation coming from a context.
+
+#### Automated tests using the test plugin
+
 Plugin tests can be run by installing the admin `test` plugin.
 Currently, we only support testing plugins built locally.
 
 **Note:** The `test` admin functionality has been deprecated and no future enhancements are planned for this plugin.
 
-Steps to test plugin :-
+Steps to test a plugin:
 
 1. Bootstrap a new plugin
 2. Build a plugin binary

--- a/pkg/constants/env_variables.go
+++ b/pkg/constants/env_variables.go
@@ -12,6 +12,7 @@ const (
 	AllowedRegistries                                 = "ALLOWED_REGISTRY"
 	ConfigVariableAdditionalDiscoveryForTesting       = "TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY"
 	ConfigVariableIncludeDeactivatedPluginsForTesting = "TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY"
+	ConfigVariableStandaloneOverContextPlugins        = "TANZU_CLI_STANDALONE_OVER_CONTEXT_PLUGINS"
 	// PluginDiscoveryImageSignatureVerificationSkipList is a comma separated list of discovery image urls
 	PluginDiscoveryImageSignatureVerificationSkipList = "TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST"
 	PublicKeyPathForPluginDiscoveryImageSignature     = "TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_PUBLIC_KEY_PATH"

--- a/pkg/pluginsupplier/plugin_supplier_test.go
+++ b/pkg/pluginsupplier/plugin_supplier_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/vmware-tanzu/tanzu-cli/pkg/catalog"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/plugin"
 
@@ -51,7 +52,7 @@ var _ = Describe("GetInstalledStandalonePlugins", func() {
 	})
 	Context("when a standalone plugins installed", func() {
 		BeforeEach(func() {
-			pd1, err = fakeInstallPlugin("", "fake-server-plugin1", types.TargetK8s)
+			pd1, err = fakeInstallPlugin("", "fake-server-plugin1", types.TargetK8s, "v1.0.0")
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -112,7 +113,7 @@ var _ = Describe("GetInstalledServerPlugins", func() {
 	Context("when a server plugin for k8s target installed", func() {
 		BeforeEach(func() {
 			contextNameFromConfig := k8sContextName
-			pd1, err = fakeInstallPlugin(contextNameFromConfig, "fake-server-plugin1", types.TargetK8s)
+			pd1, err = fakeInstallPlugin(contextNameFromConfig, "fake-server-plugin1", types.TargetK8s, "v1.0.0")
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -126,7 +127,7 @@ var _ = Describe("GetInstalledServerPlugins", func() {
 	Context("when a server plugin for tmc target installed", func() {
 		BeforeEach(func() {
 			contextNameFromConfig := tmcContextName
-			pd1, err = fakeInstallPlugin(contextNameFromConfig, "fake-server-plugin2", types.TargetTMC)
+			pd1, err = fakeInstallPlugin(contextNameFromConfig, "fake-server-plugin2", types.TargetTMC, "v1.0.0")
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -140,11 +141,11 @@ var _ = Describe("GetInstalledServerPlugins", func() {
 	Context("when a server plugin for both tmc and k8s targets installed", func() {
 		BeforeEach(func() {
 			contextNameFromConfig := k8sContextName
-			pd1, err = fakeInstallPlugin(contextNameFromConfig, "fake-server-plugin1", types.TargetTMC)
+			pd1, err = fakeInstallPlugin(contextNameFromConfig, "fake-server-plugin1", types.TargetTMC, "v1.0.0")
 			Expect(err).ToNot(HaveOccurred())
 
 			contextNameFromConfig = tmcContextName
-			pd2, err = fakeInstallPlugin(contextNameFromConfig, "fake-server-plugin2", types.TargetTMC)
+			pd2, err = fakeInstallPlugin(contextNameFromConfig, "fake-server-plugin2", types.TargetTMC, "v1.0.0")
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -160,14 +161,17 @@ var _ = Describe("GetInstalledServerPlugins", func() {
 
 var _ = Describe("GetInstalledPlugins (both standalone and context plugins)", func() {
 	var (
-		cdir         string
-		err          error
-		configFile   *os.File
-		configFileNG *os.File
-		pd1          *cli.PluginInfo
-		pd2          *cli.PluginInfo
-		pd3          *cli.PluginInfo
-		pd4          *cli.PluginInfo
+		cdir             string
+		err              error
+		configFile       *os.File
+		configFileNG     *os.File
+		pd1              *cli.PluginInfo
+		pd2              *cli.PluginInfo
+		pd3              *cli.PluginInfo
+		pd4              *cli.PluginInfo
+		pd5              *cli.PluginInfo
+		pd6              *cli.PluginInfo
+		originalVarValue string
 	)
 	const (
 		tmcContextName = "test-tmc-context"
@@ -189,6 +193,8 @@ var _ = Describe("GetInstalledPlugins (both standalone and context plugins)", fu
 		os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
 		err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config_ng.yaml"), configFileNG.Name())
 		Expect(err).To(BeNil(), "Error while coping tanzu config-ng file for testing")
+
+		originalVarValue = os.Getenv(constants.ConfigVariableStandaloneOverContextPlugins)
 	})
 	AfterEach(func() {
 		os.RemoveAll(cdir)
@@ -196,6 +202,8 @@ var _ = Describe("GetInstalledPlugins (both standalone and context plugins)", fu
 		os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
 		os.RemoveAll(configFile.Name())
 		os.RemoveAll(configFileNG.Name())
+
+		os.Setenv(constants.ConfigVariableStandaloneOverContextPlugins, originalVarValue)
 	})
 
 	Context("when no standalone or server plugins installed", func() {
@@ -208,7 +216,7 @@ var _ = Describe("GetInstalledPlugins (both standalone and context plugins)", fu
 	})
 	Context("when a standalone plugins installed", func() {
 		BeforeEach(func() {
-			pd1, err = fakeInstallPlugin("", "fake-server-plugin1", types.TargetK8s)
+			pd1, err = fakeInstallPlugin("", "fake-server-plugin1", types.TargetK8s, "v1.0.0")
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -221,11 +229,11 @@ var _ = Describe("GetInstalledPlugins (both standalone and context plugins)", fu
 	})
 	Context("when a standalone and server plugin for k8s target installed", func() {
 		BeforeEach(func() {
-			pd1, err = fakeInstallPlugin("", "fake-server-plugin1", types.TargetK8s)
+			pd1, err = fakeInstallPlugin("", "fake-server-plugin1", types.TargetK8s, "v1.0.0")
 			Expect(err).ToNot(HaveOccurred())
 
 			contextNameFromConfig := k8sContextName
-			pd2, err = fakeInstallPlugin(contextNameFromConfig, "fake-server-plugin2", types.TargetK8s)
+			pd2, err = fakeInstallPlugin(contextNameFromConfig, "fake-server-plugin2", types.TargetK8s, "v1.0.0")
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -240,15 +248,15 @@ var _ = Describe("GetInstalledPlugins (both standalone and context plugins)", fu
 
 	Context("when a standalone plugin and server plugin for both tmc and k8s targets installed", func() {
 		BeforeEach(func() {
-			pd1, err = fakeInstallPlugin("", "fake-server-plugin1", types.TargetK8s)
+			pd1, err = fakeInstallPlugin("", "fake-server-plugin1", types.TargetK8s, "v1.0.0")
 			Expect(err).ToNot(HaveOccurred())
 
 			contextNameFromConfig := k8sContextName
-			pd2, err = fakeInstallPlugin(contextNameFromConfig, "fake-server-plugin2", types.TargetK8s)
+			pd2, err = fakeInstallPlugin(contextNameFromConfig, "fake-server-plugin2", types.TargetK8s, "v1.0.0")
 			Expect(err).ToNot(HaveOccurred())
 
 			contextNameFromConfig = tmcContextName
-			pd3, err = fakeInstallPlugin(contextNameFromConfig, "fake-server-plugin3", types.TargetTMC)
+			pd3, err = fakeInstallPlugin(contextNameFromConfig, "fake-server-plugin3", types.TargetTMC, "v1.0.0")
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -266,11 +274,11 @@ var _ = Describe("GetInstalledPlugins (both standalone and context plugins)", fu
 		BeforeEach(func() {
 			sharedPluginName := "fake-plugin"
 			sharedPluginTarget := types.TargetK8s
-			pd1, err = fakeInstallPlugin("", sharedPluginName, sharedPluginTarget)
+			pd1, err = fakeInstallPlugin("", sharedPluginName, sharedPluginTarget, "v1.0.0")
 			Expect(err).ToNot(HaveOccurred())
 
 			contextNameFromConfig := k8sContextName
-			pd2, err = fakeInstallPlugin(contextNameFromConfig, sharedPluginName, sharedPluginTarget)
+			pd2, err = fakeInstallPlugin(contextNameFromConfig, sharedPluginName, sharedPluginTarget, "v2.0.0")
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -280,29 +288,38 @@ var _ = Describe("GetInstalledPlugins (both standalone and context plugins)", fu
 			Expect(len(installedPlugins)).To(Equal(1))
 			Expect(installedPlugins).Should(ContainElement(*pd2))
 		})
+		It("if TANZU_CLI_STANDALONE_OVER_CONTEXT_PLUGINS=1 it should return the standalone plugin only", func() {
+			err := os.Setenv(constants.ConfigVariableStandaloneOverContextPlugins, "1")
+			Expect(err).ToNot(HaveOccurred())
+
+			installedPlugins, err := GetInstalledPlugins()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(installedPlugins)).To(Equal(1))
+			Expect(installedPlugins).Should(ContainElement(*pd1))
+		})
 	})
 
 	Context("when multiple standalone plugins and server plugins are installed with some overlap", func() {
 		BeforeEach(func() {
-			pd1, err = fakeInstallPlugin("", "fake-server-plugin1", types.TargetK8s)
+			pd1, err = fakeInstallPlugin("", "fake-server-plugin1", types.TargetK8s, "v1.0.0")
 			Expect(err).ToNot(HaveOccurred())
 
 			contextNameFromConfig := k8sContextName
-			pd2, err = fakeInstallPlugin(contextNameFromConfig, "fake-server-plugin2", types.TargetK8s)
+			pd2, err = fakeInstallPlugin(contextNameFromConfig, "fake-server-plugin2", types.TargetK8s, "v1.0.0")
 			Expect(err).ToNot(HaveOccurred())
 
 			sharedPluginName := "fake-plugin1"
 			sharedPluginTarget := types.TargetK8s
-			_, err = fakeInstallPlugin("", sharedPluginName, sharedPluginTarget)
+			pd3, err = fakeInstallPlugin("", sharedPluginName, sharedPluginTarget, "v1.0.0")
 			Expect(err).ToNot(HaveOccurred())
-			pd3, err = fakeInstallPlugin(contextNameFromConfig, sharedPluginName, sharedPluginTarget)
+			pd4, err = fakeInstallPlugin(contextNameFromConfig, sharedPluginName, sharedPluginTarget, "v2.0.0")
 			Expect(err).ToNot(HaveOccurred())
 
 			sharedPluginName = "fake-plugin2"
 			sharedPluginTarget = types.TargetTMC
-			_, err = fakeInstallPlugin("", sharedPluginName, sharedPluginTarget)
+			pd5, err = fakeInstallPlugin("", sharedPluginName, sharedPluginTarget, "v1.0.0")
 			Expect(err).ToNot(HaveOccurred())
-			pd4, err = fakeInstallPlugin(contextNameFromConfig, sharedPluginName, sharedPluginTarget)
+			pd6, err = fakeInstallPlugin(contextNameFromConfig, sharedPluginName, sharedPluginTarget, "v2.0.0")
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -312,8 +329,19 @@ var _ = Describe("GetInstalledPlugins (both standalone and context plugins)", fu
 			Expect(len(installedPlugins)).To(Equal(4))
 			Expect(installedPlugins).Should(ContainElement(*pd1))
 			Expect(installedPlugins).Should(ContainElement(*pd2))
-			Expect(installedPlugins).Should(ContainElement(*pd3))
 			Expect(installedPlugins).Should(ContainElement(*pd4))
+			Expect(installedPlugins).Should(ContainElement(*pd6))
+		})
+		It("if TANZU_CLI_STANDALONE_OVER_CONTEXT_PLUGINS=1 it should not return any server plugins that are also standalone plugins", func() {
+			err := os.Setenv(constants.ConfigVariableStandaloneOverContextPlugins, "1")
+			Expect(err).ToNot(HaveOccurred())
+			installedPlugins, err := GetInstalledPlugins()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(installedPlugins)).To(Equal(4))
+			Expect(installedPlugins).Should(ContainElement(*pd1))
+			Expect(installedPlugins).Should(ContainElement(*pd2))
+			Expect(installedPlugins).Should(ContainElement(*pd3))
+			Expect(installedPlugins).Should(ContainElement(*pd5))
 		})
 	})
 	Context("with a catalog cache from an older CLI version", func() {
@@ -433,15 +461,15 @@ var _ = Describe("GetInstalledPlugins (both standalone and context plugins)", fu
 	})
 })
 
-func fakeInstallPlugin(contextName, pluginName string, target types.Target) (*cli.PluginInfo, error) {
+func fakeInstallPlugin(contextName, pluginName string, target types.Target, version string) (*cli.PluginInfo, error) {
 	cc, err := catalog.NewContextCatalog(contextName)
 	if err != nil {
 		return nil, err
 	}
 	pi := &cli.PluginInfo{
 		Name:             pluginName,
-		InstallationPath: "/path/to/plugin/" + pluginName,
-		Version:          "1.0.0",
+		InstallationPath: "/path/to/plugin/" + pluginName + "/" + version,
+		Version:          version,
 		Hidden:           true,
 		Target:           target,
 		DefaultFeatureFlags: map[string]bool{


### PR DESCRIPTION
### What this PR does / why we need it

The new `TANZU_CLI_STANDALONE_OVER_CONTEXT_PLUGINS` variable allows testing a specific version of a plugin without having a context replace that version with its recommended version.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #255

### Describe testing done for PR

```
# Start fresh
$ rm ~/.config/tanzu/config*
$ tz ceip-participation set false
$ tz plugin clean
[ok] successfully cleaned up all plugins
$ tz plugin source update default -u localhost:9876/tanzu-cli/plugins/central:small
[ok] updated discovery source default
$ tz config set env.TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_PUBLIC_KEY_PATH $tc/hack/central-repo/cosign-key-pair/cosign.pub
$ make start-test-central-repo
[...]

# Create a context which will sync plugins
$ tz context create --name tkg2 --kubecontext tkg2 --kubeconfig /Users/kmarc/.k3d/kubeconfig-tkg2.yaml
[ok] successfully created a kubernetes context using the kubeconfig /Users/kmarc/.k3d/kubeconfig-tkg2.yaml
[i] Checking for required plugins...
[i] Reading plugin inventory for "localhost:9876/tanzu-cli/plugins/central:small", this will take a few seconds.
[i] Installing plugin 'cluster:v9.9.9' with target 'kubernetes'
[i] Installing plugin 'kubernetes-release:v9.9.9' with target 'kubernetes'
[i] Installing plugin 'feature:v9.9.9' with target 'kubernetes'
[i] Successfully installed all required plugins
$
$ tz plugin list
Standalone Plugins
  NAME  DESCRIPTION  TARGET  VERSION  STATUS

Plugins from Context:  tkg2
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v9.9.9   installed
  feature             Operate on features and featuregates  kubernetes  v9.9.9   installed
  kubernetes-release  Kubernetes release operations         kubernetes  v9.9.9   installed

# Install one of the context plugins as a standalone
$ tz plugin install feature --version v0.0.1
[i] Installing plugin 'feature:v0.0.1' with target 'kubernetes'
[ok] successfully installed 'feature' plugin

# Since we haven't set the new variable, the context plugin version wins
$ tz plugin list
Standalone Plugins
  NAME  DESCRIPTION  TARGET  VERSION  STATUS

Plugins from Context:  tkg2
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v9.9.9   installed
  feature             Operate on features and featuregates  kubernetes  v9.9.9   installed
  kubernetes-release  Kubernetes release operations         kubernetes  v9.9.9   installed
$ tz feature version
Stub plugin "feature" "v9.9.9" for "kubernetes"

# Now set the new variable and see that the standalone plugin version wins
$ tz config set env.TANZU_CLI_STANDALONE_OVER_CONTEXT_PLUGINS true
$ tz plugin list
Standalone Plugins
  NAME     DESCRIPTION            TARGET      VERSION  STATUS
  feature  feature functionality  kubernetes  v0.0.1   installed

Plugins from Context:  tkg2
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v9.9.9   installed
  feature             Operate on features and featuregates  kubernetes  v9.9.9   not installed
  kubernetes-release  Kubernetes release operations         kubernetes  v9.9.9   installed

[!] As shown above, some recommended plugins have not been installed. To install them please run 'tanzu plugin sync'.
$ tz feature version
Stub plugin "feature" "v0.0.1" for "kubernetes"

# Turn off the variable explicitly and check again
$ tz config set env.TANZU_CLI_STANDALONE_OVER_CONTEXT_PLUGINS 0
$ tz plugin list
Standalone Plugins
  NAME  DESCRIPTION  TARGET  VERSION  STATUS

Plugins from Context:  tkg2
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v9.9.9   installed
  feature             Operate on features and featuregates  kubernetes  v9.9.9   installed
  kubernetes-release  Kubernetes release operations         kubernetes  v9.9.9   installed
$ tz feature version
Stub plugin "feature" "v9.9.9" for "kubernetes"

# Turn it on with a '1' instead of 'true'
$ tz config set env.TANZU_CLI_STANDALONE_OVER_CONTEXT_PLUGINS 1
$ tz plugin list
Standalone Plugins
  NAME     DESCRIPTION            TARGET      VERSION  STATUS
  feature  feature functionality  kubernetes  v0.0.1   installed

Plugins from Context:  tkg2
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v9.9.9   installed
  feature             Operate on features and featuregates  kubernetes  v9.9.9   not installed
  kubernetes-release  Kubernetes release operations         kubernetes  v9.9.9   installed

[!] As shown above, some recommended plugins have not been installed. To install them please run 'tanzu plugin sync'.

# Perform a sync and check that the standalone version still wins
$ tz plugin sync
[i] Checking for required plugins...
[i] Installing plugin 'feature:v9.9.9' with target 'kubernetes'
[i] Successfully installed all required plugins
[ok] Done
$ tz plugin list
Standalone Plugins
  NAME     DESCRIPTION            TARGET      VERSION  STATUS
  feature  feature functionality  kubernetes  v0.0.1   installed

Plugins from Context:  tkg2
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v9.9.9   installed
  feature             Operate on features and featuregates  kubernetes  v9.9.9   not installed
  kubernetes-release  Kubernetes release operations         kubernetes  v9.9.9   installed

[!] As shown above, some recommended plugins have not been installed. To install them please run 'tanzu plugin sync'.
$ tz feature version
Stub plugin "feature" "v0.0.1" for "kubernetes"

# Delete the plugin completely
$ tz plugin delete feature
Deleting Plugin 'feature' for target 'kubernetes'. Are you sure? [y/N]: y
[ok] successfully deleted plugin 'feature'
$ tz plugin list
Standalone Plugins
  NAME  DESCRIPTION  TARGET  VERSION  STATUS

Plugins from Context:  tkg2
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v9.9.9   installed
  feature             Operate on features and featuregates  kubernetes  v9.9.9   not installed
  kubernetes-release  Kubernetes release operations         kubernetes  v9.9.9   installed

[!] As shown above, some recommended plugins have not been installed. To install them please run 'tanzu plugin sync'.

# Perform a sync and check that the context plugin is used (since the standalone was also deleted)
$ tz plugin sync
[i] Checking for required plugins...
[i] Installing plugin 'feature:v9.9.9' with target 'kubernetes'
[i] Successfully installed all required plugins
[ok] Done
$ tz plugin list
Standalone Plugins
  NAME  DESCRIPTION  TARGET  VERSION  STATUS

Plugins from Context:  tkg2
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v9.9.9   installed
  feature             Operate on features and featuregates  kubernetes  v9.9.9   installed
  kubernetes-release  Kubernetes release operations         kubernetes  v9.9.9   installed
$ tz feature version
Stub plugin "feature" "v9.9.9" for "kubernetes"

# Re-install the v0.0.1 version of the plugin as standalone and check it wins
$ tz plugin install feature --version v0.0.1
[i] Installing plugin 'feature:v0.0.1' with target 'kubernetes'
[ok] successfully installed 'feature' plugin
$ tz plugin list
Standalone Plugins
  NAME     DESCRIPTION            TARGET      VERSION  STATUS
  feature  feature functionality  kubernetes  v0.0.1   installed

Plugins from Context:  tkg2
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v9.9.9   installed
  feature             Operate on features and featuregates  kubernetes  v9.9.9   not installed
  kubernetes-release  Kubernetes release operations         kubernetes  v9.9.9   installed

[!] As shown above, some recommended plugins have not been installed. To install them please run 'tanzu plugin sync'.
$ tz feature version
Stub plugin "feature" "v0.0.1" for "kubernetes"
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The TANZU_CLI_STANDALONE_OVER_CONTEXT_PLUGINS=1 variable can be used to instruct the CLI to prioritize a standalone version of an installed plugin over the version recommended from a context.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

When a user deals with the same plugin installed both manually (standalone) and from a context, I find that the UX is not always friendly.

For example, doing 
```
$ tz plugin install feature --version v9.9.9
[i] Installing plugin 'feature:v9.9.9' with target 'kubernetes'
[ok] successfully installed 'feature' plugin
```
gives the impression that version `v9.9.9` of the plugin `feature` is now installed and can be used, but if the context version is also present, it is the context recommended version that takes precedence.  The printed installation messages can be confusing.

This situation is only made worse with the new `TANZU_CLI_STANDALONE_OVER_CONTEXT_PLUGINS` variable introduced by this PR.  For example:

```
# I start with a context that syncs three plugins
$ tz plugin list
Standalone Plugins
  NAME  DESCRIPTION  TARGET  VERSION  STATUS

Plugins from Context:  tkg2
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v9.9.9   installed
  feature             Operate on features and featuregates  kubernetes  v0.28.0  installed
  kubernetes-release  Kubernetes release operations         kubernetes  v0.28.0  installed

# Then I install the feature plugin manually (standalone) at a different version
tz plugin install feature --version v9.9.9
[i] Installing plugin 'feature:v9.9.9' with target 'kubernetes'
[ok] successfully installed 'feature' plugin

# Then I set the new variable
$ tz config set env.TANZU_CLI_STANDALONE_OVER_CONTEXT_PLUGINS 1 
# The behaviour below is correct but I still see the context 'feature' plugin but uninstalled
# with a warning telling me to run plugin sync...
$ tz plugin list
Standalone Plugins
  NAME     DESCRIPTION            TARGET      VERSION  STATUS
  feature  feature functionality  kubernetes  v9.9.9   installed

Plugins from Context:  tkg2
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v9.9.9   installed
  feature             Operate on features and featuregates  kubernetes  v0.28.0  not installed
  kubernetes-release  Kubernetes release operations         kubernetes  v0.28.0  installed

[!] As shown above, some recommended plugins have not been installed. To install them please run 'tanzu plugin sync'.

# Now I run plugin sync
# It says it installed the recommended version of the 'feature' plugin but...
$ tz plugin sync
[i] Checking for required plugins...
[i] Installing plugin 'feature:v0.28.0' with target 'kubernetes'
[i] Successfully installed all required plugins
[ok] Done

# The context 'feature' plugin still shows "not installed" and although
# this is correct, it is confusing
# AND I still get a warning telling me to run 'plugin sync'
$ tz plugin list
Standalone Plugins
  NAME     DESCRIPTION            TARGET      VERSION  STATUS
  feature  feature functionality  kubernetes  v9.9.9   installed

Plugins from Context:  tkg2
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v9.9.9   installed
  feature             Operate on features and featuregates  kubernetes  v0.28.0  not installed
  kubernetes-release  Kubernetes release operations         kubernetes  v0.28.0  installed

[!] As shown above, some recommended plugins have not been installed. To install them please run 'tanzu plugin sync'.
```

I feel we should improve this UX.
However, since this is a testing scenario, I will leave it for a following up PR.