### PR TITLE
Build bin/builder each time the target is invoked

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,13 +126,9 @@ build-cli-%: ##Build the Tanzu Core CLI for a platform
 ## Plugins-specific
 ## --------------------------------------
 
-BUILDER := $(ROOT_DIR)/bin/builder
-BUILDER_SRC := $(shell find cmd/plugin/builder -type f -print)
-$(BUILDER): $(BUILDER_SRC)
-	cd cmd/plugin/builder && $(GO) build -o $(BUILDER) .
-
 .PHONY: prepare-builder
-prepare-builder: $(BUILDER) ## Build Tanzu CLI builder plugin
+prepare-builder: ## Build Tanzu CLI builder plugin
+	cd cmd/plugin/builder && $(GO) build -o $(ROOT_DIR)/bin/builder .
 
 ## --------------------------------------
 ## OS Packages


### PR DESCRIPTION
### What this PR does / why we need it

Rebuild `bin/builder` each time the `make prepare-builder` target is invoked.
Since the builder plugin depends on CLI code it is difficult to find all the dependency to optimize the Makefile.  We could instead look for any change in any file under tanzu-cli, but at the speed the builder is built, I figure we might as well rebuild it each time.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #260

### Describe testing done for PR

Notice that the `bin/builder` binary is built each time I call the make target even if nothing has changed.
```
$ make prepare-builder
cd cmd/plugin/builder && go build -o /Users/kmarc/git/tanzu-cli/bin/builder .
$ make prepare-builder
cd cmd/plugin/builder && go build -o /Users/kmarc/git/tanzu-cli/bin/builder .
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
