### PR TITLE
Have "plugin clean" also clean the inventory cache

### DIFF
--- a/pkg/common/defaults.go
+++ b/pkg/common/defaults.go
@@ -11,10 +11,6 @@ import (
 )
 
 var (
-	// TODO(vuil): all directories prefixed with '_', but are expected to be
-	// reconsolidated back to their unprefixed equivalents once backward
-	// compatibility is achieved.
-
 	// DefaultPluginRoot is the default plugin root.
 	DefaultPluginRoot = filepath.Join(xdg.DataHome, "tanzu-cli")
 
@@ -24,4 +20,11 @@ var (
 	// DefaultLocalPluginDistroDir is the default Local plugin distribution root directory
 	// This directory will be used for local discovery and local distribute of plugins
 	DefaultLocalPluginDistroDir = filepath.Join(xdg.Home, ".config", "tanzu-plugins")
+)
+
+const (
+	// PluginInventoryDirName is the name of the directory where the file(s) describing
+	// the inventory of the discovery will be downloaded and stored.
+	// It should be used as a sub-directory of the cache directory (DefaultCacheDir).
+	PluginInventoryDirName = "plugin_inventory"
 )

--- a/pkg/discovery/oci.go
+++ b/pkg/discovery/oci.go
@@ -59,7 +59,7 @@ func newDBBackedOCIDiscovery(name, image string) *DBBackedOCIDiscovery {
 	// then the image prefix should be project.registry.vmware.com/tanzu-cli/plugins/
 	imagePrefix := path.Dir(image)
 	// The data for the inventory is stored in the cache
-	pluginDataDir := filepath.Join(common.DefaultCacheDir, inventoryDirName, name)
+	pluginDataDir := filepath.Join(common.DefaultCacheDir, common.PluginInventoryDirName, name)
 
 	inventory := plugininventory.NewSQLiteInventory(filepath.Join(pluginDataDir, plugininventory.SQliteDBFileName), imagePrefix)
 	return &DBBackedOCIDiscovery{

--- a/pkg/discovery/oci_dbbacked.go
+++ b/pkg/discovery/oci_dbbacked.go
@@ -21,11 +21,6 @@ import (
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
 
-// inventoryDirName is the name of the directory where the file(s) describing
-// the inventory of the discovery will be downloaded and stored.
-// It should be a sub-directory of the cache directory.
-const inventoryDirName = "plugin_inventory"
-
 // DBBackedOCIDiscovery is an artifact discovery utilizing an OCI image
 // which contains an SQLite database describing the content of the plugin
 // discovery.


### PR DESCRIPTION
### What this PR does / why we need it

This PR enhances the `tanzu plugin clean` command to also remove the plugin inventory cache (located at `~/.cache/tanzu/plugin_inventory`)

The PR also adds a unit test for the `pluginmanager.Clean()` function.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

```
# Setup the plugin inventory repos
$ tz config set env.TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest
$ tz plugin source init
[ok] successfully initialized discovery source

# Install a plugin
$ tz plugin install telemetry
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Reading plugin inventory for "harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Installing plugin 'telemetry:v0.28.1' with target 'kubernetes'
[ok] successfully installed 'telemetry' plugin

# Look at the content of the three locations affected by "plugin clean"
$ ls -a ~/.cache/tanzu ~/Library/Application\ Support/tanzu-cli
/Users/kmarc/.cache/tanzu:
.                ..               catalog.yaml     plugin_inventory

/Users/kmarc/Library/Application Support/tanzu-cli:
.         ..        telemetry test

# Run the new "plugin clean"
$ tz plugin clean
[ok] successfully cleaned up all plugins

# Notice that the plugin inventory is also gone
$ ls -a ~/.cache/tanzu ~/Library/Application\ Support/tanzu-cli
ls: /Users/kmarc/Library/Application Support/tanzu-cli: No such file or directory
/Users/kmarc/.cache/tanzu:
.  ..

# Plugins are gone
$ tz plugin list
Standalone Plugins
  NAME  DESCRIPTION  TARGET  VERSION  STATUS

# A new plugin search has to fetch the inventory DBs again
$ tz plugin search
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Reading plugin inventory for "harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest", this will take a few seconds.
[...]
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The `tanzu plugin clean` command will now also purge the plugin inventory cache.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
