### PR TITLE
Verify plugin source before accepting to update it

### DIFF
--- a/pkg/command/discovery_source.go
+++ b/pkg/command/discovery_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/config"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/discovery"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -274,7 +275,20 @@ func createDiscoverySource(dsType, dsName, uri string) (configtypes.PluginDiscov
 	default:
 		return pluginDiscoverySource, errors.Errorf("unknown discovery source type '%s'", dsType)
 	}
-	return pluginDiscoverySource, nil
+
+	err := checkDiscoverySource(pluginDiscoverySource)
+	return pluginDiscoverySource, err
+}
+
+// checkDiscoverySource attempts to access the content of the discovery to
+// confirm it is valid
+func checkDiscoverySource(source configtypes.PluginDiscovery) error {
+	discObject, err := discovery.CreateDiscoveryFromV1alpha1(source, nil)
+	if err != nil {
+		return err
+	}
+	_, err = discObject.List()
+	return err
 }
 
 func createLocalDiscoverySource(discoveryName, uri string) *configtypes.LocalDiscovery {

--- a/test/e2e/airgapped/airgapped_suite_test.go
+++ b/test/e2e/airgapped/airgapped_suite_test.go
@@ -51,10 +51,6 @@ var _ = BeforeSuite(func() {
 
 	os.Setenv(framework.TanzuCliPluginDiscoverySignatureVerificationSkipList, e2eAirgappedCentralRepoImage)
 
-	// setup the test central repo
-	_, err := tf.PluginCmd.UpdatePluginDiscoverySource(&framework.DiscoveryOptions{Name: "default", SourceType: framework.SourceType, URI: e2eTestLocalCentralRepoImage})
-	Expect(err).To(BeNil(), "should not get any error for plugin source update")
-
 	e2eTestLocalCentralRepoPluginHost := os.Getenv(framework.TanzuCliE2ETestLocalCentralRepositoryHost)
 	Expect(e2eTestLocalCentralRepoPluginHost).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with local central repository host", framework.TanzuCliE2ETestLocalCentralRepositoryHost))
 
@@ -70,6 +66,10 @@ var _ = BeforeSuite(func() {
 	e2eTestLocalCentralRepoPluginDiscoveryImageSignaturePublicKeyPath := os.Getenv(framework.TanzuCliE2ETestLocalCentralRepositoryPluginDiscoveryImageSignaturePublicKeyPath)
 	Expect(e2eTestLocalCentralRepoPluginDiscoveryImageSignaturePublicKeyPath).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with local central repository discovery image signature public key path", framework.TanzuCliE2ETestLocalCentralRepositoryPluginDiscoveryImageSignaturePublicKeyPath))
 	os.Setenv(framework.TanzuCliPluginDiscoveryImageSignaturePublicKeyPath, e2eTestLocalCentralRepoPluginDiscoveryImageSignaturePublicKeyPath)
+
+	// setup the test central repo
+	_, err := tf.PluginCmd.UpdatePluginDiscoverySource(&framework.DiscoveryOptions{Name: "default", SourceType: framework.SourceType, URI: e2eTestLocalCentralRepoImage})
+	Expect(err).To(BeNil(), "should not get any error for plugin source update")
 
 	// search plugin groups and make sure there plugin groups available
 	pluginGroups, err = pluginlifecyclee2e.SearchAllPluginGroups(tf)

--- a/test/e2e/plugin_lifecycle/plugin_lifecycle_suite_test.go
+++ b/test/e2e/plugin_lifecycle/plugin_lifecycle_suite_test.go
@@ -39,10 +39,6 @@ var _ = BeforeSuite(func() {
 	e2eTestLocalCentralRepoURL = os.Getenv(framework.TanzuCliE2ETestLocalCentralRepositoryURL)
 	Expect(e2eTestLocalCentralRepoURL).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with local central repository URL", framework.TanzuCliE2ETestLocalCentralRepositoryURL))
 
-	// set up the test central repo
-	_, err = tf.PluginCmd.UpdatePluginDiscoverySource(&framework.DiscoveryOptions{Name: "default", SourceType: framework.SourceType, URI: e2eTestLocalCentralRepoURL})
-	Expect(err).To(BeNil(), "should not get any error for plugin source update")
-
 	e2eTestLocalCentralRepoPluginHost := os.Getenv(framework.TanzuCliE2ETestLocalCentralRepositoryHost)
 	Expect(e2eTestLocalCentralRepoPluginHost).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with local central repository host", framework.TanzuCliE2ETestLocalCentralRepositoryHost))
 
@@ -58,6 +54,10 @@ var _ = BeforeSuite(func() {
 	e2eTestLocalCentralRepoPluginDiscoveryImageSignaturePublicKeyPath := os.Getenv(framework.TanzuCliE2ETestLocalCentralRepositoryPluginDiscoveryImageSignaturePublicKeyPath)
 	Expect(e2eTestLocalCentralRepoPluginDiscoveryImageSignaturePublicKeyPath).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with local central repository discovery image signature public key path", framework.TanzuCliE2ETestLocalCentralRepositoryPluginDiscoveryImageSignaturePublicKeyPath))
 	os.Setenv(framework.TanzuCliPluginDiscoveryImageSignaturePublicKeyPath, e2eTestLocalCentralRepoPluginDiscoveryImageSignaturePublicKeyPath)
+
+	// set up the test central repo
+	_, err = tf.PluginCmd.UpdatePluginDiscoverySource(&framework.DiscoveryOptions{Name: "default", SourceType: framework.SourceType, URI: e2eTestLocalCentralRepoURL})
+	Expect(err).To(BeNil(), "should not get any error for plugin source update")
 
 	// search plugin groups and make sure there plugin groups available
 	pluginGroups, err = SearchAllPluginGroups(tf)

--- a/test/e2e/plugin_lifecycle/plugin_lifecycle_test.go
+++ b/test/e2e/plugin_lifecycle/plugin_lifecycle_test.go
@@ -44,11 +44,12 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-lifecycle]", func(
 		It("update previously created plugin source URL", func() {
 			newImage := framework.RandomString(5)
 			_, err := tf.PluginCmd.UpdatePluginDiscoverySource(&framework.DiscoveryOptions{Name: pluginSourceName, SourceType: framework.SourceType, URI: newImage})
-			Expect(err).To(BeNil(), "should not get any error for plugin source update")
+			Expect(err).ToNot(BeNil(), "should get an error for an invalid image for plugin source update")
 			list, err := tf.PluginCmd.ListPluginSources()
 			Expect(err).To(BeNil(), "should not get any error for plugin source list")
 			Expect(framework.IsPluginSourceExists(list, pluginSourceName)).To(BeTrue())
-			Expect(list[0].Image).To(Equal(newImage))
+			// The plugin source should note have changed
+			Expect(list[0].Image).To(Equal(e2eTestLocalCentralRepoURL))
 		})
 		// Test case: (negative test) delete plugin source which is not exists
 		It("negative test case: delete plugin source which is not exists", func() {

--- a/test/e2e/plugin_sync/k8s/plugin_sync_k8s_lifecycle_suite_test.go
+++ b/test/e2e/plugin_sync/k8s/plugin_sync_k8s_lifecycle_suite_test.go
@@ -46,10 +46,6 @@ var _ = BeforeSuite(func() {
 	e2eTestLocalCentralRepoURL = os.Getenv(framework.TanzuCliE2ETestLocalCentralRepositoryURL)
 	Expect(e2eTestLocalCentralRepoURL).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with local central repository URL", framework.TanzuCliE2ETestLocalCentralRepositoryURL))
 
-	// set up the test central repo
-	_, err = tf.PluginCmd.UpdatePluginDiscoverySource(&framework.DiscoveryOptions{Name: "default", SourceType: framework.SourceType, URI: e2eTestLocalCentralRepoURL})
-	Expect(err).To(BeNil(), "should not get any error for plugin source update")
-
 	e2eTestLocalCentralRepoPluginHost = os.Getenv(framework.TanzuCliE2ETestLocalCentralRepositoryHost)
 	Expect(e2eTestLocalCentralRepoPluginHost).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with local central repository host", framework.TanzuCliE2ETestLocalCentralRepositoryHost))
 
@@ -69,6 +65,10 @@ var _ = BeforeSuite(func() {
 	e2eTestLocalCentralRepoPluginDiscoveryImageSignaturePublicKeyPath := os.Getenv(framework.TanzuCliE2ETestLocalCentralRepositoryPluginDiscoveryImageSignaturePublicKeyPath)
 	Expect(e2eTestLocalCentralRepoPluginDiscoveryImageSignaturePublicKeyPath).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with local central repository discovery image signature public key path", framework.TanzuCliE2ETestLocalCentralRepositoryPluginDiscoveryImageSignaturePublicKeyPath))
 	os.Setenv(framework.TanzuCliPluginDiscoveryImageSignaturePublicKeyPath, e2eTestLocalCentralRepoPluginDiscoveryImageSignaturePublicKeyPath)
+
+	// set up the test central repo
+	_, err = tf.PluginCmd.UpdatePluginDiscoverySource(&framework.DiscoveryOptions{Name: "default", SourceType: framework.SourceType, URI: e2eTestLocalCentralRepoURL})
+	Expect(err).To(BeNil(), "should not get any error for plugin source update")
 
 	// search plugin groups and make sure there plugin groups available
 	pluginGroups, err = helper.SearchAllPluginGroups(tf)

--- a/test/e2e/plugin_sync/k8s/plugin_sync_k8s_lifecycle_test.go
+++ b/test/e2e/plugin_sync/k8s/plugin_sync_k8s_lifecycle_test.go
@@ -30,16 +30,16 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 			err := f.CleanConfigFiles(tf)
 			Expect(err).To(BeNil())
 
-			// update plugin discovery source
-			err = f.UpdatePluginDiscoverySource(tf, e2eTestLocalCentralRepoURL)
-			Expect(err).To(BeNil(), "should not get any error for plugin source update")
-
 			// Add Cert
 			_, err = tf.Config.ConfigCertAdd(&f.CertAddOptions{Host: e2eTestLocalCentralRepoPluginHost, CACertificatePath: e2eTestLocalCentralRepoCACertPath, SkipCertVerify: "false", Insecure: "false"})
 			Expect(err).To(BeNil(), "should not be any error for cert add")
 			list, err := tf.Config.ConfigCertList()
 			Expect(err).To(BeNil(), "should not be any error for cert list")
 			Expect(len(list)).To(Equal(1), "should not be any error for cert list")
+
+			// update plugin discovery source
+			err = f.UpdatePluginDiscoverySource(tf, e2eTestLocalCentralRepoURL)
+			Expect(err).To(BeNil(), "should not get any error for plugin source update")
 		})
 	})
 


### PR DESCRIPTION
### What this PR does / why we need it

This PR checks the validity of a plugin discovery source when it is being updated through "plugin source update".

Things to note:
1. The validation of the plugin inventory OCI image causes it to be downloaded to the cache as soon as `plugin source update` is called.  I feel this is nice.  That way, once the plugin source is finished updated, the cache is already populated for `plugin search` to be even more responsive.
1. Additional test repos set using `TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY` are not verified.  The failure will be detected on a `plugin search`.  These are for testing only and I didn't feel it was necessary to pre-check them
2. `plugin source init` is not checked for image-validity.  The image used is provided by the CLI itself and we know it is valid.

This commit also removes the `log.Fatal()` when fetching the plugin inventory OCI image.  It is not possible to use unit tests on a function that calls `log.Fatal()`, and since this commit now verifies the validity of the OCI image in the `createDiscoverySource()` function, I wanted to be able to have some unit tests make sure the verification was correct.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

This is a follow-up to a suggestion from @anujc25 here: https://github.com/vmware-tanzu/tanzu-cli/pull/232#discussion_r1177405865

### Describe testing done for PR

```
# Initialize the CLI
$ rm ~/.cache/tanzu/plugin_inventory
$ rm ~/.config/tanzu/config*
$ make start-test-central-repo
[...]
$ tz plugin source list
  NAME     IMAGE
  default  projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest

# Try updating the plugin source to an invalid value
$ tz plugin source update default -u invalid
[!] Unable to resolve the plugin discovery image: error getting the image digest: GET https://index.docker.io/v2/library/invalid/manifests/latest: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:library/invalid Type:repository]]
[x] : unable to fetch the inventory of discovery 'default' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "invalid" is correct

# Notice the plugin source was not changed
$ tz plugin source list
  NAME     IMAGE
  default  projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest

# Set the plugin source to a valid value
$ tz plugin source update default -u harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest
[i] Reading plugin inventory for "harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest", this will take a few seconds.
[ok] updated discovery source default
$ tz plugin source list
  NAME     IMAGE
  default  harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest

# Try an invalid source because of an wrong tag
$ tz plugin source update default -u harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:invalid
[!] Unable to resolve the plugin discovery image: error getting the image digest: GET https://harbor-repo.vmware.com/v2/tanzu_cli_stage/plugins/plugin-inventory/manifests/invalid: NOT_FOUND: artifact tanzu_cli_stage/plugins/plugin-inventory:invalid not found
[x] : unable to fetch the inventory of discovery 'default' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:invalid" is correct
$ tz plugin source list
  NAME     IMAGE
  default  harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest

# These are the groups we have in the harbor image
$ tz plugin group search
  GROUP               DESCRIPTION      LATEST
  vmware-tap/default  Plugins for TAP  v1.4.0
  vmware-tkg/default  Plugins for TKG  v2.1.1

# Notice that a source update will fail if the image is not signed properly
$ tz plugin source update default -u localhost:9876/tanzu-cli/plugins/central:small
[i] Reading plugin inventory for "localhost:9876/tanzu-cli/plugins/central:small", this will take a few seconds.
[!] Unable to verify the plugins discovery image signature: failed validating the signature of the image localhost:9876/tanzu-cli/plugins/central:small :no matching signatures:
invalid signature when validating ASN.1 encoded signature
[x] Fatal, plugins discovery image signature verification failed. The `tanzu` CLI can not ensure the integrity of the plugins to be installed. To ignore this validation please append "localhost:9876/tanzu-cli/plugins/central:small" to the comma-separated list in the environment variable "TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST".  This is NOT RECOMMENDED and could put your environment at risk!
$ tz plugin source list
  NAME     IMAGE
  default  harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest

# Now it passes
$ tz config set env.TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST localhost:9876/tanzu-cli/plugins/central:small
$ tz plugin source update default -u localhost:9876/tanzu-cli/plugins/central:small
[i] Reading plugin inventory for "localhost:9876/tanzu-cli/plugins/central:small", this will take a few seconds.
[!] Skipping the plugins discovery image signature verification for "localhost:9876/tanzu-cli/plugins/central:small"

[ok] updated discovery source default
# We get the groups from the local repo
$ tz plugin group search
  GROUP                DESCRIPTION                   LATEST
  vmware-tmc/tmc-user  Desc for vmware-tmc/tmc-user  v9.9.9
  vmware-tkg/default   Desc for vmware-tkg/default   v9.9.9

# Re-initializing the source does not check the validity: the image used comes from the CLI itself and is valid.
$ tz plugin source init
[ok] successfully initialized discovery source
$ tz plugin search
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest", this will take a few seconds.
  NAME     DESCRIPTION             TARGET  LATEST
  builder  Build Tanzu components  global  v0.90.0-alpha.2
  test     Test the CLI            global  v0.90.0-alpha.2

# Additional test repos are not checked in advance.
$ tz config set env.TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY localhost:9876/tanzu-cli/plugins/central:small
$ tz plugin search
[i] Reading plugin inventory for "localhost:9876/tanzu-cli/plugins/central:small", this will take a few seconds.
[!] Skipping the plugins discovery image signature verification for "localhost:9876/tanzu-cli/plugins/central:small"

  NAME                DESCRIPTION                  TARGET           LATEST
  builder             Build Tanzu components       global           v0.90.0-alpha.2
  isolated-cluster    Desc for isolated-cluster    global           v9.9.9
  pinniped-auth       Desc for pinniped-auth       global           v9.9.9
  test                Test the CLI                 global           v0.90.0-alpha.2
```
Test airgapped:
```
$ tz plugin download-bundle --image localhost:9876/tanzu-cli/plugins/airgapped:small --to-tar plugin_bundle.tar
[!] Skipping the plugins discovery image signature verification for "localhost:9876/tanzu-cli/plugins/airgapped:small"

[i] downloading image "localhost:9876/tanzu-cli/plugins/airgapped:small"
[...]
[i] saving plugin bundle at: plugin_bundle.tar

$ tz plugin upload-bundle --tar plugin_bundle.tar --to-repo localhost:9876/test/airgapped/v2/tanzu-cli/plugins
[i] ---------------------------
[i] uploading image "localhost:9876/test/airgapped/v2/tanzu-cli/plugins/airgapped"
[i] copy | importing 2 images...
[...]
[i] ---------------------------
[i] successfully published all plugin images to "localhost:9876/test/airgapped/v2/tanzu-cli/plugins/airgapped:small"

$ tz config unset env.TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY
$ tz config unset env.TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST
$ rm ~/.cache/tanzu/plugin_inventory

# Test updating to a valid air-gapped repo
# It first fails because of the signature
$ tz plugin source update default -u localhost:9876/test/airgapped/v2/tanzu-cli/plugins/airgapped:small
[i] Reading plugin inventory for "localhost:9876/test/airgapped/v2/tanzu-cli/plugins/airgapped:small", this will take a few seconds.
[!] Unable to verify the plugins discovery image signature: failed validating the signature of the image localhost:9876/test/airgapped/v2/tanzu-cli/plugins/airgapped:small :no matching signatures:
invalid signature when validating ASN.1 encoded signature
[x] Fatal, plugins discovery image signature verification failed. The `tanzu` CLI can not ensure the integrity of the plugins to be installed. To ignore this validation please append "localhost:9876/test/airgapped/v2/tanzu-cli/plugins/airgapped:small" to the comma-separated list in the environment variable "TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST".  This is NOT RECOMMENDED and could put your environment at risk!

# the plugin source was not updated, as expected
$ tz plugin source list
  NAME     IMAGE
  default  projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest

# After adding the repo to the skip list, it can be added
$ tz config set env.TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST localhost:9876/test/airgapped/v2/tanzu-cli/plugins/airgapped:small
$ tz plugin source update default -u localhost:9876/test/airgapped/v2/tanzu-cli/plugins/airgapped:small
[i] Reading plugin inventory for "localhost:9876/test/airgapped/v2/tanzu-cli/plugins/airgapped:small", this will take a few seconds.
[!] Skipping the plugins discovery image signature verification for "localhost:9876/test/airgapped/v2/tanzu-cli/plugins/airgapped:small"

[ok] updated discovery source default
$ tz plugin group search
  GROUP                DESCRIPTION                   LATEST
  vmware-tkg/default   Desc for vmware-tkg/default   v9.9.9
  vmware-tmc/tmc-user  Desc for vmware-tmc/tmc-user  v9.9.9

# Now let's try with an invalid image
# Let's use the metadata image, which I had tried to use by mistake a few weeks ago and didn't notice for a long time
$ tz plugin source update default -u localhost:9876/test/airgapped/v2/tanzu-cli/plugins/airgapped-metadata:small
[i] Reading plugin inventory for "localhost:9876/test/airgapped/v2/tanzu-cli/plugins/airgapped-metadata:small", this will take a few seconds.
[!] Unable to verify the plugins discovery image signature: failed validating the signature of the image localhost:9876/test/airgapped/v2/tanzu-cli/plugins/airgapped-metadata:small :no signatures found for image
[x] Fatal, plugins discovery image signature verification failed. The `tanzu` CLI can not ensure the integrity of the plugins to be installed. To ignore this validation please append "localhost:9876/test/airgapped/v2/tanzu-cli/plugins/airgapped-metadata:small" to the comma-separated list in the environment variable "TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST".  This is NOT RECOMMENDED and could put your environment at risk!

# Add it to the skip list
$ tz config set env.TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST localhost:9876/test/airgapped/v2/tanzu-cli/plugins/airgapped-metadata:small

# Adding this wrong image still fails since it is not a valid plugin inventory.  That would have saved me time 😄 
$ tz plugin source update default -u localhost:9876/test/airgapped/v2/tanzu-cli/plugins/airgapped-metadata:small
[i] Reading plugin inventory for "localhost:9876/test/airgapped/v2/tanzu-cli/plugins/airgapped-metadata:small", this will take a few seconds.
[!] Skipping the plugins discovery image signature verification for "localhost:9876/test/airgapped/v2/tanzu-cli/plugins/airgapped-metadata:small"

[x] : unable to fetch the inventory of discovery 'default' for plugins: open /var/folders/k0/lwnx9y_n7393cfx7mj7dct580000gq/T/2655510121/plugin_inventory.db: no such file or directory
$ tz plugin source list
  NAME     IMAGE
  default  localhost:9876/test/airgapped/v2/tanzu-cli/plugins/airgapped:small
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The `tanzu plugin source update` command will fail if the supplied OCI image path is not a valid plugin inventory repository.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
