### PR TITLE
Add support to configure proxy certificate to interact with registry

### DIFF
--- a/docs/quickstart/install.md
+++ b/docs/quickstart/install.md
@@ -242,3 +242,9 @@ interacting with the registry.
 Users can update or delete the certificate configuration using the `tanzu config cert update`
 and `tanzu config cert delete` commands.
 Also, users can list the certificate configuration using the `tanzu config cert list` command.
+
+#### Proxy CA certificate
+
+If the user configured a proxy between the Tanzu CLI and the central repository and if the proxy certificate
+needs to be configured, the user should set the environment variable `PROXY_CA_CERT` with base64 value of
+proxy CA certificate.

--- a/docs/quickstart/quickstart.md
+++ b/docs/quickstart/quickstart.md
@@ -301,3 +301,12 @@ functionality available to the legacy CLI will function as before.
 
 Note that running `tanzu plugin sync` with the legacy CLI may undo certain
 plugin installation actions performed with the new CLI
+
+### Configuring the Registry and Proxy CA certificate
+
+Tanzu CLI would not be honoring existing environment variables `TKG_CUSTOM_IMAGE_REPOSITORY_CA_CERTIFICATE`
+and `TKG_PROXY_CA_CERT`.
+If the user is interacting with a central repository hosted on a registry with self-signed CA, please
+refer to the section `Interacting with a central repository hosted on a registry with self-signed CA or with expired CA`
+in [installation doc](install.md)
+for configuration steps

--- a/pkg/registry/helpers_test.go
+++ b/pkg/registry/helpers_test.go
@@ -11,18 +11,19 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/configpaths"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
 
-func TestClientConfigHelperSuite(t *testing.T) {
+func TestRegistrySuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "pkg/clientconfighelpers suite")
+	RunSpecs(t, "pkg/registry suite")
 }
 
-var _ = Describe("config cert command tests", func() {
+var _ = Describe("GetRegistryCertOptions", func() {
 
-	Describe("config cert add/list command tests", func() {
+	Describe("GetRegistryCertOptions without proxy configuration", func() {
 		var (
 			tanzuConfigFile   *os.File
 			tanzuConfigFileNG *os.File
@@ -113,5 +114,131 @@ var _ = Describe("config cert command tests", func() {
 
 			})
 		})
+
 	})
+
+	Describe("GetRegistryCertOptions with proxy configured", func() {
+		var (
+			tanzuConfigFile    *os.File
+			tanzuConfigFileNG  *os.File
+			caCertDataOpt      string
+			skipCertVerifyOpt  string
+			insecureOpt        string
+			noProxyOpt         string
+			proxyCACertDataB64 string
+			err                error
+		)
+		const (
+			fakeCACertData      = "fake ca cert data"
+			fakeProxyCACertData = "fake proxy ca cert data"
+			testHost            = "test.vmware.com"
+			testHTTPProxyHost   = "192.168.116.1:3128"
+			testHTTPSProxyHost  = "192.168.116.1:3129"
+		)
+
+		BeforeEach(func() {
+			tanzuConfigFile, err = os.CreateTemp("", "config")
+			Expect(err).To(BeNil())
+			os.Setenv("TANZU_CONFIG", tanzuConfigFile.Name())
+
+			tanzuConfigFileNG, err = os.CreateTemp("", "config_ng")
+			Expect(err).To(BeNil())
+			os.Setenv("TANZU_CONFIG_NEXT_GEN", tanzuConfigFileNG.Name())
+
+			os.Setenv("http_proxy", "http://"+testHTTPProxyHost)
+			os.Setenv("https_proxy", "http://"+testHTTPSProxyHost)
+		})
+		AfterEach(func() {
+			os.Unsetenv("TANZU_CONFIG")
+			os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
+			os.RemoveAll(tanzuConfigFile.Name())
+			os.RemoveAll(tanzuConfigFileNG.Name())
+			os.Unsetenv("http_proxy")
+			os.Unsetenv("https_proxy")
+			os.Unsetenv("no_proxy")
+			os.Unsetenv(constants.ProxyCACert)
+		})
+		JustBeforeEach(func() {
+			caCertDataOptB64 := ""
+			if len(caCertDataOpt) > 0 {
+				caCertDataOptB64 = base64.StdEncoding.EncodeToString([]byte(caCertDataOpt))
+			}
+			cert := &configtypes.Cert{
+				Host:           testHost,
+				CACertData:     caCertDataOptB64,
+				SkipCertVerify: skipCertVerifyOpt,
+				Insecure:       insecureOpt,
+			}
+			err := configlib.SetCert(cert)
+			Expect(err).To(BeNil())
+			os.Setenv("no_proxy", noProxyOpt)
+			os.Setenv(constants.ProxyCACert, proxyCACertDataB64)
+		})
+
+		Context("When custom CA cert data is provided for the registry host in the config and proxy cert config(PROXY_CA_CERT) is not provided  ", func() {
+			BeforeEach(func() {
+				caCertDataOpt = fakeCACertData
+			})
+			It("should return success and cert options should have registry cert path updated with registry host CA cert data", func() {
+				certOptions, err := GetRegistryCertOptions(testHost)
+				Expect(err).To(BeNil())
+				Expect(certOptions).ToNot(BeNil())
+
+				regFilePath, err := configpaths.GetRegistryCertFile()
+				Expect(err).To(BeNil())
+				Expect(certOptions.CACertPaths).To(ContainElement(regFilePath))
+				certData, err := os.ReadFile(regFilePath)
+				Expect(err).To(BeNil())
+				Expect(string(certData)).To(Equal(fakeCACertData))
+				Expect(certOptions.SkipCertVerify).To(Equal(false))
+				Expect(certOptions.Insecure).To(Equal(false))
+			})
+		})
+		Context("When custom CA cert data is provided for the registry host in the config and also proxy cert config(PROXY_CA_CERT) is provided", func() {
+			BeforeEach(func() {
+				caCertDataOpt = fakeCACertData
+				proxyCACertDataB64 = base64.StdEncoding.EncodeToString([]byte(fakeProxyCACertData))
+			})
+			It("should return success and cert options should have registry cert path updated with proxy CA cert data", func() {
+
+				certOptions, err := GetRegistryCertOptions(testHost)
+				Expect(err).To(BeNil())
+				Expect(certOptions).ToNot(BeNil())
+
+				regFilePath, err := configpaths.GetRegistryCertFile()
+				Expect(err).To(BeNil())
+				Expect(certOptions.CACertPaths).To(ContainElement(regFilePath))
+				certData, err := os.ReadFile(regFilePath)
+				Expect(err).To(BeNil())
+				Expect(string(certData)).To(Equal(fakeProxyCACertData))
+				Expect(certOptions.SkipCertVerify).To(Equal(false))
+				Expect(certOptions.Insecure).To(Equal(false))
+			})
+		})
+		Context("When cert config is NOT provided for the registry host, but proxy cert config(PROXY_CA_CERT) is provide ", func() {
+			BeforeEach(func() {
+				caCertDataOpt = fakeCACertData
+				proxyCACertDataB64 = base64.StdEncoding.EncodeToString([]byte(fakeProxyCACertData))
+			})
+			It("should return success and cert options should have registry cert path updated with proxy CA cert data", func() {
+				// delete the registry host cert config(as it is added for all the test cases)
+				err := configlib.DeleteCert(testHost)
+				Expect(err).To(BeNil())
+
+				certOptions, err := GetRegistryCertOptions(testHost)
+				Expect(err).To(BeNil())
+				Expect(certOptions).ToNot(BeNil())
+
+				regFilePath, err := configpaths.GetRegistryCertFile()
+				Expect(err).To(BeNil())
+				Expect(certOptions.CACertPaths).To(ContainElement(regFilePath))
+				certData, err := os.ReadFile(regFilePath)
+				Expect(err).To(BeNil())
+				Expect(string(certData)).To(Equal(fakeProxyCACertData))
+				Expect(certOptions.SkipCertVerify).To(Equal(false))
+				Expect(certOptions.Insecure).To(Equal(false))
+			})
+		})
+	})
+
 })


### PR DESCRIPTION
### What this PR does / why we need it

This PR adds support to configure proxy certificate to interact with registry

Summary:
- If proxy is configured between CLI and registry which needs a certificate, user can set the environment variable "PROXY_CA_CERT" with base64 value of the proxy cert. The proxy cert would be used while interacting with registry.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #284 

### Describe testing done for PR
Unit tests and CI passed.


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add support to configure proxy certificate to interact with registry. User has to set the environment variable "TANZU_CLI_PROXY_CA_CERT" value to base64 value of proxy certificate
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer


<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
