### PR TITLE
Plugin describe json support

### DIFF
--- a/test/e2e/coexistence/cli_coexistence_test.go
+++ b/test/e2e/coexistence/cli_coexistence_test.go
@@ -70,7 +70,7 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 				}
 				err := tf.PluginCmd.InstallPlugin(plugin.Name, target, plugin.Version)
 				gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin install for legacy tanzu cli")
-				str, err := tf.PluginCmd.DescribePlugin(plugin.Name, plugin.Target)
+				str, err := tf.PluginCmd.DescribePluginLegacy(plugin.Name, plugin.Target)
 				gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin describe for legacy tanzu cli")
 				gomega.Expect(str).NotTo(gomega.BeNil(), "there should be output for plugin describe for legacy tanzu cli")
 			}
@@ -112,7 +112,7 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 				}
 				err := tf.PluginCmd.InstallPlugin(plugin.Name, target, plugin.Version, framework.WithTanzuCommandPrefix(framework.TzPrefix))
 				gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin install for new tanzu cli")
-				str, err := tf.PluginCmd.DescribePlugin(plugin.Name, plugin.Target, framework.WithTanzuCommandPrefix(framework.TzPrefix))
+				str, err := tf.PluginCmd.DescribePlugin(plugin.Name, plugin.Target, framework.WithTanzuCommandPrefix(framework.TzPrefix), framework.GetJsonOutputFormatAdditionalFlagFunction())
 				gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin describe for new tanzu cli")
 				gomega.Expect(str).NotTo(gomega.BeNil(), "there should be output for plugin describe for new tanzu cli")
 			}
@@ -146,7 +146,7 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 				}
 				err := tf.PluginCmd.InstallPlugin(plugin.Name, target, plugin.Version)
 				gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin install using legacy tanzu cli")
-				str, err := tf.PluginCmd.DescribePlugin(plugin.Name, plugin.Target)
+				str, err := tf.PluginCmd.DescribePluginLegacy(plugin.Name, plugin.Target)
 				gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin describe using legacy tanzu cli")
 				gomega.Expect(str).NotTo(gomega.BeNil(), "there should be output for plugin describe using legcy tanzu cli")
 			}
@@ -188,7 +188,8 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 				}
 				err := tf.PluginCmd.InstallPlugin(plugin.Name, target, plugin.Version)
 				gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin install using new tanzu cli")
-				str, err := tf.PluginCmd.DescribePlugin(plugin.Name, plugin.Target)
+				str, err := tf.PluginCmd.DescribePlugin(plugin.Name, plugin.Target, framework.GetJsonOutputFormatAdditionalFlagFunction())
+
 				gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin describe using new tanzu cli")
 				gomega.Expect(str).NotTo(gomega.BeNil(), "there should be output for plugin describe using new tanzu cli")
 			}
@@ -217,7 +218,7 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 				}
 				err := tf.PluginCmd.InstallPlugin(plugin.Name, target, plugin.Version)
 				gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin install using legacy tanzu cli")
-				str, err := tf.PluginCmd.DescribePlugin(plugin.Name, plugin.Target)
+				str, err := tf.PluginCmd.DescribePluginLegacy(plugin.Name, plugin.Target)
 				gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin describe using legacy tanzu cli")
 				gomega.Expect(str).NotTo(gomega.BeNil(), "there should be output for plugin describe using legcy tanzu cli")
 			}
@@ -259,7 +260,7 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 				}
 				err := tf.PluginCmd.InstallPlugin(plugin.Name, target, plugin.Version)
 				gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin install using new tanzu cli")
-				str, err := tf.PluginCmd.DescribePlugin(plugin.Name, plugin.Target)
+				str, err := tf.PluginCmd.DescribePlugin(plugin.Name, plugin.Target, framework.GetJsonOutputFormatAdditionalFlagFunction())
 				gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin describe using new tanzu cli")
 				gomega.Expect(str).NotTo(gomega.BeNil(), "there should be output for plugin describe using new tanzu cli")
 			}
@@ -298,7 +299,7 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 				}
 				err := tf.PluginCmd.InstallPlugin(plugin.Name, target, plugin.Version)
 				gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin install using legacy tanzu cli")
-				str, err := tf.PluginCmd.DescribePlugin(plugin.Name, plugin.Target)
+				str, err := tf.PluginCmd.DescribePluginLegacy(plugin.Name, plugin.Target)
 				gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin describe using legacy tanzu cli")
 				gomega.Expect(str).NotTo(gomega.BeNil(), "there should be output for plugin describe using legcy tanzu cli")
 			}
@@ -340,7 +341,7 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 				}
 				err := tf.PluginCmd.InstallPlugin(plugin.Name, target, plugin.Version, framework.WithTanzuCommandPrefix(framework.TzPrefix))
 				gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin install using new tanzu cli")
-				str, err := tf.PluginCmd.DescribePlugin(plugin.Name, plugin.Target, framework.WithTanzuCommandPrefix(framework.TzPrefix))
+				str, err := tf.PluginCmd.DescribePlugin(plugin.Name, plugin.Target, framework.WithTanzuCommandPrefix(framework.TzPrefix), framework.GetJsonOutputFormatAdditionalFlagFunction())
 				gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin describe using new tanzu cli")
 				gomega.Expect(str).NotTo(gomega.BeNil(), "there should be output for plugin describe using new tanzu cli")
 			}
@@ -379,7 +380,7 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 				}
 				err := tf.PluginCmd.InstallPlugin(plugin.Name, target, plugin.Version)
 				gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin install using legacy tanzu cli")
-				str, err := tf.PluginCmd.DescribePlugin(plugin.Name, plugin.Target)
+				str, err := tf.PluginCmd.DescribePluginLegacy(plugin.Name, plugin.Target)
 				gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin describe using legacy tanzu cli")
 				gomega.Expect(str).NotTo(gomega.BeNil(), "there should be output for plugin describe using legacy tanzu cli")
 			}
@@ -421,7 +422,7 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 				}
 				err := tf.PluginCmd.InstallPlugin(plugin.Name, target, plugin.Version)
 				gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin install using new tanzu cli")
-				str, err := tf.PluginCmd.DescribePlugin(plugin.Name, plugin.Target)
+				str, err := tf.PluginCmd.DescribePlugin(plugin.Name, plugin.Target, framework.GetJsonOutputFormatAdditionalFlagFunction())
 				gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin describe using new tanzu cli")
 				gomega.Expect(str).NotTo(gomega.BeNil(), "there should be output for plugin describe using new tanzu cli")
 			}

--- a/test/e2e/framework/config_lifecycle_operations.go
+++ b/test/e2e/framework/config_lifecycle_operations.go
@@ -131,7 +131,8 @@ func (co *configOps) ConfigInit(opts ...E2EOption) (err error) {
 // ConfigServerList returns the server list
 func (co *configOps) ConfigServerList(opts ...E2EOption) ([]*Server, error) {
 	ConfigServerListWithJSONOutput := ConfigServerList + JSONOutput
-	return ExecuteCmdAndBuildJSONOutput[Server](co.cmdExe, ConfigServerListWithJSONOutput, opts...)
+	list, _, _, err := ExecuteCmdAndBuildJSONOutput[Server](co.cmdExe, ConfigServerListWithJSONOutput, opts...)
+	return list, err
 }
 
 // ConfigServerDelete deletes a server from tanzu config
@@ -192,5 +193,6 @@ func (co *configOps) ConfigCertDelete(host string, opts ...E2EOption) error {
 }
 
 func (co *configOps) ConfigCertList(opts ...E2EOption) ([]*CertDetails, error) {
-	return ExecuteCmdAndBuildJSONOutput[CertDetails](co.cmdExe, ConfigCertList, opts...)
+	list, _, _, err := ExecuteCmdAndBuildJSONOutput[CertDetails](co.cmdExe, ConfigCertList, opts...)
+	return list, err
 }

--- a/test/e2e/framework/context_lifecycle_operations.go
+++ b/test/e2e/framework/context_lifecycle_operations.go
@@ -63,7 +63,8 @@ func (cc *contextCmdOps) GetContext(contextName string, opts ...E2EOption) (Cont
 }
 
 func (cc *contextCmdOps) ListContext(opts ...E2EOption) ([]*ContextListInfo, error) {
-	return ExecuteCmdAndBuildJSONOutput[ContextListInfo](cc.cmdExe, ListContextOutputInJSON, opts...)
+	list, _, _, err := ExecuteCmdAndBuildJSONOutput[ContextListInfo](cc.cmdExe, ListContextOutputInJSON, opts...)
+	return list, err
 }
 
 func (cc *contextCmdOps) GetActiveContext(targetType string, opts ...E2EOption) (string, error) {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -78,6 +78,7 @@ const (
 	True         = "true"
 	Installed    = "installed"
 	NotInstalled = "not installed"
+	JSONOtuput   = "-o json"
 
 	// Context commands
 	CreateContextWithEndPoint              = "%s context create --endpoint %s --name %s"
@@ -136,6 +137,9 @@ const (
 	NoErrorForPluginGroupSearch                   = "should not get any error for plugin group search"
 	NoErrorForPluginSearch                        = "should not get any error for plugin search"
 	UnableToSync                                  = "unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually"
+	PluginDescribeShouldNotThrowErr               = "should not get any error for plugin describe"
+	PluginDescShouldExist                         = "there should be one plugin description"
+	PluginNameShouldMatch                         = "plugin name should be same as input value"
 
 	// config related constants
 	FailedToCreateContext           = "failed to create context"

--- a/test/e2e/framework/output_handling.go
+++ b/test/e2e/framework/output_handling.go
@@ -94,3 +94,21 @@ type CertDetails struct {
 	Insecure             string `json:"insecure"`
 	SkipCertVerification string `json:"skip-cert-verification"`
 }
+
+type PluginDescribe struct {
+	Buildsha                     string `yaml:"buildsha"`
+	Completiontype               string `yaml:"completiontype"`
+	Defaultfeatureflags          string `yaml:"defaultfeatureflags"`
+	Description                  string `yaml:"description"`
+	Digest                       string `yaml:"digest"`
+	Discoveredrecommendedversion string `yaml:"discoveredrecommendedversion"`
+	Discovery                    string `yaml:"discovery"`
+	Docurl                       string `yaml:"docurl"`
+	Group                        string `yaml:"group"`
+	Installationpath             string `yaml:"installationpath"`
+	Name                         string `yaml:"name"`
+	Scope                        string `yaml:"scope"`
+	Status                       string `yaml:"status"`
+	Target                       string `yaml:"target"`
+	Version                      string `yaml:"version"`
+}

--- a/test/e2e/plugin_lifecycle/plugin_group_lifecycle_test.go
+++ b/test/e2e/plugin_lifecycle/plugin_group_lifecycle_test.go
@@ -48,9 +48,11 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Group-lifecycle]",
 				err := tf.PluginCmd.InstallPluginsFromGroup(plugins[0].Name, pg)
 				Expect(err).To(BeNil(), "should not get any error for plugin install from plugin group")
 
-				str, err := tf.PluginCmd.DescribePlugin(plugins[0].Name, plugins[0].Target)
-				Expect(err).To(BeNil(), "should not get any error for plugin describe")
-				Expect(str).NotTo(BeNil(), "there should be output for plugin describe")
+				pd, err := tf.PluginCmd.DescribePlugin(plugins[0].Name, plugins[0].Target, framework.GetJsonOutputFormatAdditionalFlagFunction())
+				Expect(err).To(BeNil(), framework.PluginDescribeShouldNotThrowErr)
+				Expect(len(pd)).To(Equal(1), framework.PluginDescShouldExist)
+				Expect(pd[0].Name).To(Equal(plugins[0].Name), framework.PluginNameShouldMatch)
+
 			}
 		})
 		// Test case: install a plugin from each plugin group and validate the installation with plugin describe
@@ -60,13 +62,15 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Group-lifecycle]",
 				Expect(err).To(BeNil(), "should not get any error for plugin install from plugin group")
 				plugins := pluginGroupToPluginListMap[pg]
 				for i := range plugins {
-					str, err := tf.PluginCmd.DescribePlugin(plugins[i].Name, plugins[i].Target)
-					Expect(err).To(BeNil(), "should not get any error for plugin describe")
-					Expect(str).NotTo(BeNil(), "there should be output for plugin describe")
+					pd, err := tf.PluginCmd.DescribePlugin(plugins[i].Name, plugins[i].Target, framework.GetJsonOutputFormatAdditionalFlagFunction())
+					Expect(err).To(BeNil(), framework.PluginDescribeShouldNotThrowErr)
+					Expect(len(pd)).To(Equal(1), framework.PluginDescShouldExist)
+					Expect(pd[0].Name).To(Equal(plugins[i].Name), framework.PluginNameShouldMatch)
 				}
 			}
 		})
 	})
+
 	// Use cases:
 	// a. clean installation with "all": clean, install all plugin from a plugin group and validate the installation by running plugin describe.
 	// b. clean installation without "all": clean, install all plugin from a plugin group (pass empty string instead of "all") and validate the installation by running plugin describe.
@@ -86,9 +90,11 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Group-lifecycle]",
 				Expect(err).To(BeNil(), "should not get any error for plugin install from plugin group")
 				plugins := pluginGroupToPluginListMap[pg]
 				for i := range plugins {
-					str, err := tf.PluginCmd.DescribePlugin(plugins[i].Name, plugins[i].Target)
-					Expect(err).To(BeNil(), "should not get any error for plugin describe")
-					Expect(str).NotTo(BeNil(), "there should be output for plugin describe")
+					pd, err := tf.PluginCmd.DescribePlugin(plugins[i].Name, plugins[i].Target, framework.GetJsonOutputFormatAdditionalFlagFunction())
+					Expect(err).To(BeNil(), framework.PluginDescribeShouldNotThrowErr)
+					Expect(len(pd)).To(Equal(1), framework.PluginDescShouldExist)
+					Expect(pd[0].Name).To(Equal(plugins[i].Name), framework.PluginNameShouldMatch)
+
 				}
 			}
 		})
@@ -107,9 +113,10 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Group-lifecycle]",
 				Expect(err).To(BeNil(), "should not get any error for plugin install from plugin group")
 				plugins := pluginGroupToPluginListMap[pg]
 				for i := range plugins {
-					str, err := tf.PluginCmd.DescribePlugin(plugins[i].Name, plugins[i].Target)
-					Expect(err).To(BeNil(), "should not get any error for plugin describe")
-					Expect(str).NotTo(BeNil(), "there should be output for plugin describe")
+					pd, err := tf.PluginCmd.DescribePlugin(plugins[i].Name, plugins[i].Target, framework.GetJsonOutputFormatAdditionalFlagFunction())
+					Expect(err).To(BeNil(), framework.PluginDescribeShouldNotThrowErr)
+					Expect(len(pd)).To(Equal(1), framework.PluginDescShouldExist)
+					Expect(pd[0].Name).To(Equal(plugins[i].Name), framework.PluginNameShouldMatch)
 				}
 			}
 		})
@@ -151,5 +158,4 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Group-lifecycle]",
 	//	2) Use case: 	Install a same plugin (with same version) from a same group, but different targets, eg: group: 'vmware-tkg/v9.9.9' plugin: secret target: kubernetes, and another plugin:  plugin: secret target: mission-control
 	//					Install all plugins in the group: tanzu plugin install --group 'vmware-tkg/v9.9.9'
 	//		expected results: it should install all plugins, and there should be two secret plugins installed one for kubernetes and another for mission-control with same version.
-
 })

--- a/test/e2e/plugin_lifecycle/plugin_lifecycle_suite_test.go
+++ b/test/e2e/plugin_lifecycle/plugin_lifecycle_suite_test.go
@@ -31,12 +31,16 @@ var (
 // BeforeSuite initializes and set up the environment to execute the plugin life cycle and plugin group life cycle end-to-end test cases
 var _ = BeforeSuite(func() {
 	tf = framework.NewFramework()
+
+	err := framework.CleanConfigFiles(tf)
+	Expect(err).To(BeNil())
+
 	// check E2E test central repo URL (TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL)
 	e2eTestLocalCentralRepoURL = os.Getenv(framework.TanzuCliE2ETestLocalCentralRepositoryURL)
 	Expect(e2eTestLocalCentralRepoURL).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with local central repository URL", framework.TanzuCliE2ETestLocalCentralRepositoryURL))
 
 	// set up the test central repo
-	_, err := tf.PluginCmd.UpdatePluginDiscoverySource(&framework.DiscoveryOptions{Name: "default", SourceType: framework.SourceType, URI: e2eTestLocalCentralRepoURL})
+	_, err = tf.PluginCmd.UpdatePluginDiscoverySource(&framework.DiscoveryOptions{Name: "default", SourceType: framework.SourceType, URI: e2eTestLocalCentralRepoURL})
 	Expect(err).To(BeNil(), "should not get any error for plugin source update")
 
 	e2eTestLocalCentralRepoPluginHost := os.Getenv(framework.TanzuCliE2ETestLocalCentralRepositoryHost)

--- a/test/e2e/plugin_lifecycle/plugin_lifecycle_test.go
+++ b/test/e2e/plugin_lifecycle/plugin_lifecycle_test.go
@@ -24,6 +24,7 @@ import (
 // 1. plugin search, install, delete, describe, list (with negative use cases)
 // 2. plugin source add/update/list/delete (with negative use cases)
 var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-lifecycle]", func() {
+
 	// use case: tanzu plugin source list, update, delete, init
 	// a. list plugin sources and validate plugin source created in previous step
 	// b. update plugin source URL
@@ -102,22 +103,22 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-lifecycle]", func(
 				}
 				err := tf.PluginCmd.InstallPlugin(plugin.Name, target, plugin.Version)
 				Expect(err).To(BeNil(), "should not get any error for plugin install")
-				str, err := tf.PluginCmd.DescribePlugin(plugin.Name, plugin.Target)
-				Expect(err).To(BeNil(), "should not get any error for plugin describe")
-				Expect(str).NotTo(BeNil(), "there should be output for plugin describe")
+
+				pd, err := tf.PluginCmd.DescribePlugin(plugin.Name, plugin.Target, framework.GetJsonOutputFormatAdditionalFlagFunction())
+				Expect(err).To(BeNil(), framework.PluginDescribeShouldNotThrowErr)
+				Expect(len(pd)).To(Equal(1), framework.PluginDescShouldExist)
+				Expect(pd[0].Name).To(Equal(plugin.Name), framework.PluginNameShouldMatch)
 			}
 		})
 		// Test case: (negative) describe plugin with incorrect target type
 		It("plugin describe: describe installed plugin with incorrect target type", func() {
-			str, err := tf.PluginCmd.DescribePlugin(framework.PluginsForLifeCycleTests[0].Name, framework.RandomString(5))
-			Expect(str).To(BeEmpty(), "stdout should be empty when target type is incorrect for plugin describe")
+			_, err := tf.PluginCmd.DescribePlugin(framework.PluginsForLifeCycleTests[0].Name, framework.RandomString(5), framework.GetJsonOutputFormatAdditionalFlagFunction())
 			Expect(err.Error()).To(ContainSubstring(framework.InvalidTargetSpecified))
 		})
 		// Test case: (negative) describe plugin with incorrect plugin name
 		It("plugin describe: describe installed plugin with incorrect plugin name as input", func() {
 			name := framework.RandomString(5)
-			str, err := tf.PluginCmd.DescribePlugin(name, framework.PluginsForLifeCycleTests[0].Target)
-			Expect(str).To(BeEmpty(), "stdout should be empty when plugin name is incorrect for plugin describe command")
+			_, err := tf.PluginCmd.DescribePlugin(name, framework.PluginsForLifeCycleTests[0].Target, framework.GetJsonOutputFormatAdditionalFlagFunction())
 			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(framework.UnableToFindPlugin, name)))
 		})
 		// Test case: list plugins and validate the list plugins output has all plugins which are installed in previous steps
@@ -158,9 +159,11 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-lifecycle]", func(
 				target := plugin.Target
 				err := tf.PluginCmd.InstallPlugin(plugin.Name, target, plugin.Version)
 				Expect(err).To(BeNil(), "should not get any error for plugin install")
-				str, err := tf.PluginCmd.DescribePlugin(plugin.Name, plugin.Target)
-				Expect(err).To(BeNil(), "should not get any error for plugin describe")
-				Expect(str).NotTo(BeNil(), "there should be output for plugin describe")
+
+				pd, err := tf.PluginCmd.DescribePlugin(plugin.Name, plugin.Target, framework.GetJsonOutputFormatAdditionalFlagFunction())
+				Expect(err).To(BeNil(), framework.PluginDescribeShouldNotThrowErr)
+				Expect(len(pd)).To(Equal(1), framework.PluginDescShouldExist)
+				Expect(pd[0].Name).To(Equal(plugin.Name), framework.PluginNameShouldMatch)
 			}
 			// validate installed plugins count same as number of plugins installed
 			pluginsList, err := framework.GetPluginsList(tf, true)
@@ -176,6 +179,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-lifecycle]", func(
 			Expect(len(pluginsList)).Should(Equal(0), "there should not be any plugins available after uninstall all")
 		})
 	})
+
 	// use case: negative test cases for plugin install and plugin delete commands
 	// a. install plugin with incorrect value target flag
 	// b. install plugin with incorrect plugin name


### PR DESCRIPTION
### What this PR does / why we need it
This pull request is to support the json/yaml output format for the command 'tanzu plugin describe [plugin-name] -o json`
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

```
1. Unit test cases are updated
2. E2E test cases are updated
3. Local testing has done: below is before/after fix output:
**Before Fix:**
❯ t plugin list
Standalone Plugins
  NAME       DESCRIPTION                       TARGET           VERSION                 STATUS     
  test       Test the CLI                      global           v0.1.0-dev-8-g6087ea00  installed  
  workspace  A group of Kubernetes namespaces  mission-control  v0.0.1                  installed  
❯ 
❯ t plugin describe test -o json
[x] : unknown shorthand flag: 'o' in -o
❯ t plugin describe test -o yaml
[x] : unknown shorthand flag: 'o' in -o
❯ 
**After Fix:**
❯ t plugin list
Standalone Plugins
  NAME       DESCRIPTION                       TARGET           VERSION                 STATUS     
  test       Test the CLI                      global           v0.1.0-dev-8-g6087ea00  installed  
  workspace  A group of Kubernetes namespaces  mission-control  v0.0.1                  installed  
❯ t plugin describe test -o json
[
  {
    "buildsha": "6087ea00-dirty",
    "completiontype": "0",
    "defaultfeatureflags": "map[]",
    "description": "Test the CLI",
    "digest": "",
    "discoveredrecommendedversion": "v0.1.0-dev-8-g6087ea00",
    "discovery": "default",
    "docurl": "",
    "group": "Admin",
    "installationpath": "/Users/cpamuluri/Library/Application Support/tanzu-cli/test/v0.1.0-dev-8-g6087ea00_372ca93ae5eba740509c0277bdf431f305666ee449b2be4b9c8d412e9b91ea52_global",
    "name": "test",
    "scope": "Standalone",
    "status": "installed",
    "target": "global",
    "version": "v0.1.0-dev-8-g6087ea00"
  }
]%                                                                                                                                        
❯ t plugin describe test -o yaml
- buildsha: 6087ea00-dirty
  completiontype: "0"
  defaultfeatureflags: map[]
  description: Test the CLI
  digest: ""
  discoveredrecommendedversion: v0.1.0-dev-8-g6087ea00
  discovery: default
  docurl: ""
  group: Admin
  installationpath: /Users/cpamuluri/Library/Application Support/tanzu-cli/test/v0.1.0-dev-8-g6087ea00_372ca93ae5eba740509c0277bdf431f305666ee449b2be4b9c8d412e9b91ea52_global
  name: test
  scope: Standalone
  status: installed
  target: global
  version: v0.1.0-dev-8-g6087ea00
❯
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
