### PR TITLE
Show the group version when installing from latest

### DIFF
--- a/pkg/command/plugin.go
+++ b/pkg/command/plugin.go
@@ -252,14 +252,15 @@ func newInstallPluginCmd() *cobra.Command {
 					pluginName = args[0]
 				}
 
-				err = pluginmanager.InstallPluginsFromGroup(pluginName, group)
+				groupWithVersion, err := pluginmanager.InstallPluginsFromGroup(pluginName, group)
 				if err != nil {
 					return err
 				}
+
 				if pluginName == cli.AllPlugins {
-					log.Successf("successfully installed all plugins from group '%s'", group)
+					log.Successf("successfully installed all plugins from group '%s'", groupWithVersion)
 				} else {
-					log.Successf("successfully installed '%s' from group '%s'", pluginName, group)
+					log.Successf("successfully installed '%s' from group '%s'", pluginName, groupWithVersion)
 				}
 
 				return nil

--- a/pkg/pluginmanager/manager_test.go
+++ b/pkg/pluginmanager/manager_test.go
@@ -323,33 +323,33 @@ func Test_InstallPluginFromGroup(t *testing.T) {
 	// A local discovery currently does not support groups, but we can
 	// at least do negative testing
 	groupID := "vmware-tkg/default:v2.1.0"
-	err := InstallPluginsFromGroup("cluster", groupID)
+	_, err := InstallPluginsFromGroup("cluster", groupID)
 	assertions.NotNil(err)
 	assertions.Contains(err.Error(), "unable to create group discovery: unknown group discovery source")
 
 	// make sure a poorly formatted group is properly handled
 	groupID = "invalid"
-	err = InstallPluginsFromGroup("cluster", groupID)
+	_, err = InstallPluginsFromGroup("cluster", groupID)
 	assertions.NotNil(err)
 	assertions.Contains(err.Error(), "could not find group")
 
 	groupID = "invalid/withslash"
-	err = InstallPluginsFromGroup("cluster", groupID)
+	_, err = InstallPluginsFromGroup("cluster", groupID)
 	assertions.NotNil(err)
 	assertions.Contains(err.Error(), "could not find group")
 
 	groupID = "vendor-publisher/"
-	err = InstallPluginsFromGroup("cluster", groupID)
+	_, err = InstallPluginsFromGroup("cluster", groupID)
 	assertions.NotNil(err)
 	assertions.Contains(err.Error(), "could not find group")
 
 	groupID = "vendor-/name"
-	err = InstallPluginsFromGroup("cluster", groupID)
+	_, err = InstallPluginsFromGroup("cluster", groupID)
 	assertions.NotNil(err)
 	assertions.Contains(err.Error(), "could not find group")
 
 	groupID = "-publisher/name"
-	err = InstallPluginsFromGroup("cluster", groupID)
+	_, err = InstallPluginsFromGroup("cluster", groupID)
 	assertions.NotNil(err)
 	assertions.Contains(err.Error(), "could not find group")
 }


### PR DESCRIPTION
### What this PR does / why we need it

When the user installs plugins from a group without specifying the group version, the latest version of the group is used.  With this commit, the success or error messages of such an operation include the group version that was used.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

```
# Initialize the CLI
$ make start-test-central-repo
$ tz config set env.TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY localhost:9876/tanzu-cli/plugins/central:small
$ tz config set env.TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST localhost:9876/tanzu-cli/plugins/central:small

# Check the group versions
$ tz plugin group search --show-details
name: vmware-tkg/default
description: Desc for vmware-tkg/default
latest: v9.9.9
versions:
    - v0.0.1
    - v9.9.9

name: vmware-tmc/tmc-user
description: Desc for vmware-tmc/tmc-user
latest: v9.9.9
versions:
    - v0.0.1
    - v9.9.9

# Install from a group without specifying the version
# Notice that the last printout now shows the version of the group
$ tz plugin install --group vmware-tkg/default
[i] Installing plugin 'cluster:v9.9.9' with target 'kubernetes'
[i] Installing plugin 'feature:v9.9.9' with target 'kubernetes'
[i] Installing plugin 'kubernetes-release:v9.9.9' with target 'kubernetes'
[i] Installing plugin 'management-cluster:v9.9.9' with target 'kubernetes'
[i] Installing plugin 'package:v9.9.9' with target 'kubernetes'
[i] Installing plugin 'secret:v9.9.9' with target 'kubernetes'
[i] Installing plugin 'telemetry:v9.9.9' with target 'kubernetes'
[ok] successfully installed all plugins from group 'vmware-tkg/default:v9.9.9'

# Same thing as the previous command but using a specific plugin
$ tz plugin install --group vmware-tkg/default secret
[i] Installing plugin 'secret:v9.9.9' with target 'kubernetes'
[ok] successfully installed 'secret' from group 'vmware-tkg/default:v9.9.9'

# Make sure the printout is still correct when the user specifies the group version
$ tz plugin install --group vmware-tkg/default:v0.0.1
[i] Installing plugin 'cluster:v0.0.1' with target 'kubernetes'
[i] Installing plugin 'feature:v0.0.1' with target 'kubernetes'
[i] Installing plugin 'kubernetes-release:v0.0.1' with target 'kubernetes'
[i] Installing plugin 'management-cluster:v0.0.1' with target 'kubernetes'
[i] Installing plugin 'package:v0.0.1' with target 'kubernetes'
[i] Installing plugin 'secret:v0.0.1' with target 'kubernetes'
[i] Installing plugin 'telemetry:v0.0.1' with target 'kubernetes'
[ok] successfully installed all plugins from group 'vmware-tkg/default:v0.0.1'

$ tz plugin install --group vmware-tkg/default:v0.0.1 secret
[i] Installing plugin 'secret:v0.0.1' with target 'kubernetes'
[ok] successfully installed 'secret' from group 'vmware-tkg/default:v0.0.1'

# Notice the error message now contains the group version
$ tz plugin install --group vmware-tkg/default invalid
[x] : plugin 'invalid' is not part of the group 'vmware-tkg/default:v9.9.9'

# Make sure the printout is still correct when the user specifies the group version
$ tz plugin install --group vmware-tkg/default:v0.0.1 invalid
[x] : plugin 'invalid' is not part of the group 'vmware-tkg/default:v0.0.1'

# Setup a repo that has non-mandatory plugins in a group
$ tz config set env.TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest
$ tz plugin group search --name vmware-tkg/default
  GROUP               DESCRIPTION      LATEST
  vmware-tkg/default  Plugins for TKG  v2.1.1

# Notice the error message now contains the group version
$ tz plugin install --group vmware-tkg/default cluster
[i] Reading plugin inventory for "harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest", this will take a few seconds.
[x] : plugin 'cluster' from group 'vmware-tkg/default:v2.1.1' is not mandatory to install
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
When installing plugins from the latest version of a group, the group version used will be printed to the user.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
