### PR TITLE
Fail command if EULA terms are not accepted

### DIFF
--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -5,6 +5,7 @@
 package command
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -132,6 +133,13 @@ func newRootCmd() *cobra.Command {
 					if err := cliconfig.ConfigureEULA(false); err != nil {
 						return err
 					}
+
+					configVal, _ := config.GetEULAStatus()
+					if configVal != config.EULAStatusAccepted {
+						fmt.Fprintf(os.Stderr, "The Tanzu CLI is only usable with reduced functionality until the General Terms are agreed to.\nPlease use `tanzu config eula show` to review the terms, or `tanzu config eula accept` to accept them directly\n")
+						return errors.New("terms not accepted")
+					}
+
 					if err := cliconfig.ConfigureCEIPOptIn(); err != nil {
 						return err
 					}


### PR DESCRIPTION
When invoking a command and it is deemed necessary to display the EULA prompt to solicit acceptance by the user, fail the command unless acceptance is received, with a message stating that the terms have to have to be accepted

Also: updated unit tests for eula show as well as situations when the prompt should be auto-triggered.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Ran unit tests.
Also ran arbitrary command e..g `tanzu context list`
to verify that it fails should EULA not be accepted

```
> tanzu context list
? You must agree to the VMware General Terms in order to install software via
Tanzu CLI.  The term of acceptance of the VMware General Terms will cover all
software installed via the Tanzu CLI until/unless there's a change to VMware
General Terms, a major release of the Tanzu CLI has been installed, or the
underlying software distribution registry has been changed.

To view the VMware General Terms, please see https://network.tanzu.vmware.com/legal_document_agreements/1982364

Do you agree to the VMware General Terms?
 No
The Tanzu CLI is only usable with reduced functionality until the General Terms are agreed to.
Please use `tanzu config eula show` to review the terms, or `tanzu config eula accept` to accept them directly
[x] : terms not accepted
```


### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Commands that prompts for EULA acceptance fails should EULA not be accepted.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
