### PR TITLE
plugin list should show plugins even when specific context has issues

### DIFF
--- a/test/e2e/coexistence/cli_coexistence_test.go
+++ b/test/e2e/coexistence/cli_coexistence_test.go
@@ -76,7 +76,7 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 			}
 
 			ginkgo.By("Verify the installed plugins using legacy Tanzu CLI")
-			pluginsList, err := tf.PluginCmd.ListPlugins()
+			pluginsList, _, _, err := tf.PluginCmd.ListPlugins()
 			gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin list for legacy tanzu cli")
 			gomega.Expect(pluginlifecyclee2e.CheckAllLegacyPluginsExists(pluginsList, PluginsForLegacyTanzuCLICoexistenceTests)).Should(gomega.BeTrue(), "the plugin list output using legacy tanzu cli is not same as the plugins being installed using legacy tanzu cli")
 
@@ -118,12 +118,12 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 			}
 
 			ginkgo.By("Installing few plugins using new Tanzu CLI")
-			pluginsList, err = tf.PluginCmd.ListPlugins(framework.WithTanzuCommandPrefix(framework.TzPrefix))
+			pluginsList, _, _, err = tf.PluginCmd.ListPlugins(framework.WithTanzuCommandPrefix(framework.TzPrefix))
 			gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin list for new tanzu cli")
 			gomega.Expect(framework.CheckAllPluginsExists(pluginsList, PluginsForNewTanzuCLICoexistenceTests)).Should(gomega.BeTrue(), "the plugin list output using new tanzu cli is not same as the plugins being installed using new tanzu cli")
 
 			ginkgo.By("Verify the installed plugins using legacy Tanzu CLI")
-			pluginsList, err = tf.PluginCmd.ListPlugins()
+			pluginsList, _, _, err = tf.PluginCmd.ListPlugins()
 			gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin list using legacy tanzu cli")
 			gomega.Expect(pluginlifecyclee2e.CheckAllLegacyPluginsExists(pluginsList, PluginsForLegacyTanzuCLICoexistenceTests)).Should(gomega.BeTrue(), "the plugin list output using legacy tanzu cli is not same as the plugins being installed using legacy tanzu cli")
 		})
@@ -152,7 +152,7 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 			}
 
 			ginkgo.By("Verify the installed plugins using legacy Tanzu CLI")
-			pluginsList, err := tf.PluginCmd.ListPlugins()
+			pluginsList, _, _, err := tf.PluginCmd.ListPlugins()
 			gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin list")
 			gomega.Expect(pluginlifecyclee2e.CheckAllLegacyPluginsExists(pluginsList, PluginsForLegacyTanzuCLICoexistenceTests)).Should(gomega.BeTrue(), "the plugin list output using legacy tanzu cli is not same as the plugins being installed using legacy tanzu cli")
 
@@ -195,7 +195,7 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 			}
 
 			ginkgo.By("Verify the installed plugins using new Tanzu CLI")
-			pluginsList, err = tf.PluginCmd.ListPlugins()
+			pluginsList, _, _, err = tf.PluginCmd.ListPlugins()
 			gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin list using new tanzu cli")
 			gomega.Expect(framework.CheckAllPluginsExists(pluginsList, PluginsForNewTanzuCLICoexistenceTests)).Should(gomega.BeTrue(), "the plugin list output using new tanzu cli is not same as the plugins being installed using new tanzu cli")
 		})
@@ -224,7 +224,7 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 			}
 
 			ginkgo.By("Verify the installed plugins using legacy Tanzu CLI")
-			pluginsList, err := tf.PluginCmd.ListPlugins()
+			pluginsList, _, _, err := tf.PluginCmd.ListPlugins()
 			gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin list")
 			gomega.Expect(pluginlifecyclee2e.CheckAllLegacyPluginsExists(pluginsList, PluginsForLegacyTanzuCLICoexistenceTests)).Should(gomega.BeTrue(), "the plugin list output using legacy tanzu cli is not same as the plugins being installed using legacy tanzu cli")
 
@@ -266,7 +266,7 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 			}
 
 			ginkgo.By("Verify the installed plugins using new Tanzu CLI")
-			pluginsList, err = tf.PluginCmd.ListPlugins()
+			pluginsList, _, _, err = tf.PluginCmd.ListPlugins()
 			gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin list using new tanzu cli")
 			gomega.Expect(framework.CheckAllPluginsExists(pluginsList, PluginsForNewTanzuCLICoexistenceTests)).Should(gomega.BeTrue(), "the plugin list output using new tanzu cli is not same as the plugins being installed using new tanzu cli")
 
@@ -275,7 +275,7 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 			gomega.Expect(err).To(gomega.BeNil())
 
 			ginkgo.By("Verify the installed plugins using reinstalled new Tanzu CLI")
-			pluginsList, err = tf.PluginCmd.ListPlugins()
+			pluginsList, _, _, err = tf.PluginCmd.ListPlugins()
 			gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin list using new tanzu cli")
 			gomega.Expect(framework.CheckAllPluginsExists(pluginsList, PluginsForNewTanzuCLICoexistenceTests)).Should(gomega.BeTrue(), "the plugin list output using new tanzu cli is not same as the plugins being installed using new tanzu cli")
 			gomega.Expect(pluginlifecyclee2e.CheckAllLegacyPluginsExists(pluginsList, PluginsForLegacyTanzuCLICoexistenceTests)).Should(gomega.BeTrue(), "the plugin list output using new tanzu cli is not same as the plugins being installed using legacy tanzu cli")
@@ -305,7 +305,7 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 			}
 
 			ginkgo.By("Verify the installed plugins using legacy Tanzu CLI")
-			pluginsList, err := tf.PluginCmd.ListPlugins()
+			pluginsList, _, _, err := tf.PluginCmd.ListPlugins()
 			gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin list")
 			gomega.Expect(pluginlifecyclee2e.CheckAllLegacyPluginsExists(pluginsList, PluginsForLegacyTanzuCLICoexistenceTests)).Should(gomega.BeTrue(), "the plugin list output using legacy tanzu cli is not same as the plugins being installed using legacy tanzu cli")
 
@@ -347,7 +347,7 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 			}
 
 			ginkgo.By("Verify the installed plugins using new Tanzu CLI")
-			pluginsList, err = tf.PluginCmd.ListPlugins(framework.WithTanzuCommandPrefix(framework.TzPrefix))
+			pluginsList, _, _, err = tf.PluginCmd.ListPlugins(framework.WithTanzuCommandPrefix(framework.TzPrefix))
 			gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin list using new tanzu cli")
 			gomega.Expect(framework.CheckAllPluginsExists(pluginsList, PluginsForNewTanzuCLICoexistenceTests)).Should(gomega.BeTrue(), "the plugin list output using new tanzu cli is not same as the plugins being installed using new tanzu cli")
 
@@ -356,7 +356,7 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 			gomega.Expect(err).To(gomega.BeNil())
 
 			ginkgo.By("Verify the installed plugins using reinstalled new Tanzu CLI")
-			pluginsList, err = tf.PluginCmd.ListPlugins(framework.WithTanzuCommandPrefix(framework.TzPrefix))
+			pluginsList, _, _, err = tf.PluginCmd.ListPlugins(framework.WithTanzuCommandPrefix(framework.TzPrefix))
 			gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin list using new tanzu cli")
 			gomega.Expect(framework.CheckAllPluginsExists(pluginsList, PluginsForNewTanzuCLICoexistenceTests)).Should(gomega.BeTrue(), "the plugin list output using new tanzu cli is not same as the plugins being installed using new tanzu cli")
 			gomega.Expect(pluginlifecyclee2e.CheckAllLegacyPluginsExists(pluginsList, PluginsForLegacyTanzuCLICoexistenceTests)).Should(gomega.BeTrue(), "the plugin list output using new tanzu cli is not same as the plugins being installed using legacy tanzu cli")
@@ -386,7 +386,7 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 			}
 
 			ginkgo.By("Verify the installed plugins using legacy Tanzu CLI")
-			pluginsList, err := tf.PluginCmd.ListPlugins()
+			pluginsList, _, _, err := tf.PluginCmd.ListPlugins()
 			gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin list")
 			gomega.Expect(pluginlifecyclee2e.CheckAllLegacyPluginsExists(pluginsList, PluginsForLegacyTanzuCLICoexistenceTests)).Should(gomega.BeTrue(), "the plugin list output using legacy tanzu cli is not same as the plugins being installed using legacy tanzu cli")
 
@@ -428,7 +428,7 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 			}
 
 			ginkgo.By("Verify the installed plugins using new Tanzu CLI")
-			pluginsList, err = tf.PluginCmd.ListPlugins()
+			pluginsList, _, _, err = tf.PluginCmd.ListPlugins()
 			gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin list using new tanzu cli")
 			gomega.Expect(framework.CheckAllPluginsExists(pluginsList, PluginsForNewTanzuCLICoexistenceTests)).Should(gomega.BeTrue(), "the plugin list output using new tanzu cli is not same as the plugins being installed using new tanzu cli")
 
@@ -437,7 +437,7 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 			gomega.Expect(err).To(gomega.BeNil())
 
 			ginkgo.By("Verify the installed plugins using legacy Tanzu CLI")
-			pluginsList, err = tf.PluginCmd.ListPlugins()
+			pluginsList, _, _, err = tf.PluginCmd.ListPlugins()
 			gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin list using legacy tanzu cli")
 			gomega.Expect(pluginlifecyclee2e.CheckAllLegacyPluginsExists(pluginsList, PluginsForLegacyTanzuCLICoexistenceTests)).Should(gomega.BeTrue(), "the plugin list output using legacy tanzu cli is not same as the plugins being installed using legacy tanzu cli")
 			gomega.Expect(framework.CheckAllPluginsExists(pluginsList, PluginsForNewTanzuCLICoexistenceTests)).Should(gomega.BeFalse(), "the plugin list output using new tanzu cli is not same as the plugins being installed using new tanzu cli")

--- a/test/e2e/context/tmc/context_tmc_k8s_contexts_test.go
+++ b/test/e2e/context/tmc/context_tmc_k8s_contexts_test.go
@@ -25,7 +25,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-lifecycle-tmc-k8s
 	// Test case: b. create k8s context, make sure its active
 	// Test case: c. list all active contexts, make both tmc and k8s contexts are active
 	// Test case: d. delte both k8s and tmc contexts
-	Context("Context lifecycle tests for TMC target", func() {
+	Context("Context lifecycle tests for TMC and k8s targets", func() {
 		var k8sCtx, tmcCtx string
 		// Test case: a. create tmc context
 		It("create tmc context with endpoint and check active context", func() {
@@ -79,7 +79,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-lifecycle-tmc-k8s
 	// Test case: c. list all active contexts, make both tmc and k8s contexts are active
 	// Test case: d. list all contexts
 	// Test case: e. delete all contexts
-	Context("Context lifecycle tests for TMC target", func() {
+	Context("Context lifecycle tests for TMC and k8s targets, with multiple contexts", func() {
 		var k8sCtx, tmcCtx string
 		k8sCtxs := make([]string, 0)
 		tmcCtxs := make([]string, 0)

--- a/test/e2e/framework/cli_lifecycle_operations.go
+++ b/test/e2e/framework/cli_lifecycle_operations.go
@@ -191,7 +191,7 @@ func (co *cliOps) RollbackToLegacyTanzuCLI(tf *Framework, opts ...E2EOption) err
 		return err
 	}
 
-	_, err = tf.PluginCmd.Sync(opts...)
+	_, _, err = tf.PluginCmd.Sync(opts...)
 
 	if err != nil {
 		return err

--- a/test/e2e/framework/plugin_lifecycle_operations.go
+++ b/test/e2e/framework/plugin_lifecycle_operations.go
@@ -14,8 +14,9 @@ import (
 
 // PluginBasicOps helps to perform the plugin command operations
 type PluginBasicOps interface {
-	// ListPlugins lists all plugins by running 'tanzu plugin list' command
-	ListPlugins(opts ...E2EOption) ([]*PluginInfo, error)
+	// ListPlugins execytes 'tanzu plugin list' command and
+	// returns the output, stdOut, stdErr and error
+	ListPlugins(opts ...E2EOption) ([]*PluginInfo, string, string, error)
 	// ListInstalledPlugins lists all installed plugins
 	ListInstalledPlugins(opts ...E2EOption) ([]*PluginInfo, error)
 	// ListPluginsForGivenContext lists all plugins for a given context and either installed only or all
@@ -24,8 +25,8 @@ type PluginBasicOps interface {
 	SearchPlugins(filter string, opts ...E2EOption) ([]*PluginInfo, error)
 	// InstallPlugin installs given plugin and flags
 	InstallPlugin(pluginName, target, versions string, opts ...E2EOption) error
-	// Sync performs sync operation
-	Sync(opts ...E2EOption) (string, error)
+	// Sync performs sync operation and returns stdOut, stdErr and error
+	Sync(opts ...E2EOption) (string, string, error)
 	// DescribePlugin describes given plugin and flags, returns the plugin description as PluginDescribe
 	DescribePlugin(pluginName, target string, opts ...E2EOption) ([]*PluginDescribe, error)
 	// DescribePluginLegacy describes given plugin and flags, returns plugin description in string format
@@ -131,9 +132,9 @@ func (po *pluginCmdOps) InitPluginDiscoverySource(opts ...E2EOption) (string, er
 	return out.String(), err
 }
 
-func (po *pluginCmdOps) ListPlugins(opts ...E2EOption) ([]*PluginInfo, error) {
-	output, _, _, err := ExecuteCmdAndBuildJSONOutput[PluginInfo](po.cmdExe, ListPluginsCmdWithJSONOutputFlag, opts...)
-	return output, err
+func (po *pluginCmdOps) ListPlugins(opts ...E2EOption) ([]*PluginInfo, string, string, error) {
+	output, stdOut, stdErr, err := ExecuteCmdAndBuildJSONOutput[PluginInfo](po.cmdExe, ListPluginsCmdWithJSONOutputFlag, opts...)
+	return output, stdOut, stdErr, err
 }
 
 func (po *pluginCmdOps) ListInstalledPlugins(opts ...E2EOption) ([]*PluginInfo, error) {
@@ -164,12 +165,12 @@ func (po *pluginCmdOps) ListPluginsForGivenContext(context string, installedOnly
 	return contextSpecificPlugins, err
 }
 
-func (po *pluginCmdOps) Sync(opts ...E2EOption) (string, error) {
+func (po *pluginCmdOps) Sync(opts ...E2EOption) (string, string, error) {
 	out, stdErr, err := po.cmdExe.TanzuCmdExec(pluginSyncCmd, opts...)
 	if err != nil {
 		log.Errorf(ErrorLogForCommandWithErrStdErrAndStdOut, pluginSyncCmd, err.Error(), stdErr.String(), out.String())
 	}
-	return out.String(), err
+	return out.String(), stdErr.String(), err
 }
 
 func (po *pluginCmdOps) SearchPlugins(filter string, opts ...E2EOption) ([]*PluginInfo, error) {

--- a/test/e2e/plugin_sync/k8s/plugin_sync_k8s_lifecycle_test.go
+++ b/test/e2e/plugin_sync/k8s/plugin_sync_k8s_lifecycle_test.go
@@ -150,7 +150,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 			Expect(len(installedPluginsList)).Should(Equal(len(latestPluginsInstalledList)), "number of plugins should be same as number of plugins CRs applied")
 			Expect(f.CheckAllPluginsExists(installedPluginsList, latestPluginsInstalledList)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
 
-			_, err = tf.PluginCmd.Sync()
+			_, _, err = tf.PluginCmd.Sync()
 			Expect(err).To(BeNil(), "should not get any error for plugin sync")
 
 			installedPluginsList, err = tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
@@ -229,7 +229,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 		// Test case: e. run plugin sync and validate the plugin list
 		It("run plugin sync and validate err response in plugin sync, validate plugin list output", func() {
 			// sync should fail with error as there is a plugin which does not exists in repository with the given random version
-			_, err = tf.PluginCmd.Sync()
+			_, _, err = tf.PluginCmd.Sync()
 			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(f.UnableToFindPluginWithVersionForTarget, pluginsWithIncorrectVer[0].Name, pluginsWithIncorrectVer[0].Version, pluginsWithIncorrectVer[0].Target)))
 
 			pluginsList, err = tf.PluginCmd.ListPluginsForGivenContext(contextName, true)

--- a/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_suite_test.go
+++ b/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_suite_test.go
@@ -49,13 +49,21 @@ const numberOfPluginsSameAsNoOfPluginsInfoMocked = "number of plugins should be 
 const pluginsInstalledAndMockedShouldBeSame = "plugins being installed and plugins being mocked in tmc endpoint response should be same"
 const noErrorForMockResponseFileUpdate = "there should not be any error while updating the tmc endpoint mock response"
 const noErrorForMockResponsePreparation = "there should not be any error while preparing the tmc endpoint mock response"
+
 const deleteContextWithoutError = "context should be deleted without error"
 const mockServerShouldStartWithoutError = "mock server should start without error"
 const mockServerShouldStopWithoutError = "mock server should stop without error"
 const noErrorWhileCreatingContext = "context should create without any error"
 const activeContextShouldExists = "there should be a active context"
 const pluginGroupShouldExists = "plugin group should exist in the map"
+
 const noErrorForPluginList = "should not get any error for plugin list"
+const noErrorForPluginSearch = "should not get any error for plugin search"
+const noErrorForPluginDelete = "should not get any error for plugin delete"
+const noErrorForPluginInstall = "should not get any error for plugin install"
+const noErrorForPluginSync = "should not get any error for plugin sync"
+const shouldBeSomePluginsForPluginSearch = "there should be some plugins for plugin search"
+
 const activeContextShouldBeRecentlyAddedOne = "the active context should be recently added context"
 const testRepoDoesNotHaveEnoughPlugins = "test central repo does not have enough plugins to continue e2e tests"
 
@@ -69,6 +77,11 @@ var _ = BeforeSuite(func() {
 	// check E2E test central repo URL (TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_URL) and update the same for plugin discovery
 	e2eTestLocalCentralRepoURL = os.Getenv(framework.TanzuCliE2ETestLocalCentralRepositoryURL)
 	Expect(e2eTestLocalCentralRepoURL).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with local central repository URL", framework.TanzuCliE2ETestLocalCentralRepositoryURL))
+
+	// set up the local central repository discovery image public key path
+	e2eTestLocalCentralRepoPluginDiscoveryImageSignaturePublicKeyPath := os.Getenv(framework.TanzuCliE2ETestLocalCentralRepositoryPluginDiscoveryImageSignaturePublicKeyPath)
+	Expect(e2eTestLocalCentralRepoPluginDiscoveryImageSignaturePublicKeyPath).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with local central repository discovery image signature public key path", framework.TanzuCliE2ETestLocalCentralRepositoryPluginDiscoveryImageSignaturePublicKeyPath))
+	os.Setenv(framework.TanzuCliPluginDiscoveryImageSignaturePublicKeyPath, e2eTestLocalCentralRepoPluginDiscoveryImageSignaturePublicKeyPath)
 
 	// Check whether the TMC token is set and whether TANZU_CLI_E2E_TEST_ENVIRONMENT is set to skip HTTPS hardcoding when mocking TMC response.
 	Expect(os.Getenv(framework.TanzuAPIToken)).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with TMC API Token", framework.TanzuAPIToken))

--- a/test/e2e/plugins_compatibility/plugins_compatibility_helper.go
+++ b/test/e2e/plugins_compatibility/plugins_compatibility_helper.go
@@ -29,7 +29,7 @@ func PluginsForCompatibilityTesting(tf *framework.Framework) []*framework.Plugin
 
 // IsAllPluginsInstalled takes list of plugins and checks if all plugins are installed
 func IsAllPluginsInstalled(tf *framework.Framework, plugins []*framework.PluginInfo) bool {
-	pluginListOutput, err := tf.PluginCmd.ListPlugins()
+	pluginListOutput, _, _, err := tf.PluginCmd.ListPlugins()
 	gomega.Expect(err).To(gomega.BeNil(), "should not occur any error while listing plugins")
 	pluginMap := framework.PluginListToSet(plugins)
 	for _, pluginInfo := range pluginListOutput {
@@ -44,7 +44,7 @@ func IsAllPluginsInstalled(tf *framework.Framework, plugins []*framework.PluginI
 
 // IsAllPluginsUnInstalled takes list of plugins and checks if all plugins are uninstalled
 func IsAllPluginsUnInstalled(tf *framework.Framework, plugins []*framework.PluginInfo) bool {
-	pluginListOutput, err := tf.PluginCmd.ListPlugins()
+	pluginListOutput, _, _, err := tf.PluginCmd.ListPlugins()
 	gomega.Expect(err).To(gomega.BeNil(), "should not occur any error while listing plugins")
 	pluginMap := framework.PluginListToSet(plugins)
 	for _, pluginInfo := range pluginListOutput {
@@ -60,7 +60,7 @@ func IsAllPluginsUnInstalled(tf *framework.Framework, plugins []*framework.Plugi
 
 // UninstallPlugins lists plugins and uninstalls provided plugins if any plugins are installed
 func UninstallPlugins(tf *framework.Framework, plugins []*framework.PluginInfo) {
-	pluginListOutput, err := tf.PluginCmd.ListPlugins()
+	pluginListOutput, _, _, err := tf.PluginCmd.ListPlugins()
 	gomega.Expect(err).To(gomega.BeNil(), "should not occur any error while listing plugins")
 	pluginMap := framework.PluginListToSet(plugins)
 	for _, pluginInfo := range pluginListOutput {


### PR DESCRIPTION
### What this PR does / why we need it
This PR resolves the regression introduced by https://github.com/vmware-tanzu/tanzu-cli/pull/269. The issue addressed by this PR is that the tanzu plugin list command does not display plugins when there are issues with any of the contexts during plugin discovery.

**What is the Fix:**
In the previous PR (https://github.com/vmware-tanzu/tanzu-cli/pull/269), errors were returned if there were any issues while discovering plugins for a specific context. In the tanzu plugin list command, the flow was terminated if an error occurred while retrieving context-specific plugins. The fix in this PR updates the logic in the tanzu plugin list flow to log a warning if there are errors while retrieving context-specific plugins, and continues the flow to display the discovered plugins.

**Which commands has impact this changes:**
- `tanzu plugin list` command (which was not working prior to this fix, specific to this PR use case)"
- `tanzu plugin sync` command (which was not working prior to this fix, specific to this PR use case)"
- `tanzu plugin search`
- `tanzu plugin install`
- `tanzu plugin upgrade`
- `tanzu install <plugin-name> --group <group-name>`
- `tanzu install --group <group-name>`


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
1. Start local test central repo
```
❯ make start-test-central-repo
echo "Adding docker test central repo cert to the config file"
Adding docker test central repo cert to the config file
TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="No" TANZU_CLI_EULA_PROMPT_ANSWER="Yes" /Users/cpamuluri/tkg/tasks/e2e_tests/tmc_sync_temp/tanzu-cli/bin/tanzu config cert delete localhost:9876 || true
[ok] deleted certificate data for host localhost:9876
/Users/cpamuluri/tkg/tasks/e2e_tests/tmc_sync_temp/tanzu-cli/bin/tanzu config cert add --host localhost:9876 --ca-certificate /Users/cpamuluri/tkg/tasks/e2e_tests/tmc_sync_temp/tanzu-cli/hack/central-repo/certs/localhost.crt
[ok] successfully added certificate data for host localhost:9876
Started docker test central repo with images:
=> localhost:9876/tanzu-cli/plugins/central:small
    - a small amount of plugins matching product plugin names
    - only versions v0.0.1 and v9.9.9 can be installed
```
2. Create two k8s contexts with two different kind clusters
```
❯ tm context create --kubeconfig /Users/cpamuluri/.kube/config --kubecontext kind-kind11 --name kind11a  
[ok] successfully created a kubernetes context using the kubeconfig /Users/cpamuluri/.kube/config
[i] Checking for required plugins...
[i] All required plugins are already installed and up-to-date
❯ tm context create --kubeconfig /Users/cpamuluri/.kube/config --kubecontext kind-kind12 --name kind12a
[ok] successfully created a kubernetes context using the kubeconfig /Users/cpamuluri/.kube/config
[i] Checking for required plugins...
[i] All required plugins are already installed and up-to-date
```
3. Now delete the kind cluster related to active k8s context (in this case kind12a), now the active k8s context has issue
4. Now add TMC context
```
❯ tf context create --endpoint  unstable.tmc-dev.cloud.vmware.com --staging  --name tmc1
[i] API token env var is set

[ok] successfully created a TMC context
[i] Checking for required plugins...
[!] there was an error while discovering plugins, error information: 'unable to list plugins from discovery source 'default-kind12a': Unable to set up rest config due to : context "kind-kind12" does not exist'
[i] Installing plugin 'apply:v0.0.1' with target 'mission-control'
[i] Installing plugin 'tanzupackage:v0.0.1' with target 'mission-control'
[i] Installing plugin 'events:v0.0.1' with target 'mission-control'
[i] Installing plugin 'integration:v0.0.1' with target 'mission-control'
[i] Installing plugin 'account:v0.0.1' with target 'mission-control'
[i] Installing plugin 'clustergroup:v0.0.1' with target 'mission-control'
[i] Installing plugin 'policy:v0.0.1' with target 'mission-control'
[i] Installing plugin 'helm:v0.0.1' with target 'mission-control'
[i] Installing plugin 'inspection:v0.0.1' with target 'mission-control'
[i] Installing plugin 'secret:v0.0.1' with target 'mission-control'
[i] Installing plugin 'continuousdelivery:v0.0.1' with target 'mission-control'
[i] Installing plugin 'workspace:v0.0.1' with target 'mission-control'
[i] Installing plugin 'ekscluster:v0.0.1' with target 'mission-control'
[i] Installing plugin 'cluster:v0.0.1' with target 'mission-control'
[i] Installing plugin 'iam:v0.0.1' with target 'mission-control'
[i] Installing plugin 'management-cluster:v0.0.1' with target 'mission-control'
[i] Installing plugin 'data-protection:v0.0.1' with target 'mission-control'
[i] Installing plugin 'audit:v0.0.1' with target 'mission-control'
[!] unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually, error: '[unable to find plugin 'setting' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'agentartifacts' with version 'v0.0.1' for target 'mission-control']'
❯ 
```
**5. `tanzu plugin list` before fix and after fix:**
```
BEFORE FIX:
❯ tm plugin list
[x] : unable to list plugins from discovery source 'default-kind12a': Unable to set up rest config due to : context "kind-kind12" does not exist
AFTER FIX:
❯ tf plugin list
[!] there was an error while discovering plugins, error information: 'unable to list plugins from discovery source 'default-kind12a': Unable to set up rest config due to : context "kind-kind12" does not exist'
[!] there was an error while getting installed context plugins, error information: 'unable to list plugins from discovery source 'default-kind12a': Unable to set up rest config due to : context "kind-kind12" does not exist'
Standalone Plugins
  NAME                DESCRIPTION                       TARGET      VERSION  STATUS     
  kubernetes-release  kubernetes-release functionality  kubernetes  v9.9.9   installed  
  management-cluster  management-cluster functionality  kubernetes  v9.9.9   installed  
  package             package functionality             kubernetes  v9.9.9   installed  
  telemetry           telemetry functionality           kubernetes  v9.9.9   installed  

Plugins from Context:  tmc1
  NAME                DESCRIPTION                                                     TARGET           VERSION  STATUS         
  account             Account for tmc resources                                       mission-control  v0.0.1   installed      
  agentartifacts      helm for tmc resources                                          mission-control  v0.0.1   not installed  
  apply               Create/Update a resource with a resource file                   mission-control  v0.0.1   installed      
  audit               Run an audit request on an org                                  mission-control  v0.0.1   installed      
  cluster                                                                             mission-control  v0.0.1   installed      
  clustergroup        A group of Kubernetes clusters                                  mission-control  v0.0.1   installed      
  continuousdelivery  Continuousdelivery for tmc resources                            mission-control  v0.0.1   installed      
  data-protection     Data protection for tmc resources                               mission-control  v0.0.1   installed      
  ekscluster                                                                          mission-control  v0.0.1   installed      
  events              Events for any meaningful user activity or system state change  mission-control  v0.0.1   installed      
  helm                helm for tmc resources                                          mission-control  v0.0.1   installed      
  iam                 IAM Policies for tmc resources                                  mission-control  v0.0.1   installed      
  inspection          Inspection for tmc resources                                    mission-control  v0.0.1   installed      
  integration         Get available integrations and their information from registry  mission-control  v0.0.1   installed      
  management-cluster  A TMC registered Management cluster                             mission-control  v0.0.1   installed      
  policy              Policy for tmc resources                                        mission-control  v0.0.1   installed      
  secret              secret for tmc resources                                        mission-control  v0.0.1   installed      
  setting             Setting plugin for tmc resources                                mission-control  v0.0.1   not installed  
  tanzupackage        Tanzupackage for tmc resources                                  mission-control  v0.0.1   installed      
  workspace           A group of Kubernetes namespaces                                mission-control  v0.0.1   installed      

[!] As shown above, some recommended plugins have not been installed. To install them please run 'tanzu plugin sync'.
[x] : unable to list plugins from discovery source 'default-kind12a': Unable to set up rest config due to : context "kind-kind12" does not exist
❯ 
```
**6. plugin install and delete: `tanzu plugin delete` and `tanzu plugin install` command before and after:**
```
Before Fix:
❯ tm plugin delete apply --target tmc
Deleting Plugin 'apply' for target 'mission-control'. Are you sure? [y/N]: y
[ok] successfully deleted plugin 'apply'
❯ tm plugin install account --target tmc
[i] Installing plugin 'account:v9.9.9' with target 'mission-control'
[ok] successfully installed 'account' plugin


After Fix:
❯ tf plugin delete account --target tmc
Deleting Plugin 'account' for target 'mission-control'. Are you sure? [y/N]: y
[ok] successfully deleted plugin 'account'
❯ tf plugin install apply --target tmc
[i] Installing plugin 'apply:v9.9.9' with target 'mission-control'
[ok] successfully installed 'apply' plugin
❯ 
```
7. plugin search:
```
Before Fix:
❯ tm plugin search
  NAME                DESCRIPTION                  TARGET           LATEST  
  isolated-cluster    Desc for isolated-cluster    global           v9.9.9  
  pinniped-auth       Desc for pinniped-auth       global           v9.9.9  
  cluster             Desc for cluster             kubernetes       v9.9.9  
  feature             Desc for feature             kubernetes       v9.9.9  
  kubernetes-release  Desc for kubernetes-release  kubernetes       v9.9.9  
  management-cluster  Desc for management-cluster  kubernetes       v9.9.9  
  package             Desc for package             kubernetes       v9.9.9  
  secret              Desc for secret              kubernetes       v9.9.9  
  telemetry           Desc for telemetry           kubernetes       v9.9.9  
  account             Desc for account             mission-control  v9.9.9  
  apply               Desc for apply               mission-control  v9.9.9  
  audit               Desc for audit               mission-control  v9.9.9  

After Fix:
❯ tf plugin search
  NAME                DESCRIPTION                  TARGET           LATEST  
  isolated-cluster    Desc for isolated-cluster    global           v9.9.9  
  pinniped-auth       Desc for pinniped-auth       global           v9.9.9  
  cluster             Desc for cluster             kubernetes       v9.9.9  
  feature             Desc for feature             kubernetes       v9.9.9  
  kubernetes-release  Desc for kubernetes-release  kubernetes       v9.9.9  
  management-cluster  Desc for management-cluster  kubernetes       v9.9.9  
  package             Desc for package             kubernetes       v9.9.9  
  secret              Desc for secret              kubernetes       v9.9.9  
  telemetry           Desc for telemetry           kubernetes       v9.9.9  
  account             Desc for account             mission-control  v9.9.9  
  apply               Desc for apply               mission-control  v9.9.9  
  audit               Desc for audit               mission-control  v9.9.9  
```
**8. plugin sync: Before fix it is not working, after FIX its working fine:**

```
**Before FIX:**
❯ tm plugin sync
[i] Checking for required plugins...
[x] : unable to list plugins from discovery source 'default-kind12a': Unable to set up rest config due to : context "kind-kind12" does not exist

**After Fix:**
❯ tf plugin sync
[i] Checking for required plugins...
[!] there was an error while discovering plugins, error information: 'unable to list plugins from discovery source 'default-kind12a': Unable to set up rest config due to : context "kind-kind12" does not exist'
[i] Installing plugin 'account:v0.0.1' with target 'mission-control'
[i] Installing plugin 'apply:v0.0.1' with target 'mission-control'
[x] : [unable to find plugin 'setting' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'agentartifacts' with version 'v0.0.1' for target 'mission-control']
❯ 
```
9. plugin upgrade: Before and After fix, same behaviour:
```
❯ tm plugin upgrade apply --target tmc
[i] Installing plugin 'apply:v9.9.9' with target 'mission-control'
[ok] successfully upgraded plugin 'apply'
❯ tf plugin upgrade audit --target tmc
[i] Installing plugin 'audit:v9.9.9' with target 'mission-control'
[ok] successfully upgraded plugin 'audit'
❯ tf plugin upgrade audit --target tmc
[i] Installing plugin 'audit:v9.9.9' with target 'mission-control'
[ok] successfully upgraded plugin 'audit'
❯ tm plugin upgrade apply --target tmc
[i] Installing plugin 'apply:v9.9.9' with target 'mission-control'
[ok] successfully upgraded plugin 'apply'
```

**10. plugin install and plugin install from group:**
```
❯ tf plugin group search          
  GROUP                DESCRIPTION                          LATEST  
  vmware-tkg/default   Desc for vmware-tkg/default:v9.9.9   v9.9.9  
  vmware-tmc/tmc-user  Desc for vmware-tmc/tmc-user:v9.9.9  v9.9.9  
❯ tf plugin install apply --group vmware-tmc/tmc-user:v9.9.9  
[i] Installing plugin 'apply:v9.9.9' with target 'mission-control'
[ok] successfully installed 'apply' from group 'vmware-tmc/tmc-user:v9.9.9'
❯ tf plugin install --group vmware-tmc/tmc-user:v9.9.9  
[i] Installing plugin 'account:v9.9.9' with target 'mission-control'
[i] Installing plugin 'apply:v9.9.9' with target 'mission-control'
[i] Installing plugin 'audit:v9.9.9' with target 'mission-control'
[i] Installing plugin 'cluster:v9.9.9' with target 'mission-control'
[i] Installing plugin 'clustergroup:v9.9.9' with target 'mission-control'
[i] Installing plugin 'continuousdelivery:v9.9.9' with target 'mission-control'
[i] Installing plugin 'data-protection:v9.9.9' with target 'mission-control'
[i] Installing plugin 'ekscluster:v9.9.9' with target 'mission-control'
[i] Installing plugin 'events:v9.9.9' with target 'mission-control'
[i] Installing plugin 'helm:v9.9.9' with target 'mission-control'
[i] Installing plugin 'iam:v9.9.9' with target 'mission-control'
[i] Installing plugin 'inspection:v9.9.9' with target 'mission-control'
[i] Installing plugin 'integration:v9.9.9' with target 'mission-control'
[i] Installing plugin 'management-cluster:v9.9.9' with target 'mission-control'
[i] Installing plugin 'policy:v9.9.9' with target 'mission-control'
[i] Installing plugin 'secret:v9.9.9' with target 'mission-control'
[i] Installing plugin 'tanzupackage:v9.9.9' with target 'mission-control'
[i] Installing plugin 'workspace:v9.9.9' with target 'mission-control'
[ok] successfully installed all plugins from group 'vmware-tmc/tmc-user:v9.9.9'
❯ tf plugin install --group  vmware-tkg/default:v9.9.9 
[i] Installing plugin 'cluster:v9.9.9' with target 'kubernetes'
[i] Installing plugin 'feature:v9.9.9' with target 'kubernetes'
[i] Installing plugin 'kubernetes-release:v9.9.9' with target 'kubernetes'
[i] Installing plugin 'management-cluster:v9.9.9' with target 'kubernetes'
[i] Installing plugin 'package:v9.9.9' with target 'kubernetes'
[i] Installing plugin 'secret:v9.9.9' with target 'kubernetes'
[i] Installing plugin 'telemetry:v9.9.9' with target 'kubernetes'
[ok] successfully installed all plugins from group 'vmware-tkg/default:v9.9.9'
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The issue with `tanzu plugin list` command not showing output when a specific context has issues has been fixed. The command will now display the available plugins regardless of any context-related issues.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
