### PR TITLE
Add the "plugin group get" command

### DIFF
--- a/docs/quickstart/quickstart.md
+++ b/docs/quickstart/quickstart.md
@@ -66,6 +66,31 @@ $ tanzu plugin group search
   vmware-tmc/tmc-user  Plugins for Tanzu Mission-Control       v0.0.1
 ```
 
+### List the plugins of a plugin group
+
+```console
+$ tz plugin group get vmware-tkg/default:v2.1.0
+Plugins in Group:  vmware-tkg/default:v2.1.0
+  NAME                TARGET      LATEST
+  cluster             kubernetes  v0.28.0
+  feature             kubernetes  v0.28.0
+  isolated-cluster    global      v0.28.0
+  kubernetes-release  kubernetes  v0.28.0
+  management-cluster  kubernetes  v0.28.0
+  package             kubernetes  v0.28.0
+  pinniped-auth       global      v0.28.0
+  secret              kubernetes  v0.28.0
+  telemetry           kubernetes  v0.28.0
+```
+
+Note that you can omit the version if you are interested in the contents of the latest version of a group:
+
+```console
+$ tz plugin group get vmware-tkg/default
+Plugins in Group:  vmware-tkg/default:v2.1.0
+[...]
+```
+
 ### Install all plugins in a group
 
 ```console


### PR DESCRIPTION
**This PR is on top of #270 to first provide plugin group version support.  Only the top-most commit is new**

### What this PR does / why we need it

This PR adds a command to see the list of plugins part of a plugin group version (finally!): 

```
$ tz plugin group get vmware-tkg/default:v2.1.1
Plugins in Group:  vmware-tkg/default:v2.1.1
  NAME                TARGET      LATEST
  cluster             kubernetes  v0.28.1
  feature             kubernetes  v0.28.1
  isolated-cluster    global      v0.28.1
  kubernetes-release  kubernetes  v0.28.1
  management-cluster  kubernetes  v0.28.1
  package             kubernetes  v0.28.1
  pinniped-auth       global      v0.28.1
  secret              kubernetes  v0.28.1
  telemetry           kubernetes  v0.28.1
```

The user can omit the version to get the content of the latest version of a group: `tz plugin group get vmware-tkg/default`

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

```
# Initialize stuff
$ rm ~/.cache/tanzu/plugin_inventory
$ rm ~/.config/tanzu/config*
$ \rm -rf hack/central-repo/registry-content
$ make start-test-central-repo
[...]
$ tz plugin source update default -u localhost:9876/tanzu-cli/plugins/central:small
[ok] updated discovery source default
$ tz config set env.TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_PUBLIC_KEY_PATH $tc/hack/central-repo/cosign-key-pair/cosign.pub

# Look for the plugins we have
$ tz plugin group search --show-details
name: vmware-tkg/default
description: Desc for vmware-tkg/default
latest: v9.9.9
versions:
    - v0.0.1
    - v9.9.9

name: vmware-tmc/tmc-user
description: Desc for vmware-tmc/tmc-user
latest: v9.9.9
versions:
    - v0.0.1
    - v9.9.9

# Now try the new command
# First the help
$ tz plugin group get -h
Get the content of the specified plugin-group.  A plugin-group provides a list of plugin name/version combinations which can be installed in one step.  This command allows to see the list of plugins included in the specified group.

Usage:
tanzu plugin group get <group> [flags]

Flags:
  -h, --help            help for get
  -o, --output string   output format (yaml|json|table)

# Missing group name
$ tz plugin group get
[x] : accepts 1 arg(s), received 0

# Too many args
$ tz plugin group get two args
[x] : accepts 1 arg(s), received 2

# Now get the content of vmware-tkg/default:v0.0.1 
$ tz plugin group get vmware-tkg/default:v0.0.1
Plugins in Group:  vmware-tkg/default:v0.0.1
  NAME                TARGET      LATEST
  cluster             kubernetes  v0.0.1
  feature             kubernetes  v0.0.1
  kubernetes-release  kubernetes  v0.0.1
  management-cluster  kubernetes  v0.0.1
  package             kubernetes  v0.0.1
  secret              kubernetes  v0.0.1
  telemetry           kubernetes  v0.0.1

# Notice that in the list format, I chose to add the "plugin" prefix for "pluginname", "plugintarget" and "pluginversion"
# This is because when I first tried it without a prefix, the "version" field was confusing as it could have applied
# to the group version
$ tz plugin group get vmware-tkg/default:v0.0.1 -o yaml
- group: vmware-tkg/default:v0.0.1
  pluginname: cluster
  plugintarget: kubernetes
  pluginversion: v0.0.1
- group: vmware-tkg/default:v0.0.1
  pluginname: feature
  plugintarget: kubernetes
  pluginversion: v0.0.1
- group: vmware-tkg/default:v0.0.1
  pluginname: kubernetes-release
  plugintarget: kubernetes
  pluginversion: v0.0.1
- group: vmware-tkg/default:v0.0.1
  pluginname: management-cluster
  plugintarget: kubernetes
  pluginversion: v0.0.1
- group: vmware-tkg/default:v0.0.1
  pluginname: package
  plugintarget: kubernetes
  pluginversion: v0.0.1
- group: vmware-tkg/default:v0.0.1
  pluginname: secret
  plugintarget: kubernetes
  pluginversion: v0.0.1
- group: vmware-tkg/default:v0.0.1
  pluginname: telemetry
  plugintarget: kubernetes
  pluginversion: v0.0.1

# No need to specify the version
$ tz plugin group get vmware-tkg/default
Plugins in Group:  vmware-tkg/default:v9.9.9
  NAME                TARGET      LATEST
  cluster             kubernetes  v9.9.9
  feature             kubernetes  v9.9.9
  kubernetes-release  kubernetes  v9.9.9
  management-cluster  kubernetes  v9.9.9
  package             kubernetes  v9.9.9
  secret              kubernetes  v9.9.9
  telemetry           kubernetes  v9.9.9

$ tz plugin group get vmware-tkg/default -o yaml
- group: vmware-tkg/default:v9.9.9
  pluginname: cluster
  plugintarget: kubernetes
  pluginversion: v9.9.9
- group: vmware-tkg/default:v9.9.9
  pluginname: feature
  plugintarget: kubernetes
  pluginversion: v9.9.9
- group: vmware-tkg/default:v9.9.9
  pluginname: kubernetes-release
  plugintarget: kubernetes
  pluginversion: v9.9.9
- group: vmware-tkg/default:v9.9.9
  pluginname: management-cluster
  plugintarget: kubernetes
  pluginversion: v9.9.9
- group: vmware-tkg/default:v9.9.9
  pluginname: package
  plugintarget: kubernetes
  pluginversion: v9.9.9
- group: vmware-tkg/default:v9.9.9
  pluginname: secret
  plugintarget: kubernetes
  pluginversion: v9.9.9
- group: vmware-tkg/default:v9.9.9
  pluginname: telemetry
  plugintarget: kubernetes
  pluginversion: v9.9.9
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The new "tanzu plugin group get <group>" command allows to see what plugin versions are part of the specified group.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
