### PR TITLE
tmc and k8s contexts e2e tests

### DIFF
--- a/test/e2e/context/tmc/context_tmc_k8s_contexts_test.go
+++ b/test/e2e/context/tmc/context_tmc_k8s_contexts_test.go
@@ -1,0 +1,176 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// tmc provides context command e2e test cases for tmc target
+package tmc
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware-tanzu/tanzu-cli/test/e2e/framework"
+	types "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
+)
+
+// Test suite tests the context life cycle use cases for the TMC target
+// Here are sequence of test cases in this suite:
+// Use case 1: delete all contexts if any available
+// Use case 2: create both tmc and k8s contexts, make sure both are active
+// Use case 3: create multiple tmc and k8s contexts, make sure most recently created contexts for both tmc and k8s are active
+
+var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-lifecycle-tmc-k8s]", func() {
+
+	// Use case 1: delete config files and initialize config
+	It("should initialize configuration successfully", func() {
+		// delete config files
+		err := tf.Config.DeleteCLIConfigurationFiles()
+		Expect(err).To(BeNil())
+		// call init
+		err = tf.Config.ConfigInit()
+		Expect(err).To(BeNil())
+		// should create config files
+		Expect(tf.Config.IsCLIConfigurationFilesExists()).To(BeTrue())
+	})
+	// use case 2: create both tmc and k8s contexts, make sure both are active
+	// Test case: a. create tmc context
+	// Test case: b. create k8s context, make sure its active
+	// Test case: c. list all active contexts, make both tmc and k8s contexts are active
+	// Test case: d. delte both k8s and tmc contexts
+	Context("Context lifecycle tests for TMC target", func() {
+		var k8sCtx, tmcCtx string
+		// Test case: a. create tmc context
+		It("create tmc context with endpoint and check active context", func() {
+			tmcCtx = prefix + framework.RandomString(4)
+			_, _, err := tf.ContextCmd.CreateContextWithEndPointStaging(tmcCtx, tmcClusterInfo.EndPoint)
+			Expect(err).To(BeNil(), "context should create without any error")
+			Expect(framework.IsContextExists(tf, tmcCtx)).To(BeTrue(), fmt.Sprintf(ContextShouldExistsAsCreated, tmcCtx))
+			active, err := tf.ContextCmd.GetActiveContext(string(types.TargetTMC))
+			Expect(err).To(BeNil(), "there should be a active context")
+			Expect(active).To(Equal(tmcCtx), "the active context should be recently added context")
+		})
+
+		// Test case: b. create k8s context, make sure its active
+		It("create k8s context", func() {
+			k8sCtx = prefixK8s + framework.RandomString(4)
+			err := tf.ContextCmd.CreateContextWithKubeconfig(k8sCtx, k8sClusterInfo.KubeConfigPath, k8sClusterInfo.ClusterKubeContext)
+			Expect(err).To(BeNil(), "context should create without any error")
+			Expect(framework.IsContextExists(tf, k8sCtx)).To(BeTrue(), fmt.Sprintf(framework.ContextShouldExistsAsCreated, k8sCtx))
+
+			active, err := tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
+			Expect(err).To(BeNil(), "there should be a active context")
+			Expect(active).To(Equal(k8sCtx), "the active context should be recently added context")
+
+		})
+
+		// Test case: c. list all active contexts, make both tmc and k8s contexts are active
+		It("list all active contexts", func() {
+			cts, err := tf.ContextCmd.GetActiveContexts()
+			Expect(err).To(BeNil(), "there should no error for list contexts")
+			m := framework.ContextInfoToMap(cts)
+			_, ok := m[k8sCtx]
+			Expect(ok).To(BeTrue(), "k8s context should exists and active")
+			_, ok = m[tmcCtx]
+			Expect(ok).To(BeTrue(), "tmc context should exists and active")
+		})
+
+		// Test case: d. delete both k8s and tmc contexts
+		It("delete context command", func() {
+			err := tf.ContextCmd.DeleteContext(k8sCtx)
+			Expect(err).To(BeNil(), "delete context should delete context without any error")
+			Expect(framework.IsContextExists(tf, k8sCtx)).To(BeFalse(), fmt.Sprintf(ContextShouldNotExists+" as been deleted", k8sCtx))
+			err = tf.ContextCmd.DeleteContext(tmcCtx)
+			Expect(err).To(BeNil(), "delete context should delete context without any error")
+			Expect(framework.IsContextExists(tf, tmcCtx)).To(BeFalse(), fmt.Sprintf(ContextShouldNotExists+" as been deleted", tmcCtx))
+		})
+	})
+	// Use case 3: create multiple tmc and k8s contexts, make sure most recently created contexts for both tmc and k8s are active
+	// Test case: a. create tmc contexts
+	// Test case: b. create k8s contexts
+	// Test case: c. list all active contexts, make both tmc and k8s contexts are active
+	// Test case: d. list all contexts
+	// Test case: e. delete all contexts
+	Context("Context lifecycle tests for TMC target", func() {
+		var k8sCtx, tmcCtx string
+		k8sCtxs := make([]string, 0)
+		tmcCtxs := make([]string, 0)
+		// Test case: a. create tmc context
+		It("create tmc context with endpoint and check active context", func() {
+			for i := 0; i < 5; i++ {
+				tmcCtx = prefix + framework.RandomString(4)
+				_, _, err := tf.ContextCmd.CreateContextWithEndPointStaging(tmcCtx, tmcClusterInfo.EndPoint)
+				Expect(err).To(BeNil(), "context should create without any error")
+				Expect(framework.IsContextExists(tf, tmcCtx)).To(BeTrue(), fmt.Sprintf(ContextShouldExistsAsCreated, tmcCtx))
+				active, err := tf.ContextCmd.GetActiveContext(string(types.TargetTMC))
+				Expect(err).To(BeNil(), "there should be a active context")
+				Expect(active).To(Equal(tmcCtx), "the active context should be recently added context")
+				tmcCtxs = append(tmcCtxs, tmcCtx)
+			}
+
+		})
+
+		// Test case: b. create k8s contexts
+		It("create k8s context", func() {
+			for i := 0; i < 5; i++ {
+				k8sCtx = prefixK8s + framework.RandomString(4)
+				err := tf.ContextCmd.CreateContextWithKubeconfig(k8sCtx, k8sClusterInfo.KubeConfigPath, k8sClusterInfo.ClusterKubeContext)
+				Expect(err).To(BeNil(), "context should create without any error")
+				Expect(framework.IsContextExists(tf, k8sCtx)).To(BeTrue(), fmt.Sprintf(framework.ContextShouldExistsAsCreated, k8sCtx))
+
+				active, err := tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
+				Expect(err).To(BeNil(), "there should be a active context")
+				Expect(active).To(Equal(k8sCtx), "the active context should be recently added context")
+				k8sCtxs = append(k8sCtxs, k8sCtx)
+			}
+		})
+
+		// Test case: c. list all active contexts, make both tmc and k8s contexts are active
+		It("list all active contexts", func() {
+			cts, err := tf.ContextCmd.GetActiveContexts()
+			Expect(err).To(BeNil(), "there should no error for list contexts")
+			Expect(len(cts)).To(Equal(2), "there should be only 2 contexts active")
+			m := framework.ContextInfoToMap(cts)
+			_, ok := m[k8sCtx]
+			Expect(ok).To(BeTrue(), "latest k8s context should exists and active")
+			_, ok = m[tmcCtx]
+			Expect(ok).To(BeTrue(), "latest tmc context should exists and active")
+		})
+
+		// Test case: d. list all contexts
+		It("list all contexts", func() {
+			cts, err := tf.ContextCmd.ListContext()
+			Expect(err).To(BeNil(), "there should no error for list contexts")
+			Expect(len(cts)).To(Equal(len(k8sCtxs)+len(tmcCtxs)), "there should be all k8s+tmc contexts")
+			m := framework.ContextInfoToMap(cts)
+			for _, ctx := range k8sCtxs {
+				_, ok := m[ctx]
+				Expect(ok).To(BeTrue(), "all k8s contexts should exists")
+				delete(m, ctx)
+			}
+			for _, ctx := range tmcCtxs {
+				_, ok := m[ctx]
+				Expect(ok).To(BeTrue(), "all tmc contexts should exists")
+				delete(m, ctx)
+			}
+			Expect(len(m)).To(Equal(0), "after tmc and k8s context deleted, there should not be any contexts exists")
+		})
+
+		// Test case: e. delete all contexts
+		It("delete all contexts", func() {
+
+			for _, ctx := range k8sCtxs {
+				err := tf.ContextCmd.DeleteContext(ctx)
+				Expect(err).To(BeNil(), "delete context should delete context without any error")
+			}
+			for _, ctx := range tmcCtxs {
+
+				err := tf.ContextCmd.DeleteContext(ctx)
+				Expect(err).To(BeNil(), "delete context should delete context without any error")
+			}
+			cts, err := tf.ContextCmd.ListContext()
+			Expect(err).To(BeNil(), "there should no error for list contexts")
+			Expect(len(cts)).To(Equal(0), "there should be no contexts available after deleting all contexts")
+		})
+	})
+})

--- a/test/e2e/context/tmc/context_tmc_lifecycle_stress_test.go
+++ b/test/e2e/context/tmc/context_tmc_lifecycle_stress_test.go
@@ -39,7 +39,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-lifecycle-stress-
 			By("create tmc context with tmc endpoint")
 			for i := 0; i < maxCtx; i++ {
 				ctxName := prefix + framework.RandomString(5)
-				_, _, err := tf.ContextCmd.CreateContextWithEndPointStaging(ctxName, clusterInfo.EndPoint)
+				_, _, err := tf.ContextCmd.CreateContextWithEndPointStaging(ctxName, tmcClusterInfo.EndPoint)
 				Expect(err).To(BeNil(), "context should create without any error")
 				Expect(framework.IsContextExists(tf, ctxName)).To(BeTrue(), fmt.Sprintf(ContextShouldExistsAsCreated, ctxName))
 				contextNames = append(contextNames, ctxName)

--- a/test/e2e/context/tmc/context_tmc_lifecycle_test.go
+++ b/test/e2e/context/tmc/context_tmc_lifecycle_test.go
@@ -47,7 +47,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-lifecycle-tmc]", 
 		// Test case: b. Create context for TMC target with TMC cluster URL as endpoint
 		It("create tmc context with endpoint", func() {
 			ctxName := prefix + framework.RandomString(4)
-			_, _, err := tf.ContextCmd.CreateContextWithEndPointStaging(ctxName, clusterInfo.EndPoint)
+			_, _, err := tf.ContextCmd.CreateContextWithEndPointStaging(ctxName, tmcClusterInfo.EndPoint)
 			Expect(err).To(BeNil(), "context should create without any error")
 			Expect(framework.IsContextExists(tf, ctxName)).To(BeTrue(), fmt.Sprintf(ContextShouldExistsAsCreated, ctxName))
 			contextNames = append(contextNames, ctxName)
@@ -65,18 +65,18 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-lifecycle-tmc]", 
 			err := os.Setenv(framework.TanzuAPIToken, framework.RandomString(4))
 			Expect(err).To(BeNil(), "There should not be any error in setting environment variables.")
 			ctxName := framework.RandomString(4)
-			_, _, err = tf.ContextCmd.CreateContextWithEndPointStaging(ctxName, clusterInfo.EndPoint)
-			os.Setenv(framework.TanzuAPIToken, clusterInfo.APIKey)
+			_, _, err = tf.ContextCmd.CreateContextWithEndPointStaging(ctxName, tmcClusterInfo.EndPoint)
+			os.Setenv(framework.TanzuAPIToken, tmcClusterInfo.APIKey)
 			Expect(err).ToNot(BeNil())
 			Expect(strings.Contains(err.Error(), framework.FailedToCreateContext)).To(BeTrue())
 			Expect(framework.IsContextExists(tf, ctxName)).To(BeFalse(), fmt.Sprintf(ContextShouldNotExists, ctxName))
-			err = os.Setenv(framework.TanzuAPIToken, clusterInfo.APIKey)
+			err = os.Setenv(framework.TanzuAPIToken, tmcClusterInfo.APIKey)
 			Expect(err).To(BeNil(), "There should not be any error in setting environment variables.")
 		})
 		// Test case: e. Create context for TMC target with TMC cluster URL as endpoint, and validate the active context, should be recently create context
 		It("create tmc context with endpoint and check active context", func() {
 			ctxName := prefix + framework.RandomString(4)
-			_, _, err := tf.ContextCmd.CreateContextWithEndPointStaging(ctxName, clusterInfo.EndPoint)
+			_, _, err := tf.ContextCmd.CreateContextWithEndPointStaging(ctxName, tmcClusterInfo.EndPoint)
 			Expect(err).To(BeNil(), "context should create without any error")
 			Expect(framework.IsContextExists(tf, ctxName)).To(BeTrue(), fmt.Sprintf(ContextShouldExistsAsCreated, ctxName))
 			contextNames = append(contextNames, ctxName)

--- a/test/e2e/framework/context_lifecycle_operations.go
+++ b/test/e2e/framework/context_lifecycle_operations.go
@@ -26,6 +26,8 @@ type ContextCmdOps interface {
 	DeleteContext(contextName string, opts ...E2EOption) error
 	// GetActiveContext returns current active context
 	GetActiveContext(targetType string, opts ...E2EOption) (string, error)
+	// GetActiveContexts returns all active contexts
+	GetActiveContexts(opts ...E2EOption) ([]*ContextListInfo, error)
 }
 
 // contextCmdOps implements the interface ContextCmdOps
@@ -82,6 +84,20 @@ func (cc *contextCmdOps) GetActiveContext(targetType string, opts ...E2EOption) 
 		}
 	}
 	return activeCtx, nil
+}
+
+func (cc *contextCmdOps) GetActiveContexts(opts ...E2EOption) ([]*ContextListInfo, error) {
+	list, err := cc.ListContext(opts...)
+	contexts := make([]*ContextListInfo, 0)
+	if err != nil {
+		return contexts, err
+	}
+	for i, _ := range list {
+		if list[i].Iscurrent == "true" {
+			contexts = append(contexts, list[i])
+		}
+	}
+	return contexts, nil
 }
 
 func (cc *contextCmdOps) DeleteContext(contextName string, opts ...E2EOption) error {

--- a/test/e2e/framework/framework_helper.go
+++ b/test/e2e/framework/framework_helper.go
@@ -559,3 +559,12 @@ func CleanConfigFiles(tf *Framework) error {
 func GetJsonOutputFormatAdditionalFlagFunction() E2EOption {
 	return AddAdditionalFlagAndValue(JSONOtuput)
 }
+
+// ContextInfoToMap takes the contexts list, and returns the map with context name as key and context info as value
+func ContextInfoToMap(ctxs []*ContextListInfo) map[string]*ContextListInfo {
+	m := make(map[string]*ContextListInfo)
+	for i := range ctxs {
+		m[ctxs[i].Name] = ctxs[i]
+	}
+	return m
+}

--- a/test/e2e/plugin_sync/k8s/plugin_sync_k8s_lifecycle_test.go
+++ b/test/e2e/plugin_sync/k8s/plugin_sync_k8s_lifecycle_test.go
@@ -14,6 +14,14 @@ import (
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
 
+// Below Use cases executed in this test suite
+// cleanup and initialize the config files
+// Use case 1: create a KIND cluster, don't apply CRD and CRs, create context, make sure no plugins are installed
+// Use case 2: Create kind cluster, apply CRD and CRs, create context, should install all plugins, uninstall the specific plugin, and perform plugin sync
+// Use case 3: Test plugin sync when central repo does not have all plugin CRs being applied in KIND cluster
+// Use case 4: test delete context use case, it should uninstall plugins installed for the context
+// Use case 5: test switch context use case, make installed plugins should be updated as per the context
+
 var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 
 	// cleanup and initialize the config files


### PR DESCRIPTION
### What this PR does / why we need it
This pull request updates the context-specific end-to-end (e2e) tests to cover use cases where both tmc and k8s contexts are used simultaneously.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
1. E2E tests are updated
2. Tests executed successfully in local:
```
❯ make e2e-context-tmc-tests
=== RUN   TestTmc
Running Suite: Context-TMC Suite - /Users/cpamuluri/tkg/tasks/e2e_tests/separate_module/tanzu-cli/test/e2e/context/tmc
======================================================================================================================
Random Seed: 1684067269

Will run 10 of 10 specs
[i] Executing command: docker info
[i] Executing command: kind create cluster --name context-e2e-9900
[i] Executing command: docker info
[i] Executing command: tanzu config init
•[i] Executing command: tanzu context create --endpoint unstable.tmc-dev.cloud.vmware.com --name ctx-tmc-72dd --staging
[i] out:
 stdErr:[i] API token env var is set
[ok] successfully created a TMC context
[i] Checking for required plugins...
[!] unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually
[i] context ctx-tmc-72dd created successfully
[i] Executing command: tanzu context list -o json
[i] Executing command: tanzu context list -o json
•[i] Executing command: tanzu context create --kubeconfig /Users/cpamuluri/.tanzu-cli-e2e/.kube/config --kubecontext kind-context-e2e-9900 --name ctx-k8s-5ruZ
[i] context ctx-k8s-5ruZ created successfully
[i] Executing command: tanzu context list -o json
[i] Executing command: tanzu context list -o json
•[i] Executing command: tanzu context list -o json
•[i] Executing command: tanzu context delete ctx-k8s-5ruZ --yes
[i] context ctx-k8s-5ruZ deleted successfully
[i] Executing command: tanzu context list -o json
[i] Executing command: tanzu context delete ctx-tmc-72dd --yes
[i] context ctx-tmc-72dd deleted successfully
[i] Executing command: tanzu context list -o json
•[i] Executing command: tanzu context create --endpoint unstable.tmc-dev.cloud.vmware.com --name ctx-tmc-Z5OX --staging
[i] out:
 stdErr:[i] API token env var is set
[ok] successfully created a TMC context
[i] Checking for required plugins...
[!] unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually
[i] context ctx-tmc-Z5OX created successfully
[i] Executing command: tanzu context list -o json
[i] Executing command: tanzu context list -o json
[i] Executing command: tanzu context create --endpoint unstable.tmc-dev.cloud.vmware.com --name ctx-tmc-jCEn --staging
[i] out:
 stdErr:[i] API token env var is set
[ok] successfully created a TMC context
[i] Checking for required plugins...
[!] unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually
[i] context ctx-tmc-jCEn created successfully
[i] Executing command: tanzu context list -o json
[i] Executing command: tanzu context list -o json
[i] Executing command: tanzu context create --endpoint unstable.tmc-dev.cloud.vmware.com --name ctx-tmc-BZke --staging
[i] out:
 stdErr:[i] API token env var is set
[ok] successfully created a TMC context
[i] Checking for required plugins...
[!] unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually
[i] context ctx-tmc-BZke created successfully
[i] Executing command: tanzu context list -o json
[i] Executing command: tanzu context list -o json
[i] Executing command: tanzu context create --endpoint unstable.tmc-dev.cloud.vmware.com --name ctx-tmc-nXEj --staging
[i] out:
 stdErr:[i] API token env var is set
[ok] successfully created a TMC context
[i] Checking for required plugins...
[!] unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually
[i] context ctx-tmc-nXEj created successfully
[i] Executing command: tanzu context list -o json
[i] Executing command: tanzu context list -o json
[i] Executing command: tanzu context create --endpoint unstable.tmc-dev.cloud.vmware.com --name ctx-tmc-FXF7 --staging
[i] out:
 stdErr:[i] API token env var is set
[ok] successfully created a TMC context
[i] Checking for required plugins...
[!] unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually
[i] context ctx-tmc-FXF7 created successfully
[i] Executing command: tanzu context list -o json
[i] Executing command: tanzu context list -o json
•[i] Executing command: tanzu context create --kubeconfig /Users/cpamuluri/.tanzu-cli-e2e/.kube/config --kubecontext kind-context-e2e-9900 --name ctx-k8s-InVG
[i] context ctx-k8s-InVG created successfully
[i] Executing command: tanzu context list -o json
[i] Executing command: tanzu context list -o json
[i] Executing command: tanzu context create --kubeconfig /Users/cpamuluri/.tanzu-cli-e2e/.kube/config --kubecontext kind-context-e2e-9900 --name ctx-k8s-mn7C
[i] context ctx-k8s-mn7C created successfully
[i] Executing command: tanzu context list -o json
[i] Executing command: tanzu context list -o json
[i] Executing command: tanzu context create --kubeconfig /Users/cpamuluri/.tanzu-cli-e2e/.kube/config --kubecontext kind-context-e2e-9900 --name ctx-k8s-ZfO9
[i] context ctx-k8s-ZfO9 created successfully
[i] Executing command: tanzu context list -o json
[i] Executing command: tanzu context list -o json
[i] Executing command: tanzu context create --kubeconfig /Users/cpamuluri/.tanzu-cli-e2e/.kube/config --kubecontext kind-context-e2e-9900 --name ctx-k8s-HGKf
[i] context ctx-k8s-HGKf created successfully
[i] Executing command: tanzu context list -o json
[i] Executing command: tanzu context list -o json
[i] Executing command: tanzu context create --kubeconfig /Users/cpamuluri/.tanzu-cli-e2e/.kube/config --kubecontext kind-context-e2e-9900 --name ctx-k8s-RiyE
[i] context ctx-k8s-RiyE created successfully
[i] Executing command: tanzu context list -o json
[i] Executing command: tanzu context list -o json
•[i] Executing command: tanzu context list -o json
•[i] Executing command: tanzu context list -o json
•[i] Executing command: tanzu context delete ctx-k8s-InVG --yes
[i] context ctx-k8s-InVG deleted successfully
[i] Executing command: tanzu context delete ctx-k8s-mn7C --yes
[i] context ctx-k8s-mn7C deleted successfully
[i] Executing command: tanzu context delete ctx-k8s-ZfO9 --yes
[i] context ctx-k8s-ZfO9 deleted successfully
[i] Executing command: tanzu context delete ctx-k8s-HGKf --yes
[i] context ctx-k8s-HGKf deleted successfully
[i] Executing command: tanzu context delete ctx-k8s-RiyE --yes
[i] context ctx-k8s-RiyE deleted successfully
[i] Executing command: tanzu context delete ctx-tmc-Z5OX --yes
[i] context ctx-tmc-Z5OX deleted successfully
[i] Executing command: tanzu context delete ctx-tmc-jCEn --yes
[i] context ctx-tmc-jCEn deleted successfully
[i] Executing command: tanzu context delete ctx-tmc-BZke --yes
[i] context ctx-tmc-BZke deleted successfully
[i] Executing command: tanzu context delete ctx-tmc-nXEj --yes
[i] context ctx-tmc-nXEj deleted successfully
[i] Executing command: tanzu context delete ctx-tmc-FXF7 --yes
[i] context ctx-tmc-FXF7 deleted successfully
[i] Executing command: tanzu context list -o json
•[i] Executing command: docker info
[i] Executing command: kind delete cluster --name context-e2e-9900


Ran 10 of 10 Specs in 388.775 seconds
SUCCESS! -- 10 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestTmc (388.78s)
PASS
coverage: [no statements]
ok      github.com/vmware-tanzu/tanzu-cli/test/e2e/context/tmc  389.222s        coverage: [no statements]
❯ 
```


### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
