### PR TITLE
Fix corrupt catalog cache issue when plugins were installed with old CLI

### DIFF
--- a/pkg/catalog/cleanup.go
+++ b/pkg/catalog/cleanup.go
@@ -1,0 +1,52 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
+)
+
+// DeleteIncorrectPluginEntriesFromCatalog deletes the old plugin entries associated with
+// 'global' target if a plugin with the same name and different target already exists
+// This can happen because of an existing bug in v0.28.x and v0.29.x version of tanzu-cli
+// where we allow plugins to be installed when target value is different even if target
+// values of “(empty), `global` and `kubernetes` can correspond to same root level command
+func DeleteIncorrectPluginEntriesFromCatalog() {
+	for _, c := range getCatalogs() {
+		plugins := c.List()
+		for i := range plugins {
+			// The "unknown" target was previously used in two scenarios:
+			// 1- to represent the global target (>= v0.28 and < v0.90)
+			// 2- to represent either the global or kubernetes target (< v0.28)
+			// If we have a plugin with the "global" or "k8s" target we should remove any similar plugin using
+			// the "unknown" target.
+			if plugins[i].Target == configtypes.TargetGlobal || plugins[i].Target == configtypes.TargetK8s {
+				c.deleteOldTargetEntries(PluginNameTarget(plugins[i].Name, configtypes.TargetUnknown))
+			}
+		}
+		_ = saveCatalogCache(c.sharedCatalog)
+	}
+}
+
+// getCatalogs returns all catalogs as array
+// this includes catalog for standalone plugins
+// as well all catalogs for all contexts
+func getCatalogs() []*ContextCatalog {
+	allCatalogs := []*ContextCatalog{}
+	sc, err := getCatalogCache()
+	if err != nil {
+		return allCatalogs
+	}
+	c, _ := NewContextCatalog("")
+	if c != nil {
+		allCatalogs = append(allCatalogs, c)
+	}
+	for context := range sc.ServerPlugins {
+		c, _ := NewContextCatalog(context)
+		if c != nil {
+			allCatalogs = append(allCatalogs, c)
+		}
+	}
+	return allCatalogs
+}

--- a/pkg/catalog/cleanup.go
+++ b/pkg/catalog/cleanup.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc. All Rights Reserved.
+// Copyright 2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package catalog

--- a/pkg/cli/plugin_cmd.go
+++ b/pkg/cli/plugin_cmd.go
@@ -29,6 +29,7 @@ func GetCmdForPlugin(p *PluginInfo) *cobra.Command {
 		Annotations: map[string]string{
 			"group": string(p.Group),
 			"scope": p.Scope,
+			"type":  "plugin",
 		},
 		Hidden:  p.Hidden,
 		Aliases: p.Aliases,

--- a/pkg/cli/plugin_cmd.go
+++ b/pkg/cli/plugin_cmd.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
 
@@ -29,7 +30,7 @@ func GetCmdForPlugin(p *PluginInfo) *cobra.Command {
 		Annotations: map[string]string{
 			"group": string(p.Group),
 			"scope": p.Scope,
-			"type":  "plugin",
+			"type":  common.CommandTypePlugin,
 		},
 		Hidden:  p.Hidden,
 		Aliases: p.Aliases,

--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -220,7 +220,7 @@ func isStandalonePluginCommand(cmd *cobra.Command) bool {
 
 func isPluginCommand(cmd *cobra.Command) bool {
 	t, exists := cmd.Annotations["type"]
-	return exists && t == "plugin"
+	return exists && t == common.CommandTypePlugin
 }
 
 func duplicateAliasWarning(rootCmd *cobra.Command) {

--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -16,6 +16,7 @@ import (
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/plugin"
 
+	"github.com/vmware-tanzu/tanzu-cli/pkg/catalog"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
 	cliconfig "github.com/vmware-tanzu/tanzu-cli/pkg/config"
@@ -71,7 +72,8 @@ func NewRootCmd() (*cobra.Command, error) {
 		return nil, fmt.Errorf("failed to copy legacy configuration directory to new location: %w", err)
 	}
 
-	var maskedPlugins []string
+	var maskedPluginsWithPluginOverlap []string
+	var maskedPluginsWithCoreCmdOverlap []string
 
 	for i := range plugins {
 		// Only add plugins that should be available as root level command
@@ -86,20 +88,27 @@ func NewRootCmd() (*cobra.Command, error) {
 				// is `Context-Scoped` then the new context-scoped plugin gets higher precedence.
 				// We therefore replace the existing command with the new command by removing the old and
 				// adding the new one.
-				maskedPlugins = append(maskedPlugins, matchedCmd.Name())
+				maskedPluginsWithPluginOverlap = append(maskedPluginsWithPluginOverlap, matchedCmd.Name())
 				rootCmd.RemoveCommand(matchedCmd)
 				rootCmd.AddCommand(cmd)
 			} else if plugins[i].Name != "login" {
 				// As the `login` plugin is now part of the core Tanzu CLI command and not a plugin
 				// anymore, skip the `login` plugin from adding it to the maskedPlugins array to avoid
 				// the warning message from getting shown to the user on each command invocation.
-				maskedPlugins = append(maskedPlugins, plugins[i].Name)
+				if isPluginCommand(matchedCmd) {
+					maskedPluginsWithPluginOverlap = append(maskedPluginsWithPluginOverlap, plugins[i].Name)
+				} else {
+					maskedPluginsWithCoreCmdOverlap = append(maskedPluginsWithCoreCmdOverlap, plugins[i].Name)
+				}
 			}
 		}
 	}
 
-	if len(maskedPlugins) > 0 {
-		fmt.Fprintf(os.Stderr, "Warning, Masking commands for plugins %q because a core command or other plugin with that name already exists. \n", strings.Join(maskedPlugins, ", "))
+	if len(maskedPluginsWithPluginOverlap) > 0 {
+		catalog.DeleteIncorrectPluginEntriesFromCatalog()
+	}
+	if len(maskedPluginsWithCoreCmdOverlap) > 0 {
+		fmt.Fprintf(os.Stderr, "Warning, Masking commands for plugins %q because a core command with that name already exists. \n", strings.Join(maskedPluginsWithCoreCmdOverlap, ", "))
 	}
 
 	duplicateAliasWarning(rootCmd)
@@ -207,6 +216,11 @@ func isPluginRootCmdTargeted(pluginInfo *cli.PluginInfo) bool {
 func isStandalonePluginCommand(cmd *cobra.Command) bool {
 	scope, exists := cmd.Annotations["scope"]
 	return exists && scope == common.PluginScopeStandalone
+}
+
+func isPluginCommand(cmd *cobra.Command) bool {
+	t, exists := cmd.Annotations["type"]
+	return exists && t == "plugin"
 }
 
 func duplicateAliasWarning(rootCmd *cobra.Command) {

--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -108,7 +108,7 @@ func NewRootCmd() (*cobra.Command, error) {
 		catalog.DeleteIncorrectPluginEntriesFromCatalog()
 	}
 	if len(maskedPluginsWithCoreCmdOverlap) > 0 {
-		fmt.Fprintf(os.Stderr, "Warning, Masking commands for plugins %q because a core command with that name already exists. \n", strings.Join(maskedPluginsWithCoreCmdOverlap, ", "))
+		fmt.Fprintf(os.Stderr, "Warning, masking commands for plugins %q because a core command with that name already exists. \n", strings.Join(maskedPluginsWithCoreCmdOverlap, ", "))
 	}
 
 	duplicateAliasWarning(rootCmd)

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -35,3 +35,6 @@ const (
 
 // CoreName is the name of the core binary.
 const CoreName = "core"
+
+// CommandTypePlugin represents the command type is plugin
+const CommandTypePlugin = "plugin"


### PR DESCRIPTION
### What this PR does / why we need it

**Issue:**
1. Install management-cluster v0.25.4 plugin with tanzu-cli v0.25.4.
2. Create management-cluster
3. Install independent Tanzu CLI v0.90.0-alpha.1
4. Upgrade management-cluster plugin to v0.28.0
5. Upgrade management-cluster itself to newer TKG version with new plugin
6. At the end of the management-cluster upgrade, management-cluster plugin runs tanzu plugin sync through API to sync newer plugins
7. After the plugins gets installed, a warning Warning, Masking commands for plugins "cluster, feature, kubernetes-release" because a core command or other plugin with that name already exists.  is always shown with any Tanzu CLI command.

This is happening because of the bug in the Tanzu CLI library for v0.28.0 and v0.29.0. The issue was fixed as part of #201 in the independent Tanzu CLI release. However, if old plugin runs tanzu plugin sync programmatically which has this bug present we still see this warning.

This PR tries to delete any incorrect plugin entries from the catalog cache to recover the CLI from showing the warning message.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #312

### Describe testing done for PR
```
#### Install a plugin for which the target has been updated in the newer releases. (`` target to `kubernetes` target for `package` plugin
$ tanzu-0.25.4 plugin install package
Installing plugin 'package:v0.25.4'
✔  successfully installed 'package' plugin

$ tanzu-0.25.4 plugin list
  NAME                DESCRIPTION                                                        SCOPE       DISCOVERY               VERSION  STATUS
  cluster             Cluster Plugin For Kubernetes                                      Context     default-test-cluster-1  v0.25    not installed
  feature             Feature Plugin For Kubernetes                                      Context     default-test-cluster-1  v0.25    not installed
  kubernetes-release  KR Plugin For Kubernetes                                           Context     default-test-cluster-1  v0.25    not installed
  login               Login to the platform                                              Standalone  default                 v0.25.4  not installed
  management-cluster  Kubernetes management-cluster operations                           Standalone  default                 v0.25.4  not installed
  package             Tanzu package management                                           Standalone  default                 v0.25.4  installed
  pinniped-auth       Pinniped authentication operations (usually not directly invoked)  Standalone  default                 v0.25.4  not installed
  secret              Tanzu secret management                                            Standalone  default                 v0.25.4  not installed
  telemetry           Configure cluster-wide telemetry settings                          Standalone  default                 v0.25.4  not installed


#### Install the same `package` plugin with v0.28.0 version of Tanzu-CLI where the target of that plugin was updated to `kubernetes`
$ tanzu-0.28.0 plugin install package
ℹ  Installing plugin 'package:v0.28.0' with target 'kubernetes'
✔  successfully installed 'package' plugin


### After the installation of the package plugin any command run will show a warning as below
$ tanzu-0.28.0 plugin list
Warning, Masking commands for plugins "package" because a core command or other plugin with that name already exists.
Standalone Plugins
  NAME                DESCRIPTION                                                        TARGET      DISCOVERY  VERSION  STATUS
  isolated-cluster    isolated-cluster operations                                                    default    v0.28.0  not installed
  login               Login to the platform                                                          default    v0.28.0  not installed
  pinniped-auth       Pinniped authentication operations (usually not directly invoked)              default    v0.28.0  not installed
  management-cluster  Kubernetes management-cluster operations                           kubernetes  default    v0.28.0  not installed
  package             Tanzu package management                                           kubernetes  default    v0.25.4  installed
  secret              Tanzu secret management                                            kubernetes  default    v0.28.0  not installed
  telemetry           Configure cluster-wide telemetry settings                          kubernetes  default    v0.28.0  not installed


### This is because the old CLI allowed a new entry for the package 
### plugin to be added to the cache without removing the old entry. 
### This bug was fixed recently in the v0.90.0-alpha.0 release with https://github.com/vmware-tanzu/tanzu-cli/pull/201
### However, if the entry already exists and the user uses the `v0.90.0-alpha.2` CLI this is still an issue.
$ cat ~/.cache/tanzu/catalog.yaml
...
standAlonePlugins:
  package: /Users/anujc/Library/Application Support/tanzu-cli/package/v0.25.4
  package_kubernetes: /Users/anujc/Library/Application Support/tanzu-cli/package/v0.28.0_2602f8da6d2101d44dd4bbfb8905e231ed261baf5b529d435f6e52894a927f11_kubernetes


### THIS PR TRIES TO FIX THIS BY DELETING THE OLD INCORRECT ENTRIES FROM THE CATALOG WHEN THIS
### ISSUE GETS OBSERVED FOR THE FIRST TIME
### Using the New CLI with this Bug fix should not show any warning and should fix the catalog cache when any command
### Gets invoked
$ tz --help
Usage:
  tanzu [command]

Available command groups:
...


### Checking the catalog cache after running the above command to verify the cache was updated
$ cat ~/.cache/tanzu/catalog.yaml
...
standAlonePlugins:
    package_kubernetes: /Users/anujc/Library/Application Support/tanzu-cli/package/v0.28.0_2602f8da6d2101d44dd4bbfb8905e231ed261baf5b529d435f6e52894a927f11_kubernetes
```


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix corrupt catalog cache issue when plugins were installed with old CLI
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
