### PR TITLE
Add --name to plugin group search

### DIFF
--- a/pkg/airgapped/plugin_bundle_download.go
+++ b/pkg/airgapped/plugin_bundle_download.go
@@ -136,7 +136,7 @@ func (o *DownloadPluginBundleOptions) getSelectedPluginInfo() ([]*plugininventor
 
 func (o *DownloadPluginBundleOptions) getAllPluginGroupsAndPluginEntriesFromPluginGroupName(pgName string, pi plugininventory.PluginInventory) ([]*plugininventory.PluginGroup, []*plugininventory.PluginInventoryEntry, error) {
 	pgi := plugininventory.PluginGroupIdentifierFromID(pgName)
-	if pgi.Name == "" || pgi.Vendor == "" || pgi.Publisher == "" {
+	if pgi == nil {
 		return nil, nil, errors.Errorf("incorrect plugin group %q specified", pgName)
 	}
 	pgFilter := plugininventory.PluginGroupFilter{

--- a/pkg/command/plugin_group.go
+++ b/pkg/command/plugin_group.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/spf13/cobra"
 
@@ -12,7 +13,13 @@ import (
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/discovery"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/plugininventory"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/pluginmanager"
+)
+
+var (
+	groupID string
 )
 
 func newPluginGroupCmd() *cobra.Command {
@@ -36,42 +43,58 @@ func newSearchCmd() *cobra.Command {
 		Short: "Search for available plugin groups",
 		Long:  "Search from the list of available plugin groups.  A plugin group provides a list of plugin name/version combinations which can be installed in one step.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			output := component.NewOutputWriter(cmd.OutOrStdout(), outputFormat, "group")
-
-			groupsByDiscovery, err := pluginmanager.DiscoverPluginGroups()
+			var criteria *discovery.GroupDiscoveryCriteria
+			if groupID != "" {
+				groupIdentifier := plugininventory.PluginGroupIdentifierFromID(groupID)
+				criteria = &discovery.GroupDiscoveryCriteria{
+					Vendor:    groupIdentifier.Vendor,
+					Publisher: groupIdentifier.Publisher,
+					Name:      groupIdentifier.Name,
+				}
+			}
+			groupsByDiscovery, err := pluginmanager.DiscoverPluginGroups(criteria)
 			if err != nil {
 				return err
 			}
 
-			discoveriesByGroupID := make(map[string][]string)
-			for _, discAndGroups := range groupsByDiscovery {
-				for _, group := range discAndGroups.Groups {
-					id := fmt.Sprintf("%s-%s/%s", group.Vendor, group.Publisher, group.Name)
-					output.AddRow(id)
-					discoveriesByGroupID[id] = append(discoveriesByGroupID[id], discAndGroups.Source)
-				}
-			}
+			displayGroupsFound(groupsByDiscovery, cmd.OutOrStdout())
 
-			// Check if one or more groups was discovered in different discoveries.
-			var duplicateMsg string
-			for id, discoveries := range discoveriesByGroupID {
-				if len(discoveries) > 1 {
-					// This group was found in multiple discoveries.
-					if duplicateMsg != "" {
-						duplicateMsg = fmt.Sprintf("%s, ", duplicateMsg)
-					}
-					duplicateMsg = fmt.Sprintf("%s%s was found in more than one source: %v", duplicateMsg, id, discoveries)
-				}
-			}
-			if duplicateMsg != "" {
-				log.Warning(duplicateMsg)
-			}
-			output.Render()
 			return nil
 		},
 	}
 
-	searchCmd.Flags().StringVarP(&outputFormat, "output", "o", "", "output format (yaml|json|table)")
+	f := searchCmd.Flags()
+	f.StringVarP(&groupID, "name", "n", "", "limit the search to the plugin group with the specified name")
+	f.StringVarP(&outputFormat, "output", "o", "", "output format (yaml|json|table)")
 
 	return searchCmd
+}
+
+func displayGroupsFound(groupsByDiscovery []*discovery.DiscoveredPluginGroups, writer io.Writer) {
+	output := component.NewOutputWriter(writer, outputFormat, "group")
+
+	discoveriesByGroupID := make(map[string][]string)
+	for _, discAndGroups := range groupsByDiscovery {
+		for _, group := range discAndGroups.Groups {
+			id := plugininventory.PluginGroupToID(group)
+			output.AddRow(id)
+			discoveriesByGroupID[id] = append(discoveriesByGroupID[id], discAndGroups.Source)
+		}
+	}
+
+	// Check if one or more groups was discovered in different discoveries.
+	var duplicateMsg string
+	for id, discoveries := range discoveriesByGroupID {
+		if len(discoveries) > 1 {
+			// This group was found in multiple discoveries.
+			if duplicateMsg != "" {
+				duplicateMsg = fmt.Sprintf("%s, ", duplicateMsg)
+			}
+			duplicateMsg = fmt.Sprintf("%s%s was found in more than one source: %v", duplicateMsg, id, discoveries)
+		}
+	}
+	if duplicateMsg != "" {
+		log.Warning(duplicateMsg)
+	}
+	output.Render()
 }

--- a/pkg/command/plugin_group.go
+++ b/pkg/command/plugin_group.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/component"
@@ -46,6 +47,10 @@ func newSearchCmd() *cobra.Command {
 			var criteria *discovery.GroupDiscoveryCriteria
 			if groupID != "" {
 				groupIdentifier := plugininventory.PluginGroupIdentifierFromID(groupID)
+				if groupIdentifier == nil {
+					return errors.Errorf("incorrect plugin group %q specified", groupID)
+				}
+
 				criteria = &discovery.GroupDiscoveryCriteria{
 					Vendor:    groupIdentifier.Vendor,
 					Publisher: groupIdentifier.Publisher,

--- a/pkg/discovery/interface.go
+++ b/pkg/discovery/interface.go
@@ -28,6 +28,9 @@ type Discovery interface {
 }
 
 type GroupDiscovery interface {
+	// Name of the discovery
+	Name() string
+
 	// GetAllGroups returns all plugin groups defined in the discovery
 	GetAllGroups() ([]*plugininventory.PluginGroup, error)
 }
@@ -47,6 +50,20 @@ type PluginDiscoveryCriteria struct {
 	Arch string
 }
 
+// GroupDiscoveryCriteria provides criteria to look for
+// plugin groups in a discovery.
+type GroupDiscoveryCriteria struct {
+	// Vendor of the group
+	Vendor string
+	// Publisher of the group
+	Publisher string
+	// Name of the group
+	Name string
+	// Version is the version for the plugin
+	// TODO(khouzam): add when we support group versions
+	// Version string
+}
+
 // CreateDiscoveryFromV1alpha1 creates discovery interface from v1alpha1 API
 func CreateDiscoveryFromV1alpha1(pd configtypes.PluginDiscovery, criteria *PluginDiscoveryCriteria) (Discovery, error) {
 	switch {
@@ -61,4 +78,11 @@ func CreateDiscoveryFromV1alpha1(pd configtypes.PluginDiscovery, criteria *Plugi
 		return NewRESTDiscovery(pd.REST.Name, pd.REST.Endpoint, pd.REST.BasePath), nil
 	}
 	return nil, errors.New("unknown plugin discovery source")
+}
+
+func CreateGroupDiscovery(pd configtypes.PluginDiscovery, criteria *GroupDiscoveryCriteria) (GroupDiscovery, error) {
+	if pd.OCI != nil {
+		return NewOCIGroupDiscovery(pd.OCI.Name, pd.OCI.Image, criteria), nil
+	}
+	return nil, errors.New("unknown group discovery source")
 }

--- a/pkg/plugininventory/plugin_inventory.go
+++ b/pkg/plugininventory/plugin_inventory.go
@@ -142,20 +142,27 @@ func PluginGroupToID(pg *PluginGroup) string {
 	return fmt.Sprintf("%s-%s/%s", pg.Vendor, pg.Publisher, pg.Name)
 }
 
+// PluginGroupIdentifierFromID splits 'id' into 'vendor'-'publisher'/'name'.
+// Returns nil if 'id' is not of the expected format.
 func PluginGroupIdentifierFromID(id string) *PluginGroupIdentifier {
 	pg := &PluginGroupIdentifier{}
 	arr := strings.Split(id, "/")
 	if len(arr) != 2 {
-		return pg
+		return nil
 	}
 	pg.Name = arr[1]
 
 	arr1 := strings.Split(arr[0], "-")
 	if len(arr1) != 2 {
-		return pg
+		return nil
 	}
 	pg.Vendor = arr1[0]
 	pg.Publisher = arr1[1]
+
+	if pg.Name == "" || pg.Vendor == "" || pg.Publisher == "" {
+		// This can happen if the id is something like `vmware-/default` or `vmware-tkg/`
+		return nil
+	}
 	return pg
 }
 

--- a/pkg/pluginmanager/manager.go
+++ b/pkg/pluginmanager/manager.go
@@ -140,6 +140,9 @@ func discoverSpecificPluginGroups(pd []configtypes.PluginDiscovery, criteria *di
 // discoverPluginGroup returns the one matching plugin group found in the discoveries
 func discoverPluginGroup(pd []configtypes.PluginDiscovery, groupID string) (*plugininventory.PluginGroup, error) {
 	groupIdentifier := plugininventory.PluginGroupIdentifierFromID(groupID)
+	if groupIdentifier == nil {
+		return nil, fmt.Errorf("could not find group '%s'", groupID)
+	}
 	groupsByDiscovery, err := discoverSpecificPluginGroups(pd, &discovery.GroupDiscoveryCriteria{
 		Vendor:    groupIdentifier.Vendor,
 		Publisher: groupIdentifier.Publisher,

--- a/pkg/pluginmanager/manager_test.go
+++ b/pkg/pluginmanager/manager_test.go
@@ -324,7 +324,7 @@ func Test_InstallPluginFromGroup(t *testing.T) {
 	groupID := "vmware-tkg/v2.1.0"
 	err := InstallPluginsFromGroup("cluster", groupID)
 	assertions.NotNil(err)
-	assertions.Contains(err.Error(), fmt.Sprintf("could not find group '%s'", groupID))
+	assertions.Contains(err.Error(), "unable to create group discovery: unknown group discovery source")
 }
 
 func Test_DiscoverPluginGroups(t *testing.T) {
@@ -336,9 +336,9 @@ func Test_DiscoverPluginGroups(t *testing.T) {
 
 	// A local discovery currently does not support groups, but we can
 	// at least do negative testing
-	groups, err := DiscoverPluginGroups()
-	assertions.Nil(err)
-	assertions.Equal(0, len(groups))
+	_, err := DiscoverPluginGroups(nil)
+	assertions.NotNil(err)
+	assertions.Contains(err.Error(), "unable to create group discovery: unknown group discovery source")
 }
 
 func Test_AvailablePlugins(t *testing.T) {

--- a/pkg/pluginmanager/manager_test.go
+++ b/pkg/pluginmanager/manager_test.go
@@ -325,6 +325,32 @@ func Test_InstallPluginFromGroup(t *testing.T) {
 	err := InstallPluginsFromGroup("cluster", groupID)
 	assertions.NotNil(err)
 	assertions.Contains(err.Error(), "unable to create group discovery: unknown group discovery source")
+
+	// make sure a poorly formatted group is properly handled
+	groupID = "invalid"
+	err = InstallPluginsFromGroup("cluster", groupID)
+	assertions.NotNil(err)
+	assertions.Contains(err.Error(), "could not find group")
+
+	groupID = "invalid/withslash"
+	err = InstallPluginsFromGroup("cluster", groupID)
+	assertions.NotNil(err)
+	assertions.Contains(err.Error(), "could not find group")
+
+	groupID = "vendor-publisher/"
+	err = InstallPluginsFromGroup("cluster", groupID)
+	assertions.NotNil(err)
+	assertions.Contains(err.Error(), "could not find group")
+
+	groupID = "vendor-/name"
+	err = InstallPluginsFromGroup("cluster", groupID)
+	assertions.NotNil(err)
+	assertions.Contains(err.Error(), "could not find group")
+
+	groupID = "-publisher/name"
+	err = InstallPluginsFromGroup("cluster", groupID)
+	assertions.NotNil(err)
+	assertions.Contains(err.Error(), "could not find group")
 }
 
 func Test_DiscoverPluginGroups(t *testing.T) {


### PR DESCRIPTION
### What this PR does / why we need it

This commit allows filtering by name for the "tanzu plugin search" command. 
```
$ tz plugin group search -n vmware-tkg/v0.0.1
  GROUP
  vmware-tkg/v0.0.1
```
This change is not very useful for users.  I'm submitting it as a preparation for supporting plugin group versions and descriptions.

The real point of this change is to improve the plugin group discovery mechanism to have an explicit GroupDiscovery which can be created with a new type `GroupCriteria`.  This allows to filter the discovered groups. This approach is the same as what we do for plugin discovery.


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

```
# Reset the config
$ rm ~/.config/tanzu/config*
$ tz ceip-participation set false
$ tz plugin clean
[ok] successfully cleaned up all plugins

# Point to a discovery with groups
$ tz plugin source update default -u localhost:9876/tanzu-cli/plugins/central:small
[ok] updated discovery source default
$ tz config set env.TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST localhost:9876/tanzu-cli/plugins/central:small
$ make start-test-central-repo
[...]

$ tz plugin group search
[i] Reading plugin inventory for "localhost:9876/tanzu-cli/plugins/central:small", this will take a few seconds.
[!] Skipping the plugins discovery image signature verification for "localhost:9876/tanzu-cli/plugins/central:small"

  GROUP
  vmware-tkg/v0.0.1
  vmware-tkg/v9.9.9
  vmware-tmc/v0.0.1
  vmware-tmc/v9.9.9
$ tz plugin group search -o yaml
- group: vmware-tkg/v0.0.1
- group: vmware-tkg/v9.9.9
- group: vmware-tmc/v0.0.1
- group: vmware-tmc/v9.9.9

# Notice the new --name flag
$ tz plugin group search -h
Search from the list of available plugin groups.  A plugin group provides a list of plugin name/version combinations which can be installed in one step.

Usage:
tanzu plugin group search [flags]

Flags:
  -h, --help            help for search
  -n, --name string     limit the search to the plugin group with the specified name
  -o, --output string   output format (yaml|json|table)

$ tz plugin group search -n vmware-tkg/v0.0.1
  GROUP
  vmware-tkg/v0.0.1
$ tz plugin group search -n vmware-tkg/v0.0.1 -o yaml
- group: vmware-tkg/v0.0.1

# Installing a plugin
$ tz plugin install --group vmware-tkg/v0.0.1
[i] Installing plugin 'cluster:v0.0.1' with target 'kubernetes'
[i] Installing plugin 'feature:v0.0.1' with target 'kubernetes'
[i] Installing plugin 'kubernetes-release:v0.0.1' with target 'kubernetes'
[i] Installing plugin 'management-cluster:v0.0.1' with target 'kubernetes'
[i] Installing plugin 'package:v0.0.1' with target 'kubernetes'
[i] Installing plugin 'secret:v0.0.1' with target 'kubernetes'
[i] Installing plugin 'telemetry:v0.0.1' with target 'kubernetes'
[ok] successfully installed all plugins from group 'vmware-tkg/v0.0.1'
$ tz plugin list
Standalone Plugins
  NAME                DESCRIPTION                       TARGET      VERSION  STATUS
  cluster             cluster functionality             kubernetes  v0.0.1   installed
  feature             feature functionality             kubernetes  v0.0.1   installed
  kubernetes-release  kubernetes-release functionality  kubernetes  v0.0.1   installed
  management-cluster  management-cluster functionality  kubernetes  v0.0.1   installed
  package             package functionality             kubernetes  v0.0.1   installed
  secret              secret functionality              kubernetes  v0.0.1   installed
  telemetry           telemetry functionality           kubernetes  v0.0.1   installed

# Add a second discovery with the same groups to test the duplication message.
# Note that when we support group versions this duplication message will be removed.
# It is just being kept now to reduce code churn.
$ tz config set env.TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY localhost:9876/tanzu-cli/plugins/central:large
$ tz config set env.TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST localhost:9876/tanzu-cli/plugins/central:small,localhost:9876/tanzu-cli/plugins/central:large

$ tz plugin group search
[i] Reading plugin inventory for "localhost:9876/tanzu-cli/plugins/central:large", this will take a few seconds.
[!] Skipping the plugins discovery image signature verification for "localhost:9876/tanzu-cli/plugins/central:large"

[!] vmware-tmc/v9.9.9 was found in more than one source: [default test_0], vmware-tkg/v0.0.1 was found in more than one source: [default test_0], vmware-tkg/v9.9.9 was found in more than one source: [default test_0], vmware-tmc/v0.0.1 was found in more than one source: [default test_0]
  GROUP
  vmware-tkg/v0.0.1
  vmware-tkg/v9.9.9
  vmware-tmc/v0.0.1
  vmware-tmc/v9.9.9
  vmware-tkg/v0.0.1
  vmware-tkg/v9.9.9
  vmware-tmc/v0.0.1
  vmware-tmc/v9.9.9
$ tz plugin group search -o yaml
[!] vmware-tmc/v9.9.9 was found in more than one source: [default test_0], vmware-tkg/v0.0.1 was found in more than one source: [default test_0], vmware-tkg/v9.9.9 was found in more than one source: [default test_0], vmware-tmc/v0.0.1 was found in more than one source: [default test_0]
- group: vmware-tkg/v0.0.1
- group: vmware-tkg/v9.9.9
- group: vmware-tmc/v0.0.1
- group: vmware-tmc/v9.9.9
- group: vmware-tkg/v0.0.1
- group: vmware-tkg/v9.9.9
- group: vmware-tmc/v0.0.1
- group: vmware-tmc/v9.9.9

$ tz plugin install --group vmware-tmc/v9.9.9
[!] group 'vmware-tmc/v9.9.9' was found in multiple discoveries: [default test_0].  Using the first one.
[i] Installing plugin 'account:v9.9.9' with target 'mission-control'
[i] Installing plugin 'apply:v9.9.9' with target 'mission-control'
[i] Installing plugin 'audit:v9.9.9' with target 'mission-control'
[i] Installing plugin 'cluster:v9.9.9' with target 'mission-control'
[i] Installing plugin 'clustergroup:v9.9.9' with target 'mission-control'
[i] Installing plugin 'continuousdelivery:v9.9.9' with target 'mission-control'
[i] Installing plugin 'data-protection:v9.9.9' with target 'mission-control'
[i] Installing plugin 'ekscluster:v9.9.9' with target 'mission-control'
[i] Installing plugin 'events:v9.9.9' with target 'mission-control'
[i] Installing plugin 'helm:v9.9.9' with target 'mission-control'
[i] Installing plugin 'iam:v9.9.9' with target 'mission-control'
[i] Installing plugin 'inspection:v9.9.9' with target 'mission-control'
[i] Installing plugin 'integration:v9.9.9' with target 'mission-control'
[i] Installing plugin 'management-cluster:v9.9.9' with target 'mission-control'
[i] Installing plugin 'policy:v9.9.9' with target 'mission-control'
[i] Installing plugin 'secret:v9.9.9' with target 'mission-control'
[i] Installing plugin 'tanzupackage:v9.9.9' with target 'mission-control'
[i] Installing plugin 'workspace:v9.9.9' with target 'mission-control'
[ok] successfully installed all plugins from group 'vmware-tmc/v9.9.9'
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The `tanzu plugin group search` command now accepts a `--name` flag allowing to filter the search.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
