### PR TITLE
Fix the latency issue caused after not using anonymous user while reading or downloading image from registry

### DIFF
--- a/pkg/carvelhelpers/fetcher.go
+++ b/pkg/carvelhelpers/fetcher.go
@@ -32,7 +32,9 @@ func GetImageDigest(imageWithTag string) (string, string, error) {
 // newRegistry returns a new registry object by also taking
 // into account for any custom registry provided by the user
 func newRegistry(registryHost string) (registry.Registry, error) {
-	registryOpts := &ctlimg.Opts{}
+	registryOpts := &ctlimg.Opts{
+		Anon: true,
+	}
 
 	regCertOptions, err := registry.GetRegistryCertOptions(registryHost)
 	if err != nil {

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -193,6 +193,7 @@ func (r *registry) CopyImageToTar(sourceImageName, destTarFile string) error {
 			CACertPaths: r.opts.CACertPaths,
 			VerifyCerts: r.opts.VerifyCerts,
 			Insecure:    r.opts.Insecure,
+			Anon:        r.opts.Anon,
 		}
 	}
 
@@ -245,6 +246,7 @@ func (r *registry) downloadBundleOrImage(imageName, outputDir string, isBundle b
 			CACertPaths: r.opts.CACertPaths,
 			VerifyCerts: r.opts.VerifyCerts,
 			Insecure:    r.opts.Insecure,
+			Anon:        r.opts.Anon,
 		}
 	}
 


### PR DESCRIPTION
### What this PR does / why we need it

This PR fixes the latency issue caused after ignoring the anonymous user setting while reading or downloading the image from registry

Summary:
- In the recent commit, the anonymous user setting for registry was set to false, so that imgpkg library would use the docker login session/config while uploading the images to registry, after this commit, we observed latency in downloading images as well. So to optimize the behavior, Anonymous user setting for registry would be used for download/reading from the registry and for upload anonymous user would be ignored so that imgpkg would use the docker login session

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
Unit test and CI passed.
Tested the latency , I see improvement in the latency

Before the change:
```
❯ ./bin/tanzu version
version: v0.90.0-alpha.0
buildDate: 2023-05-11
sha: 7fd4f40e

❯ time ./bin/tanzu plugin search
  NAME                DESCRIPTION                  TARGET           LATEST
  builder             Build Tanzu components       global           v0.90.0-alpha.1
  test                Test the CLI                 global           v0.90.0-alpha.1
  cluster             Desc for cluster             kubernetes       v22.22.22
  feature             Desc for feature             kubernetes       v22.22.22
  kubernetes-release  Desc for kubernetes-release  kubernetes       v22.22.22
  management-cluster  Desc for management-cluster  kubernetes       v22.22.22
  package             Desc for package             kubernetes       v22.22.22
  secret              Desc for secret              kubernetes       v22.22.22
  telemetry           Desc for telemetry           kubernetes       v22.22.22
  account             Desc for account             mission-control  v22.22.22
  apply               Desc for apply               mission-control  v22.22.22
  audit               Desc for audit               mission-control  v22.22.22
  cluster             Desc for cluster             mission-control  v22.22.22
  clustergroup        Desc for clustergroup        mission-control  v22.22.22
  continuousdelivery  Desc for continuousdelivery  mission-control  v22.22.22
  data-protection     Desc for data-protection     mission-control  v22.22.22
  ekscluster          Desc for ekscluster          mission-control  v22.22.22
  events              Desc for events              mission-control  v22.22.22
  helm                Desc for helm                mission-control  v22.22.22
  iam                 Desc for iam                 mission-control  v22.22.22
  inspection          Desc for inspection          mission-control  v22.22.22
  integration         Desc for integration         mission-control  v22.22.22
  management-cluster  Desc for management-cluster  mission-control  v22.22.22
  policy              Desc for policy              mission-control  v22.22.22
  secret              Desc for secret              mission-control  v22.22.22
  tanzupackage        Desc for tanzupackage        mission-control  v22.22.22
  workspace           Desc for workspace           mission-control  v22.22.22
./bin/tanzu plugin search  0.40s user 0.28s system 48% cpu 1.423 total

```
After change:

```
❯ ./bin/tanzu version
version: v0.90.0-alpha.0
buildDate: 2023-05-11
sha: 14917848

❯ time ./bin/tanzu plugin search
  NAME                DESCRIPTION                  TARGET           LATEST
  builder             Build Tanzu components       global           v0.90.0-alpha.1
  test                Test the CLI                 global           v0.90.0-alpha.1
  cluster             Desc for cluster             kubernetes       v22.22.22
  feature             Desc for feature             kubernetes       v22.22.22
  kubernetes-release  Desc for kubernetes-release  kubernetes       v22.22.22
  management-cluster  Desc for management-cluster  kubernetes       v22.22.22
  package             Desc for package             kubernetes       v22.22.22
  secret              Desc for secret              kubernetes       v22.22.22
  telemetry           Desc for telemetry           kubernetes       v22.22.22
  account             Desc for account             mission-control  v22.22.22
  apply               Desc for apply               mission-control  v22.22.22
  audit               Desc for audit               mission-control  v22.22.22
  cluster             Desc for cluster             mission-control  v22.22.22
  clustergroup        Desc for clustergroup        mission-control  v22.22.22
  continuousdelivery  Desc for continuousdelivery  mission-control  v22.22.22
  data-protection     Desc for data-protection     mission-control  v22.22.22
  ekscluster          Desc for ekscluster          mission-control  v22.22.22
  events              Desc for events              mission-control  v22.22.22
  helm                Desc for helm                mission-control  v22.22.22
  iam                 Desc for iam                 mission-control  v22.22.22
  inspection          Desc for inspection          mission-control  v22.22.22
  integration         Desc for integration         mission-control  v22.22.22
  management-cluster  Desc for management-cluster  mission-control  v22.22.22
  policy              Desc for policy              mission-control  v22.22.22
  secret              Desc for secret              mission-control  v22.22.22
  tanzupackage        Desc for tanzupackage        mission-control  v22.22.22
  workspace           Desc for workspace           mission-control  v22.22.22
./bin/tanzu plugin search  0.28s user 0.07s system 37% cpu 0.935 total
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
