### PR TITLE
Fix vcs status error by allowing passing in build go flags to plugin builder

### DIFF
--- a/cmd/plugin/builder/plugin.go
+++ b/cmd/plugin/builder/plugin.go
@@ -37,6 +37,7 @@ type pluginBuildFlags struct {
 	Version                    string
 	Match                      string
 	PluginScopeAssociationFile string
+	GoFlags                    string
 }
 
 type pluginBuildPackageFlags struct {
@@ -78,6 +79,7 @@ func newPluginBuildCmd() *cobra.Command {
 				Version:                    pbFlags.Version,
 				PluginScopeAssociationFile: pbFlags.PluginScopeAssociationFile,
 				GroupByOSArch:              true,
+				GoFlags:                    pbFlags.GoFlags,
 			}
 
 			return command.Compile(compileArgs)
@@ -91,6 +93,7 @@ func newPluginBuildCmd() *cobra.Command {
 	pluginBuildCmd.Flags().StringVarP(&pbFlags.Version, "version", "v", "", "version of the plugins")
 	pluginBuildCmd.Flags().StringVarP(&pbFlags.Match, "match", "", "*", "match a plugin name to build, supports globbing")
 	pluginBuildCmd.Flags().StringVarP(&pbFlags.PluginScopeAssociationFile, "plugin-scope-association-file", "", "", "file specifying plugin scope association")
+	pluginBuildCmd.Flags().StringVarP(&pbFlags.GoFlags, "goflags", "", "", "goflags to set on build")
 
 	_ = pluginBuildCmd.MarkFlagRequired("version")
 

--- a/cmd/plugin/builder/template/plugintemplates/plugin-tooling.mk.tmpl
+++ b/cmd/plugin/builder/template/plugintemplates/plugin-tooling.mk.tmpl
@@ -20,6 +20,7 @@ endif
 PLUGIN_LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=$(PLUGIN_BUILD_DATE)'
 PLUGIN_LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=$(PLUGIN_BUILD_SHA)'
 PLUGIN_LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=$(PLUGIN_BUILD_VERSION)'
+PLUGIN_GO_FLAGS ?=
 
 # Add supported OS-ARCHITECTURE combinations here
 PLUGIN_BUILD_OS_ARCH ?= linux-amd64 windows-amd64 darwin-amd64
@@ -82,6 +83,7 @@ plugin-build-%:
 		--binary-artifacts $(PLUGIN_BINARY_ARTIFACTS_DIR) \
 		--version $(PLUGIN_BUILD_VERSION) \
 		--ldflags "$(PLUGIN_LD_FLAGS)" \
+		--goflags "$(PLUGIN_GO_FLAGS)" \
 		--os-arch $(OS)_$(ARCH) \
 		--match "$(PLUGIN_NAME)" \
 		--plugin-scope-association-file $(PLUGIN_SCOPE_ASSOCIATION_FILE)

--- a/plugin-tooling.mk
+++ b/plugin-tooling.mk
@@ -24,6 +24,7 @@ endif
 PLUGIN_LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=$(PLUGIN_BUILD_DATE)'
 PLUGIN_LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=$(PLUGIN_BUILD_SHA)'
 PLUGIN_LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=$(PLUGIN_BUILD_VERSION)'
+PLUGIN_GO_FLAGS ?=
 
 # Add supported OS-ARCHITECTURE combinations here
 PLUGIN_BUILD_OS_ARCH ?= linux-amd64 windows-amd64 darwin-amd64
@@ -84,6 +85,7 @@ plugin-build-%:
 		--binary-artifacts $(PLUGIN_BINARY_ARTIFACTS_DIR) \
 		--version $(PLUGIN_BUILD_VERSION) \
 		--ldflags "$(PLUGIN_LD_FLAGS)" \
+		--goflags "$(PLUGIN_GO_FLAGS)" \
 		--os-arch $(OS)_$(ARCH) \
 		--match "$(PLUGIN_NAME)" \
 		--plugin-scope-association-file $(PLUGIN_SCOPE_ASSOCIATION_FILE)


### PR DESCRIPTION
### What this PR does / why we need it

This PR allows for the passing of Go flags to the `go build` command during the building of plugins using Tanzu Plugin Builder.

The reason I need it is because it will allow me to prevent a VCS status error that happens in our downstream build environment: 

```
building local repository at ./artifacts/plugins, v0.1.0, [all]
ðŸ¦ - building plugin at path "cmd/plugin/feature"
ðŸ¦ - running godep path "cmd/plugin/feature"
ðŸ¦$ /usr/local/go/bin/go mod download
ðŸ¦ - $ /usr/local/go/bin/go build -o /workspace/artifacts/plugins/linux/arm64/kubernetes/feature/v0.1.0/tanzu-feature-linux_arm64 -ldflags  -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.1.0' -tags  ./.
ðŸ¦ - error: exit status 1
ðŸ¦ - output: error obtaining VCS status: exit status 128
 	Use -buildvcs=false to disable VCS stamping.
ðŸ¦ - error compiling plugin feature 
```

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #263 

### Describe testing done for PR

I ran `builder plugin build` with and without the `--goflags '-buildvcs=false'` and the plugins built as intended. 

I also tested passing in the argument in our downstream build environment, and it worked without giving the vcs status error.

To test the Makefile changes and multiple go flags, I have also successfully run the commands,
- make plugin-build
- make plugin-build PLUGIN_GO_FLAGS="-buildvcs=false"
- make plugin-build PLUGIN_GO_FLAGS="-buildvcs=false -a"

Here is the output from running the above commands: [2023-05-09_make-plugin-build-log.txt](https://github.com/vmware-tanzu/tanzu-cli/files/11435225/2023-05-09_make-plugin-build-log.txt)


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Allow for passing go flags when building plugins.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
