### PR TITLE
Add changes to ignore the `tanzu pinniped-auth` command for EULA and CEIP prompts

### DIFF
--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -23,8 +23,6 @@ import (
 	"github.com/vmware-tanzu/tanzu-cli/pkg/pluginsupplier"
 )
 
-const cmdNameSet = "set"
-
 // NewRootCmd creates a root command.
 func NewRootCmd() (*cobra.Command, error) {
 	var rootCmd = newRootCmd()
@@ -118,31 +116,44 @@ func newRootCmd() *cobra.Command {
 		// Flag parsing must be deactivated because the root plugin won't know about all flags.
 		DisableFlagParsing: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			// Prompt user for EULA and CEIP agreement if necessary, except when
-			//   - performing shell completion (The shell completion setup is not interactive,
-			//     so it should not trigger a prompt)
-			//   - 'tanzu version'(common first command to run),
-			//   - 'config set' (would be a chicken and egg issue if user tries to set CEIP configuration
-			//      using "tanzu config set env.TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER yes")
-			//   - 'config eula xxx', 'ceip set' (auto prompting when running these commands is confusing)
-			if cmd.Name() != cobra.ShellCompRequestCmd && cmd.Name() != completionCmd.Name() &&
-				cmd.Name() != newVersionCmd().Name() &&
-				!(cmd.Name() == cmdNameSet && cmd.Parent().Name() == configCmd.Name()) {
-				if !(cmd.Parent().Name() == newEULACmd().Name()) &&
-					!(cmd.Name() == cmdNameSet && cmd.Parent().Name() == newCEIPParticipationCmd().Name()) {
-					if err := cliconfig.ConfigureEULA(false); err != nil {
-						return err
-					}
+			// Prompt user for EULA and CEIP agreement if necessary, except for
+			skipCommands := []string{
+				// The shell completion setup is not interactive, so it should not trigger a prompt
+				"tanzu __complete",
+				"tanzu completion",
+				// Common first command to run,
+				"tanzu version",
+				// It would be a chicken and egg issue if user tries to set CEIP configuration
+				// using "tanzu config set env.TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER yes"
+				"tanzu config set",
+				// Auto prompting when running these commands is confusing
+				"tanzu config eula",
+				"tanzu ceip-participation set",
+				// This command is being invoked by the kubectl exec binary where the user doesn't
+				// get to see the prompts and the kubectl command execution just gets stuck, and it
+				// is very hard for users to figure out what is going wrong
+				"tanzu pinniped-auth",
+			}
+			skipPrompts := false
+			for _, cmdPath := range skipCommands {
+				if strings.HasPrefix(cmd.CommandPath(), cmdPath) {
+					skipPrompts = true
+					break
+				}
+			}
+			if !skipPrompts {
+				if err := cliconfig.ConfigureEULA(false); err != nil {
+					return err
+				}
 
-					configVal, _ := config.GetEULAStatus()
-					if configVal != config.EULAStatusAccepted {
-						fmt.Fprintf(os.Stderr, "The Tanzu CLI is only usable with reduced functionality until the General Terms are agreed to.\nPlease use `tanzu config eula show` to review the terms, or `tanzu config eula accept` to accept them directly\n")
-						return errors.New("terms not accepted")
-					}
+				configVal, _ := config.GetEULAStatus()
+				if configVal != config.EULAStatusAccepted {
+					fmt.Fprintf(os.Stderr, "The Tanzu CLI is only usable with reduced functionality until the General Terms are agreed to.\nPlease use `tanzu config eula show` to review the terms, or `tanzu config eula accept` to accept them directly\n")
+					return errors.New("terms not accepted")
+				}
 
-					if err := cliconfig.ConfigureCEIPOptIn(); err != nil {
-						return err
-					}
+				if err := cliconfig.ConfigureCEIPOptIn(); err != nil {
+					return err
 				}
 			}
 			return nil


### PR DESCRIPTION
This PR add changes to ignore the "tanzu pinniped-auth" command for EULA and CEIP prompts.

Changes summary:

- Since the "tanzu pinniped-auth" command would be part of kubeconfig generated with pinniped-auth, the kubectl runs the tanzu pinniped-auth login command to get the cluster credentials dynamically. Since it is executed as part of kubectl, EULA and CEIP prompts won't be visible to user, so ignoring these prompts for tanzu pinniped-auth command.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
Ran the kubectl command with pinniped-kubeconfig and the command got stuck forever without the prompt being visible. Later when I exit the command(CTRL+c) i can see the EULA prompt failed

```
❯ kubectl get pods -A --kubeconfig ~/.kube-tanzu/config
[x] : failed to get EULA status: prompt failed: interrupt
Unable to connect to the server: getting credentials: exec: executable tanzu failed with exit code 1
```

With the changes, I ran the same command and it ran successfully 

```
❯ kubectl get pods -A --kubeconfig ~/.kube-tanzu/config
Error from server (Forbidden): pods is forbidden: User "pkalle" cannot list resource "pods" in API group "" at the cluster scope
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
