### PR TITLE
Rename column for "plugin group get" and update E2E tests

### DIFF
--- a/pkg/command/plugin_group.go
+++ b/pkg/command/plugin_group.go
@@ -199,7 +199,7 @@ func displayGroupDetails(groups []*plugininventory.PluginGroup, writer io.Writer
 func displayGroupContentAsTable(group *plugininventory.PluginGroup, writer io.Writer) {
 	cyanBold := color.New(color.FgCyan).Add(color.Bold)
 	cyanBoldItalic := color.New(color.FgCyan).Add(color.Bold, color.Italic)
-	output := component.NewOutputWriter(writer, outputFormat, "Name", "Target", "Latest")
+	output := component.NewOutputWriter(writer, outputFormat, "Name", "Target", "Version")
 
 	groupID := plugininventory.PluginGroupToID(group)
 	_, _ = cyanBold.Println("Plugins in Group: ", cyanBoldItalic.Sprintf("%s:%s", groupID, group.RecommendedVersion))

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -6,7 +6,7 @@ E2E_TEST_TIMEOUT ?= 60m
 GOTEST_VERBOSE ?= -v
 ROOT_DIR := $(shell git rev-parse --show-toplevel)
 GO := go
-GINKGO := ginkgo
+GINKGO := ${ROOT_DIR}/hack/tools/bin/ginkgo
 
 ifndef TANZU_API_TOKEN
 TANZU_API_TOKEN = ""

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -126,6 +126,10 @@ type PluginGroupOps interface {
     // input: flagsWithValues - flags and values if any
     SearchPluginGroups(flagsWithValues string) ([]*PluginGroup, error)
 
+    // GetPluginGroup performs plugin group get
+    // input: flagsWithValues - flags and values if any
+    GetPluginGroup(groupName string, flagsWithValues string, opts ...E2EOption) ([]*PluginGroupGet, error)
+
     // InstallPluginsFromGroup a plugin or all plugins from the given plugin group
     InstallPluginsFromGroup(pluginNameORAll, groupName string) error
 }

--- a/test/e2e/airgapped/airgapped_suite_test.go
+++ b/test/e2e/airgapped/airgapped_suite_test.go
@@ -30,7 +30,6 @@ var (
 	e2eAirgappedCentralRepoImage string
 	pluginsSearchList            []*framework.PluginInfo
 	pluginGroups                 []*framework.PluginGroup
-	pluginGroupToPluginListMap   map[string][]*framework.PluginInfo
 	pluginSourceName             string
 	tempDir                      string
 	err                          error

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -41,6 +41,7 @@ const (
 	ListPluginsCmdWithJSONOutputFlag    = "%s plugin list -o json"
 	SearchPluginsCmd                    = "%s plugin search"
 	SearchPluginGroupsCmd               = "%s plugin group search"
+	GetPluginGroupCmd                   = "%s plugin group get %s"
 	InstallPluginCmd                    = "%s plugin install %s"
 	InstallPluginFromGroupCmd           = "%s plugin install %s --group %s"
 	InstallAllPluginsFromGroupCmd       = "%s plugin install --group %s"
@@ -137,6 +138,7 @@ const (
 	FailedToConstructJSONNodeFromOutputAndErrInfo = "failed to construct json node from output:'%s' error:'%s' "
 	FailedToConstructJSONNodeFromOutput           = "failed to construct json node from output:'%s'"
 	NoErrorForPluginGroupSearch                   = "should not get any error for plugin group search"
+	NoErrorForPluginGroupGet                      = "should not get any error for plugin group get"
 	NoErrorForPluginSearch                        = "should not get any error for plugin search"
 	UnableToSync                                  = "unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually"
 	PluginDescribeShouldNotThrowErr               = "should not get any error for plugin describe"
@@ -205,11 +207,6 @@ var PluginsForLifeCycleTests []*PluginInfo
 
 // PluginGroupsForLifeCycleTests is list of plugin groups (which are published in local central repo) used in plugin group life cycle test cases
 var PluginGroupsForLifeCycleTests []*PluginGroup
-
-// PluginGroupsLatestToOldVersions is plugin group names mapping latest version to old version, of same target,
-// we are mapping because the 'tanzu plugin search' is not displaying plugins for old versions, showing only latest version of plugins
-// we need this mapping for plugin sync test cases, we want to install same plugins but for different versions
-var PluginGroupsLatestToOldVersions map[string]string
 
 // CLICoreDescribe annotates the test with the CLICore label.
 func CLICoreDescribe(text string, body func()) bool {
@@ -315,8 +312,4 @@ func init() {
 
 	// TODO:cpamuluri: need to move Plugin Groups to configuration file with positive and negative use cases - github issue: https://github.com/vmware-tanzu/tanzu-cli/issues/122
 	PluginGroupsForLifeCycleTests = []*PluginGroup{{Group: "vmware-tkg/default", Latest: "v9.9.9", Description: "Desc for vmware-tkg/default:v9.9.9"}, {Group: "vmware-tmc/tmc-user", Latest: "v9.9.9", Description: "Desc for vmware-tmc/tmc-user:v9.9.9"}}
-
-	PluginGroupsLatestToOldVersions = make(map[string]string)
-	PluginGroupsLatestToOldVersions["vmware-tmc/tmc-user:v9.9.9"] = "vmware-tmc/tmc-user:v0.0.1"
-	PluginGroupsLatestToOldVersions["vmware-tkg/default:v9.9.9"] = "vmware-tkg/default:v0.0.1"
 }

--- a/test/e2e/framework/output_handling.go
+++ b/test/e2e/framework/output_handling.go
@@ -27,6 +27,13 @@ type PluginGroup struct {
 	Latest      string `json:"latest"`
 }
 
+type PluginGroupGet struct {
+	Group         string `json:"group"`
+	PluginName    string `json:"pluginname"`
+	PluginTarget  string `json:"plugintarget"`
+	PluginVersion string `json:"pluginversion"`
+}
+
 type PluginSourceInfo struct {
 	Name  string `json:"name"`
 	Image string `json:"image"`

--- a/test/e2e/framework/plugin_lifecycle_operations.go
+++ b/test/e2e/framework/plugin_lifecycle_operations.go
@@ -60,6 +60,10 @@ type PluginGroupOps interface {
 	// input: flagsWithValues - flags and values if any
 	SearchPluginGroups(flagsWithValues string, opts ...E2EOption) ([]*PluginGroup, error)
 
+	// GetPluginGroup performs plugin group get
+	// input: flagsWithValues - flags and values if any
+	GetPluginGroup(groupName string, flagsWithValues string, opts ...E2EOption) ([]*PluginGroupGet, error)
+
 	// InstallPluginsFromGroup a plugin or all plugins from the given plugin group
 	InstallPluginsFromGroup(pluginNameORAll, groupName string, opts ...E2EOption) error
 }
@@ -197,6 +201,15 @@ func (po *pluginCmdOps) SearchPluginGroups(flagsWithValues string, opts ...E2EOp
 	}
 	list, _, _, err := ExecuteCmdAndBuildJSONOutput[PluginGroup](po.cmdExe, searchPluginGroupCmdWithOptions+JSONOutput, opts...)
 	return list, err
+}
+
+func (po *pluginCmdOps) GetPluginGroup(groupName string, flagsWithValues string, opts ...E2EOption) ([]*PluginGroupGet, error) {
+	getPluginGroupCmdWithOptions := fmt.Sprintf(GetPluginGroupCmd, "%s", groupName)
+	if len(strings.TrimSpace(flagsWithValues)) > 0 {
+		getPluginGroupCmdWithOptions = getPluginGroupCmdWithOptions + " " + strings.TrimSpace(flagsWithValues)
+	}
+	pluginList, _, _, err := ExecuteCmdAndBuildJSONOutput[PluginGroupGet](po.cmdExe, getPluginGroupCmdWithOptions+JSONOutput, opts...)
+	return pluginList, err
 }
 
 func (po *pluginCmdOps) InstallPlugin(pluginName, target, versions string, opts ...E2EOption) error {

--- a/test/e2e/plugin_lifecycle/plugin_lifecycle_helper.go
+++ b/test/e2e/plugin_lifecycle/plugin_lifecycle_helper.go
@@ -5,6 +5,8 @@
 package pluginlifecyclee2e
 
 import (
+	"fmt"
+
 	"github.com/vmware-tanzu/tanzu-cli/test/e2e/framework"
 )
 
@@ -32,4 +34,10 @@ func SearchAllPlugins(tf *framework.Framework, opts ...framework.E2EOption) ([]*
 func SearchAllPluginGroups(tf *framework.Framework, opts ...framework.E2EOption) ([]*framework.PluginGroup, error) {
 	pluginGroups, err := tf.PluginCmd.SearchPluginGroups("", opts...)
 	return pluginGroups, err
+}
+
+// GetAllPluginsFromGroup runs the plugin group get command and returns all the plugins in the specified group
+func GetAllPluginsFromGroup(tf *framework.Framework, pg *framework.PluginGroup, opts ...framework.E2EOption) ([]*framework.PluginGroupGet, error) {
+	plugins, err := tf.PluginCmd.GetPluginGroup(fmt.Sprintf("%s:%s", pg.Group, pg.Latest), "", opts...)
+	return plugins, err
 }

--- a/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_suite_test.go
+++ b/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -123,15 +122,26 @@ var _ = BeforeSuite(func() {
 	Expect(err).To(BeNil(), framework.NoErrorForPluginSearch)
 	Expect(len(pluginsSearchList)).Should(BeNumerically(">", 0))
 
-	// Map plugins to their respective plugin groups.
-	pluginGroupToPluginListMap = framework.MapPluginsToPluginGroups(pluginsSearchList, framework.PluginGroupsForLifeCycleTests)
-	for pluginGroupLatest := range framework.PluginGroupsLatestToOldVersions {
-		framework.CopyPluginsBetweenPluginGroupsAndUpdatePluginsVersion(pluginGroupToPluginListMap, pluginGroupLatest, framework.PluginGroupsLatestToOldVersions[pluginGroupLatest], strings.Split(strings.Split(framework.PluginGroupsLatestToOldVersions[pluginGroupLatest], "/")[1], ":")[1])
-	}
+	pluginGroupToPluginListMap = make(map[string][]*framework.PluginInfo)
+	for _, pg := range framework.PluginGroupsForLifeCycleTests {
+		// Setup plugin list for both versions of the group
+		for _, v := range []string{"v9.9.9", "v0.0.1"} {
+			pg.Latest = v
+			plugins, err := helper.GetAllPluginsFromGroup(tf, pg)
+			Expect(err).To(BeNil(), framework.NoErrorForPluginGroupGet)
 
-	// Check that for every plugin group listed in framework.PluginGroupsForLifeCycleTests, there are available plugins.
-	for pg := range pluginGroupToPluginListMap {
-		Expect(len(pluginGroupToPluginListMap[pg])).Should(BeNumerically(">", 0), "there should be at least one plugin available for each plugin group in plugin group life cycle list")
+			key := pg.Group + ":" + pg.Latest
+			pluginGroupToPluginListMap[key] = make([]*framework.PluginInfo, 0)
+			for _, p := range plugins {
+				pluginGroupToPluginListMap[key] = append(pluginGroupToPluginListMap[key], &framework.PluginInfo{
+					Name:    p.PluginName,
+					Target:  p.PluginTarget,
+					Version: p.PluginVersion,
+				})
+			}
+			// check for every plugin group (in framework.PluginGroupsForLifeCycleTests) there should be plugins available
+			Expect(len(pluginGroupToPluginListMap[key])).Should(BeNumerically(">", 0), "there should be at least one plugin available for each plugin group in plugin group life cycle list")
+		}
 	}
 })
 


### PR DESCRIPTION
### What this PR does / why we need it

This PR changes the name of the column of "tanzu plugin group get" from "Latest" to "Version".  When listing the content of a plugin group, it is really a single version of a plugin that is present and not necessarily the latest available version, which is why it does not make sense to name the column "latest".  Thanks @anujc25 for noticing this error.

The PR also adds the use of "tanzu plugin group get" to the E2E tests which is then used to fill the different `pluginGroupToPluginListMap` with the actual content of the plugin group, instead of hard-coding that content.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Check the new column name:
```
$ tz plugin group get vmware-tkg/default
Plugins in Group:  vmware-tkg/default:v9.9.9
  NAME                TARGET      VERSION
  cluster             kubernetes  v9.9.9
  feature             kubernetes  v9.9.9
  kubernetes-release  kubernetes  v9.9.9
  management-cluster  kubernetes  v9.9.9
  package             kubernetes  v9.9.9
  secret              kubernetes  v9.9.9
  telemetry           kubernetes  v9.9.9

# Note that this column was already properly named when not using a table format:
$ tz plugin group get vmware-tkg/default -o yaml
- group: vmware-tkg/default:v9.9.9
  pluginname: cluster
  plugintarget: kubernetes
  pluginversion: v9.9.9
- group: vmware-tkg/default:v9.9.9
  pluginname: feature
  plugintarget: kubernetes
  pluginversion: v9.9.9
```

And make sure the E2E test pass along with all other CI.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
