### PR TITLE
Sync should throw an error for any error in plugin discovery

### DIFF
--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -142,15 +142,17 @@ func createCtx(_ *cobra.Command, _ []string) (err error) {
 	}
 
 	// Sync all required plugins
-	syncContextPlugins()
+	_ = syncContextPlugins()
 
 	return nil
 }
 
-func syncContextPlugins() {
-	if err := pluginmanager.SyncPlugins(); err != nil {
-		log.Warning("unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually")
+func syncContextPlugins() error {
+	err := pluginmanager.SyncPlugins()
+	if err != nil {
+		log.Warningf("unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually, error: '%v'", err.Error())
 	}
+	return err
 }
 
 func isGlobalContext(endpoint string) bool {
@@ -732,7 +734,7 @@ func useCtx(_ *cobra.Command, args []string) error {
 	}
 
 	// Sync all required plugins
-	syncContextPlugins()
+	_ = syncContextPlugins()
 
 	return nil
 }

--- a/test/e2e/context/tmc/context_tmc_lifecycle_stress_test.go
+++ b/test/e2e/context/tmc/context_tmc_lifecycle_stress_test.go
@@ -39,7 +39,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-lifecycle-stress-
 			By("create tmc context with tmc endpoint")
 			for i := 0; i < maxCtx; i++ {
 				ctxName := prefix + framework.RandomString(5)
-				_, err := tf.ContextCmd.CreateContextWithEndPointStaging(ctxName, clusterInfo.EndPoint)
+				_, _, err := tf.ContextCmd.CreateContextWithEndPointStaging(ctxName, clusterInfo.EndPoint)
 				Expect(err).To(BeNil(), "context should create without any error")
 				Expect(framework.IsContextExists(tf, ctxName)).To(BeTrue(), fmt.Sprintf(ContextShouldExistsAsCreated, ctxName))
 				contextNames = append(contextNames, ctxName)

--- a/test/e2e/context/tmc/context_tmc_lifecycle_test.go
+++ b/test/e2e/context/tmc/context_tmc_lifecycle_test.go
@@ -47,7 +47,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-lifecycle-tmc]", 
 		// Test case: b. Create context for TMC target with TMC cluster URL as endpoint
 		It("create tmc context with endpoint", func() {
 			ctxName := prefix + framework.RandomString(4)
-			_, err := tf.ContextCmd.CreateContextWithEndPointStaging(ctxName, clusterInfo.EndPoint)
+			_, _, err := tf.ContextCmd.CreateContextWithEndPointStaging(ctxName, clusterInfo.EndPoint)
 			Expect(err).To(BeNil(), "context should create without any error")
 			Expect(framework.IsContextExists(tf, ctxName)).To(BeTrue(), fmt.Sprintf(ContextShouldExistsAsCreated, ctxName))
 			contextNames = append(contextNames, ctxName)
@@ -55,7 +55,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-lifecycle-tmc]", 
 		// Test case: c. (negative test) Create context for TMC target with TMC cluster "incorrect" URL as endpoint
 		It("create tmc context with incorrect endpoint", func() {
 			ctxName := prefix + framework.RandomString(4)
-			_, err := tf.ContextCmd.CreateContextWithEndPointStaging(ctxName, framework.RandomString(4))
+			_, _, err := tf.ContextCmd.CreateContextWithEndPointStaging(ctxName, framework.RandomString(4))
 			Expect(err).ToNot(BeNil())
 			Expect(strings.Contains(err.Error(), framework.FailedToCreateContext)).To(BeTrue())
 			Expect(framework.IsContextExists(tf, ctxName)).To(BeFalse(), fmt.Sprintf(ContextShouldNotExists, ctxName))
@@ -65,7 +65,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-lifecycle-tmc]", 
 			err := os.Setenv(framework.TanzuAPIToken, framework.RandomString(4))
 			Expect(err).To(BeNil(), "There should not be any error in setting environment variables.")
 			ctxName := framework.RandomString(4)
-			_, err = tf.ContextCmd.CreateContextWithEndPointStaging(ctxName, clusterInfo.EndPoint)
+			_, _, err = tf.ContextCmd.CreateContextWithEndPointStaging(ctxName, clusterInfo.EndPoint)
 			os.Setenv(framework.TanzuAPIToken, clusterInfo.APIKey)
 			Expect(err).ToNot(BeNil())
 			Expect(strings.Contains(err.Error(), framework.FailedToCreateContext)).To(BeTrue())
@@ -76,7 +76,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-lifecycle-tmc]", 
 		// Test case: e. Create context for TMC target with TMC cluster URL as endpoint, and validate the active context, should be recently create context
 		It("create tmc context with endpoint and check active context", func() {
 			ctxName := prefix + framework.RandomString(4)
-			_, err := tf.ContextCmd.CreateContextWithEndPointStaging(ctxName, clusterInfo.EndPoint)
+			_, _, err := tf.ContextCmd.CreateContextWithEndPointStaging(ctxName, clusterInfo.EndPoint)
 			Expect(err).To(BeNil(), "context should create without any error")
 			Expect(framework.IsContextExists(tf, ctxName)).To(BeTrue(), fmt.Sprintf(ContextShouldExistsAsCreated, ctxName))
 			contextNames = append(contextNames, ctxName)

--- a/test/e2e/framework/context_create_operations.go
+++ b/test/e2e/framework/context_create_operations.go
@@ -15,8 +15,8 @@ import (
 type ContextCreateOps interface {
 	// CreateContextWithEndPoint creates a context with a given endpoint URL
 	CreateContextWithEndPoint(contextName, endpoint string, opts ...E2EOption) error
-	// CreateContextWithEndPointStaging creates a context with a given endpoint URL for staging, returns stdout and error
-	CreateContextWithEndPointStaging(contextName, endpoint string, opts ...E2EOption) (string, error)
+	// CreateContextWithEndPointStaging creates a context with a given endpoint URL for staging, returns stdout, stderr and error
+	CreateContextWithEndPointStaging(contextName, endpoint string, opts ...E2EOption) (string, string, error)
 	// CreateContextWithKubeconfig creates a context with the given kubeconfig file path and a context from the kubeconfig file
 	CreateContextWithKubeconfig(contextName, kubeconfigPath, kubeContext string, opts ...E2EOption) error
 	// CreateContextWithDefaultKubeconfig creates a context with the default kubeconfig file and a given input context name if it exists in the default kubeconfig file
@@ -45,16 +45,16 @@ func (cc *contextCreateOps) CreateContextWithEndPoint(contextName, endpoint stri
 	return err
 }
 
-func (cc *contextCreateOps) CreateContextWithEndPointStaging(contextName, endpoint string, opts ...E2EOption) (string, error) {
+func (cc *contextCreateOps) CreateContextWithEndPointStaging(contextName, endpoint string, opts ...E2EOption) (string, string, error) {
 	createContextCmd := fmt.Sprintf(CreateContextWithEndPointStaging, "%s", endpoint, contextName)
 	out, stdErr, err := cc.cmdExe.TanzuCmdExec(createContextCmd, opts...)
 	log.Infof("out:%s stdErr:%s", out.String(), stdErr.String())
 	if err != nil {
 		log.Info(fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
-		return out.String(), errors.Wrap(err, fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
+		return out.String(), stdErr.String(), errors.Wrap(err, fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
 	}
 	log.Infof(ContextCreated, contextName)
-	return out.String(), err
+	return out.String(), stdErr.String(), err
 }
 
 func (cc *contextCreateOps) CreateContextWithKubeconfig(contextName, kubeconfigPath, kubeContext string, opts ...E2EOption) error {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -135,6 +135,7 @@ const (
 	FailedToConstructJSONNodeFromOutput           = "failed to construct json node from output:'%s'"
 	NoErrorForPluginGroupSearch                   = "should not get any error for plugin group search"
 	NoErrorForPluginSearch                        = "should not get any error for plugin search"
+	UnableToSync                                  = "unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually"
 
 	// config related constants
 	FailedToCreateContext           = "failed to create context"

--- a/test/e2e/framework/framework_helper.go
+++ b/test/e2e/framework/framework_helper.go
@@ -530,3 +530,14 @@ func GetAvailableServers(tf *Framework, serverNames []string) []string {
 func GetTMCClusterInfo() *ClusterInfo {
 	return &ClusterInfo{EndPoint: os.Getenv(TanzuCliTmcUnstableURL), APIKey: os.Getenv(TanzuAPIToken)}
 }
+
+// CleanConfigFiles deletes the tanzu CLI config files and initializes the tanzu CLI config
+func CleanConfigFiles(tf *Framework) error {
+	err := tf.Config.DeleteCLIConfigurationFiles()
+	if err != nil {
+		return err
+	}
+	// call init
+	err = tf.Config.ConfigInit()
+	return err
+}

--- a/test/e2e/plugin_sync/k8s/plugin_sync_k8s_lifecycle_suite_test.go
+++ b/test/e2e/plugin_sync/k8s/plugin_sync_k8s_lifecycle_suite_test.go
@@ -39,12 +39,15 @@ const numberOfPluginsToInstall = 3
 var _ = BeforeSuite(func() {
 	tf = framework.NewFramework()
 
+	err := framework.CleanConfigFiles(tf)
+	Expect(err).To(BeNil())
+
 	// check E2E test central repo URL (TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL)
 	e2eTestLocalCentralRepoURL = os.Getenv(framework.TanzuCliE2ETestLocalCentralRepositoryURL)
 	Expect(e2eTestLocalCentralRepoURL).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with local central repository URL", framework.TanzuCliE2ETestLocalCentralRepositoryURL))
 
 	// set up the test central repo
-	_, err := tf.PluginCmd.UpdatePluginDiscoverySource(&framework.DiscoveryOptions{Name: "default", SourceType: framework.SourceType, URI: e2eTestLocalCentralRepoURL})
+	_, err = tf.PluginCmd.UpdatePluginDiscoverySource(&framework.DiscoveryOptions{Name: "default", SourceType: framework.SourceType, URI: e2eTestLocalCentralRepoURL})
 	Expect(err).To(BeNil(), "should not get any error for plugin source update")
 
 	e2eTestLocalCentralRepoPluginHost = os.Getenv(framework.TanzuCliE2ETestLocalCentralRepositoryHost)

--- a/test/e2e/plugin_sync/k8s/plugin_sync_k8s_lifecycle_test.go
+++ b/test/e2e/plugin_sync/k8s/plugin_sync_k8s_lifecycle_test.go
@@ -19,10 +19,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 	// cleanup and initialize the config files
 	Context("Delete config files and initialize", func() {
 		It("Delete config files and initialize", func() {
-			err := tf.Config.DeleteCLIConfigurationFiles()
-			Expect(err).To(BeNil())
-			// call init
-			err = tf.Config.ConfigInit()
+			err := f.CleanConfigFiles(tf)
 			Expect(err).To(BeNil())
 
 			// update plugin discovery source
@@ -240,7 +237,6 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 			Expect(err).To(BeNil(), "kind cluster should be deleted without any error")
 		})
 	})
-
 	// Use case 4: test delete context use case, it should uninstall plugins installed for the context
 	// Steps:
 	// a. create KIND cluster

--- a/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_suite_test.go
+++ b/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_suite_test.go
@@ -64,10 +64,13 @@ const testRepoDoesNotHaveEnoughPlugins = "test central repo does not have enough
 var _ = BeforeSuite(func() {
 	tf = framework.NewFramework()
 
+	err := framework.CleanConfigFiles(tf)
+	Expect(err).To(BeNil())
+
 	// check E2E test central repo URL (TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL) and update the same for plugin discovery
 	e2eTestLocalCentralRepoURL = os.Getenv(framework.TanzuCliE2ETestLocalCentralRepositoryURL)
 	Expect(e2eTestLocalCentralRepoURL).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with local central repository URL", framework.TanzuCliE2ETestLocalCentralRepositoryURL))
-	err := framework.UpdatePluginDiscoverySource(tf, e2eTestLocalCentralRepoURL)
+	err = framework.UpdatePluginDiscoverySource(tf, e2eTestLocalCentralRepoURL)
 	Expect(err).To(BeNil(), "should not be any error while updating plugin discovery source")
 
 	// Check whether the TMC token is set and whether TANZU_CLI_E2E_TEST_ENVIRONMENT is set to skip HTTPS hardcoding when mocking TMC response.


### PR DESCRIPTION
### What this PR does / why we need it

This pull request is to fix the UX message that appears when a plugin sync fails during `context creation`. Prior to this fix, any errors that occurred during plugin discovery were ignored, so the create context command would erroneously show that `All required plugins are already installed and up-to-date`, even though plugin discovery had actually failed. With this fix, the command will display the message `Unable to automatically sync the plugins from the target context. Please run the 'tanzu plugin sync' command to sync plugins manually`.



### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
1. The E2E tests haven been updated
2. Tested locally
```
**Before this fix:**
❯ t  context create --name tmc12 --endpoint unstable22.tmc-dev.cloud.vmware.com --staging
[i] API token env var is set

[ok] successfully created a TMC context
[i] Checking for required plugins...
[!] unable to list plugin from discovery 'default-tmc12': API error, status code: 404
[i] All required plugins are already installed and up-to-date
❯ 
**After fix:**
❯ t  context create --name tmc24 --endpoint unstable22.tmc-dev.cloud.vmware.com --staging
[i] API token env var is set

[ok] successfully created a TMC context
[i] Checking for required plugins...
[!] unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually, error: 'unable to list plugins from discovery source 'default-tmc24': API error, status code: 404'
❯ 
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
