### PR TITLE
Fix the "tanzu plugin upload-bundle" to use the docker login config to upload the bundle to a registry which requires credentials

### DIFF
--- a/pkg/carvelhelpers/fetcher.go
+++ b/pkg/carvelhelpers/fetcher.go
@@ -32,9 +32,7 @@ func GetImageDigest(imageWithTag string) (string, string, error) {
 // newRegistry returns a new registry object by also taking
 // into account for any custom registry provided by the user
 func newRegistry(registryHost string) (registry.Registry, error) {
-	registryOpts := &ctlimg.Opts{
-		Anon: true,
-	}
+	registryOpts := &ctlimg.Opts{}
 
 	regCertOptions, err := registry.GetRegistryCertOptions(registryHost)
 	if err != nil {

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -27,7 +27,7 @@ type registry struct {
 func New(opts *ctlimg.Opts) (Registry, error) {
 	reg, err := ctlimg.NewSimpleRegistry(*opts)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to initialze registry client")
+		return nil, errors.Wrap(err, "failed to initialize registry client")
 	}
 
 	return &registry{
@@ -193,7 +193,6 @@ func (r *registry) CopyImageToTar(sourceImageName, destTarFile string) error {
 			CACertPaths: r.opts.CACertPaths,
 			VerifyCerts: r.opts.VerifyCerts,
 			Insecure:    r.opts.Insecure,
-			Anon:        r.opts.Anon,
 		}
 	}
 
@@ -219,7 +218,6 @@ func (r *registry) CopyImageFromTar(sourceTarFile, destImageRepo string) error {
 			CACertPaths: r.opts.CACertPaths,
 			VerifyCerts: r.opts.VerifyCerts,
 			Insecure:    r.opts.Insecure,
-			Anon:        r.opts.Anon,
 		}
 	}
 	err := copyOptions.Run()
@@ -247,7 +245,6 @@ func (r *registry) downloadBundleOrImage(imageName, outputDir string, isBundle b
 			CACertPaths: r.opts.CACertPaths,
 			VerifyCerts: r.opts.VerifyCerts,
 			Insecure:    r.opts.Insecure,
-			Anon:        r.opts.Anon,
 		}
 	}
 
@@ -283,7 +280,6 @@ func (r *registry) PushImage(imageWithTag string, filePaths []string) error {
 			CACertPaths: r.opts.CACertPaths,
 			VerifyCerts: r.opts.VerifyCerts,
 			Insecure:    r.opts.Insecure,
-			Anon:        r.opts.Anon,
 		}
 	}
 


### PR DESCRIPTION

### What this PR does / why we need it
This PR fixes the `tanzu plugin upload-bundle` failing to use the docker login config(docker login done outside CLI) to upload the bundle to registry with restricted access(requires credentials)
Summary:
- Modified the registry client operations to not use `Anonymous` user and instead use the docker login configuration/session done outside the CLI to upload images to a registry that requires login credentials

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Removed the bundle on the client machine and did docker logout
```
kubo@gGo6U4eQF7biA:/home/kubo$ rm /tmp/plugin_bundle_prem_tkg_v2.1.1.tar.gz
kubo@gGo6U4eQF7biA:/home/kubo$
kubo@gGo6U4eQF7biA:/home/kubo$ docker logout 10.89.164.214:8443
Removing login credentials for 10.89.164.214:8443
```

Downloaded the bundle from the existing repository
```
kubo@gGo6U4eQF7biA:/home/kubo$ /tmp/tanzu-cli-linux_amd64 plugin download-bundle --image 10.89.164.214:8443/library/plugin1/plugin-inventory:latest --group vmware-tkg/default:v2.1.1 --to-tar /tmp/plugin_bundle_prem_tkg_v2.1.1.tar.gz
[i] downloading image "10.89.164.214:8443/library/plugin1/plugin-inventory:latest"
[i] copy | exporting 2 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/plugin-inventory@sha256:1d9c99cd8a147daadaaba953fe04e2ba5a8e78ee20a8bced68b329106901da87
[i] copy | will export 10.89.164.214:8443/library/plugin1/plugin-inventory@sha256:3fe669dae00222f705c00bf4d682c6c41b0a7ef107b0583370f7edda33245838
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.679µs)
[i] copy | done: file 'sha256-7bee37fb4fc91b9a4249c48838315ec8ab2a046c5f5d8417eb0fa51f7d328cbe.tar.gz' (39.603µs)
[i] copy | done: file 'sha256-944bc13f4c8f8304dfbc2c6732af39cdd4e04902a50880c29b8c4452c4abceef.tar.gz' (100.333µs)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/darwin/amd64/kubernetes/cluster:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/darwin/amd64/kubernetes/cluster@sha256:796e80df9e3f08ca7bbbc826383b739a13d2598326779f7de9249ff70f00e602
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.496µs)
[i] copy | done: file 'sha256-16d340316225dba76293b899fea254d8fe46b30f3740bca3dfc08890a72fdea1.tar.gz' (206.859532ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/linux/amd64/kubernetes/cluster:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/linux/amd64/kubernetes/cluster@sha256:47b9d2052900876ca9782c1b0b622e99ec0d2d0112076eb228744465123d6b3f
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.424µs)
[i] copy | done: file 'sha256-e3bc555580552f9422880beed331a403fa3354a07b34f0773f1f09292321fa26.tar.gz' (147.357973ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/windows/amd64/kubernetes/cluster:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/windows/amd64/kubernetes/cluster@sha256:8af22b827814d4a311c4ef3920e92aca8b4169d3fe9edf3e4221b6d859e5a7de
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (3.078µs)
[i] copy | done: file 'sha256-9ae8e83e7684418e319708788e0f76b1ecafa72c2201e44201fdec63b0e6296c.tar.gz' (144.055084ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/darwin/amd64/kubernetes/feature:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/darwin/amd64/kubernetes/feature@sha256:6e784591ab5045825fbb574d5fd13340fd48341529daa07139729ba22906bdaa
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.586µs)
[i] copy | done: file 'sha256-bd0314bdd9fb808474ee4b45d3f615d9277376e832b1e1c5116348a4f7fd0d8b.tar.gz' (70.785602ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/linux/amd64/kubernetes/feature:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/linux/amd64/kubernetes/feature@sha256:0829ed0ea1968a995c375254e1c4579b02e9c26d97cfbbbaa1c379ee472ee0d7
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.267µs)
[i] copy | done: file 'sha256-a327397c63b0a247551ceb21d152009cc72f03dae840570838da9a649a3a5b9f.tar.gz' (61.004261ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/windows/amd64/kubernetes/feature:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/windows/amd64/kubernetes/feature@sha256:a05d654a0b38d3d031e7b0fc87e9d5f0b4cb6ee7330f70782108aa6d3bbdc653
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.417µs)
[i] copy | done: file 'sha256-0f6e55896e3d84d760176bc386143ec89f127cc89e69b3b1c5612a8ebeaa010f.tar.gz' (61.779662ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/darwin/amd64/global/isolated-cluster:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/darwin/amd64/global/isolated-cluster@sha256:893689f305c818ce8c1507553aa26dee190a1fd78a86af786bc0d76dca358929
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.15µs)
[i] copy | done: file 'sha256-82a640358965550bdc66abeff7419f4e44beaafb5a350aefd8c77d1aa0e0e0d3.tar.gz' (64.162724ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/linux/amd64/global/isolated-cluster:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/linux/amd64/global/isolated-cluster@sha256:f7ff7b40edb423b286245db8380a913ebb18643084a3cae2d69a8c547e0d6df2
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.367µs)
[i] copy | done: file 'sha256-27872a26b886ca107689dc953559b552606b9f892a06ec559e26f653d570216b.tar.gz' (48.414245ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/windows/amd64/global/isolated-cluster:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/windows/amd64/global/isolated-cluster@sha256:fe7e712c3bc0f95a7dadfa74345fd1f0ac2d42d99a0aa63be3f6491dc4267aeb
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.109µs)
[i] copy | done: file 'sha256-25ea50cc9b6cd4d6d661d338498c7a9caa66ed7d629b63d801ae3eb1ce08574c.tar.gz' (44.907563ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/darwin/amd64/kubernetes/kubernetes-release:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/darwin/amd64/kubernetes/kubernetes-release@sha256:8f6cd83dd7155ee10bf9799471b45721152cd9117e66b14140f2291235d6b185
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.432µs)
[i] copy | done: file 'sha256-382c1f1f96215bd64b6906647e42731eade01e7934863acdf10d250abaa6c258.tar.gz' (182.471175ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/linux/amd64/kubernetes/kubernetes-release:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/linux/amd64/kubernetes/kubernetes-release@sha256:38ce89ad9870777cb30aaa3500fbf1e2fca3af95855194f00103a8636d70d1ed
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.497µs)
[i] copy | done: file 'sha256-d768f662c8efb967e5096ca916d90b972caad26d8aca6dfa1ab6c060a6a26fed.tar.gz' (148.202466ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/windows/amd64/kubernetes/kubernetes-release:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/windows/amd64/kubernetes/kubernetes-release@sha256:eba115a1ed03af1b8d8ab5b85c90f78b5f24919a7ce3fb9f362a057da6b145bf
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.252µs)
[i] copy | done: file 'sha256-a5704dc9560909855f29d7febb06ea3baa6b161766621fab33642e9b8f490f72.tar.gz' (145.498569ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/darwin/amd64/kubernetes/management-cluster:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/darwin/amd64/kubernetes/management-cluster@sha256:05c55a9f892748fa6932fbd555420adc66f9a3aa0b1c9590bfa8158a36c5bdbf
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (3.35µs)
[i] copy | done: file 'sha256-dc2032c9286c01e7425e4cb75aac849e41718331eaf070d48acf9bbed2460d79.tar.gz' (199.876155ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/linux/amd64/kubernetes/management-cluster:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/linux/amd64/kubernetes/management-cluster@sha256:862e9228d411b96252718ec72ccf2fd7ed9f7cf4618da622aedb28ca34fac697
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.665µs)
[i] copy | done: file 'sha256-2269a75a9f403b79cc6aff7925bc1256a9cad14bbf866c559719d86e26659ff6.tar.gz' (159.177588ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/windows/amd64/kubernetes/management-cluster:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/windows/amd64/kubernetes/management-cluster@sha256:a7a540ef7f9e383ef355803775c19cddb393fe468ed5b37ddcbf19ac2bb102ad
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.467µs)
[i] copy | done: file 'sha256-85c63ff5c528aa3727ed99196602928067b602b9bbcf3d48e74f2f5b6fdb087b.tar.gz' (148.356504ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/darwin/amd64/kubernetes/package:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/darwin/amd64/kubernetes/package@sha256:b059ed67b822299b3a0ab88fe9748c74599560ed51d52c59d858f65e122ae9ab
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.421µs)
[i] copy | done: file 'sha256-9339e50e418a61972dbfbf1745b6946638e4bda631bd97d8f824a2749c22b1f5.tar.gz' (99.947594ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/linux/amd64/kubernetes/package:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/linux/amd64/kubernetes/package@sha256:91f703d9d6c62d5e274bea692a7e026f4f8ad9aba2d77e8bf95328f78f29fba9
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.324µs)
[i] copy | done: file 'sha256-dd0d331bad5d46d6ce64e23fc471ac76b735913ff755bf655ef87bf4d4b2f3c5.tar.gz' (91.08595ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/windows/amd64/kubernetes/package:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/windows/amd64/kubernetes/package@sha256:f171647bb4d73cec162fedcb679f81d50bd28ffff47a49f0911a91c72804fe4a
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.265µs)
[i] copy | done: file 'sha256-86e024b69ffe128b7c79feaad15955340a38547ed211caa4c01a417cd679ffe9.tar.gz' (129.629816ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/darwin/amd64/global/pinniped-auth:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/darwin/amd64/global/pinniped-auth@sha256:1be9741cf1e54e227ccf7c6e19fb7cb11b0f3926195bea97205cb066d17c49bd
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.443µs)
[i] copy | done: file 'sha256-ebb0b08fa3326cee587a5ef59dfd93ca5f9b3d9a0e28f7dfed04127d01bf0b7c.tar.gz' (283.01913ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/linux/amd64/global/pinniped-auth:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/linux/amd64/global/pinniped-auth@sha256:f3f7b4c4fc9cfa5e8e5aa0a72869fb1510922f4df9967b7dc6cf36092b0ebd45
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.269µs)
[i] copy | done: file 'sha256-2dd3dbc7ce6da6a170d5ffc9ed494aaf7ac17627887b2c426d8a0153e1d2cc6b.tar.gz' (256.610665ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/windows/amd64/global/pinniped-auth:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/windows/amd64/global/pinniped-auth@sha256:a1fac1f0287a918a277a37cf30ebf30ac141b27a46e419e3cf058622c14f7c56
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.172µs)
[i] copy | done: file 'sha256-06ba0c3a6463eb20741162190ba4f60f581c0b093769c79b7f59813ae944bb96.tar.gz' (247.180404ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/darwin/amd64/kubernetes/secret:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/darwin/amd64/kubernetes/secret@sha256:e48ce3586ea45e8399ad84864aaebe91dd8b734c48676c7432f342513b78ba37
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.097µs)
[i] copy | done: file 'sha256-856a4751342ef9dc2e383348c5ff9d40eb36d2d6c17bbb64e2207cef42e6aeb1.tar.gz' (85.03708ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/linux/amd64/kubernetes/secret:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/linux/amd64/kubernetes/secret@sha256:e6fc8a75c58939be0e418e5d497ef971f4ec5ffd96e5480d3cac232a5863d1e8
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.666µs)
[i] copy | done: file 'sha256-4c9655c361caac0dbb26c22b318acc9c2da85185bf9321a8117da10d72ffa27b.tar.gz' (81.429986ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/windows/amd64/kubernetes/secret:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/windows/amd64/kubernetes/secret@sha256:6ebd1bc7815b440911e5e2cd074392208850f82a83d4ec4c23d8ecbbb80cf91c
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.203µs)
[i] copy | done: file 'sha256-af6dd4ef6ebfa7985bf57ee104a8c787630864216507c5ca833cdcf9711bc8d1.tar.gz' (87.024423ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/darwin/amd64/kubernetes/telemetry:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/darwin/amd64/kubernetes/telemetry@sha256:fc7d1a47f1f4a7eaac67c8eb34c9f8bde0ef85e61edc249d6bd38b690eb40ed6
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.201µs)
[i] copy | done: file 'sha256-89dd89efa8b30def6904d9bbe2bfa94394b81a430116e094585e84fc2de5fa39.tar.gz' (45.229313ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/linux/amd64/kubernetes/telemetry:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/linux/amd64/kubernetes/telemetry@sha256:0f684325afc09d0179e2bd4638254bc0a817e77a799b91c04412ae340a3896af
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.586µs)
[i] copy | done: file 'sha256-91c15b5781feefde5bbe1b9a434920216af89f5525687e0c875b0f13206243bf.tar.gz' (39.904876ms)
[i] ---------------------------
[i] downloading image "10.89.164.214:8443/library/plugin1/vmware/tkg/windows/amd64/kubernetes/telemetry:v0.28.1"
[i] copy | exporting 1 images...
[i] copy | will export 10.89.164.214:8443/library/plugin1/vmware/tkg/windows/amd64/kubernetes/telemetry@sha256:ac9d55f9b208a086a898297821f745c2ae2ff528f4f3d482d9bd2b22dff20c92
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (2.584µs)
[i] copy | done: file 'sha256-ce0b3b1e4cb718ffb70c7304fe73acffa9bf2f8d4530e394622ff7e1ae5e40f2.tar.gz' (37.489555ms)
[i] saving plugin bundle at: /tmp/plugin_bundle_prem_tkg_v2.1.1.tar.gz
kubo@gGo6U4eQF7biA:/home/kubo$

```

Tried uploading the bundle to the registry without docker login and it failed
```
kubo@gGo6U4eQF7biA:/home/kubo$ /tmp/tanzu-cli-linux_amd64 plugin upload-bundle --tar /tmp/plugin_bundle_prem_tkg_v2.1.1.tar.gz --to-repo 10.89.164.214:8443/library/plugin-prem
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/plugin-inventory"
[i] copy | importing 2 images...

[i] copy |
copy | done uploading images
[i] copy | Error: Error uploading images: POST https://10.89.164.214:8443/v2/library/plugin-prem/plugin-inventory/blobs/uploads/?from=library%!F(MISSING)plugin1%!F(MISSING)plugin-inventory&mount=sha256%!A(MISSING)944bc13f4c8f8304dfbc2c6732af39cdd4e04902a50880c29b8c4452c4abceef&origin=REDACTED: UNAUTHORIZED: unauthorized to access repository: library/plugin-prem/plugin-inventory, action: push: unauthorized to access repository: library/plugin-prem/plugin-inventory, action: push
[x] : error while uploading image: POST https://10.89.164.214:8443/v2/library/plugin-prem/plugin-inventory/blobs/uploads/?from=library%2Fplugin1%2Fplugin-inventory&mount=sha256%3A944bc13f4c8f8304dfbc2c6732af39cdd4e04902a50880c29b8c4452c4abceef&origin=REDACTED: UNAUTHORIZED: unauthorized to access repository: library/plugin-prem/plugin-inventory, action: push: unauthorized to access repository: library/plugin-prem/plugin-inventory, action: push
kubo@gGo6U4eQF7biA:/home/kubo$
```

Performed the docker login
```
kubo@gGo6U4eQF7biA:/home/kubo$ docker login 10.89.164.214:8443 -u admin -p Harbor12345
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
WARNING! Your password will be stored unencrypted in /tmp/prem_temp_home/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded
kubo@gGo6U4eQF7biA:/home/kubo$

```

Now tried upload bundle and it was success (it used the docker login config)

```
kubo@gGo6U4eQF7biA:/home/kubo$ /tmp/tanzu-cli-linux_amd64 plugin upload-bundle --tar /tmp/plugin_bundle_prem_tkg_v2.1.1.tar.gz --to-repo 10.89.164.214:8443/library/plugin-prem
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/plugin-inventory"
[i] copy | importing 2 images...

12.68 KiB / 12.68 KiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 102.48 KiB p/s
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/darwin/amd64/kubernetes/cluster"
[i] copy | importing 1 images...

32.49 MiB / 32.49 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 649.30 MiB p/s
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/linux/amd64/kubernetes/cluster"
[i] copy | importing 1 images...

29.70 MiB / 29.70 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 539.65 MiB p/s
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/windows/amd64/kubernetes/cluster"
[i] copy | importing 1 images...

30.16 MiB / 30.16 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 638.70 MiB p/s
30.16 MiB / 30.16 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 637.41 MiB p/s
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/darwin/amd64/kubernetes/feature"
[i] copy | importing 1 images...

12.39 MiB / 12.39 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 260.68 MiB p/s
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/linux/amd64/kubernetes/feature"
[i] copy | importing 1 images...

11.36 MiB / 11.36 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 225.89 MiB p/s
11.36 MiB / 11.36 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 225.36 MiB p/s
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/windows/amd64/kubernetes/feature"
[i] copy | importing 1 images...

11.46 MiB / 11.46 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 203.51 MiB p/s
[i] copy |
copy | done uploading images
11.46 MiB / 11.46 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 203.15 MiB p/s
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/darwin/amd64/global/isolated-cluster"
[i] copy | importing 1 images...

7.81 MiB / 7.81 MiB [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 144.88 MiB p/s
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/linux/amd64/global/isolated-cluster"
[i] copy | importing 1 images...

7.23 MiB / 7.23 MiB [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 116.08 MiB p/s
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/windows/amd64/global/isolated-cluster"
[i] copy | importing 1 images...

7.31 MiB / 7.31 MiB [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 128.56 MiB p/s
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/darwin/amd64/kubernetes/kubernetes-release"
[i] copy | importing 1 images...

32.35 MiB / 32.35 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 551.56 MiB p/s
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/linux/amd64/kubernetes/kubernetes-release"
[i] copy | importing 1 images...

29.60 MiB / 29.60 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 511.10 MiB p/s
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/windows/amd64/kubernetes/kubernetes-release"
[i] copy | importing 1 images...

30.03 MiB / 30.03 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 615.49 MiB p/s
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/darwin/amd64/kubernetes/management-cluster"
[i] copy | importing 1 images...

33.68 MiB / 33.68 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 714.62 MiB p/s
[i] copy |
copy | done uploading images
33.68 MiB / 33.68 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 712.40 MiB p/s
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/linux/amd64/kubernetes/management-cluster"
[i] copy | importing 1 images...

30.78 MiB / 30.78 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 634.14 MiB p/s
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/windows/amd64/kubernetes/management-cluster"
[i] copy | importing 1 images...

31.23 MiB / 31.23 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 675.57 MiB p/s
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/darwin/amd64/kubernetes/package"
[i] copy | importing 1 images...

16.18 MiB / 16.18 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 336.87 MiB p/s
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/linux/amd64/kubernetes/package"
[i] copy | importing 1 images...

14.84 MiB / 14.84 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 315.61 MiB p/s
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/windows/amd64/kubernetes/package"
[i] copy | importing 1 images...

14.94 MiB / 14.94 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 318.86 MiB p/s
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/darwin/amd64/global/pinniped-auth"
[i] copy | importing 1 images...

51.66 MiB / 51.66 MiB [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 1.07 GiB p/s
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/linux/amd64/global/pinniped-auth"
[i] copy | importing 1 images...

50.39 MiB / 50.39 MiB [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 1.04 GiB p/s
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/windows/amd64/global/pinniped-auth"
[i] copy | importing 1 images...

50.76 MiB / 50.76 MiB [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 1.06 GiB p/s
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/darwin/amd64/kubernetes/secret"
[i] copy | importing 1 images...

13.62 MiB / 13.62 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 285.74 MiB p/s
13.62 MiB / 13.62 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 285.21 MiB p/s
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/linux/amd64/kubernetes/secret"
[i] copy | importing 1 images...

12.51 MiB / 12.51 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 261.28 MiB p/s
[i] copy |
copy | done uploading images
12.51 MiB / 12.51 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 260.68 MiB p/s
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/windows/amd64/kubernetes/secret"
[i] copy | importing 1 images...

12.59 MiB / 12.59 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 261.60 MiB p/s
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/darwin/amd64/kubernetes/telemetry"
[i] copy | importing 1 images...

7.30 MiB / 7.30 MiB [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 152.49 MiB p/s
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/linux/amd64/kubernetes/telemetry"
[i] copy | importing 1 images...

6.75 MiB / 6.75 MiB [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 144.77 MiB p/s
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "10.89.164.214:8443/library/plugin-prem/vmware/tkg/windows/amd64/kubernetes/telemetry"
[i] copy | importing 1 images...

6.84 MiB / 6.84 MiB [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 144.83 MiB p/s
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] ---------------------------
[i] publishing plugin inventory metadata image...
[i] plugin inventory metadata image "10.89.164.214:8443/library/plugin-prem/plugin-inventory-metadata:latest" is not present. Skipping merging of the plugin inventory metadata
[i] uploading image "10.89.164.214:8443/library/plugin-prem/plugin-inventory-metadata:latest"
[i] ---------------------------
[i] successfully published all plugin images to "10.89.164.214:8443/library/plugin-prem/plugin-inventory:latest"
kubo@gGo6U4eQF7biA:/home/kubo$
```

Updated the default plugin source and also certs to interact with self-signed registry

```
kubo@gGo6U4eQF7biA:/home/kubo$ /tmp/tanzu-cli-linux_amd64 plugin source update default -u 10.89.164.214:8443/library/plugin-prem/plugin-inventory:latest
[ok] updated discovery source default
kubo@gGo6U4eQF7biA:/home/kubo$ /tmp/tanzu-cli-linux_amd64 plugin source list
  NAME     IMAGE
  default  10.89.164.214:8443/library/plugin-prem/plugin-inventory:latest
kubo@gGo6U4eQF7biA:/home/kubo$ /tmp/tanzu-cli-linux_amd64 config cert list
  HOST                CA-CERTIFICATE  SKIP-CERT-VERIFICATION  INSECURE
  10.89.164.214:8443  <REDACTED>      false                   false
```

Performed the `tanzu plugin search` and `tanzu plugin install` and it was sucess

```
kubo@gGo6U4eQF7biA:/home/kubo$ /tmp/tanzu-cli-linux_amd64 plugin search
[i] Reading plugin inventory for "10.89.164.214:8443/library/plugin-prem/plugin-inventory:latest", this will take a few seconds.
  NAME                DESCRIPTION                                                        TARGET      LATEST
  isolated-cluster    Prepopulating images/bundle for internet-restricted environments   global      v0.28.1
  pinniped-auth       Pinniped authentication operations (usually not directly invoked)  global      v0.28.1
  cluster             Kubernetes cluster operations                                      kubernetes  v0.28.1
  feature             Operate on features and featuregates                               kubernetes  v0.28.1
  kubernetes-release  Kubernetes release operations                                      kubernetes  v0.28.1
  management-cluster  Kubernetes management cluster operations                           kubernetes  v0.28.1
  package             Tanzu package management                                           kubernetes  v0.28.1
  secret              Tanzu secret management                                            kubernetes  v0.28.1
  telemetry           configure cluster-wide settings for vmware tanzu telemetry         kubernetes  v0.28.1




kubo@gGo6U4eQF7biA:/home/kubo$ /tmp/tanzu-cli-linux_amd64 plugin list
Standalone Plugins
  NAME  DESCRIPTION  TARGET  VERSION  STATUS
kubo@gGo6U4eQF7biA:/home/kubo$ /tmp/tanzu-cli-linux_amd64 plugin install isolated-cluster
[i] Installing plugin 'isolated-cluster:v0.28.1' with target 'global'
[ok] successfully installed 'isolated-cluster' plugin
kubo@gGo6U4eQF7biA:/home/kubo$ /tmp/tanzu-cli-linux_amd64 plugin list
Standalone Plugins
  NAME              DESCRIPTION                                                       TARGET  VERSION  STATUS
  isolated-cluster  Prepopulating images/bundle for internet-restricted environments  global  v0.28.1  installed
kubo@gGo6U4eQF7biA:/home/kubo$
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix the "tanzu plugin upload-bundle" to use the docker login session to upload the images to a registry with restricted acesss
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
