### PR TITLE
TMC endpoint validation for context create

### DIFF
--- a/pkg/pluginmanager/default_discoveries.go
+++ b/pkg/pluginmanager/default_discoveries.go
@@ -13,6 +13,8 @@ import (
 )
 
 const True = "true"
+const HTTPS = "https"
+const HTTP = "http"
 
 func defaultDiscoverySourceBasedOnServer(server *configtypes.Server) []configtypes.PluginDiscovery { // nolint:staticcheck // Deprecated
 	var defaultDiscoveries []configtypes.PluginDiscovery
@@ -65,9 +67,13 @@ func appendURLScheme(endpoint string) string {
 	if os.Getenv(constants.E2ETestEnvironment) == True {
 		return endpoint
 	}
-	e := strings.Split(endpoint, ":")[0]
-	if !strings.Contains(e, "https") {
-		return fmt.Sprintf("https://%s", e)
+	urlSec := strings.Split(endpoint, ":")
+	// url does not have any scheme
+	if len(urlSec) == 1 {
+		return fmt.Sprintf("%s://%s", HTTPS, urlSec[0])
+	} else if urlSec[0] == HTTPS || urlSec[0] == HTTP { // url starts with http/https scheme, do nothing
+		return endpoint
+	} else { // endpoint does not start http/https
+		return fmt.Sprintf("%s://%s", HTTPS, endpoint)
 	}
-	return e
 }

--- a/pkg/pluginmanager/default_discoveries_test.go
+++ b/pkg/pluginmanager/default_discoveries_test.go
@@ -106,7 +106,7 @@ metadata:
 	assert.Nil(t, err)
 	pdsTMC := append(context.DiscoverySources, defaultDiscoverySourceBasedOnContext(context)...)
 	assert.Equal(t, 1, len(pdsTMC))
-	assert.Equal(t, pdsTMC[0].REST.Endpoint, "https://test.cloud.vmware.com")
+	assert.Equal(t, pdsTMC[0].REST.Endpoint, "https://test.cloud.vmware.com:443")
 	assert.Equal(t, pdsTMC[0].REST.BasePath, "v1alpha1/system/binaries/plugins")
 	assert.Equal(t, pdsTMC[0].REST.Name, "default-tmc-test")
 
@@ -117,4 +117,57 @@ metadata:
 	assert.Equal(t, pdsK8s[0].Kubernetes.Name, "default-mgmt")
 	assert.Equal(t, pdsK8s[0].Kubernetes.Path, "config")
 	assert.Equal(t, pdsK8s[0].Kubernetes.Context, "mgmt-admin@mgmt")
+}
+
+func Test_appendURLScheme(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		output   string
+	}{
+		{
+			name:     "url does not start with any scheme and not port",
+			endpoint: "tmc.cloud.vmware.com",
+			output:   "https://tmc.cloud.vmware.com",
+		},
+		{
+			name:     "url does not start with any scheme, but ends with https port",
+			endpoint: "tmc.cloud.vmware.com:443",
+			output:   "https://tmc.cloud.vmware.com:443",
+		},
+
+		{
+			name:     "url does not start with any scheme, but ends with non-default https port",
+			endpoint: "tmc.cloud.vmware.com:8443",
+			output:   "https://tmc.cloud.vmware.com:8443",
+		},
+		{
+			name:     "url does start with http, but ends with https port",
+			endpoint: "http://tmc.cloud.vmware.com:443",
+			output:   "http://tmc.cloud.vmware.com:443",
+		},
+
+		{
+			name:     "url does start with https, but ends with https port",
+			endpoint: "https://tmc.cloud.vmware.com:443",
+			output:   "https://tmc.cloud.vmware.com:443",
+		},
+
+		{
+			name:     "url start with http, but ends with non-default http/https port",
+			endpoint: "http://tmc.cloud.vmware.com:9443",
+			output:   "http://tmc.cloud.vmware.com:9443",
+		},
+		{
+			name:     "url start with http, but ends with default http port",
+			endpoint: "http://tmc.cloud.vmware.com:80",
+			output:   "http://tmc.cloud.vmware.com:80",
+		},
+	}
+	for _, spec := range tests {
+		t.Run(spec.name, func(t *testing.T) {
+			output := appendURLScheme(spec.endpoint)
+			assert.Equal(t, output, spec.output)
+		})
+	}
 }


### PR DESCRIPTION
### What this PR does / why we need it
This pull request fixes a bug in the TMC plugin sync use case during the context create flow. Before this fix, the CLI assumed that the user always provided a TMC host name as the TMC endpoint URL. The CLI took the TMC endpoint URL and added the HTTPS scheme and plugin base path to discovery plugins. However, this caused a bug in use cases where the input TMC URL had an HTTP/HTTPS scheme or URL had a port number.

This pull request fixes such use cases. The fix validates the TMC endpoint URL and adds the HTTPS scheme only if needed. The following are the use cases:
```
Use case 1:
Input: URL has only hostname.
Output: Append HTTPS scheme, e.g., unstable.tmc-dev.cloud.vmware.com -> https://unstable.tmc-dev.cloud.vmware.com.

Use case 2:
Input: URL has HTTPS scheme.
Output: Do nothing, e.g., https://unstable.tmc-dev.cloud.vmware.com -> https://unstable.tmc-dev.cloud.vmware.com.

Use case 3:
Input: URL has HTTP scheme.
Output: Do nothing, e.g., http://unstable.tmc-dev.cloud.vmware.com -> http://unstable.tmc-dev.cloud.vmware.com.

Use case 4:
Input: URL has HTTPS scheme and non-default HTTPS port.
Output: Do nothing, e.g., https://unstable.tmc-dev.cloud.vmware.com:8443 -> https://unstable.tmc-dev.cloud.vmware.com:8443.

Use case 5:
Input: URL has HTTPS scheme and non-default HTTPS port and has an additional base path.
Output: Do nothing, e.g., https://unstable.tmc-dev.cloud.vmware.com:8443/additional/path -> https://unstable.tmc-dev.cloud.vmware.com:8443/additional/path.

Use case 6:
Input: URL has HTTP scheme and non-default HTTP port and additional base path.
Output: Do nothing, e.g., http://unstable.tmc-dev.cloud.vmware.com:8080/additional/path -> http://unstable.tmc-dev.cloud.vmware.com:8080/additional/path.
```

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
```
Use case 1: URL has only hostname:
❯ t context create --name tmc1 --endpoint unstable.tmc-dev.cloud.vmware.com --staging
[i] API token env var is set

[ok] successfully created a TMC context
[i] Checking for required plugins...
[!] unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually


Use case 2: URL has HTTPS scheme:
❯ t context create --name tmc2 --endpoint https://unstable.tmc-dev.cloud.vmware.com --staging
[i] API token env var is set

[ok] successfully created a TMC context
[i] Checking for required plugins...
[!] unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually

Use case 3: URL has HTTP scheme:
❯ t context create --name tmc2 --endpoint http://unstable.tmc-dev.cloud.vmware.com --staging 
[x] : context "tmc2" already exists
❯ t context create --name tmc3 --endpoint http://unstable.tmc-dev.cloud.vmware.com --staging
[i] API token env var is set

[ok] successfully created a TMC context
[i] Checking for required plugins...
[!] unable to list plugin from discovery 'default-tmc3': Get "http://unstable.tmc-dev.cloud.vmware.com/v1alpha1/system/binaries/plugins": context deadline exceeded
[i] All required plugins are already installed and up-to-date

Use case 4: URL has HTTPS scheme and non-default HTTPS port:
❯ t context create --name tmc4 --endpoint https://unstable.tmc-dev.cloud.vmware.com:8443 --staging
[i] API token env var is set

[ok] successfully created a TMC context
[i] Checking for required plugins...
[!] unable to list plugin from discovery 'default-tmc4': Get "https://unstable.tmc-dev.cloud.vmware.com:8443/v1alpha1/system/binaries/plugins": context deadline exceeded
[i] All required plugins are already installed and up-to-date

Use case 5: URL has HTTPS scheme and non-default HTTPS port, and has additional base path:
❯ t context create --name tmc5 --endpoint https://unstable.tmc-dev.cloud.vmware.com:8443/base/path --staging
[i] API token env var is set

[ok] successfully created a TMC context
[i] Checking for required plugins...
[!] unable to list plugin from discovery 'default-tmc5': Get "https://unstable.tmc-dev.cloud.vmware.com:8443/base/path/v1alpha1/system/binaries/plugins": context deadline exceeded
[i] All required plugins are already installed and up-to-date

Use case 6: URL has HTTP scheme and non-default HTTP port, and additional base path:
❯ t context create --name tmc6 --endpoint http://unstable.tmc-dev.cloud.vmware.com:8080/base/path --staging 
[i] API token env var is set

[ok] successfully created a TMC context
[i] Checking for required plugins...
[!] unable to list plugin from discovery 'default-tmc6': Get "http://unstable.tmc-dev.cloud.vmware.com:8080/base/path/v1alpha1/system/binaries/plugins": context deadline exceeded
[i] All required plugins are already installed and up-to-date
❯
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
