### PR TITLE
Add detailed help for plugin commands

### DIFF
--- a/pkg/command/plugin.go
+++ b/pkg/command/plugin.go
@@ -41,6 +41,7 @@ func newPluginCmd() *cobra.Command {
 	var pluginCmd = &cobra.Command{
 		Use:   "plugin",
 		Short: "Manage CLI plugins",
+		Long:  "Provides all lifecycle operations for plugins",
 		Annotations: map[string]string{
 			"group": string(plugin.SystemCmdGroup),
 		},
@@ -124,7 +125,8 @@ func newPluginCmd() *cobra.Command {
 func newListPluginCmd() *cobra.Command {
 	var listCmd = &cobra.Command{
 		Use:   "list",
-		Short: "List available plugins",
+		Short: "List installed plugins",
+		Long:  "List all currently installed plugins",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !config.IsFeatureActivated(constants.FeatureDisableCentralRepositoryForTesting) {
 				if local != "" {
@@ -193,6 +195,7 @@ func newDescribePluginCmd() *cobra.Command {
 	var describeCmd = &cobra.Command{
 		Use:   "describe [name]",
 		Short: "Describe a plugin",
+		Long:  "Displays detailed information for a plugin",
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			output := component.NewOutputWriter(cmd.OutOrStdout(), outputFormat, "name", "description", "version", "buildSHA", "digest", "group", "docURL", "completionType", "installationPath", "discovery", "scope", "status", "discoveredRecommendedVersion", "target", "defaultFeatureFlags")
 			if len(args) != 1 {
@@ -312,6 +315,7 @@ func newInstallPluginCmd() *cobra.Command {
 
     # Install version v1.0.0 of plugin "myPlugin" 
     tanzu plugin install myPlugin --version v1.0.0`
+		installCmd.Long = "Install a specific plugin by name or specify all to install all plugins of a group"
 	}
 	return installCmd
 }
@@ -372,6 +376,7 @@ func newUpgradePluginCmd() *cobra.Command {
 	var upgradeCmd = &cobra.Command{
 		Use:   "upgrade [name]",
 		Short: "Upgrade a plugin",
+		Long:  "Installs the latest version available for the specified plugin",
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {
 				return fmt.Errorf("must provide plugin name as positional argument")
@@ -410,6 +415,7 @@ func newDeletePluginCmd() *cobra.Command {
 	var deleteCmd = &cobra.Command{
 		Use:   "delete [name]",
 		Short: "Delete a plugin",
+		Long:  "Uninstalls the specified plugin",
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) != 1 {
 				return fmt.Errorf("must provide plugin name as positional argument")
@@ -442,6 +448,7 @@ func newCleanPluginCmd() *cobra.Command {
 	var cleanCmd = &cobra.Command{
 		Use:   "clean",
 		Short: "Clean the plugins",
+		Long:  "Remove all installed plugins from the system",
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			err = pluginmanager.Clean()
 			if err != nil {
@@ -457,7 +464,9 @@ func newCleanPluginCmd() *cobra.Command {
 func newSyncPluginCmd() *cobra.Command {
 	var syncCmd = &cobra.Command{
 		Use:   "sync",
-		Short: "Sync the plugins",
+		Short: "Installs all plugins recommended by the active contexts",
+		Long: `Installs all plugins recommended by the active contexts.
+Plugins installed with this command will only be available while the context remains active.`,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			err = pluginmanager.SyncPlugins()
 			if err != nil {

--- a/pkg/command/plugin_bundle.go
+++ b/pkg/command/plugin_bundle.go
@@ -23,7 +23,8 @@ func newDownloadBundlePluginCmd() *cobra.Command {
 	var downloadBundleCmd = &cobra.Command{
 		Use:   "download-bundle",
 		Short: "Download plugin bundle to the local system",
-		Long:  "Download plugin bundle to the local system",
+		Long: `Download a plugin bundle to the local file system to be used when migrating plugins
+to an internet-restricted environment. Please also see the "upload-bundle" command.`,
 		Example: `
 # Download a plugin bundle for a specific group version from the default discovery source
 tanzu plugin download-bundle --to-tar /tmp/plugin_bundle_vmware_tkg_default_v1.0.0.tar.gz --group vmware-tkg/default:v1.0.0
@@ -63,7 +64,8 @@ func newUploadBundlePluginCmd() *cobra.Command {
 	var uploadBundleCmd = &cobra.Command{
 		Use:   "upload-bundle",
 		Short: "Upload plugin bundle to a repository",
-		Long:  "Upload plugin bundle to a repository",
+		Long: `Upload a plugin bundle to an alternate container registry for use in an internet-restricted
+environment. The plugin bundle is obtained using the "download-bundle" command.`,
 		Example: `
 # Upload the plugin bundle to the remote repository
 tanzu plugin upload-bundle --tar /tmp/plugin_bundle_vmware_tkg_default_v1.0.0.tar.gz --to-repo custom.registry.company.com/tanzu-plugins/

--- a/pkg/command/plugin_search_test.go
+++ b/pkg/command/plugin_search_test.go
@@ -28,7 +28,7 @@ func TestPluginSearch(t *testing.T) {
 			test:                "no 'plugin search' without central repo",
 			centralRepoDisabled: "true",
 			args:                []string{"plugin", "search"},
-			expected:            "Manage CLI plugins",
+			expected:            "Provides all lifecycle operations for plugins",
 		},
 		{
 			test:            "invalid target",


### PR DESCRIPTION
### What this PR does / why we need it
- Add detailed help for plugin commands
- Enhance the help text of the following commands:
```tanzu plugin sync
tanzu plugin install
tanzu plugin upgrade
tanzu plugin list
tanzu plugin delete
tanzu plugin clean
tanzu plugin download-bundle
tanzu plugin upload-bundle
```

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
make build
tanzu plugin commands to verify the updated help text


```
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/tanzu_plugin_help_text)> tanzu plugin
Provides all lifecycle operations for plugins

Usage:
  tanzu plugin [command]

Available Commands:
  clean           Clean the plugins
  delete          Delete a plugin
  describe        Describe a plugin
  download-bundle Download plugin bundle to the local system
  group           Manage plugin-groups
  install         Install a plugin
  list            List installed plugins
  search          Search for available plugins
  source          Manage plugin discovery sources
  sync            Installs all recommended plugins from the active contexts
  upgrade         Upgrade a plugin
  upload-bundle   Upload plugin bundle to a repository

Flags:
  -h, --help   help for plugin

Use "tanzu plugin [command] --help" for more information about a command.
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/tanzu_plugin_help_text)> tanzu plugin clean -h
Remove all installed plugins from the system

Usage:
tanzu plugin clean [flags]

Flags:
  -h, --help   help for clean
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/tanzu_plugin_help_text)> tanzu plugin delete -h
Uninstalls the specified plugin

Usage:
tanzu plugin delete [name] [flags]

Flags:
  -h, --help            help for delete
  -t, --target string   target of the plugin (kubernetes[k8s]/mission-control[tmc])
  -y, --yes             delete the plugin without asking for confirmation
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/tanzu_plugin_help_text)> tanzu plugin describe -h
Displays detailed information for a plugin

Usage:
tanzu plugin describe [name] [flags]

Flags:
  -h, --help            help for describe
  -o, --output string   Output format (yaml|json|table)
  -t, --target string   target of the plugin (kubernetes[k8s]/mission-control[tmc])
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/tanzu_plugin_help_text)> tanzu plugin download-bundle -h
Download a plugin bundle to the local file system to be used when migrating plugins
to an internet-restricted environment. Please also see the "upload-bundle" command.

Usage:
tanzu plugin download-bundle [flags]

Examples:
  
# Download a plugin bundle for a specific group version from the default discovery source
tanzu plugin download-bundle --to-tar /tmp/plugin_bundle_vmware_tkg_default_v1.0.0.tar.gz --group vmware-tkg/default:v1.0.0

# Download a plugin bundle with the entire plugin repository from a custom discovery source
tanzu plugin download-bundle --image custom.registry.vmware.com/tkg/tanzu-plugins/plugin-inventory:latest --to-tar /tmp/plugin_bundle_complete.tar.gz
                

Flags:
      --group strings   only download the plugins specified in the plugin-group version (can specify multiple)
  -h, --help            help for download-bundle
      --image string    URI of the plugin discovery image providing the plugins (default "projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest")
      --to-tar string   local tar file path to store the plugin images
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/tanzu_plugin_help_text)> tanzu plugin upload-bundle -h
Upload a plugin bundle to an alternate container registry for use in an internet-restricted
environment. The plugin bundle is obtained using the "download-bundle" command.

Usage:
tanzu plugin upload-bundle [flags]

Examples:
  
# Upload the plugin bundle to the remote repository
tanzu plugin upload-bundle --tar /tmp/plugin_bundle_vmware_tkg_default_v1.0.0.tar.gz --to-repo custom.registry.company.com/tanzu-plugins/
tanzu plugin upload-bundle --tar /tmp/plugin_bundle_complete.tar.gz --to-repo custom.registry.company.com/tanzu-plugins/

Flags:
  -h, --help             help for upload-bundle
      --tar string       source tar file
      --to-repo string   destination repository for publishing plugins
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/tanzu_plugin_help_text)> tanzu plugin group -h
Manage plugin-groups. A plugin-group provides a list of plugins name/version combinations which can be installed in one step.

Usage:
  tanzu plugin group [command]

Available Commands:
  get         Get the content of the specified plugin-group
  search      Search for available plugin-groups

Flags:
  -h, --help   help for group

Use "tanzu plugin group [command] --help" for more information about a command.
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/tanzu_plugin_help_text)> tanzu plugin install -h
Install a specific plugin by name or specify all to install all plugins of a group

Usage:
tanzu plugin install [name] [flags]

Examples:
  
    # Install all plugins of the vmware-tkg/default plugin group version v2.1.0
    tanzu plugin install --group vmware-tkg/default:v2.1.0

    # Install all plugins of the latest version of the vmware-tkg/default plugin group
    tanzu plugin install --group vmware-tkg/default

    # Install the latest version of plugin "myPlugin"
        # If the plugin exists for more than one target, an error will be thrown
    tanzu plugin install myPlugin

    # Install the latest version of plugin "myPlugin" for target kubernetes
    tanzu plugin install myPlugin --target k8s

    # Install version v1.0.0 of plugin "myPlugin" 
    tanzu plugin install myPlugin --version v1.0.0

Flags:
      --group string     install the plugins specified by a plugin-group version
  -h, --help             help for install
  -t, --target string    target of the plugin (kubernetes[k8s]/mission-control[tmc])
  -v, --version string   version of the plugin (default "latest")
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/tanzu_plugin_help_text)> tanzu plugin list -h
List all currently installed plugins

Usage:
tanzu plugin list [flags]

Flags:
  -h, --help            help for list
  -o, --output string   Output format (yaml|json|table)
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/tanzu_plugin_help_text)> tanzu plugin search -h
Search provides the ability to search for plugins that can be installed.
The command lists all plugins currently available for installation.
The search command also provides flags to limit the scope of the search.

Usage:
tanzu plugin search [flags]

Flags:
  -h, --help            help for search
  -l, --local string    path to local plugin source
  -n, --name string     limit the search to plugins with the specified name
  -o, --output string   output format (yaml|json|table)
      --show-details    show the details of the specified plugin, including all available versions
  -t, --target string   limit the search to plugins of the specified target (kubernetes[k8s]/mission-control[tmc]/global)
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/tanzu_plugin_help_text)> tanzu plugin sync -h
Installs all recommended plugins from the active contexts.
Plugins installed with this command will only be available while the context remains active.

Usage:
tanzu plugin sync [flags]

Flags:
  -h, --help   help for sync
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/tanzu_plugin_help_text)> tanzu plugin upgrade -h
Installs the latest version available for the specified plugin

Usage:
tanzu plugin upgrade [name] [flags]

Flags:
  -h, --help            help for upgrade
  -t, --target string   target of the plugin (kubernetes[k8s]/mission-control[tmc])
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/tanzu_plugin_help_text)> tanzu plugin source -h
Manage plugin discovery sources. Discovery source provides metadata about the list of available plugins, their supported versions and how to download them.

Usage:
  tanzu plugin source [command]

Available Commands:
  delete      Delete a discovery source
  init        Initialize the discovery source to its default value
  list        List available discovery sources
  update      Update a discovery source configuration

Flags:
  -h, --help   help for source

Use "tanzu plugin source [command] --help" for more information about a command.
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/tanzu_plugin_help_text)> 


```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
