### PR TITLE
plugin list order should be consistent

### DIFF
--- a/pkg/command/plugin.go
+++ b/pkg/command/plugin.go
@@ -600,7 +600,14 @@ func displayInstalledAndMissingSplitView(installedStandalonePlugins []cli.Plugin
 	}
 
 	cyanBoldItalic := color.New(color.FgCyan).Add(color.Bold, color.Italic)
+
+	// sort contexts to maintain consistency in the plugin list output
+	contexts := make([]string, 0, len(ctxPluginsByContext))
 	for context := range ctxPluginsByContext {
+		contexts = append(contexts, context)
+	}
+	sort.Strings(contexts)
+	for _, context := range contexts {
 		outputWriter := component.NewOutputWriter(writer, outputFormat, "Name", "Description", "Target", "Version", "Status")
 
 		fmt.Println("")


### PR DESCRIPTION
### What this PR does / why we need it
This pull request fixes the code to maintain consistency in the output of the plugin list. The list of plugins will always be sorted by context name.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
```
1. E2E tests updated to validate the plugin list by context name when TMC and k8s contexts are exist
2. Tested locally
After Fix:
❯ t plugin list
Standalone Plugins
  NAME  DESCRIPTION  TARGET  VERSION  STATUS  

Plugins from Context:  plugin-sync-k8s-w8aj
  NAME                DESCRIPTION                    TARGET      VERSION  STATUS     
  cluster             Kubernetes cluster operations  kubernetes  v9.9.9   installed  
  feature             Kubernetes cluster operations  kubernetes  v9.9.9   installed  
  kubernetes-release  Kubernetes cluster operations  kubernetes  v9.9.9   installed  

Plugins from Context:  plugin-sync-tmc-Lgf8
  NAME     DESCRIPTION       TARGET           VERSION  STATUS     
  account  Desc for account  mission-control  v9.9.9   installed  
  apply    Desc for apply    mission-control  v9.9.9   installed  
  audit    Desc for audit    mission-control  v9.9.9   installed  
❯ t plugin list
Standalone Plugins
  NAME  DESCRIPTION  TARGET  VERSION  STATUS  

Plugins from Context:  plugin-sync-k8s-w8aj
  NAME                DESCRIPTION                    TARGET      VERSION  STATUS     
  cluster             Kubernetes cluster operations  kubernetes  v9.9.9   installed  
  feature             Kubernetes cluster operations  kubernetes  v9.9.9   installed  
  kubernetes-release  Kubernetes cluster operations  kubernetes  v9.9.9   installed  

Plugins from Context:  plugin-sync-tmc-Lgf8
  NAME     DESCRIPTION       TARGET           VERSION  STATUS     
  account  Desc for account  mission-control  v9.9.9   installed  
  apply    Desc for apply    mission-control  v9.9.9   installed  
  audit    Desc for audit    mission-control  v9.9.9   installed  
❯ t plugin list
Standalone Plugins
  NAME  DESCRIPTION  TARGET  VERSION  STATUS  

Plugins from Context:  plugin-sync-k8s-w8aj
  NAME                DESCRIPTION                    TARGET      VERSION  STATUS     
  cluster             Kubernetes cluster operations  kubernetes  v9.9.9   installed  
  feature             Kubernetes cluster operations  kubernetes  v9.9.9   installed  
  kubernetes-release  Kubernetes cluster operations  kubernetes  v9.9.9   installed  

Plugins from Context:  plugin-sync-tmc-Lgf8
  NAME     DESCRIPTION       TARGET           VERSION  STATUS     
  account  Desc for account  mission-control  v9.9.9   installed  
  apply    Desc for apply    mission-control  v9.9.9   installed  
  audit    Desc for audit    mission-control  v9.9.9   installed  
❯ t plugin list
Standalone Plugins
  NAME  DESCRIPTION  TARGET  VERSION  STATUS  

Plugins from Context:  plugin-sync-k8s-w8aj
  NAME                DESCRIPTION                    TARGET      VERSION  STATUS     
  cluster             Kubernetes cluster operations  kubernetes  v9.9.9   installed  
  feature             Kubernetes cluster operations  kubernetes  v9.9.9   installed  
  kubernetes-release  Kubernetes cluster operations  kubernetes  v9.9.9   installed  

Plugins from Context:  plugin-sync-tmc-Lgf8
  NAME     DESCRIPTION       TARGET           VERSION  STATUS     
  account  Desc for account  mission-control  v9.9.9   installed  
  apply    Desc for apply    mission-control  v9.9.9   installed  
  audit    Desc for audit    mission-control  v9.9.9   installed  
❯ t plugin list
Standalone Plugins
  NAME  DESCRIPTION  TARGET  VERSION  STATUS  

Plugins from Context:  plugin-sync-k8s-6Zdp
  NAME                DESCRIPTION                    TARGET      VERSION  STATUS     
  cluster             Kubernetes cluster operations  kubernetes  v9.9.9   installed  
  feature             Kubernetes cluster operations  kubernetes  v9.9.9   installed  
  kubernetes-release  Kubernetes cluster operations  kubernetes  v9.9.9   installed  

Plugins from Context:  plugin-sync-tmc-ywek
  NAME     DESCRIPTION       TARGET           VERSION  STATUS     
  account  Desc for account  mission-control  v9.9.9   installed  
  apply    Desc for apply    mission-control  v9.9.9   installed  
  audit    Desc for audit    mission-control  v9.9.9   installed  
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
