### PR TITLE
Use `docker` interface to build plugin OCI images as part of `tanzu builder plugin build-package`

### DIFF
--- a/cmd/plugin/builder/README.md
+++ b/cmd/plugin/builder/README.md
@@ -164,7 +164,6 @@ Below are the flags available with `tanzu builder plugin build-package` command:
 ```txt
       --binary-artifacts string    plugin binary artifact directory (default "./artifacts/plugins")
   -h, --help                       help for build-package
-      --oci-registry string        local oci-registry to use for generating packages
       --package-artifacts string   plugin package artifacts directory (default "./artifacts/packages")
 ```
 
@@ -172,7 +171,7 @@ Below are the examples:
 
 ```shell
   # Build all plugin packages available under the './artifacts/plugins' directory
-  tanzu builder plugin build-package --oci-registry localhost:5001 --binary-artifacts ./artifacts/plugins
+  tanzu builder plugin build-package --binary-artifacts ./artifacts/plugins
 ```
 
 Once user generate the plugin packages, user can use `tanzu builder plugin publish-package` command to actually publish the generate packages to the remote repository as OCI image.

--- a/cmd/plugin/builder/docker/docker.go
+++ b/cmd/plugin/builder/docker/docker.go
@@ -1,0 +1,56 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package docker
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+// DockerOptions implements the DockerWrapper interface by using `docker` binary internally
+type DockerOptions struct{}
+
+// BuildImage invokes `docker build -t <image> -f <template> <dirpath>` command
+func (do *DockerOptions) BuildImage(image, template, dirPath string) error {
+	output, err := exec.Command("docker", "build", "-t", image, "-f", template, dirPath).CombinedOutput()
+	return errors.Wrapf(err, "output: %s", string(output))
+}
+
+// SaveImage invokes `docker save <image> | gzip -c > <archivefile>` command
+func (do *DockerOptions) SaveImage(image, archiveFile string) error {
+	// Create archive directory if doesn't exists
+	err := os.MkdirAll(filepath.Dir(archiveFile), 0755)
+	if err != nil {
+		return errors.Wrap(err, "unable to create directory")
+	}
+
+	cmd := fmt.Sprintf("docker save %s | gzip -c > %s", image, archiveFile)
+	output, err := exec.Command("bash", "-c", cmd).CombinedOutput()
+	return errors.Wrapf(err, "output: %s", string(output))
+}
+
+// LoadImage invokes `docker load -i <architefile>` command
+func (do *DockerOptions) LoadImage(archiveFile string) error {
+	loadCMD := fmt.Sprintf("docker load -i %s", archiveFile)
+	output, err := exec.Command("bash", "-c", loadCMD).CombinedOutput()
+	return errors.Wrapf(err, "output: %s", string(output))
+}
+
+// TagImage invokes `docker tag <existingImage> <newImage>` command
+func (do *DockerOptions) TagImage(existingImage, newImage string) error {
+	tagCMD := fmt.Sprintf("docker tag %s %s", existingImage, newImage)
+	output, err := exec.Command("bash", "-c", tagCMD).CombinedOutput()
+	return errors.Wrapf(err, "output: %s", string(output))
+}
+
+// PushImage invokes `docker push <image>` command
+func (do *DockerOptions) PushImage(image string) error {
+	pushCMD := fmt.Sprintf("docker push %s", image)
+	output, err := exec.Command("bash", "-c", pushCMD).CombinedOutput()
+	return errors.Wrapf(err, "output: %s", string(output))
+}

--- a/cmd/plugin/builder/docker/docker.go
+++ b/cmd/plugin/builder/docker/docker.go
@@ -17,7 +17,8 @@ type DockerOptions struct{}
 
 // BuildImage invokes `docker build -t <image> -f <template> <dirpath>` command
 func (do *DockerOptions) BuildImage(image, template, dirPath string) error {
-	output, err := exec.Command("docker", "build", "-t", image, "-f", template, dirPath).CombinedOutput()
+	cmd := fmt.Sprintf("docker build -t %s -f %s %s", image, template, dirPath)
+	output, err := exec.Command("bash", "-c", cmd).CombinedOutput()
 	return errors.Wrapf(err, "output: %s", string(output))
 }
 

--- a/cmd/plugin/builder/docker/interface.go
+++ b/cmd/plugin/builder/docker/interface.go
@@ -1,0 +1,24 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package docker implements helper function for docker cli
+package docker
+
+// DockerWrapper defines the docker command wrapper functions
+type DockerWrapper interface {
+	// BuildImage invokes `docker build -t <image> -f <template> <dirpath>` command
+	BuildImage(image, template, dirPath string) error
+	// SaveImage invokes `docker save <image> | gzip -c > <archivefile>` command
+	SaveImage(image, archiveFile string) error
+	// LoadImage invokes `docker load -i <architefile>` command
+	LoadImage(archiveFile string) error
+	// TagImage invokes `docker tag <existingImage> <newImage>` command
+	TagImage(existingImage, newImage string) error
+	// PushImage invokes `docker push <image>` command
+	PushImage(image string) error
+}
+
+// NewDockerCLIWrapper creates new DockerWrapper instance
+func NewDockerCLIWrapper() DockerWrapper {
+	return &DockerOptions{}
+}

--- a/cmd/plugin/builder/fakes/imgpkgwrapper.go
+++ b/cmd/plugin/builder/fakes/imgpkgwrapper.go
@@ -8,30 +8,6 @@ import (
 )
 
 type ImgpkgWrapper struct {
-	CopyArchiveToRepoStub        func(string, string) error
-	copyArchiveToRepoMutex       sync.RWMutex
-	copyArchiveToRepoArgsForCall []struct {
-		arg1 string
-		arg2 string
-	}
-	copyArchiveToRepoReturns struct {
-		result1 error
-	}
-	copyArchiveToRepoReturnsOnCall map[int]struct {
-		result1 error
-	}
-	CopyImageToArchiveStub        func(string, string) error
-	copyImageToArchiveMutex       sync.RWMutex
-	copyImageToArchiveArgsForCall []struct {
-		arg1 string
-		arg2 string
-	}
-	copyImageToArchiveReturns struct {
-		result1 error
-	}
-	copyImageToArchiveReturnsOnCall map[int]struct {
-		result1 error
-	}
 	GetFileDigestFromImageStub        func(string, string) (string, error)
 	getFileDigestFromImageMutex       sync.RWMutex
 	getFileDigestFromImageArgsForCall []struct {
@@ -83,130 +59,6 @@ type ImgpkgWrapper struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *ImgpkgWrapper) CopyArchiveToRepo(arg1 string, arg2 string) error {
-	fake.copyArchiveToRepoMutex.Lock()
-	ret, specificReturn := fake.copyArchiveToRepoReturnsOnCall[len(fake.copyArchiveToRepoArgsForCall)]
-	fake.copyArchiveToRepoArgsForCall = append(fake.copyArchiveToRepoArgsForCall, struct {
-		arg1 string
-		arg2 string
-	}{arg1, arg2})
-	stub := fake.CopyArchiveToRepoStub
-	fakeReturns := fake.copyArchiveToRepoReturns
-	fake.recordInvocation("CopyArchiveToRepo", []interface{}{arg1, arg2})
-	fake.copyArchiveToRepoMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *ImgpkgWrapper) CopyArchiveToRepoCallCount() int {
-	fake.copyArchiveToRepoMutex.RLock()
-	defer fake.copyArchiveToRepoMutex.RUnlock()
-	return len(fake.copyArchiveToRepoArgsForCall)
-}
-
-func (fake *ImgpkgWrapper) CopyArchiveToRepoCalls(stub func(string, string) error) {
-	fake.copyArchiveToRepoMutex.Lock()
-	defer fake.copyArchiveToRepoMutex.Unlock()
-	fake.CopyArchiveToRepoStub = stub
-}
-
-func (fake *ImgpkgWrapper) CopyArchiveToRepoArgsForCall(i int) (string, string) {
-	fake.copyArchiveToRepoMutex.RLock()
-	defer fake.copyArchiveToRepoMutex.RUnlock()
-	argsForCall := fake.copyArchiveToRepoArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *ImgpkgWrapper) CopyArchiveToRepoReturns(result1 error) {
-	fake.copyArchiveToRepoMutex.Lock()
-	defer fake.copyArchiveToRepoMutex.Unlock()
-	fake.CopyArchiveToRepoStub = nil
-	fake.copyArchiveToRepoReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *ImgpkgWrapper) CopyArchiveToRepoReturnsOnCall(i int, result1 error) {
-	fake.copyArchiveToRepoMutex.Lock()
-	defer fake.copyArchiveToRepoMutex.Unlock()
-	fake.CopyArchiveToRepoStub = nil
-	if fake.copyArchiveToRepoReturnsOnCall == nil {
-		fake.copyArchiveToRepoReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.copyArchiveToRepoReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *ImgpkgWrapper) CopyImageToArchive(arg1 string, arg2 string) error {
-	fake.copyImageToArchiveMutex.Lock()
-	ret, specificReturn := fake.copyImageToArchiveReturnsOnCall[len(fake.copyImageToArchiveArgsForCall)]
-	fake.copyImageToArchiveArgsForCall = append(fake.copyImageToArchiveArgsForCall, struct {
-		arg1 string
-		arg2 string
-	}{arg1, arg2})
-	stub := fake.CopyImageToArchiveStub
-	fakeReturns := fake.copyImageToArchiveReturns
-	fake.recordInvocation("CopyImageToArchive", []interface{}{arg1, arg2})
-	fake.copyImageToArchiveMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *ImgpkgWrapper) CopyImageToArchiveCallCount() int {
-	fake.copyImageToArchiveMutex.RLock()
-	defer fake.copyImageToArchiveMutex.RUnlock()
-	return len(fake.copyImageToArchiveArgsForCall)
-}
-
-func (fake *ImgpkgWrapper) CopyImageToArchiveCalls(stub func(string, string) error) {
-	fake.copyImageToArchiveMutex.Lock()
-	defer fake.copyImageToArchiveMutex.Unlock()
-	fake.CopyImageToArchiveStub = stub
-}
-
-func (fake *ImgpkgWrapper) CopyImageToArchiveArgsForCall(i int) (string, string) {
-	fake.copyImageToArchiveMutex.RLock()
-	defer fake.copyImageToArchiveMutex.RUnlock()
-	argsForCall := fake.copyImageToArchiveArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *ImgpkgWrapper) CopyImageToArchiveReturns(result1 error) {
-	fake.copyImageToArchiveMutex.Lock()
-	defer fake.copyImageToArchiveMutex.Unlock()
-	fake.CopyImageToArchiveStub = nil
-	fake.copyImageToArchiveReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *ImgpkgWrapper) CopyImageToArchiveReturnsOnCall(i int, result1 error) {
-	fake.copyImageToArchiveMutex.Lock()
-	defer fake.copyImageToArchiveMutex.Unlock()
-	fake.CopyImageToArchiveStub = nil
-	if fake.copyImageToArchiveReturnsOnCall == nil {
-		fake.copyImageToArchiveReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.copyImageToArchiveReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
 }
 
 func (fake *ImgpkgWrapper) GetFileDigestFromImage(arg1 string, arg2 string) (string, error) {
@@ -462,10 +314,6 @@ func (fake *ImgpkgWrapper) ResolveImageReturnsOnCall(i int, result1 error) {
 func (fake *ImgpkgWrapper) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.copyArchiveToRepoMutex.RLock()
-	defer fake.copyArchiveToRepoMutex.RUnlock()
-	fake.copyImageToArchiveMutex.RLock()
-	defer fake.copyImageToArchiveMutex.RUnlock()
 	fake.getFileDigestFromImageMutex.RLock()
 	defer fake.getFileDigestFromImageMutex.RUnlock()
 	fake.pullImageMutex.RLock()

--- a/cmd/plugin/builder/imgpkg/imgpkg.go
+++ b/cmd/plugin/builder/imgpkg/imgpkg.go
@@ -34,23 +34,6 @@ func (io *ImgpkgOptions) PullImage(image, dirPath string) error {
 	return errors.Wrapf(err, "output: %s", string(output))
 }
 
-// CopyArchiveToRepo invokes `imgpkg copy --tar <archivePath> --to-repo <imageRepo>` command
-func (io *ImgpkgOptions) CopyArchiveToRepo(imageRepo, archivePath string) error {
-	output, err := exec.Command("imgpkg", "copy", "--tar", archivePath, "--to-repo", imageRepo).CombinedOutput()
-	return errors.Wrapf(err, "output: %s", string(output))
-}
-
-// CopyImageToArchive invokes `imgpkg copy -i <image> --to-tar <archivePath>` command
-func (io *ImgpkgOptions) CopyImageToArchive(image, archivePath string) error {
-	err := os.MkdirAll(filepath.Dir(archivePath), 0755)
-	if err != nil {
-		return err
-	}
-
-	output, err := exec.Command("imgpkg", "copy", "-i", image, "--to-tar", archivePath).CombinedOutput()
-	return errors.Wrapf(err, "output: %s", string(output))
-}
-
 // GetFileDigestFromImage invokes `PullImage` to fetch the image and returns the digest of the specified file
 func (io *ImgpkgOptions) GetFileDigestFromImage(image, fileName string) (string, error) {
 	tempDir, err := os.MkdirTemp("", "")

--- a/cmd/plugin/builder/imgpkg/interface.go
+++ b/cmd/plugin/builder/imgpkg/interface.go
@@ -14,10 +14,6 @@ type ImgpkgWrapper interface {
 	PushImage(image, filePath string) error
 	// PullImage invokes `imgpkg pull -i <image> -o <dirPath>` command
 	PullImage(image, dirPath string) error
-	// CopyArchiveToRepo invokes `imgpkg copy --tar <archivePath> --to-repo <imageRepo>` command
-	CopyArchiveToRepo(imageRepo, archivePath string) error
-	// CopyImageToArchive invokes `imgpkg copy -i <image> --to-tar <archivePath>` command
-	CopyImageToArchive(image, archivePath string) error
 	// GetFileDigestFromImage invokes `PullImage` to fetch the image and returns the digest of the specified file
 	GetFileDigestFromImage(image, fileName string) (string, error)
 }

--- a/cmd/plugin/builder/inventory/inventory_plugin.go
+++ b/cmd/plugin/builder/inventory/inventory_plugin.go
@@ -153,7 +153,7 @@ func (ipuo *InventoryPluginUpdateOptions) updatePluginInventoryEntry(pluginInven
 	return pluginInventoryEntry, nil
 }
 
-func (ipuo *InventoryPluginUpdateOptions) getPluginInventoryDBImage() string {
+func (ipuo *InventoryPluginUpdateOptions) getPluginInventoryDBImagePath() string {
 	return fmt.Sprintf("%s/%s:%s", ipuo.Repository, helpers.PluginInventoryDBImageName, ipuo.InventoryImageTag)
 }
 
@@ -175,7 +175,7 @@ func (ipuo *InventoryPluginUpdateOptions) getInventoryDBFile() (string, error) {
 	}
 
 	// get plugin inventory database image path
-	pluginInventoryDBImage := ipuo.getPluginInventoryDBImage()
+	pluginInventoryDBImage := ipuo.getPluginInventoryDBImagePath()
 
 	dir, err := os.MkdirTemp("", "")
 	if err != nil {
@@ -191,7 +191,7 @@ func (ipuo *InventoryPluginUpdateOptions) getInventoryDBFile() (string, error) {
 }
 
 func (ipuo *InventoryPluginUpdateOptions) putInventoryDBFile(dbFile string) error {
-	pluginInventoryDBImage := ipuo.getPluginInventoryDBImage()
+	pluginInventoryDBImage := ipuo.getPluginInventoryDBImagePath()
 
 	// If validateOnly option was provided return validation as successful
 	if ipuo.ValidateOnly {

--- a/cmd/plugin/builder/inventory/inventory_plugin_group.go
+++ b/cmd/plugin/builder/inventory/inventory_plugin_group.go
@@ -121,7 +121,7 @@ func (ipuo *InventoryPluginGroupUpdateOptions) UpdatePluginGroupActivationState(
 	return ipuo.putInventoryDBFile(dbFile)
 }
 
-func (ipuo *InventoryPluginGroupUpdateOptions) getPluginInventoryDBImage() string {
+func (ipuo *InventoryPluginGroupUpdateOptions) getPluginInventoryDBImagePath() string {
 	return fmt.Sprintf("%s/%s:%s", ipuo.Repository, helpers.PluginInventoryDBImageName, ipuo.InventoryImageTag)
 }
 
@@ -132,7 +132,7 @@ func (ipuo *InventoryPluginGroupUpdateOptions) getInventoryDBFile() (string, err
 	}
 
 	// get plugin inventory database image path
-	pluginInventoryDBImage := ipuo.getPluginInventoryDBImage()
+	pluginInventoryDBImage := ipuo.getPluginInventoryDBImagePath()
 
 	tempDir, err := os.MkdirTemp("", "")
 	if err != nil {
@@ -149,7 +149,7 @@ func (ipuo *InventoryPluginGroupUpdateOptions) getInventoryDBFile() (string, err
 }
 
 func (ipuo *InventoryPluginGroupUpdateOptions) putInventoryDBFile(dbFile string) error {
-	pluginInventoryDBImage := ipuo.getPluginInventoryDBImage()
+	pluginInventoryDBImage := ipuo.getPluginInventoryDBImagePath()
 
 	// If local inventory database file was provided nothing to publish just return
 	if ipuo.InventoryDBFile != "" {

--- a/cmd/plugin/builder/inventory_plugin.go
+++ b/cmd/plugin/builder/inventory_plugin.go
@@ -35,6 +35,7 @@ type inventoryPluginAddFlags struct {
 	ManifestFile      string
 	Publisher         string
 	Vendor            string
+	InventoryDBFile   string
 	DeactivatePlugins bool
 	ValidateOnly      bool
 }
@@ -55,6 +56,7 @@ func newInventoryPluginAddCmd() *cobra.Command {
 				Vendor:            ipaFlags.Vendor,
 				Publisher:         ipaFlags.Publisher,
 				DeactivatePlugins: ipaFlags.DeactivatePlugins,
+				InventoryDBFile:   ipaFlags.InventoryDBFile,
 				ValidateOnly:      ipaFlags.ValidateOnly,
 				ImgpkgOptions:     imgpkg.NewImgpkgCLIWrapper(),
 			}
@@ -67,6 +69,7 @@ func newInventoryPluginAddCmd() *cobra.Command {
 	pluginAddCmd.Flags().StringVarP(&ipaFlags.ManifestFile, "manifest", "", "", "manifest file specifying plugin details that needs to be processed")
 	pluginAddCmd.Flags().StringVarP(&ipaFlags.Vendor, "vendor", "", "", "name of the vendor")
 	pluginAddCmd.Flags().StringVarP(&ipaFlags.Publisher, "publisher", "", "", "name of the publisher")
+	pluginAddCmd.Flags().StringVarP(&ipaFlags.InventoryDBFile, "plugin-inventory-db-file", "", "", "local file for the inventory database")
 	pluginAddCmd.Flags().BoolVarP(&ipaFlags.DeactivatePlugins, "deactivate", "", false, "mark plugins as deactivated")
 	pluginAddCmd.Flags().BoolVarP(&ipaFlags.ValidateOnly, "validate", "", false, "validate whether plugins already exists in the plugin inventory or not")
 
@@ -84,9 +87,10 @@ type inventoryPluginActivateDeactivateFlags struct {
 	ManifestFile      string
 	Publisher         string
 	Vendor            string
+	InventoryDBFile   string
 }
 
-func newInventoryPluginActivateCmd() *cobra.Command {
+func newInventoryPluginActivateCmd() *cobra.Command { // nolint:dupl
 	pluginActivateCmd, flags := getActivateDeactivateBaseCmd()
 	pluginActivateCmd.Use = "activate" // nolint:goconst
 	pluginActivateCmd.Short = "Activate the existing plugin in the inventory database available on the remote repository"
@@ -98,6 +102,7 @@ func newInventoryPluginActivateCmd() *cobra.Command {
 			ManifestFile:      flags.ManifestFile,
 			Vendor:            flags.Vendor,
 			Publisher:         flags.Publisher,
+			InventoryDBFile:   flags.InventoryDBFile,
 			DeactivatePlugins: false,
 			ImgpkgOptions:     imgpkg.NewImgpkgCLIWrapper(),
 		}
@@ -106,7 +111,7 @@ func newInventoryPluginActivateCmd() *cobra.Command {
 	return pluginActivateCmd
 }
 
-func newInventoryPluginDeactivateCmd() *cobra.Command {
+func newInventoryPluginDeactivateCmd() *cobra.Command { // nolint:dupl
 	pluginDeactivateCmd, flags := getActivateDeactivateBaseCmd()
 	pluginDeactivateCmd.Use = "deactivate" // nolint:goconst
 	pluginDeactivateCmd.Short = "Deactivate the existing plugin in the inventory database available on the remote repository"
@@ -118,6 +123,7 @@ func newInventoryPluginDeactivateCmd() *cobra.Command {
 			ManifestFile:      flags.ManifestFile,
 			Vendor:            flags.Vendor,
 			Publisher:         flags.Publisher,
+			InventoryDBFile:   flags.InventoryDBFile,
 			DeactivatePlugins: true,
 			ImgpkgOptions:     imgpkg.NewImgpkgCLIWrapper(),
 		}
@@ -137,8 +143,8 @@ func getActivateDeactivateBaseCmd() (*cobra.Command, *inventoryPluginActivateDea
 	activateDeactivateCmd.Flags().StringVarP(&flags.ManifestFile, "manifest", "", "", "manifest file specifying plugin details that needs to be processed")
 	activateDeactivateCmd.Flags().StringVarP(&flags.Vendor, "vendor", "", "", "name of the vendor")
 	activateDeactivateCmd.Flags().StringVarP(&flags.Publisher, "publisher", "", "", "name of the publisher")
+	activateDeactivateCmd.Flags().StringVarP(&flags.InventoryDBFile, "plugin-inventory-db-file", "", "", "local file for the inventory database")
 
-	_ = activateDeactivateCmd.MarkFlagRequired("repository")
 	_ = activateDeactivateCmd.MarkFlagRequired("vendor")
 	_ = activateDeactivateCmd.MarkFlagRequired("publisher")
 	_ = activateDeactivateCmd.MarkFlagRequired("manifest")

--- a/cmd/plugin/builder/inventory_plugin_group.go
+++ b/cmd/plugin/builder/inventory_plugin_group.go
@@ -38,6 +38,7 @@ type inventoryPluginGroupAddFlags struct {
 	ManifestFile          string
 	Publisher             string
 	Vendor                string
+	InventoryDBFile       string
 	DeactivatePluginGroup bool
 	Override              bool
 }
@@ -60,6 +61,7 @@ func newInventoryPluginGroupAddCmd() *cobra.Command {
 				PluginGroupManifestFile: ipgaFlags.ManifestFile,
 				Vendor:                  ipgaFlags.Vendor,
 				Publisher:               ipgaFlags.Publisher,
+				InventoryDBFile:         ipgaFlags.InventoryDBFile,
 				DeactivatePluginGroup:   ipgaFlags.DeactivatePluginGroup,
 				Override:                ipgaFlags.Override,
 				ImgpkgOptions:           imgpkg.NewImgpkgCLIWrapper(),
@@ -76,12 +78,12 @@ func newInventoryPluginGroupAddCmd() *cobra.Command {
 	pluginGroupAddCmd.Flags().StringVarP(&ipgaFlags.ManifestFile, "manifest", "", "", "manifest file specifying plugin-group details that needs to be processed")
 	pluginGroupAddCmd.Flags().StringVarP(&ipgaFlags.Vendor, "vendor", "", "", "name of the vendor")
 	pluginGroupAddCmd.Flags().StringVarP(&ipgaFlags.Publisher, "publisher", "", "", "name of the publisher")
+	pluginGroupAddCmd.Flags().StringVarP(&ipgaFlags.InventoryDBFile, "plugin-inventory-db-file", "", "", "local file for the inventory database")
 	pluginGroupAddCmd.Flags().BoolVarP(&ipgaFlags.DeactivatePluginGroup, "deactivate", "", false, "mark plugin-group as deactivated")
 	pluginGroupAddCmd.Flags().BoolVarP(&ipgaFlags.Override, "override", "", false, "overwrite the plugin-group version if it already exists")
 
 	_ = pluginGroupAddCmd.MarkFlagRequired("name")
 	_ = pluginGroupAddCmd.MarkFlagRequired("version")
-	_ = pluginGroupAddCmd.MarkFlagRequired("repository")
 	_ = pluginGroupAddCmd.MarkFlagRequired("vendor")
 	_ = pluginGroupAddCmd.MarkFlagRequired("publisher")
 	_ = pluginGroupAddCmd.MarkFlagRequired("manifest")
@@ -97,6 +99,7 @@ type inventoryPluginGroupActivateDeactivateFlags struct {
 	ManifestFile      string
 	Publisher         string
 	Vendor            string
+	InventoryDBFile   string
 }
 
 func newInventoryPluginGroupActivateCmd() *cobra.Command { //nolint:dupl
@@ -112,6 +115,7 @@ func newInventoryPluginGroupActivateCmd() *cobra.Command { //nolint:dupl
 			InventoryImageTag:     flags.InventoryImageTag,
 			Vendor:                flags.Vendor,
 			Publisher:             flags.Publisher,
+			InventoryDBFile:       flags.InventoryDBFile,
 			DeactivatePluginGroup: false,
 			ImgpkgOptions:         imgpkg.NewImgpkgCLIWrapper(),
 		}
@@ -133,6 +137,7 @@ func newInventoryPluginGroupDeactivateCmd() *cobra.Command { //nolint:dupl
 			InventoryImageTag:     flags.InventoryImageTag,
 			Vendor:                flags.Vendor,
 			Publisher:             flags.Publisher,
+			InventoryDBFile:       flags.InventoryDBFile,
 			DeactivatePluginGroup: true,
 			ImgpkgOptions:         imgpkg.NewImgpkgCLIWrapper(),
 		}
@@ -153,10 +158,10 @@ func getPluginGroupActivateDeactivateBaseCmd() (*cobra.Command, *inventoryPlugin
 	activateDeactivateCmd.Flags().StringVarP(&flags.InventoryImageTag, "plugin-inventory-image-tag", "", "latest", "tag to which plugin inventory image needs to be published")
 	activateDeactivateCmd.Flags().StringVarP(&flags.Vendor, "vendor", "", "", "name of the vendor")
 	activateDeactivateCmd.Flags().StringVarP(&flags.Publisher, "publisher", "", "", "name of the publisher")
+	activateDeactivateCmd.Flags().StringVarP(&flags.InventoryDBFile, "plugin-inventory-db-file", "", "", "local file for the inventory database")
 
 	_ = activateDeactivateCmd.MarkFlagRequired("name")
 	_ = activateDeactivateCmd.MarkFlagRequired("version")
-	_ = activateDeactivateCmd.MarkFlagRequired("repository")
 	_ = activateDeactivateCmd.MarkFlagRequired("vendor")
 	_ = activateDeactivateCmd.MarkFlagRequired("publisher")
 

--- a/cmd/plugin/builder/plugin.go
+++ b/cmd/plugin/builder/plugin.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/command"
+	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/docker"
 	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/imgpkg"
 	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/plugin"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
@@ -43,7 +44,6 @@ type pluginBuildFlags struct {
 type pluginBuildPackageFlags struct {
 	BinaryArtifactDir  string
 	PackageArtifactDir string
-	LocalOCIRepository string
 }
 
 type pluginPublishPackageFlags struct {
@@ -112,8 +112,8 @@ func newPluginBuildPackageCmd() *cobra.Command {
 			bppArgs := &plugin.BuildPluginPackageOptions{
 				BinaryArtifactDir:  pbpFlags.BinaryArtifactDir,
 				PackageArtifactDir: pbpFlags.PackageArtifactDir,
-				LocalOCIRegistry:   pbpFlags.LocalOCIRepository,
 				ImgpkgOptions:      imgpkg.NewImgpkgCLIWrapper(),
+				DockerOptions:      docker.NewDockerCLIWrapper(),
 			}
 			return bppArgs.BuildPluginPackages()
 		},
@@ -121,7 +121,6 @@ func newPluginBuildPackageCmd() *cobra.Command {
 
 	pluginBuildPackageCmd.Flags().StringVarP(&pbpFlags.BinaryArtifactDir, "binary-artifacts", "", "./artifacts/plugins", "plugin binary artifact directory")
 	pluginBuildPackageCmd.Flags().StringVarP(&pbpFlags.PackageArtifactDir, "package-artifacts", "", "./artifacts/packages", "plugin package artifacts directory")
-	pluginBuildPackageCmd.Flags().StringVarP(&pbpFlags.LocalOCIRepository, "oci-registry", "", "", "local oci-registry to use for generating packages")
 
 	return pluginBuildPackageCmd
 }
@@ -142,6 +141,7 @@ func newPluginPublishPackageCmd() *cobra.Command {
 				Repository:         pppFlags.Repository,
 				DryRun:             pppFlags.DryRun,
 				ImgpkgOptions:      imgpkg.NewImgpkgCLIWrapper(),
+				DockerOptions:      docker.NewDockerCLIWrapper(),
 			}
 			return bppArgs.PublishPluginPackages()
 		},

--- a/cmd/plugin/builder/plugin.go
+++ b/cmd/plugin/builder/plugin.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/command"
 	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/docker"
-	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/imgpkg"
 	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/plugin"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 )
@@ -44,6 +43,7 @@ type pluginBuildFlags struct {
 type pluginBuildPackageFlags struct {
 	BinaryArtifactDir  string
 	PackageArtifactDir string
+	localOCIRepository string
 }
 
 type pluginPublishPackageFlags struct {
@@ -112,7 +112,6 @@ func newPluginBuildPackageCmd() *cobra.Command {
 			bppArgs := &plugin.BuildPluginPackageOptions{
 				BinaryArtifactDir:  pbpFlags.BinaryArtifactDir,
 				PackageArtifactDir: pbpFlags.PackageArtifactDir,
-				ImgpkgOptions:      imgpkg.NewImgpkgCLIWrapper(),
 				DockerOptions:      docker.NewDockerCLIWrapper(),
 			}
 			return bppArgs.BuildPluginPackages()
@@ -121,6 +120,11 @@ func newPluginBuildPackageCmd() *cobra.Command {
 
 	pluginBuildPackageCmd.Flags().StringVarP(&pbpFlags.BinaryArtifactDir, "binary-artifacts", "", "./artifacts/plugins", "plugin binary artifact directory")
 	pluginBuildPackageCmd.Flags().StringVarP(&pbpFlags.PackageArtifactDir, "package-artifacts", "", "./artifacts/packages", "plugin package artifacts directory")
+
+	// Marked as hidden because `build-package` command does not rely on the --oci-registry flag any more kept it for backward compatibility
+	// To be removed in future releases
+	pluginBuildPackageCmd.Flags().StringVarP(&pbpFlags.localOCIRepository, "oci-registry", "", "", "local oci-registry to use for generating packages")
+	_ = pluginBuildPackageCmd.Flags().MarkHidden("oci-registry")
 
 	return pluginBuildPackageCmd
 }
@@ -140,7 +144,6 @@ func newPluginPublishPackageCmd() *cobra.Command {
 				Vendor:             pppFlags.Vendor,
 				Repository:         pppFlags.Repository,
 				DryRun:             pppFlags.DryRun,
-				ImgpkgOptions:      imgpkg.NewImgpkgCLIWrapper(),
 				DockerOptions:      docker.NewDockerCLIWrapper(),
 			}
 			return bppArgs.PublishPluginPackages()

--- a/cmd/plugin/builder/plugin/build-packages.go
+++ b/cmd/plugin/builder/plugin/build-packages.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/docker"
 	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/helpers"
-	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/imgpkg"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/utils"
 )
@@ -23,7 +22,6 @@ import (
 type BuildPluginPackageOptions struct {
 	BinaryArtifactDir  string
 	PackageArtifactDir string
-	ImgpkgOptions      imgpkg.ImgpkgWrapper
 	DockerOptions      docker.DockerWrapper
 
 	pluginManifestFile string

--- a/cmd/plugin/builder/plugin/build-packages.go
+++ b/cmd/plugin/builder/plugin/build-packages.go
@@ -81,11 +81,7 @@ func (bpo *BuildPluginPackageOptions) BuildPluginPackages() error {
 
 				log.Infof("Generating plugin package for 'plugin:%s' 'target:%s' 'os:%s' 'arch:%s' 'version:%s'", pluginManifest.Plugins[i].Name, pluginManifest.Plugins[i].Target, osArch.OS(), osArch.Arch(), version)
 
-<<<<<<< HEAD
-				err = bpo.ImgpkgOptions.PushImage(image, pluginBinaryFilePath)
-=======
 				err = bpo.DockerOptions.BuildImage(image, dockerTemplateFile, filepath.Dir(pluginBinaryFilePath))
->>>>>>> Use docker interface to build plugin oci images
 				if err != nil {
 					return errors.Wrapf(err, "unable to build package for plugin: %s, target: %s, os: %s, arch: %s, version: %s", pluginManifest.Plugins[i].Name, pluginManifest.Plugins[i].Target, osArch.OS(), osArch.Arch(), version)
 				}

--- a/cmd/plugin/builder/plugin/helpers.go
+++ b/cmd/plugin/builder/plugin/helpers.go
@@ -1,0 +1,31 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package plugin implements plugin specific publishing functions
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/utils"
+)
+
+const (
+	localRegistry  = "localhost"
+	dockerTemplate = `FROM scratch
+COPY . ./`
+)
+
+func getDockerTemplateFileForPluginPackageBuild() (string, error) {
+	tmpDir, err := os.MkdirTemp("", "")
+	if err != nil {
+		return "", err
+	}
+	templateFile := filepath.Join(tmpDir, "Dockerfile")
+	err = utils.SaveFile(templateFile, []byte(dockerTemplate))
+	if err != nil {
+		return "", err
+	}
+	return templateFile, nil
+}

--- a/cmd/plugin/builder/plugin/publish-packages.go
+++ b/cmd/plugin/builder/plugin/publish-packages.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 
+	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/docker"
 	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/helpers"
 	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/imgpkg"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
@@ -24,6 +25,7 @@ type PublishPluginPackageOptions struct {
 	Repository         string
 	DryRun             bool
 	ImgpkgOptions      imgpkg.ImgpkgWrapper
+	DockerOptions      docker.DockerWrapper
 
 	pluginManifestFile string
 }
@@ -51,17 +53,26 @@ func (ppo *PublishPluginPackageOptions) PublishPluginPackages() error {
 					continue
 				}
 
-				imageRepo := fmt.Sprintf("%s/%s/%s/%s/%s/%s/%s", ppo.Repository, ppo.Vendor, ppo.Publisher, osArch.OS(), osArch.Arch(), pluginManifest.Plugins[i].Target, pluginManifest.Plugins[i].Name)
+				imageAfterLoad := fmt.Sprintf("%s/plugins/%s/%s/%s:%s", localRegistry, osArch.OS(), osArch.Arch(), pluginManifest.Plugins[i].Name, version)
+				imageToPush := fmt.Sprintf("%s/%s/%s/%s/%s/%s/%s:%s", ppo.Repository, ppo.Vendor, ppo.Publisher, osArch.OS(), osArch.Arch(), pluginManifest.Plugins[i].Target, pluginManifest.Plugins[i].Name, version)
 				log.Infof("publishing plugin 'name:%s' 'target:%s' 'os:%s' 'arch:%s' 'version:%s'", pluginManifest.Plugins[i].Name, pluginManifest.Plugins[i].Target, osArch.OS(), osArch.Arch(), version)
 
 				if ppo.DryRun {
-					log.Infof("command: 'imgpkg copy --tar %s --to-repo %s", pluginTarFilePath, imageRepo)
+					log.Infof("command: 'imgpkg copy --tar %s --to-repo %s", pluginTarFilePath, imageToPush)
 				} else {
-					err = ppo.ImgpkgOptions.CopyArchiveToRepo(imageRepo, pluginTarFilePath)
+					err := ppo.DockerOptions.LoadImage(pluginTarFilePath)
 					if err != nil {
-						return errors.Wrapf(err, "unable to publish plugin (name:%s, target:%s, os:%s, arch:%s, version:%s)", pluginManifest.Plugins[i].Name, pluginManifest.Plugins[i].Target, osArch.OS(), osArch.Arch(), version)
+						return errors.Wrapf(err, "unable to load image for plugin: %s, target: %s, os: %s, arch: %s, version: %s", pluginManifest.Plugins[i].Name, pluginManifest.Plugins[i].Target, osArch.OS(), osArch.Arch(), version)
 					}
-					log.Infof("published plugin at '%s:%s'", imageRepo, version)
+					err = ppo.DockerOptions.TagImage(imageAfterLoad, imageToPush)
+					if err != nil {
+						return errors.Wrapf(err, "unable to retag image for plugin: %s, target: %s, os: %s, arch: %s, version: %s", pluginManifest.Plugins[i].Name, pluginManifest.Plugins[i].Target, osArch.OS(), osArch.Arch(), version)
+					}
+					err = ppo.DockerOptions.PushImage(imageToPush)
+					if err != nil {
+						return errors.Wrapf(err, "unable to push image for plugin: %s, target: %s, os: %s, arch: %s, version: %s", pluginManifest.Plugins[i].Name, pluginManifest.Plugins[i].Target, osArch.OS(), osArch.Arch(), version)
+					}
+					log.Infof("published plugin at '%s'", imageToPush)
 				}
 			}
 		}

--- a/cmd/plugin/builder/plugin/publish-packages.go
+++ b/cmd/plugin/builder/plugin/publish-packages.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/docker"
 	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/helpers"
-	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/imgpkg"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/utils"
 )
@@ -24,7 +23,6 @@ type PublishPluginPackageOptions struct {
 	Vendor             string
 	Repository         string
 	DryRun             bool
-	ImgpkgOptions      imgpkg.ImgpkgWrapper
 	DockerOptions      docker.DockerWrapper
 
 	pluginManifestFile string
@@ -58,7 +56,9 @@ func (ppo *PublishPluginPackageOptions) PublishPluginPackages() error {
 				log.Infof("publishing plugin 'name:%s' 'target:%s' 'os:%s' 'arch:%s' 'version:%s'", pluginManifest.Plugins[i].Name, pluginManifest.Plugins[i].Target, osArch.OS(), osArch.Arch(), version)
 
 				if ppo.DryRun {
-					log.Infof("command: 'imgpkg copy --tar %s --to-repo %s", pluginTarFilePath, imageToPush)
+					log.Infof("command: 'docker load -i %s'", pluginTarFilePath)
+					log.Infof("command: 'docker tag %s %s'", imageAfterLoad, imageToPush)
+					log.Infof("command: 'docker push %s'", imageToPush)
 				} else {
 					err := ppo.DockerOptions.LoadImage(pluginTarFilePath)
 					if err != nil {

--- a/cmd/plugin/builder/template/plugintemplates/plugin-tooling.mk.tmpl
+++ b/cmd/plugin/builder/template/plugintemplates/plugin-tooling.mk.tmpl
@@ -102,14 +102,14 @@ plugin-build-%:
 		--plugin-scope-association-file $(PLUGIN_SCOPE_ASSOCIATION_FILE)
 
 .PHONY: plugin-build-packages
-plugin-build-packages: plugin-local-registry ## Build plugin packages
+plugin-build-packages: ## Build plugin packages
 	$(BUILDER_PLUGIN) plugin build-package \
 		--binary-artifacts $(PLUGIN_BINARY_ARTIFACTS_DIR) \
 		--package-artifacts $(PLUGIN_PACKAGE_ARTIFACTS_DIR) \
 		--oci-registry $(REGISTRY_ENDPOINT)
 
 .PHONY: plugin-publish-packages
-plugin-publish-packages: plugin-build-packages ## Publish plugin packages
+plugin-publish-packages: plugin-build-packages plugin-local-registry ## Publish plugin packages
 	$(BUILDER_PLUGIN) plugin publish-package \
 		--package-artifacts $(PLUGIN_PACKAGE_ARTIFACTS_DIR) \
 		--publisher $(PUBLISHER) \

--- a/cmd/plugin/builder/template/plugintemplates/plugin-tooling.mk.tmpl
+++ b/cmd/plugin/builder/template/plugintemplates/plugin-tooling.mk.tmpl
@@ -105,8 +105,7 @@ plugin-build-%:
 plugin-build-packages: ## Build plugin packages
 	$(BUILDER_PLUGIN) plugin build-package \
 		--binary-artifacts $(PLUGIN_BINARY_ARTIFACTS_DIR) \
-		--package-artifacts $(PLUGIN_PACKAGE_ARTIFACTS_DIR) \
-		--oci-registry $(REGISTRY_ENDPOINT)
+		--package-artifacts $(PLUGIN_PACKAGE_ARTIFACTS_DIR)
 
 .PHONY: plugin-publish-packages
 plugin-publish-packages: plugin-build-packages plugin-local-registry ## Publish plugin packages

--- a/docs/cli/commands/tanzu_builder_plugin_build-package.md
+++ b/docs/cli/commands/tanzu_builder_plugin_build-package.md
@@ -15,7 +15,6 @@ tanzu builder plugin build-package [flags]
 ```
       --binary-artifacts string    plugin binary artifact directory (default "./artifacts/plugins")
   -h, --help                       help for build-package
-      --oci-registry string        local oci-registry to use for generating packages
       --package-artifacts string   plugin package artifacts directory (default "./artifacts/packages")
 ```
 

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -72,3 +72,16 @@ func IsFileEmpty(filename string) (bool, error) {
 
 	return false, nil
 }
+
+// AppendFile appends data to the filePath. It creates the file if it doesn’t already exist.
+func AppendFile(filePath string, data []byte) error {
+	f, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, constants.ConfigFilePermissions)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err := f.Write(data); err != nil {
+		return err
+	}
+	return nil
+}

--- a/plugin-tooling.mk
+++ b/plugin-tooling.mk
@@ -48,6 +48,7 @@ PUBLISHER ?= tzcli
 VENDOR ?= vmware
 PLUGIN_PUBLISH_REPOSITORY ?= $(REGISTRY_ENDPOINT)/test/v1/tanzu-cli/plugins
 PLUGIN_INVENTORY_IMAGE_TAG ?= latest
+PLUGIN_INVENTORY_DATABASE_FILE ?= ""
 
 PLUGIN_SCOPE_ASSOCIATION_FILE ?= $(PLUGIN_DIR)/plugin-scope-association.yaml
 PLUGIN_GROUP_NAME_VERSION ?= # e.g. default:v1.0.0, app-developer:v0.1.0
@@ -135,7 +136,8 @@ inventory-plugin-add: ## Add plugins to the inventory database
 		--plugin-inventory-image-tag $(PLUGIN_INVENTORY_IMAGE_TAG) \
 		--publisher $(PUBLISHER) \
 		--vendor $(VENDOR) \
-		--manifest $(PLUGIN_MANIFEST_FILE)
+		--manifest $(PLUGIN_MANIFEST_FILE) \
+		--plugin-inventory-db-file $(PLUGIN_INVENTORY_DATABASE_FILE)
 
 .PHONY: inventory-plugin-activate
 inventory-plugin-activate: ## Activate plugins in the inventory database
@@ -144,7 +146,8 @@ inventory-plugin-activate: ## Activate plugins in the inventory database
 		--plugin-inventory-image-tag $(PLUGIN_INVENTORY_IMAGE_TAG) \
 		--publisher $(PUBLISHER) \
 		--vendor $(VENDOR) \
-		--manifest $(PLUGIN_MANIFEST_FILE)
+		--manifest $(PLUGIN_MANIFEST_FILE) \
+		--plugin-inventory-db-file $(PLUGIN_INVENTORY_DATABASE_FILE)
 
 .PHONY: inventory-plugin-deactivate
 inventory-plugin-deactivate: ## Deactivate plugins in the inventory database
@@ -153,10 +156,11 @@ inventory-plugin-deactivate: ## Deactivate plugins in the inventory database
 		--plugin-inventory-image-tag $(PLUGIN_INVENTORY_IMAGE_TAG) \
 		--publisher $(PUBLISHER) \
 		--vendor $(VENDOR) \
-		--manifest $(PLUGIN_MANIFEST_FILE)
+		--manifest $(PLUGIN_MANIFEST_FILE) \
+		--plugin-inventory-db-file $(PLUGIN_INVENTORY_DATABASE_FILE)
 
 .PHONY: inventory-plugin-group-add
-inventory-plugin-group-add: ## Add plugin-group to the inventory database. Requires PLUGIN_GROUP_NAME_VERSION
+inventory-plugin-group-add: ## Add plugin-group to the inventory database. Requires PLUGIN_GROUP_NAME_VERSION, PLUGIN_GROUP_DESCRIPTION
 	$(BUILDER_PLUGIN) inventory plugin-group add \
 		--repository $(PLUGIN_PUBLISH_REPOSITORY) \
 		--plugin-inventory-image-tag $(PLUGIN_INVENTORY_IMAGE_TAG) \
@@ -165,6 +169,7 @@ inventory-plugin-group-add: ## Add plugin-group to the inventory database. Requi
 		--manifest $(PLUGIN_GROUP_MANIFEST_FILE) \
 		--name $(PLUGIN_GROUP_NAME) \
 		--version $(PLUGIN_GROUP_VERSION) \
+		--plugin-inventory-db-file $(PLUGIN_INVENTORY_DATABASE_FILE) \
 		$(PLUGIN_GROUP_DESCRIPTION_FLAG_AND_VALUE) \
 		$(OVERRIDE_FLAG)
 
@@ -176,7 +181,8 @@ inventory-plugin-group-activate: ## Activate plugin-group in the inventory datab
 		--publisher $(PUBLISHER) \
 		--vendor $(VENDOR) \
 		--name $(PLUGIN_GROUP_NAME) \
-		--version $(PLUGIN_GROUP_VERSION)
+		--version $(PLUGIN_GROUP_VERSION) \
+		--plugin-inventory-db-file $(PLUGIN_INVENTORY_DATABASE_FILE)
 
 .PHONY: inventory-plugin-group-deactivate
 inventory-plugin-group-deactivate: ## Deactivate plugin-group in the inventory database. Requires PLUGIN_GROUP_NAME_VERSION
@@ -186,7 +192,8 @@ inventory-plugin-group-deactivate: ## Deactivate plugin-group in the inventory d
 		--publisher $(PUBLISHER) \
 		--vendor $(VENDOR) \
 		--name $(PLUGIN_GROUP_NAME) \
-		--version $(PLUGIN_GROUP_VERSION)
+		--version $(PLUGIN_GROUP_VERSION) \
+		--plugin-inventory-db-file $(PLUGIN_INVENTORY_DATABASE_FILE)
 
 ## --------------------------------------
 ## docker

--- a/plugin-tooling.mk
+++ b/plugin-tooling.mk
@@ -105,14 +105,13 @@ plugin-build-%:
 		--plugin-scope-association-file $(PLUGIN_SCOPE_ASSOCIATION_FILE)
 
 .PHONY: plugin-build-packages
-plugin-build-packages: plugin-local-registry ## Build plugin packages
+plugin-build-packages: ## Build plugin packages
 	$(BUILDER_PLUGIN) plugin build-package \
 		--binary-artifacts $(PLUGIN_BINARY_ARTIFACTS_DIR) \
-		--package-artifacts $(PLUGIN_PACKAGE_ARTIFACTS_DIR) \
-		--oci-registry $(REGISTRY_ENDPOINT)
+		--package-artifacts $(PLUGIN_PACKAGE_ARTIFACTS_DIR)
 
 .PHONY: plugin-publish-packages
-plugin-publish-packages: plugin-build-packages ## Publish plugin packages
+plugin-publish-packages: plugin-build-packages plugin-local-registry ## Publish plugin packages
 	$(BUILDER_PLUGIN) plugin publish-package \
 		--package-artifacts $(PLUGIN_PACKAGE_ARTIFACTS_DIR) \
 		--publisher $(PUBLISHER) \


### PR DESCRIPTION
### What this PR does / why we need it
- Use the `docker` interface to build plugin OCI images as part of the `tanzu builder plugin build-package`
- Add `--plugin-inventory-db-file` flag to inventory update commands to update the inventory db file that exists locally
  - Before this change, the CLI was always downloading the database from the remote repository, update it and was publishing it back again.
  - This change will allow us to just use the local database file to do validation as well as update it if `--plugin-inventory-db-file` flag is provided.
- Corresponding makefile changes have been done.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
```
~/D/c/tanzu-cli (anujc/test-build-v1|✔) $ make prepare-builder
cd cmd/plugin/builder && go build -o /Users/anujc/Documents/code/tanzu-cli/bin/builder .

~/D/c/tanzu-cli (anujc/test-build-v1|✔) $ rm -rf artifacts/

~/D/c/tanzu-cli (anujc/test-build-v1|✔) $ make plugin-build-and-publish-packages
/Users/anujc/Documents/code/tanzu-cli/bin/builder plugin build \
                --path ./cmd/plugin \
                --binary-artifacts /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins \
                --version v1.0.0-dev \
                --ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-05-19' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=0beef0cc' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev'" \
                --goflags "" \
                --os-arch linux_amd64 \
                --match "*" \
                --plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-05-19T09:12:55-07:00 [i] building local repository at /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins, v1.0.0-dev, [linux_amd64]
2023-05-19T09:12:55-07:00 [i] 🐯 - building plugin at path "cmd/plugin/test"
2023-05-19T09:12:55-07:00 [i] 🐱 - building plugin at path "cmd/plugin/builder"
.
.
.
/Users/anujc/Documents/code/tanzu-cli/bin/builder plugin build-package \
                --binary-artifacts /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins \
                --package-artifacts /Users/anujc/Documents/code/tanzu-cli/artifacts/packages
2023-05-19T09:13:51-07:00 [i] Using plugin binary artifacts from "/Users/anujc/Documents/code/tanzu-cli/artifacts/plugins"
2023-05-19T09:13:51-07:00 [i] Generating plugin package for 'plugin:builder' 'target:global' 'os:linux' 'arch:amd64' 'version:v1.0.0-dev'
2023-05-19T09:13:56-07:00 [i] Generated plugin package at "/Users/anujc/Documents/code/tanzu-cli/artifacts/packages/linux/amd64/global/builder/v1.0.0-dev/builder-linux_amd64.tar.gz"
.
.
.
2023-05-19T09:14:24-07:00 [i] Saved plugin manifest at "/Users/anujc/Documents/code/tanzu-cli/artifacts/packages/plugin_manifest.yaml"
docker stop temp-package-registry && docker rm -v temp-package-registry || true
temp-package-registry
temp-package-registry
docker run -d -p 5001:5000 --name temp-package-registry mirror.gcr.io/library/registry:2.7.1
41cc343d43ac3837bb9be351ab686064513a8494d4531723823da39eb90357c1
/Users/anujc/Documents/code/tanzu-cli/bin/builder plugin publish-package \
                --package-artifacts /Users/anujc/Documents/code/tanzu-cli/artifacts/packages \
                --publisher tzcli \
                --vendor vmware \
                --repository localhost:5001/test/v1/tanzu-cli/plugins
2023-05-19T09:14:26-07:00 [i] using plugin package artifacts from "/Users/anujc/Documents/code/tanzu-cli/artifacts/packages"
2023-05-19T09:14:26-07:00 [i] publishing plugin 'name:builder' 'target:global' 'os:linux' 'arch:amd64' 'version:v1.0.0-dev'
2023-05-19T09:14:29-07:00 [i] published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tzcli/linux/amd64/global/builder:v1.0.0-dev'
2023-05-19T09:14:29-07:00 [i] publishing plugin 'name:builder' 'target:global' 'os:darwin' 'arch:amd64' 'version:v1.0.0-dev'
2023-05-19T09:14:31-07:00 [i] published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tzcli/darwin/amd64/global/builder:v1.0.0-dev'
.
.


~/D/c/tanzu-cli (anujc/test-build-v1|✔) $ make inventory-init
/Users/anujc/Documents/code/tanzu-cli/bin/builder inventory init \
                --repository localhost:5001/test/v1/tanzu-cli/plugins \
                --plugin-inventory-image-tag latest \

2023-05-19T09:15:08-07:00 [i] created database locally at: "/var/folders/xc/12mmbpb50qxfb3ch8vv9nvwm0000gq/T/plugin_inventory.db"
2023-05-19T09:15:08-07:00 [i] publishing database at: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
2023-05-19T09:15:08-07:00 [i] successfully published plugin inventory database

~/D/c/tanzu-cli (anujc/test-build-v1|✔) $ imgpkg pull -i localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest -o /tmp/db/
Pulling image 'localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory@sha256:b4b3ebb5261f3e7a93fcfe06b5ed61e46132e2e53e670f11fd2d7afe721f0557'
Extracting layer 'sha256:67832b30e55a0b1fc6f96221c82b661809df2c07d8350e4a07bd6d1cd1e365ea' (1/1)

Succeeded

~/D/c/tanzu-cli (anujc/test-build-v1|✔) $ ls /tmp/db
plugin_inventory.db

~/D/c/tanzu-cli (anujc/test-build-v1|✔) $ export PLUGIN_INVENTORY_DATABASE_FILE=/tmp/db/plugin_inventory.db

~/D/c/tanzu-cli (anujc/test-build-v1|✔) $ make inventory-plugin-add
/Users/anujc/Documents/code/tanzu-cli/bin/builder inventory plugin add \
                --repository localhost:5001/test/v1/tanzu-cli/plugins \
                --plugin-inventory-image-tag latest \
                --publisher tzcli \
                --vendor vmware \
                --manifest /Users/anujc/Documents/code/tanzu-cli/artifacts/packages/plugin_manifest.yaml \
                --plugin-inventory-db-file /tmp/db/plugin_inventory.db
2023-05-19T09:17:36-07:00 [i] using local plugin inventory database file: "/tmp/db/plugin_inventory.db"
2023-05-19T09:17:36-07:00 [i] validating plugin 'builder_global_linux_amd64_v1.0.0-dev'
2023-05-19T09:17:37-07:00 [i] validating plugin 'builder_global_darwin_amd64_v1.0.0-dev'
2023-05-19T09:17:37-07:00 [i] validating plugin 'builder_global_windows_amd64_v1.0.0-dev'
2023-05-19T09:17:38-07:00 [i] validating plugin 'test_global_linux_amd64_v1.0.0-dev'
2023-05-19T09:17:39-07:00 [i] validating plugin 'test_global_darwin_amd64_v1.0.0-dev'
2023-05-19T09:17:41-07:00 [i] validating plugin 'test_global_windows_amd64_v1.0.0-dev'
2023-05-19T09:17:42-07:00 [i] successfully updated plugin inventory database file at: "/tmp/db/plugin_inventory.db"



```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Use the docker interface to build plugin OCI images with the builder plugin. Also allows updating local database file.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
