### PR TITLE
Remove the "--self-managed" flag in "tanzu context create" command

### DIFF
--- a/pkg/constants/env_variables.go
+++ b/pkg/constants/env_variables.go
@@ -19,4 +19,6 @@ const (
 	SuppressSkipSignatureVerificationWarning          = "TANZU_CLI_SUPPRESS_SKIP_SIGNATURE_VERIFICATION_WARNING"
 	CEIPOptInUserPromptAnswer                         = "TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER"
 	E2ETestEnvironment                                = "TANZU_CLI_E2E_TEST_ENVIRONMENT"
+	// ControlPlaneEndpointType is the control-plane endpoint type to be used for "self-managed-tmc"(this list may grow in future)
+	ControlPlaneEndpointType = "TANZU_CLI_CONTROL_PLANE_ENDPOINT_TYPE"
 )


### PR DESCRIPTION
### What this PR does / why we need it

This PR  removes the "--self-managed" flag in "tanzu context create" command (added for self-managed TMC) because adding flags is not scalable. This is removed temporarily until a clean UX is defined. Till the UX is improved, user can execute the login flow for self-managed TMC by setting the environment variable "TANZU_CLI_CONTROL_PLANE_ENDPOINT_TYPE" to "self-managed-tmc"

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
Try without setting the environment variable, it should fail ( it would try checking back to TMC saas endpoint and fails later checking the endpoint is TKGs)
```
❯ ./bin/tanzu context create
? Select context creation type Control plane endpoint
? Enter control plane endpoint tmc-sm-main.local-dev.7infra.com:443
? Give the context a name test-global
[i] Failed to test for vSphere supervisor: Get "tmc-sm-main.local-dev.7infra.com:443/wcp/loginbanner": unsupported protocol scheme "tmc-sm-main.local-dev.7infra.com"
[x] : error creating kubeconfig with tanzu pinniped-auth login plugin: Get "tmc-sm-main.local-dev.7infra.com:443/wcp/loginbanner": unsupported protocol scheme "tmc-sm-main.local-dev.7infra.com"
[x] : error creating kubeconfig with tanzu pinniped-auth login plugin: Get "tmc-sm-main.local-dev.7infra.com:443/wcp/loginbanner": unsupported protocol scheme "tmc-sm-main.local-dev.7infra.com"
```



set the envrionment variable `TANZU_CLI_CONTROL_PLANE_ENDPOINT_TYPE` to set the `self-managed-tmc` and  context create was successful
```
❯ tanzu config set env.TANZU_CLI_CONTROL_PLANE_ENDPOINT_TYPE "self-managed-tmc"
❯
❯
❯ ./bin/tanzu context create  --endpoint tmc-sm-main.local-dev.7infra.com:443
? Give the context a name test-new-chg-tmc-selfmgd-2
Please open this URL in a browser window to complete the login
	 https://pinniped-supervisor.tmc-sm-main.local-dev.7infra.com/provider/pinniped/oauth2/authorize?client_id=pinniped-cli&code_challenge=tyIqLy_53b8E4dtmHh0d6prWfN0yunEM5eu6f5GCIwQ&code_challenge_method=S256&redirect_uri=http%3A%2F%2F127.0.0.1%2Fcallback&response_type=code&scope=openid+offline_access+username+groups&state=ef94ff18747abdf60cb32af00c4d97a0

[ok] successfully created a TMC self-managed context
[i] Checking for required plugins...
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
