### PR TITLE
Add backward compatibility support for private customer plugins

### DIFF
--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -158,10 +158,19 @@ func GetTrustedRegistries() []string {
 	return trustedRegistries
 }
 
+// GetAdditionalTestDiscoveryImages would return the private discovery images or test discovery images.
+// The private discovery images("TANZU_CLI_PRIVATE_PLUGIN_DISCOVERY_IMAGES") was introduced to support
+// the backward compatibility where if there are customers using CLIPlugin CR to point to their private repository.
+// It would be deprecated once we confirm there are no users using it but will continue supporting additional testing plugin discoveries.
+// It would be mutually exclusive with "TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY" environment
+// variable. Users can use only one of them and "TANZU_CLI_PRIVATE_PLUGIN_DISCOVERY_IMAGES" takes the priority
 func GetAdditionalTestDiscoveryImages() []string {
 	var additionalImages []string
-	testDiscoveryImages := strings.Split(os.Getenv(constants.ConfigVariableAdditionalDiscoveryForTesting), ",")
-	for _, image := range testDiscoveryImages {
+	additionalDiscoveryImages := os.Getenv(constants.ConfigVariableAdditionalPrivateDiscoveryImages)
+	if additionalDiscoveryImages == "" {
+		additionalDiscoveryImages = os.Getenv(constants.ConfigVariableAdditionalDiscoveryForTesting)
+	}
+	for _, image := range strings.Split(additionalDiscoveryImages, ",") {
 		image = strings.TrimSpace(image)
 		if image != "" {
 			additionalImages = append(additionalImages, image)

--- a/pkg/constants/env_variables.go
+++ b/pkg/constants/env_variables.go
@@ -11,6 +11,7 @@ const (
 const (
 	AllowedRegistries                                 = "ALLOWED_REGISTRY"
 	ConfigVariableAdditionalDiscoveryForTesting       = "TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY"
+	ConfigVariableAdditionalPrivateDiscoveryImages    = "TANZU_CLI_PRIVATE_PLUGIN_DISCOVERY_IMAGES"
 	ConfigVariableIncludeDeactivatedPluginsForTesting = "TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY"
 	ConfigVariableStandaloneOverContextPlugins        = "TANZU_CLI_STANDALONE_OVER_CONTEXT_PLUGINS"
 	// PluginDiscoveryImageSignatureVerificationSkipList is a comma separated list of discovery image urls

--- a/pkg/pluginmanager/manager.go
+++ b/pkg/pluginmanager/manager.go
@@ -209,7 +209,7 @@ func getAdditionalTestPluginDiscoveries() []configtypes.PluginDiscovery {
 	for idx, image := range testDiscoveryImages {
 		testDiscoveries = append(testDiscoveries, configtypes.PluginDiscovery{
 			OCI: &configtypes.OCIDiscovery{
-				Name:  fmt.Sprintf("test_%d", idx),
+				Name:  fmt.Sprintf("disc_%d", idx),
 				Image: image,
 			},
 		})


### PR DESCRIPTION
### What this PR does / why we need it
This PR adds backward compatiblity support for private customer plugins

Summary:
- This is to support a case where, when a user using CLI prior to Central repository support, used CLIPlugin CR to download the custom private plugins hosted on their private repository. This is just to provide the backward compatibility and not for general usage.
- User should use the environment variable `TANZU_CLI_PRIVATE_PLUGIN_DISCOVERY_IMAGES` to specify the custom private repository where he hosted his custom plugins. Users who are currently using the CLIPlugin CR to point to their cutom private plugin repository, should use the CLI documentation to build and publish their plugins to their private repository so as to use this approach.
- The newly introduced environment variable is same as `TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY` except the name change and the new environment `TANZU_CLI_PRIVATE_PLUGIN_DISCOVERY_IMAGES`variable would be mutual exclusive to `TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY` (only one of them would be honored) with `TANZU_CLI_PRIVATE_PLUGIN_DISCOVERY_IMAGES` taking the priority.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Ran the tanzu plugin search and it shows only the `test` and `build` plugin from default plugin source
```
❯ ./bin/tanzu plugin search
  NAME     DESCRIPTION             TARGET  LATEST
  builder  Build Tanzu components  global  v0.90.0-alpha.1
  test     Test the CLI            global  v0.90.0-alpha.1
❯ ./bin/tanzu plugin source list
  NAME     IMAGE
  default  projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest
❯
❯

```
Exported  the new environment variable `TANZU_CLI_PRIVATE_PLUGIN_DISCOVERY_IMAGES` by pointing  it to the additional repositories and `tanzu plugin search` command shows the additional plugins as well. 
```
❯ tanzu config set env.TANZU_CLI_PRIVATE_PLUGIN_DISCOVERY_IMAGES localhost:9876/tanzu-cli/plugins/sandbox1:small
❯
❯
❯ ./bin/tanzu plugin search
  NAME                DESCRIPTION                  TARGET           LATEST
  builder             Build Tanzu components       global           v0.90.0-alpha.1
  test                Test the CLI                 global           v0.90.0-alpha.1
  cluster             Desc for cluster             kubernetes       v11.11.11
  feature             Desc for feature             kubernetes       v11.11.11
  kubernetes-release  Desc for kubernetes-release  kubernetes       v11.11.11
  management-cluster  Desc for management-cluster  kubernetes       v11.11.11
  package             Desc for package             kubernetes       v11.11.11
  secret              Desc for secret              kubernetes       v11.11.11
  telemetry           Desc for telemetry           kubernetes       v11.11.11
  account             Desc for account             mission-control  v11.11.11
  apply               Desc for apply               mission-control  v11.11.11
  audit               Desc for audit               mission-control  v11.11.11
  cluster             Desc for cluster             mission-control  v11.11.11
  clustergroup        Desc for clustergroup        mission-control  v11.11.11
  continuousdelivery  Desc for continuousdelivery  mission-control  v11.11.11
  data-protection     Desc for data-protection     mission-control  v11.11.11
  ekscluster          Desc for ekscluster          mission-control  v11.11.11
  events              Desc for events              mission-control  v11.11.11
  helm                Desc for helm                mission-control  v11.11.11
  iam                 Desc for iam                 mission-control  v11.11.11
  inspection          Desc for inspection          mission-control  v11.11.11
  integration         Desc for integration         mission-control  v11.11.11
  management-cluster  Desc for management-cluster  mission-control  v11.11.11
  policy              Desc for policy              mission-control  v11.11.11
  secret              Desc for secret              mission-control  v11.11.11
  tanzupackage        Desc for tanzupackage        mission-control  v11.11.11
  workspace           Desc for workspace           mission-control  v11.11.11
```

Installing the plugin from the additional plugin source was successful
```
❯ ./bin/tanzu plugin install feature
[i] Installing plugin 'feature:v11.11.11' with target 'kubernetes'
[ok] successfully installed 'feature' plugin
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add backward compatibility support for private customer plugins
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
