### PR TITLE
Add an official public key to the inventory image signature verification

### DIFF
--- a/pkg/cosignhelper/tanzu_cli_cert.go
+++ b/pkg/cosignhelper/tanzu_cli_cert.go
@@ -9,3 +9,10 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEAqmPz99XIt7P8OG5v9fmUjcCx0AI
 HZPkw/YmuDeV9ki0wT6USut6OcOml9pku+x3Np9eZD30TMlzRTbjdbM8kQ==
 -----END PUBLIC KEY-----
 `)
+
+var tanzuCLIPluginDBImageSignPublicKeyOfficial = []byte(`
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtDdBg1A2wJQ4IH7PP9Ke3IjyT2kO
+YwynjyBpYf9AaL3tbvlgfnN32tZgAgUnb0KNtPW8tcsu/i1QNHCzYc+uKQ==
+-----END PUBLIC KEY-----
+`)


### PR DESCRIPTION
### What this PR does / why we need it
- Add an official public key to the inventory image signature verification

- With the tanzu-cli alpha releases, we were using a custom temporary private key to sign the plugin inventory database image. This was done to ensure that the corresponding public key could be used by the Tanzu CLI for signature verification. It's all part of our commitment to providing a secure and reliable experience for our users.
- As we approach the beta releases, it's worth noting that the plugin inventory database image verification now uses VMware's official public key.
- As part of the v0.90.0-beta.1 release, the custom temporary public key verification will be removed from the CLI code and only verification with the official key will be kept.

- This intermediate change has been introduced to make sure the plugin inventory database published and signed with a temporary private key is still compatible.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
```
### Initialize the inventory database to default with is signed with the custom temporary private key
$ tz plugin source init
$ tz plugin search
[i] Reading plugin inventory for "harbor-repo.vmware.com/tanzu_cli/plugins/sandbox/a34c04/plugin-inventory", this will take a few seconds.
  NAME     DESCRIPTION             TARGET  LATEST           
  builder  Build Tanzu components  global  v0.90.0-alpha.2  
  test     Test the CLI            global  v0.90.0-alpha.2

### Initialize the inventory database to the image which is signed only with the official vmware private key
$ rm -rf ~/.cache/tanzu/plugin_inventory/
$ tz plugin source update default -u harbor-repo.vmware.com/tanzu_cli/plugins/sandbox/bd5ac3/plugin-inventory:latest
[ok] updated discovery source default
$ tz plugin search
[i] Reading plugin inventory for "harbor-repo.vmware.com/tanzu_cli/plugins/sandbox/bd5ac3/plugin-inventory:latest", this will take a few seconds.
  NAME     DESCRIPTION             TARGET  LATEST
  builder  Build Tanzu components  global  v0.90.0-alpha.0

### ### Initialize the inventory database to the image which is signed by both the private keys
$ rm -rf ~/.cache/tanzu/plugin_inventory/
$ tz plugin source update default -u harbor-repo.vmware.com/tanzu_cli/plugins/sandbox/a34c04/plugin-inventory
[ok] updated discovery source default
$ tz plugin search
[i] Reading plugin inventory for "harbor-repo.vmware.com/tanzu_cli/plugins/sandbox/a34c04/plugin-inventory", this will take a few seconds.
  NAME     DESCRIPTION             TARGET  LATEST
  builder  Build Tanzu components  global  v0.90.0-alpha.2
  test     Test the CLI            global  v0.90.0-alpha.2
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add an official public key to the plugin inventory image signature verification
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
