### PR TITLE
nil check for pointers

### DIFF
--- a/pkg/command/config.go
+++ b/pkg/command/config.go
@@ -266,9 +266,9 @@ var listServersCmd = &cobra.Command{
 		output := component.NewOutputWriter(cmd.OutOrStdout(), outputFormat, "Name", "Type", "Endpoint", "Path", "Context")
 		for _, server := range cfg.KnownServers {
 			var endpoint, path, context string
-			if server.IsGlobal() {
+			if server.GlobalOpts != nil && server.IsGlobal() {
 				endpoint = server.GlobalOpts.Endpoint
-			} else {
+			} else if server.ManagementClusterOpts != nil {
 				endpoint = server.ManagementClusterOpts.Endpoint
 				path = server.ManagementClusterOpts.Path
 				context = server.ManagementClusterOpts.Context

--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -520,7 +520,7 @@ func promptAPIToken() (apiToken string, err error) {
 }
 
 func k8sLogin(c *configtypes.Context) error {
-	if c.ClusterOpts.Path != "" && c.ClusterOpts.Context != "" {
+	if c != nil && c.ClusterOpts != nil && c.ClusterOpts.Path != "" && c.ClusterOpts.Context != "" {
 		_, err := tkgauth.GetServerKubernetesVersion(c.ClusterOpts.Path, c.ClusterOpts.Context)
 		if err != nil {
 			err := fmt.Errorf("failed to create context %q for a kubernetes cluster, %v", c.Name, err)
@@ -634,7 +634,7 @@ func promptCtx() (*configtypes.Context, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(cfg.KnownContexts) == 0 {
+	if cfg == nil || len(cfg.KnownContexts) == 0 {
 		return nil, errors.New("no contexts found")
 	}
 	return getCtxPromptMessage(cfg.KnownContexts)
@@ -661,7 +661,7 @@ func getCtxPromptMessage(ctxs []*configtypes.Context) (*configtypes.Context, err
 		if err != nil {
 			return nil, err
 		}
-		if info == "" && ctx.Target == configtypes.TargetK8s {
+		if info == "" && ctx.Target == configtypes.TargetK8s && ctx.ClusterOpts != nil {
 			info = fmt.Sprintf("%s:%s", ctx.ClusterOpts.Path, ctx.ClusterOpts.Context)
 		}
 
@@ -860,9 +860,11 @@ func displayContextListOutputListView(cfg *configtypes.ClientConfig, writer io.W
 		case configtypes.TargetTMC:
 			ep = ctx.GlobalOpts.Endpoint
 		default:
-			ep = ctx.ClusterOpts.Endpoint
-			path = ctx.ClusterOpts.Path
-			context = ctx.ClusterOpts.Context
+			if ctx.ClusterOpts != nil {
+				ep = ctx.ClusterOpts.Endpoint
+				path = ctx.ClusterOpts.Path
+				context = ctx.ClusterOpts.Context
+			}
 		}
 		op.AddRow(ctx.Name, ctx.Target, isMgmtCluster, isCurrent, ep, path, context)
 	}
@@ -886,12 +888,18 @@ func displayContextListOutputSplitViewTarget(cfg *configtypes.ClientConfig, writ
 		var ep, path, context string
 		switch ctx.Target {
 		case configtypes.TargetTMC:
-			ep = ctx.GlobalOpts.Endpoint
+			if ctx.GlobalOpts != nil {
+				ep = ctx.GlobalOpts.Endpoint
+			}
+
 			outputWriterTMCTarget.AddRow(ctx.Name, isCurrent, ep)
 		default:
-			ep = ctx.ClusterOpts.Endpoint
-			path = ctx.ClusterOpts.Path
-			context = ctx.ClusterOpts.Context
+			if ctx.ClusterOpts != nil {
+				ep = ctx.ClusterOpts.Endpoint
+				path = ctx.ClusterOpts.Path
+				context = ctx.ClusterOpts.Context
+			}
+
 			outputWriterK8sTarget.AddRow(ctx.Name, isCurrent, ep, path, context)
 		}
 	}

--- a/pkg/command/login.go
+++ b/pkg/command/login.go
@@ -403,7 +403,9 @@ func globalLoginUsingServer(s *configtypes.Server) (err error) { // nolint:stati
 	expiresAt := time.Now().Local().Add(time.Second * time.Duration(token.ExpiresIn))
 	a.Expiration = expiresAt
 
-	s.GlobalOpts.Auth = a
+	if s != nil && s.GlobalOpts != nil {
+		s.GlobalOpts.Auth = a
+	}
 
 	err = config.PutServer(s, true) // nolint:staticcheck // Deprecated
 	if err != nil {
@@ -416,7 +418,7 @@ func globalLoginUsingServer(s *configtypes.Server) (err error) { // nolint:stati
 }
 
 func managementClusterLogin(s *configtypes.Server) error { // nolint:staticcheck // Deprecated
-	if s.ManagementClusterOpts.Path != "" && s.ManagementClusterOpts.Context != "" {
+	if s != nil && s.ManagementClusterOpts != nil && s.ManagementClusterOpts.Path != "" && s.ManagementClusterOpts.Context != "" {
 		_, err := tkgauth.GetServerKubernetesVersion(s.ManagementClusterOpts.Path, s.ManagementClusterOpts.Context)
 		if err != nil {
 			err := fmt.Errorf("failed to login to the management cluster %s, %v", s.Name, err)

--- a/pkg/config/features.go
+++ b/pkg/config/features.go
@@ -63,7 +63,6 @@ func addFeatureFlag(c *configtypes.ClientConfig, plugin, flag string, flagValue 
 // and returns TRUE if any were added (so the config can be written out to disk, if the caller wants to)
 func AddDefaultFeatureFlagsIfMissing(config *configtypes.ClientConfig, defaultFeatureFlags map[string]bool) bool {
 	added := false
-
 	for featurePath, activated := range defaultFeatureFlags {
 		plugin, feature, err := config.SplitFeaturePath(featurePath)
 		if err == nil && !containsFeatureFlag(config, plugin, feature) {

--- a/pkg/pluginmanager/default_discoveries.go
+++ b/pkg/pluginmanager/default_discoveries.go
@@ -21,7 +21,7 @@ func defaultDiscoverySourceBasedOnServer(server *configtypes.Server) []configtyp
 	// If current server type is management-cluster, then add
 	// the default kubernetes discovery endpoint pointing to the
 	// management-cluster kubeconfig
-	if server.Type == configtypes.ManagementClusterServerType && server.ManagementClusterOpts != nil { // nolint:staticcheck // Deprecated
+	if server != nil && server.Type == configtypes.ManagementClusterServerType && server.ManagementClusterOpts != nil { // nolint:staticcheck // Deprecated
 		defaultDiscoveries = append(defaultDiscoveries, defaultDiscoverySourceForK8sTargetedContext(server.Name, server.ManagementClusterOpts.Path, server.ManagementClusterOpts.Context))
 	}
 	return defaultDiscoveries

--- a/test/e2e/framework/config_lifecycle_operations.go
+++ b/test/e2e/framework/config_lifecycle_operations.go
@@ -109,7 +109,7 @@ func (co *configOps) ConfigGetFeatureFlag(path string, opts ...E2EOption) (strin
 	}
 	featureName := strings.Split(path, ".")[len(strings.Split(path, "."))-1]
 	pluginName := strings.Split(path, ".")[len(strings.Split(path, "."))-2]
-	if cnf != nil && cnf.ClientOptions.Features[pluginName] != nil {
+	if cnf != nil && cnf.ClientOptions != nil && cnf.ClientOptions.Features[pluginName] != nil {
 		return cnf.ClientOptions.Features[pluginName][featureName], nil
 	}
 	return "", err


### PR DESCRIPTION
### What this PR does / why we need it
This pull request aims to fix a bug encountered in the CLI `tanzu context list` command. Currently, when the CLI configuration file at `~/.config/tanzu/config-ng.yaml` contains a `mission-control` context with `globalOpts` but without `clusterOpts`, the command fails with the error `panic: runtime error: invalid memory address or nil pointer dereference`.

Additionally, this pull request addresses the issue of pointer member variables being referenced without prior verification of their `non-nil` value. All relevant code has been modified to include proper checks.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
The bug is tested with the below content in `~/.config/tanzu/config-ng.yaml`, `tanzu plugin list` is working fine after the fix:
```
contexts: 
    - name: aws-mc-vui-main-cc-1
      type: k8s
      clusterOpts: 
        path: /Users/vuichiap/.kube/config
        context: aws-mc-vui-main-cc-1-admin@aws-mc-vui-main-cc-1
        endpoint: unstable.tmc-dev.cloud.vmware.com:443
        isManagementCluster: true
      discoverySources: []
    - name: tmc-unstable-vui
      type: mission-control
      globalOpts: 
        endpoint: unstable.tmc-dev.cloud.vmware.com:443
      discoverySources: []
currentContext: 
    k8s: aws-mc-vui-main-cc-1
    tmc: tmc-unstable-vui
```

After fix output:
```
❯ tanzu context list       
Target:  kubernetes
  NAME                  ISACTIVE  ENDPOINT                               KUBECONFIGPATH                KUBECONTEXT                                      
  aws-mc-vui-main-cc-1  false     unstable.tmc-dev.cloud.vmware.com:443  /Users/vuichiap/.kube/config  aws-mc-vui-main-cc-1-admin@aws-mc-vui-main-cc-1  
  tmc-unstable-vui      true                                                                                                                            
Target:  mission-control
  NAME  ISACTIVE  ENDPOINT  
❯ 
```
Before fix output:
```
❯ tanzu context list
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x5c18056]

goroutine 1 [running]:
github.com/vmware-tanzu/tanzu-cli/pkg/command.displayContextListOutputSplitViewTarget(0xc0007c9340, {0x65e6760, 0xc000128008})
/Users/cpamuluri/tkg/tasks/cli_core_main/tanzu-cli/pkg/command/context.go:790 +0x496
github.com/vmware-tanzu/tanzu-cli/pkg/command.listCtx(0x7972fe0?, {0x61f4a6a?, 0x0?, 0x0?})
/Users/cpamuluri/tkg/tasks/cli_core_main/tanzu-cli/pkg/command/context.go:588 +0x125
github.com/spf13/cobra.(*Command).execute(0x7972fe0, {0x79e1cb0, 0x0, 0x0})
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
