### PR TITLE
Enable completion when installing with APT and RPM

### DIFF
--- a/hack/apt/build_package.sh
+++ b/hack/apt/build_package.sh
@@ -64,6 +64,23 @@ Homepage: https://github.com/vmware-tanzu/tanzu-cli
 Description: The core Tanzu CLI" \
       > ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}/DEBIAN/control
 
+   # Add a postinstall script to setup shell completion
+   echo "#!/bin/bash
+
+mkdir -p /usr/share/bash-completion/completions
+tanzu completion bash > /usr/share/bash-completion/completions/tanzu
+chmod a+r /usr/share/bash-completion/completions/tanzu
+
+mkdir -p /usr/local/share/zsh/site-functions
+tanzu completion zsh > /usr/local/share/zsh/site-functions/_tanzu
+chmod a+r /usr/local/share/zsh/site-functions/_tanzu
+
+mkdir -p /usr/share/fish/vendor_completions.d
+tanzu completion fish > /usr/share/fish/vendor_completions.d/tanzu.fish
+chmod a+r /usr/share/fish/vendor_completions.d/tanzu.fish" \
+      > ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}/DEBIAN/postinst
+   chmod a+x ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}/DEBIAN/postinst
+
    # Create the .deb package
    dpkg-deb --build -Zgzip ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}
 

--- a/hack/rpm/tanzu-cli.spec
+++ b/hack/rpm/tanzu-cli.spec
@@ -42,5 +42,21 @@ rm -rf $RPM_BUILD_ROOT
 mkdir -p $RPM_BUILD_ROOT/%{_bindir}
 mv tanzu-cli-linux_%{arch} $RPM_BUILD_ROOT/%{_bindir}/tanzu
 
+%post
+# Setup bash completion
+mkdir -p /usr/share/bash-completion/completions
+tanzu completion bash > /usr/share/bash-completion/completions/tanzu
+chmod a+r /usr/share/bash-completion/completions/tanzu
+
+# Setup zsh completion
+mkdir -p /usr/local/share/zsh/site-functions
+tanzu completion zsh > /usr/local/share/zsh/site-functions/_tanzu
+chmod a+r /usr/local/share/zsh/site-functions/_tanzu
+
+# Setup fish completion
+mkdir -p /usr/share/fish/vendor_completions.d
+tanzu completion fish > /usr/share/fish/vendor_completions.d/tanzu.fish
+chmod a+r /usr/share/fish/vendor_completions.d/tanzu.fish
+
 %files
 %{_bindir}/tanzu


### PR DESCRIPTION
### What this PR does / why we need it

This prepares shell completion for bash, zsh and fish when installing the CLI using APT or YUM/DNF.

The idea is that as long as the user has already enabled general shell completion for their shell, installing the Tanzu CLI through APT or YUM/DNF will automatically have shell completion working for the Tanzu CLI binary.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Test for the APT package (ubuntu):
```
$ \rm -rf hack/apt/_output/
$ BUILD_VERSION=v0.90.0-alpha.2 make apt-package
[...]
====================================
Building debian package for amd64...
====================================
dpkg-deb: building package 'tanzu-cli' in '/Users/kmarc/git/tanzu-cli/hack/apt/_output/tanzu-cli_0.90.0-alpha.2_linux_amd64.deb'.
Exporting indices...
====================================
Building debian package for arm64...
====================================
dpkg-deb: building package 'tanzu-cli' in '/Users/kmarc/git/tanzu-cli/hack/apt/_output/tanzu-cli_0.90.0-alpha.2_linux_arm64.deb'.
Exporting indices...
$
$ docker run --rm -it -v $(pwd)/hack/apt/_output/apt:/tmp/apt ubuntu
# Install the CLI
root@0ba928a756b4:/# echo "deb file:///tmp/apt tanzu-cli-jessie main" | tee /etc/apt/sources.list.d/tanzu.list
apt-get update --allow-insecure-repositories
apt install -y tanzu-cli --allow-unauthenticated
[...]
Preparing to unpack .../tanzu-cli_0.90.0-alpha.2_arm64.deb ...
Unpacking tanzu-cli (0.90.0-alpha.2) ...
Setting up tanzu-cli (0.90.0-alpha.2) ...

# Check that the three completion files are present
root@0ba928a756b4:/# ls /usr/share/bash-completion/completions/tanzu
/usr/share/bash-completion/completions/tanzu
root@0ba928a756b4:/# ls /usr/local/share/zsh/site-functions/_tanzu
/usr/local/share/zsh/site-functions/_tanzu
root@0ba928a756b4:/# ls /usr/share/fish/vendor_completions.d/tanzu.fish
/usr/share/fish/vendor_completions.d/tanzu.fish


# Install the bash-completion package as well as zsh and fish
root@0ba928a756b4:/# apt install -y bash-completion zsh fish
[...]

# Setup general bash completion and test it with tanzu
root@0ba928a756b4:/# source /usr/share/bash-completion/bash_completion
root@0ba928a756b4:/# tanzu [tab][tab]
ceip-participation  (Manage VMware's Customer Experience Improvement Program (CEIP) Participation (subject to change))
completion          (Output shell completion code)
config              (Configuration for the CLI)
context             (Configure and manage contexts for the Tanzu CLI)
help                (Help about any command)
init                (Initialize the CLI)
plugin              (Manage CLI plugins)
version             (Version information)

# Test completion with zsh
root@0ba928a756b4:/# zsh
0ba928a756b4# tanzu [tab]
ceip-participation  -- Manage VMware's Customer Experience Improvement Program (CEIP) Participation (subject to change)
completion          -- Output shell completion code
config              -- Configuration for the CLI
context             -- Configure and manage contexts for the Tanzu CLI
help                -- Help about any command
init                -- Initialize the CLI
plugin              -- Manage CLI plugins
version             -- Version information

# Test completion with fish
0ba928a756b4# fish
Welcome to fish, the friendly interactive shell
Type help for instructions on how to use fish
root@0ba928a756b4 /# tanzu [tab]
ceip-participation  (Manage VMware's Customer Experience Improvement Program (CEIP) Participation (subject to change))  help  (Help about any command)
completion                                                                              (Output shell completion code)  init      (Initialize the CLI)
config                                                                                     (Configuration for the CLI)  plugin    (Manage CLI plugins)
context                                                              (Configure and manage contexts for the Tanzu CLI)  version  (Version information)
```

Test the RPM package (RHEL/fedora)
```
$ \rm -rf hack/rpm/_output/
$ BUILD_VERSION=v0.90.0-alpha.2 make rpm-package
[...]
Pool started (with 5 workers)
Pool finished
$
$ docker run --rm -it -v $(pwd)/hack/rpm/_output/rpm:/tmp/rpm fedora
# Install the CLI
[root@012a062d0265 /]# cat << EOF | sudo tee /etc/yum.repos.d/tanzu-cli.repo
[tanzu-cli]
name=Tanzu CLI
baseurl=file:///tmp/rpm/tanzu-cli
enabled=1
gpgcheck=0
EOF
yum install -y tanzu-cli
[...]
Installed:
  tanzu-cli-0.90.0_alpha.2-1.aarch64

Complete!

# Check that the three completion files are present
[root@012a062d0265 /]# ls /usr/share/bash-completion/completions/tanzu
/usr/share/bash-completion/completions/tanzu
[root@012a062d0265 /]# ls /usr/local/share/zsh/site-functions/_tanzu
/usr/local/share/zsh/site-functions/_tanzu
[root@012a062d0265 /]# ls /usr/share/fish/vendor_completions.d/tanzu.fish
/usr/share/fish/vendor_completions.d/tanzu.fish

# Install the bash-completion package as well as zsh and fish
[root@012a062d0265 /]# yum install -y bash-completion zsh fish
[...]
Complete!

# Setup general bash completion and test it with tanzu
[root@012a062d0265 /]# source /usr/share/bash-completion/bash_completion
[root@012a062d0265 /]# tanzu [tab][tab]
ceip-participation  (Manage VMware's Customer Experience Improvement Program (CEIP) Participation (subject to change))
completion          (Output shell completion code)
config              (Configuration for the CLI)
context             (Configure and manage contexts for the Tanzu CLI)
help                (Help about any command)
init                (Initialize the CLI)
plugin              (Manage CLI plugins)
version             (Version information)

# Test completion with zsh
[root@012a062d0265 /]# zsh
[root@012a062d0265]/# autoload -Uz compinit && compinit
[root@012a062d0265]/# tanzu [tab]
ceip-participation  -- Manage VMware's Customer Experience Improvement Program (CEIP) Participation (subject to change)
completion          -- Output shell completion code
config              -- Configuration for the CLI
context             -- Configure and manage contexts for the Tanzu CLI
help                -- Help about any command
init                -- Initialize the CLI
plugin              -- Manage CLI plugins
version             -- Version information

# Test completion with fish
[root@012a062d0265]/# fish
Welcome to fish, the friendly interactive shell
Type help for instructions on how to use fish
root@012a062d0265 /# tanzu
ceip-participation  (Manage VMware's Customer Experience Improvement Program (CEIP) Participation (subject to change))  help  (Help about any command)
completion                                                                              (Output shell completion code)  init      (Initialize the CLI)
config                                                                                     (Configuration for the CLI)  plugin    (Manage CLI plugins)
context                                                              (Configure and manage contexts for the Tanzu CLI)  version  (Version information)
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Installation through APT and YUM/DNF now sets up shell completion for the Tanzu CLI for the bash, zsh and fish shells. 
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
