### PR TITLE
Remove mention of filter for search

### DIFF
--- a/pkg/command/plugin_search.go
+++ b/pkg/command/plugin_search.go
@@ -24,25 +24,18 @@ var (
 )
 
 const searchLongDesc = `Search provides the ability to search for plugins that can be installed.
-Without an argument, the command lists all plugins currently available.
-The search command can also be used with a keyword filter to filter the
-list of available plugins. If the filter is flanked with slashes, the
-filter will be treated as a regex.
+The command lists all plugins currently available for installation.
+The search command also provides flags to limit the scope of the search.
 `
 
 func newSearchPluginCmd() *cobra.Command {
 	var searchCmd = &cobra.Command{
-		Use:               "search [keyword|/regex/]",
-		Short:             "Search for a keyword or regex in the list of available plugins",
+		Use:               "search",
+		Short:             "Search for available plugins",
 		Long:              searchLongDesc,
-		Args:              cobra.MaximumNArgs(1),
+		Args:              cobra.MaximumNArgs(0),
 		ValidArgsFunction: cobra.NoFileCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO(khouzam): Implement the filter arg
-			if len(args) == 1 {
-				return fmt.Errorf("the filter argument is not yet implemented")
-			}
-
 			if !configtypes.IsValidTarget(targetStr, true, true) {
 				return errors.New("invalid target specified. Please specify correct value of `--target` or `-t` flag from 'global/kubernetes/k8s/mission-control/tmc'")
 			}
@@ -85,7 +78,7 @@ func newSearchPluginCmd() *cobra.Command {
 	f.StringVarP(&pluginName, "name", "n", "", "limit the search to plugins with the specified name")
 	f.StringVarP(&outputFormat, "output", "o", "", "output format (yaml|json|table)")
 	f.StringVarP(&local, "local", "l", "", "path to local plugin source")
-	f.StringVarP(&targetStr, "target", "t", "", "list plugins for the specified target (kubernetes[k8s]/mission-control[tmc])")
+	f.StringVarP(&targetStr, "target", "t", "", "limit the search to plugins of the specified target (kubernetes[k8s]/mission-control[tmc]/global)")
 
 	searchCmd.MarkFlagsMutuallyExclusive("local", "name")
 	searchCmd.MarkFlagsMutuallyExclusive("local", "target")


### PR DESCRIPTION
### What this PR does / why we need it

We have decided postpone the implementation of the filter for `tanzu plugin search`.
This PR adjusts the `tanzu plugin search` command to remove any mention of the filtering argument.

The reasoning:
- We already support filtering on name and target using the `--target` and/or `--name` flags
- The user can just as easily use `grep`: `tanzu plugin search | grep cluster`
- The implementation and UX turned out to be difficult and need more thought:
    - if we want to use the sqlite DB to search for things, we run into problems such as:
        - say the users does `tanzu plugin search mission-control`, they probably expect to see plugins applicable to mission-control.  The problem is that in the sqlite database we don't use the string "mission-control" but use "tmc" instead, so a DB query would not find anything
        - so instead of querying the database, we may prefer to filter the visible output of `tanzu plugin search` which would then not surprise the user, but that amounts to doing a `grep`
    - if we start supporting "tags" or "keywords" when publishing plugins, then a search would take a slightly different meaning and needs to be defined in more detail

This can be revisited as an enhancement in the future.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

```
$ tz plugin search -h
Search provides the ability to search for plugins that can be installed.
The command lists all plugins currently available for installation.
The search command also provides flags to limit the scope of the search.

Usage:
tanzu plugin search [keyword|/regex/] [flags]

Flags:
  -h, --help            help for search
  -l, --local string    path to local plugin source
  -n, --name string     limit the search to plugins with the specified name
  -o, --output string   output format (yaml|json|table)
      --show-details    show the details of the specified plugin, including all available versions
  -t, --target string   limit the search to plugins of the specified target (kubernetes[k8s]/mission-control[tmc]/global)
$ tz plugin search myfilter
[x] : accepts at most 0 arg(s), received 1
$ tz plugin search
  NAME                DESCRIPTION                                                        TARGET           LATEST
  builder             Build Tanzu components                                             global           v0.90.0-alpha.1
  isolated-cluster    Prepopulating images/bundle for internet-restricted environments   global           v0.28.1
  pinniped-auth       Pinniped authentication operations (usually not directly invoked)  global           v0.28.1
  test                Test the CLI                                                       global           v0.90.0-alpha.1
  accelerator         Manage accelerators in a Kubernetes cluster                        kubernetes       v1.4.0
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
