### PR TITLE
Eula commands and prompt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ setup-custom-cert-for-test-central-repo: ## Setup up the custom ca cert for test
   		tar xjf $(ROOT_DIR)/hack/central-repo/local-central-repo-testcontent.bz2 -C $(ROOT_DIR)/hack/central-repo/;\
 	fi
 	echo "Adding docker test central repo cert to the config file"
-	TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="No" $(ROOT_DIR)/bin/tanzu config cert delete localhost:9876 || true
+	TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="No" TANZU_CLI_EULA_PROMPT_ANSWER="Yes" $(ROOT_DIR)/bin/tanzu config cert delete localhost:9876 || true
 	$(ROOT_DIR)/bin/tanzu config cert add --host localhost:9876 --ca-certificate $(ROOT_DIR)/hack/central-repo/certs/localhost.crt
 
 .PHONY: start-test-central-repo
@@ -312,6 +312,10 @@ ifndef TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER
 TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER = no
 endif
 
+ifndef TANZU_CLI_EULA_PROMPT_ANSWER
+TANZU_CLI_EULA_PROMPT_ANSWER = yes
+endif
+
 .PHONY: build-cli-coexistence ## Build CLI Coexistence docker image
 build-cli-coexistence: start-test-central-repo
 	docker build \
@@ -322,6 +326,7 @@ build-cli-coexistence: start-test-central-repo
 		--build-arg TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL=$(TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL) \
 		--build-arg TANZU_CLI_PRE_RELEASE_REPO_IMAGE=$(TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL) \
 		--build-arg TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER=$(TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER) \
+		--build-arg TANZU_CLI_EULA_PROMPT_ANSWER=$(TANZU_CLI_EULA_PROMPT_ANSWER) \
 		-t cli-coexistence \
 		.
 
@@ -337,6 +342,7 @@ cli-coexistence-tests:start-test-central-repo
 	  -e TANZU_CLI_PRE_RELEASE_REPO_IMAGE=$(TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL) \
 	  -e TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST=$(TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL) \
 	  -e TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER=$(TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER) \
+	  -e TANZU_CLI_EULA_PROMPT_ANSWER=$(TANZU_CLI_EULA_PROMPT_ANSWER) \
 	  -e TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_HOST=$(TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_HOST)  \
 	  -v $(ROOT_DIR):/tmp/tanzu-cli/ \
 	  -v $(ROOT_DIR)/hack/central-repo/certs:/localhost_certs/ \

--- a/docs/quickstart/install.md
+++ b/docs/quickstart/install.md
@@ -84,13 +84,26 @@ EOF
 sudo yum install tanzu-cli # dnf install can also be used
 ```
 
-## Continuous Integration
+## Automatic Prompts, and Potential Mitigations
+
+At the first suitable opportunity, (and on subsequent CLI use until the EULA is
+accepted), the CLI will present the following prompts to solicit inputs from
+the CLI user:
+
+****EULA Prompt**** :
+The Tanzu CLI prompts the user to review and agree to the VMware General terms.
+Agreeing to the terms is a prerequisite to being able to install or update plugins
+available in the default central plugin repository.
 
 ****Customer Experience Improvement Program (CEIP) Prompt**** :
-The Tanzu CLI prompts the user for CEIP participation on their first use of any `tanzu` command
-except for `tanzu version`, `tanzu ceip-participation set` and `tanzu config set` commands.
-Users installing/using the CLI through CI or by any automation means should be able to skip the prompt by
-calling `tanzu ceip-participation set <true/false>` as their first command to set the CEIP participation status.
+The Tanzu CLI prompts the user to accept participation in CEIP or not.
+
+Systems and users (via automation scripts, for instance) that expect
+non-interactive use of the CLI can avoid being prompted with either of the
+above by running the following before any other CLI commands:
+
+- `tanzu config eula accept` to accept the EULA.
+- `tanzu ceip-participation set <true/false>` to set the CEIP participation status.
 
 ## Installing and using the Tanzu CLI in internet-restricted environments
 

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/vmware-tanzu/carvel-imgpkg v0.36.1
 	github.com/vmware-tanzu/carvel-ytt v0.40.0
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230415084831-9331f55d2999
-	github.com/vmware-tanzu/tanzu-plugin-runtime v1.0.0-dev
+	github.com/vmware-tanzu/tanzu-plugin-runtime v1.0.0-dev.0.20230511155710-9131cb986ae8
 	go.pinniped.dev v0.20.0
 	go.uber.org/multierr v1.8.0
 	golang.org/x/mod v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -1289,8 +1289,8 @@ github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20221207131309-7323ca04b
 github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20221207131309-7323ca04b86c/go.mod h1:ukZpKQ0hf5bjWdJLjn2M6qXP+9giZWQPxt8nOfrCR+o=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230415084831-9331f55d2999 h1:WITDH+wpdl/clw1hwy+2jtq4Pt//i/Mq9lQXGwg3q4c=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230415084831-9331f55d2999/go.mod h1:umFZBUfJ8VI3p0VO/xocuE+4fO9s9QbytEiOqFcH/Tw=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.0.0-dev h1:AcjgTGDTwdl7I3uurnTOH1WofwHUSl/rzGNXwvocMpU=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.0.0-dev/go.mod h1:FlvOcF26rX4EA+ADjYTJdFh6WVur6O4jh25FDP9Lp7E=
+github.com/vmware-tanzu/tanzu-plugin-runtime v1.0.0-dev.0.20230511155710-9131cb986ae8 h1:qg/c0+nglQjQbmSdLqPBlqkQTR+NZpadCmnlHG0g7ag=
+github.com/vmware-tanzu/tanzu-plugin-runtime v1.0.0-dev.0.20230511155710-9131cb986ae8/go.mod h1:FlvOcF26rX4EA+ADjYTJdFh6WVur6O4jh25FDP9Lp7E=
 github.com/xanzy/go-gitlab v0.31.0/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
 github.com/xanzy/go-gitlab v0.73.1 h1:UMagqUZLJdjss1SovIC+kJCH4k2AZWXl58gJd38Y/hI=
 github.com/xanzy/go-gitlab v0.73.1/go.mod h1:d/a0vswScO7Agg1CZNz15Ic6SSvBG9vfw8egL99t4kA=

--- a/pkg/command/config.go
+++ b/pkg/command/config.go
@@ -37,6 +37,7 @@ func init() {
 		setConfigCmd,
 		unsetConfigCmd,
 		serversCmd,
+		newEULACmd(),
 		newCertCmd(),
 	)
 	serversCmd.AddCommand(listServersCmd)

--- a/pkg/command/eula.go
+++ b/pkg/command/eula.go
@@ -1,0 +1,63 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package command
+
+import (
+	"github.com/spf13/cobra"
+
+	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/config"
+)
+
+func newEULACmd() *cobra.Command {
+	var eulaCmd = &cobra.Command{
+		Use:   "eula",
+		Short: "Manage EULA acceptance",
+		Long:  "Manage EULA acceptance for Tanzu CLI use",
+	}
+	eulaCmd.SetUsageFunc(cli.SubCmdUsageFunc)
+
+	showEULACmd := newShowEULACmd()
+	acceptEULACmd := newAcceptEULACmd()
+
+	eulaCmd.AddCommand(
+		showEULACmd,
+		acceptEULACmd,
+	)
+
+	return eulaCmd
+}
+
+func newShowEULACmd() *cobra.Command {
+	var showEULACmd = &cobra.Command{
+		Use:   "show",
+		Short: "Present EULA",
+		Long:  "Present EULA for review",
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return config.ConfigureEULA(true)
+		},
+	}
+	return showEULACmd
+}
+
+func newAcceptEULACmd() *cobra.Command {
+	var acceptEULACmd = &cobra.Command{
+		Use:   "accept",
+		Short: "Accept the EULA",
+		Long:  "Accept the EULA for Tanzu CLI non-interactively.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := configlib.SetEULAStatus(configlib.EULAStatusAccepted)
+			if err != nil {
+				return err
+			}
+			log.Successf("Marking agreement as accepted.")
+			return nil
+		},
+	}
+	return acceptEULACmd
+}

--- a/pkg/command/eula_test.go
+++ b/pkg/command/eula_test.go
@@ -1,0 +1,56 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package command
+
+import (
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
+)
+
+var _ = Describe("EULA command tests", func() {
+	Describe("config eula show tests", func() {
+		var (
+			tanzuConfigFile   *os.File
+			tanzuConfigFileNG *os.File
+			err               error
+		)
+		BeforeEach(func() {
+			tanzuConfigFile, err = os.CreateTemp("", "config")
+			Expect(err).To(BeNil())
+			os.Setenv("TANZU_CONFIG", tanzuConfigFile.Name())
+
+			tanzuConfigFileNG, err = os.CreateTemp("", "config_ng")
+			Expect(err).To(BeNil())
+			os.Setenv("TANZU_CONFIG_NEXT_GEN", tanzuConfigFileNG.Name())
+
+			featureArray := strings.Split(constants.FeatureContextCommand, ".")
+			err = config.SetFeature(featureArray[1], featureArray[2], "true")
+			Expect(err).To(BeNil())
+		})
+		AfterEach(func() {
+			os.Unsetenv("TANZU_CONFIG")
+			os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
+			os.RemoveAll(tanzuConfigFile.Name())
+			os.RemoveAll(tanzuConfigFileNG.Name())
+		})
+		// TODO(vuil) : add tests for show command
+		Context("When invoking the accept command", func() {
+			It("should return successfully with agreement acceptance registered", func() {
+				eulaCmd := newEULACmd()
+				eulaCmd.SetArgs([]string{"accept"})
+				err = eulaCmd.Execute()
+				Expect(err).To(BeNil())
+
+				eulaStatus, err := config.GetEULAStatus()
+				Expect(err).To(BeNil())
+				Expect(eulaStatus).To(Equal(config.EULAStatusAccepted))
+			})
+		})
+	})
+})

--- a/pkg/command/plugin_search_test.go
+++ b/pkg/command/plugin_search_test.go
@@ -66,6 +66,7 @@ func TestPluginSearch(t *testing.T) {
 	assert.Nil(err)
 	os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
 	os.Setenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER", "No")
+	os.Setenv("TANZU_CLI_EULA_PROMPT_ANSWER", "Yes")
 
 	featureArray := strings.Split(constants.FeatureContextCommand, ".")
 	err = config.SetFeature(featureArray[1], featureArray[2], "true")
@@ -75,6 +76,7 @@ func TestPluginSearch(t *testing.T) {
 		os.Unsetenv("TANZU_CONFIG")
 		os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
 		os.Unsetenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER")
+		os.Unsetenv("TANZU_CLI_EULA_PROMPT_ANSWER")
 		os.RemoveAll(configFile.Name())
 		os.RemoveAll(configFileNG.Name())
 	}()

--- a/pkg/command/plugin_test.go
+++ b/pkg/command/plugin_test.go
@@ -148,6 +148,7 @@ func TestPluginList(t *testing.T) {
 		defer os.RemoveAll(dir)
 		os.Setenv("TEST_CUSTOM_CATALOG_CACHE_DIR", dir)
 		os.Setenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER", "No")
+		os.Setenv("TANZU_CLI_EULA_PROMPT_ANSWER", "Yes")
 
 		// Always turn on the context feature
 		featureArray := strings.Split(constants.FeatureContextCommand, ".")
@@ -210,6 +211,7 @@ func TestPluginList(t *testing.T) {
 		os.Unsetenv("TANZU_CONFIG")
 		os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
 		os.Unsetenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER")
+		os.Unsetenv("TANZU_CLI_EULA_PROMPT_ANSWER")
 	}
 }
 
@@ -247,6 +249,7 @@ func TestDeletePlugin(t *testing.T) {
 		defer os.RemoveAll(dir)
 		os.Setenv("TEST_CUSTOM_CATALOG_CACHE_DIR", dir)
 		os.Setenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER", "No")
+		os.Setenv("TANZU_CLI_EULA_PROMPT_ANSWER", "Yes")
 		var completionType uint8
 		t.Run(spec.test, func(t *testing.T) {
 			assert := assert.New(t)
@@ -286,6 +289,7 @@ func TestDeletePlugin(t *testing.T) {
 		})
 		os.Unsetenv("TEST_CUSTOM_CATALOG_CACHE_DIR")
 		os.Unsetenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER")
+		os.Unsetenv("TANZU_CLI_EULA_PROMPT_ANSWER")
 	}
 }
 
@@ -358,6 +362,7 @@ func TestInstallPlugin(t *testing.T) {
 	assert.Nil(err)
 	os.Setenv("TANZU_CONFIG_NEXT_GEN", tkgConfigFileNG.Name())
 	os.Setenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER", "No")
+	os.Setenv("TANZU_CLI_EULA_PROMPT_ANSWER", "Yes")
 
 	featureArray := strings.Split(constants.FeatureContextCommand, ".")
 	err = config.SetFeature(featureArray[1], featureArray[2], "true")
@@ -367,6 +372,7 @@ func TestInstallPlugin(t *testing.T) {
 		os.Unsetenv("TANZU_CONFIG")
 		os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
 		os.Unsetenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER")
+		os.Unsetenv("TANZU_CLI_EULA_PROMPT_ANSWER")
 		os.RemoveAll(tkgConfigFile.Name())
 		os.RemoveAll(tkgConfigFileNG.Name())
 	}()
@@ -416,6 +422,7 @@ func TestUpgradePlugin(t *testing.T) {
 	assert.Nil(err)
 	os.Setenv("TANZU_CONFIG_NEXT_GEN", tkgConfigFileNG.Name())
 	os.Setenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER", "No")
+	os.Setenv("TANZU_CLI_EULA_PROMPT_ANSWER", "Yes")
 
 	featureArray := strings.Split(constants.FeatureContextCommand, ".")
 	err = config.SetFeature(featureArray[1], featureArray[2], "true")
@@ -425,6 +432,7 @@ func TestUpgradePlugin(t *testing.T) {
 		os.Unsetenv("TANZU_CONFIG")
 		os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
 		os.Unsetenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER")
+		os.Unsetenv("TANZU_CLI_EULA_PROMPT_ANSWER")
 		os.RemoveAll(tkgConfigFile.Name())
 		os.RemoveAll(tkgConfigFileNG.Name())
 	}()

--- a/pkg/command/root_test.go
+++ b/pkg/command/root_test.go
@@ -319,6 +319,7 @@ func TestEnvVarsSet(t *testing.T) {
 	configFileNG, _ := os.CreateTemp("", "config_ng")
 	os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
 	os.Setenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER", "No")
+	os.Setenv("TANZU_CLI_EULA_PROMPT_ANSWER", "Yes")
 	defer os.RemoveAll(configFileNG.Name())
 
 	// Setup default feature flags since we have created new config files
@@ -355,6 +356,7 @@ func TestEnvVarsSet(t *testing.T) {
 	os.Unsetenv("TANZU_CONFIG")
 	os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
 	os.Unsetenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER")
+	os.Unsetenv("TANZU_CLI_EULA_PROMPT_ANSWER")
 	os.Unsetenv(envVarName)
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,11 +21,23 @@ import (
 var (
 	configClient interfaces.ConfigClientWrapper
 	// TODO(prkalle): Update the below CEIP message if necessary
-	ceipPromptMsg = `
-VMware's Customer Experience Improvement Program ("CEIP") provides VMware with information that enables VMware to improve its products and services and fix problems. By choosing to participate in CEIP, you agree that VMware may collect technical information about your use of VMware products and services on a regular basis. This information does not personally identify you.
+	ceipPromptMsg = `VMware's Customer Experience Improvement Program ("CEIP") provides VMware with information that enables VMware to improve its products and services and fix problems. By choosing to participate in CEIP, you agree that VMware may collect technical information about your use of VMware products and services on a regular basis. This information does not personally identify you.
 For more details about the Program, please see http://www.vmware.com/trustvmware/ceip.html
 
 Do you agree to Participate in the Customer Experience Improvement Program? 
+
+`
+
+	// TODO(vuil): Placeholder content, update to actual verbiage
+	eulaPromptMsg = `You must agree to the VMware General Terms in order to install software via
+Tanzu CLI.  The term of acceptance of the VMware General Terms will cover all
+software installed via the Tanzu CLI until/unless there's a change to VMware
+General Terms, a major release of the Tanzu CLI has been installed, or the
+underlying software distribution registry has been changed.
+
+To view the VMware General Terms, please see https://network.tanzu.vmware.com/legal_document_agreements/1982364
+
+Do you agree to the VMware General Terms?
 `
 )
 
@@ -89,5 +101,56 @@ func getCEIPUserOptIn() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return (ceipOptIn == "Yes"), nil
+	return strings.EqualFold(ceipOptIn, "Yes"), nil
+}
+
+// ConfigureEULA checks and configures the user's EULA acceptance status
+func ConfigureEULA(alwaysPrompt bool) error {
+	configVal, _ := configlib.GetEULAStatus()
+
+	// Unless forced to always prompt, it is a no-op if EULA is already accepted.
+	if !alwaysPrompt && configVal == configlib.EULAStatusAccepted {
+		return nil
+	}
+
+	accepted, err := promptForEULA()
+	if err != nil {
+		return errors.Wrapf(err, "failed to get EULA status")
+	}
+
+	status := configlib.EULAStatusShown
+	if accepted {
+		status = configlib.EULAStatusAccepted
+	}
+
+	err = configlib.SetEULAStatus(status)
+	if err != nil {
+		return errors.Wrapf(err, "failed to update the EULA status to %s", status)
+	}
+
+	return nil
+}
+
+func promptForEULA() (bool, error) {
+	var eulaAccepted string
+
+	eulaPromptChoiceEnvVal := os.Getenv(constants.EULAPromptAnswer)
+	if eulaPromptChoiceEnvVal != "" {
+		return strings.EqualFold(eulaPromptChoiceEnvVal, "Yes"), nil
+	}
+
+	// prompt user and record their choice
+	err := component.Prompt(
+		&component.PromptConfig{
+			Message: eulaPromptMsg,
+			Options: []string{"Yes", "No"},
+			Default: "Yes",
+		},
+		&eulaAccepted,
+	)
+	if err != nil {
+		return false, errors.Wrapf(err, "prompt failed")
+	}
+
+	return strings.EqualFold(eulaAccepted, "Yes"), nil
 }

--- a/pkg/config/discovery_test.go
+++ b/pkg/config/discovery_test.go
@@ -30,6 +30,7 @@ var _ = Describe("Populate default central discovery", func() {
 		Expect(err).To(BeNil())
 		os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
 		os.Setenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER", "No")
+		os.Setenv("TANZU_CLI_EULA_PROMPT_ANSWER", "Yes")
 
 		featureArray := strings.Split(constants.FeatureContextCommand, ".")
 		err = configlib.SetFeature(featureArray[1], featureArray[2], "true")
@@ -39,6 +40,7 @@ var _ = Describe("Populate default central discovery", func() {
 		os.Unsetenv("TANZU_CONFIG")
 		os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
 		os.Unsetenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER")
+		os.Unsetenv("TANZU_CLI_EULA_PROMPT_ANSWER")
 		os.RemoveAll(configFile.Name())
 		os.RemoveAll(configFileNG.Name())
 	})

--- a/pkg/constants/env_variables.go
+++ b/pkg/constants/env_variables.go
@@ -18,6 +18,7 @@ const (
 	PublicKeyPathForPluginDiscoveryImageSignature     = "TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_PUBLIC_KEY_PATH"
 	SuppressSkipSignatureVerificationWarning          = "TANZU_CLI_SUPPRESS_SKIP_SIGNATURE_VERIFICATION_WARNING"
 	CEIPOptInUserPromptAnswer                         = "TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER"
+	EULAPromptAnswer                                  = "TANZU_CLI_EULA_PROMPT_ANSWER"
 	E2ETestEnvironment                                = "TANZU_CLI_E2E_TEST_ENVIRONMENT"
 	// ControlPlaneEndpointType is the control-plane endpoint type to be used for "self-managed-tmc"(this list may grow in future)
 	ControlPlaneEndpointType = "TANZU_CLI_CONTROL_PLANE_ENDPOINT_TYPE"

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -53,11 +53,13 @@ e2e-cli-core-all: e2e-cli-lifecycle e2e-cli-config e2e-plugin-compatibility-test
 .PHONY: e2e-cli-lifecycle ## Execute CLI life cycle specific e2e tests
 e2e-cli-lifecycle:
 	export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="No" ; \
+	export TANZU_CLI_EULA_PROMPT_ANSWER="Yes" ; \
 	${GO} test ${ROOT_DIR}/test/e2e/cli_lifecycle -timeout ${E2E_TEST_TIMEOUT} -race -coverprofile ${E2E_TEST_OUTPUT} ${GOTEST_VERBOSE} ; \
 
 .PHONY: e2e-cli-config ## Execute CLI config life cycle specific e2e tests
 e2e-cli-config:
 	export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="No" ; \
+	export TANZU_CLI_EULA_PROMPT_ANSWER="Yes" ; \
 	${GO} test ${ROOT_DIR}/test/e2e/config -timeout ${E2E_TEST_TIMEOUT} -race -coverprofile ${E2E_TEST_OUTPUT} ${GOTEST_VERBOSE} ; \
 
 .PHONY: e2e-plugin-compatibility-tests ## Execute CLI Core Plugin Compatibility E2E test cases
@@ -65,6 +67,7 @@ e2e-plugin-compatibility-tests:
 	export TANZU_CLI_E2E_TEST_CENTRAL_REPO_URL=$(TANZU_CLI_E2E_TEST_CENTRAL_REPO_URL) ; \
 	export TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST=$(TANZU_CLI_E2E_TEST_CENTRAL_REPO_URL) ; \
 	export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="No" ; \
+	export TANZU_CLI_EULA_PROMPT_ANSWER="Yes" ; \
 	${GO} test ${ROOT_DIR}/test/e2e/plugins_compatibility -timeout ${E2E_TEST_TIMEOUT} -race -coverprofile ${E2E_TEST_OUTPUT} ${GOTEST_VERBOSE} ; \
 
 .PHONY: e2e-plugin-lifecycle-tests ## Execute CLI Core Plugin life cycle E2E test cases
@@ -74,6 +77,7 @@ e2e-plugin-lifecycle-tests:
 	export TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_HOST=${TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_HOST} ; \
 	export TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_CA_CERT_PATH=${TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_CA_CERT_PATH} ; \
 	export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="No" ; \
+	export TANZU_CLI_EULA_PROMPT_ANSWER="Yes" ; \
 	${GO} test ${ROOT_DIR}/test/e2e/plugin_lifecycle -timeout ${E2E_TEST_TIMEOUT} -race -coverprofile ${E2E_TEST_OUTPUT} ${GOTEST_VERBOSE} ; \
 
 .PHONY: e2e-plugin-sync-k8s ## Execute CLI Core Plugin sync E2E test cases for k8s target
@@ -83,6 +87,7 @@ e2e-plugin-sync-k8s:
 	export TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_HOST=${TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_HOST} ; \
 	export TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_CA_CERT_PATH=${TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_CA_CERT_PATH} ; \
 	export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="No" ; \
+	export TANZU_CLI_EULA_PROMPT_ANSWER="Yes" ; \
 	${GO} test ${ROOT_DIR}/test/e2e/plugin_sync/k8s -timeout ${E2E_TEST_TIMEOUT} -race -coverprofile ${E2E_TEST_OUTPUT} ${GOTEST_VERBOSE} ; \
 
 
@@ -97,6 +102,7 @@ e2e-plugin-sync-tmc:
 		export TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_HOST=${TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_HOST} ; \
 		export TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_CA_CERT_PATH=${TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_CA_CERT_PATH} ; \
 		export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="No" ; \
+		export TANZU_CLI_EULA_PROMPT_ANSWER="Yes" ; \
 		export TANZU_CLI_E2E_TEST_ENVIRONMENT="true" ; \
 		export TANZU_API_TOKEN=$(TANZU_API_TOKEN) ; \
 		${GO} test -p 1 ${ROOT_DIR}/test/e2e/plugin_sync/tmc -timeout ${E2E_TEST_TIMEOUT} -race -coverprofile ${E2E_TEST_OUTPUT} ${GOTEST_VERBOSE} ; \
@@ -110,6 +116,7 @@ e2e-context-tmc-tests:
 		echo "***Skipping TMC specific e2e tests cases because environment variables TANZU_API_TOKEN and TANZU_CLI_TMC_UNSTABLE_URL are not set***" ; \
 	else \
 	    export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="No" ; \
+		export TANZU_CLI_EULA_PROMPT_ANSWER="Yes" ; \
 		${GO} test ${ROOT_DIR}/test/e2e/context/tmc -timeout ${E2E_TEST_TIMEOUT} -race -coverprofile ${E2E_TEST_OUTPUT} ${GOTEST_VERBOSE} ; \
 	fi
 
@@ -120,6 +127,7 @@ e2e-context-k8s-tests:
 	export TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_HOST=${TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_HOST} ; \
 	export TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_CA_CERT_PATH=${TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_CA_CERT_PATH} ; \
 	export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="No" ; \
+	export TANZU_CLI_EULA_PROMPT_ANSWER="Yes" ; \
 	${GO} test `go list ${ROOT_DIR}/test/e2e/context/... | grep -v test/e2e/context/tmc` -timeout ${E2E_TEST_TIMEOUT} -race -coverprofile ${E2E_TEST_OUTPUT} ${GOTEST_VERBOSE}
 
 .PHONY: e2e-airgapped-tests ## Execute CLI airgapped tests
@@ -131,4 +139,5 @@ e2e-airgapped-tests:
 	export TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST=$(TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_IMAGE_FOR_AIRGAPPED) ; \
 	export TANZU_CLI_E2E_AIRGAPPED_REPO=$(TANZU_CLI_E2E_AIRGAPPED_REPO) ; \
 	export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="Yes" ; \
+	export TANZU_CLI_EULA_PROMPT_ANSWER="Yes" ; \
 	${GO} test ${ROOT_DIR}/test/e2e/airgapped -timeout ${E2E_TEST_TIMEOUT} -race -coverprofile ${E2E_TEST_OUTPUT} ${GOTEST_VERBOSE} ;


### PR DESCRIPTION
### What this PR does / why we need it

Add EULA commands, auto prompting for EULA

    tanzu config eula accept
    - accepts the EULA agreement non-interactively

    tanzu config eula show
    - presents the EULA agreement, captures user's agreement

    env var
    TANZU_CLI_EULA_PROMPT_ANSWER=yes
    mainly used for testing, can be used to simulate that user
    has agreed to the EULA.

    Note that the EULA prompt will be presented automatically
    under most conditions (see root.go for exceptions).
    It is unlikely that the user would need to invoke
    'tanzu eula config show' directly

    Note: the text of the EULA prompt is placeholder and intentionally
    formatted to look as such. Will follow up to confirm on the actual
    text to use.


Change depends on:
https://github.com/vmware-tanzu/tanzu-plugin-runtime/pull/69
The commit to update go.mod will not be included in the final merge, but is required for now until 
https://github.com/vmware-tanzu/tanzu-plugin-runtime/pull/69
is merged.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #N/A

### Describe testing done for PR

Ran updated unit tests.

verify that neither ceip nor eula prompts appear on the following commands

- tanzu version
- tanzu
- tanzu config set
- tanzu config eula show
- tanzu ceip-participation set
- tanzu config eula

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
User will be presented with a prompt to accept EULA. Commands `tanzu config eula show` and `tanzu config eula accept` provided to review the EULA and accept it noninteractively, respectively.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
