### PR TITLE
Remove unnecessary operations of "tanzu init"

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -246,17 +246,6 @@ func testPath() string {
 	return filepath.Join(pluginRoot, "test")
 }
 
-// UpdateCatalogCache when updating the core CLI from v0.x.x to v1.x.x. This is
-// needed to group the standalone plugins by context type.
-func UpdateCatalogCache() error {
-	c, err := getCatalogCache()
-	if err != nil {
-		return err
-	}
-
-	return saveCatalogCache(c)
-}
-
 // PluginNameTarget constructs a string to uniquely refer to a plugin associated
 // with a specific target when target is provided.
 func PluginNameTarget(pluginName string, target configtypes.Target) string {

--- a/pkg/command/init.go
+++ b/pkg/command/init.go
@@ -8,9 +8,7 @@ import (
 
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/plugin"
 
-	"github.com/vmware-tanzu/tanzu-cli/pkg/catalog"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
-	"github.com/vmware-tanzu/tanzu-cli/pkg/pluginmanager"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
 
@@ -26,18 +24,10 @@ var initCmd = &cobra.Command{
 	},
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := initPluginsWithContextAwareCLI()
-		if err != nil {
-			return err
-		}
+		// Currently nothing to initialize.
+		// We are keeping this command as it may become useful
+		// again in the future.
 		log.Success("successfully initialized CLI")
 		return nil
 	},
-}
-
-func initPluginsWithContextAwareCLI() error {
-	if err := catalog.UpdateCatalogCache(); err != nil {
-		return err
-	}
-	return pluginmanager.SyncPlugins()
 }


### PR DESCRIPTION
### What this PR does / why we need it

The "tanzu init" command was previously required to install the TKG plugins through a "plugin sync" (when the CLI was tightly-coupled with TKG). Users would be told to call "tanzu init" after installation.

With the Independent CLI, "plugin sync" is no longer used in the same way.  Instead users use "plugin install --group <group>"; but since the group to use is dependent on the product of interest, this installation command cannot be part of a generic "tanzu init" command but has to be run manually by the user.

This commit therefore removes the "plugin sync" call from "tanzu init".

Furthermore, a empty read/write of the plugin catalog was being performed with the goal to normalize the contents of the catalog. This was added when the concept of CLI "targets" was introduced.  However, the logic to handle targets has been revamped and this normalization is no longer required. It has therefore been removed.

The "tanzu init" command is now a no-op.
We have decided to keep it for two reasons:
1. backwards-compatibility (some scripts and even users still call it)
2. the command may be needed by a future feature so we wanted to avoid removing it to re-introduce it some time later.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

For months now I have been running the Independent CLI without ever calling "tanzu init".
There have been different upgrade tests performed from old CLIs to the newest version, also without running "tanzu init".
This confirms the command was not doing anything useful.

And have CI pass.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The "tanzu init" command is now a no-op but is kept for possible future use.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
