### PR TITLE
Add printouts about plugins being downloaded for "plugin download-bundle"

### DIFF
--- a/pkg/airgapped/plugin_bundle_download.go
+++ b/pkg/airgapped/plugin_bundle_download.go
@@ -120,6 +120,11 @@ func (o *DownloadPluginBundleOptions) getSelectedPluginInfo() ([]*plugininventor
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "unable to read all plugins from database")
 		}
+		if len(selectedPluginEntries) == 1 {
+			log.Infof("will be downloading the one plugin from: %s", o.PluginInventoryImage)
+		} else {
+			log.Infof("will be downloading the %d plugins from: %s", len(selectedPluginEntries), o.PluginInventoryImage)
+		}
 	} else {
 		// If groups were provided as argument select only provided plugin groups and
 		// plugins available from the specified plugin groups
@@ -161,6 +166,7 @@ func (o *DownloadPluginBundleOptions) getAllPluginGroupsAndPluginEntriesFromPlug
 
 	var allPluginEntries []*plugininventory.PluginInventoryEntry
 	for _, pg := range pluginGroups {
+		var groupPluginsCount int
 		for _, plugins := range pg.Versions {
 			for _, p := range plugins {
 				pif := &plugininventory.PluginInventoryFilter{
@@ -174,7 +180,14 @@ func (o *DownloadPluginBundleOptions) getAllPluginGroupsAndPluginEntriesFromPlug
 					return nil, nil, errors.Wrapf(err, "unable to get plugins in plugin group %v", plugininventory.PluginGroupToID(pg))
 				}
 				allPluginEntries = append(allPluginEntries, pluginEntries...)
+				groupPluginsCount += len(pluginEntries)
 			}
+		}
+		groupIDWithVersion := fmt.Sprintf("%s:%s", plugininventory.PluginGroupToID(pg), pg.RecommendedVersion)
+		if groupPluginsCount == 1 {
+			log.Infof("will be downloading the one plugin from group: %s", groupIDWithVersion)
+		} else {
+			log.Infof("will be downloading the %d plugins from group: %s", groupPluginsCount, groupIDWithVersion)
 		}
 	}
 	return pluginGroups, allPluginEntries, nil


### PR DESCRIPTION
### What this PR does / why we need it

For the "plugin download-bundle" this commit adds printouts specifying the number of plugins that will be downloaded, and if specified, from which group:version.

This simply aims to improve the user experience we setting up an airgapped environment.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

```
# Initialize the CLI
$ make start-test-central-repo
$ tz config set env.TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST localhost:9876/tanzu-cli/plugins/central:small
$ tz config set env.TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY localhost:9876/tanzu-cli/plugins/central:small

# Download all plugins from a repo
# Notice the new printout "will be downloading all the 27 plugins from:..."
$ tz plugin download-bundle --image localhost:9876/tanzu-cli/plugins/central:small --to-tar plugin_bundle.tar
[!] Skipping the plugins discovery image signature verification for "localhost:9876/tanzu-cli/plugins/central:small"

[i] will be downloading all the 27 plugins from: localhost:9876/tanzu-cli/plugins/central:small
[i] downloading image "localhost:9876/tanzu-cli/plugins/central:small"
[i] copy | exporting 2 images...
[...]

# Download plugins from a specific group without specifying the version
# Notice the new printout, which includes the version: 
# "will be downloading the 7 plugins from group: vmware-tkg/default:v9.9.9"
$ tz plugin download-bundle --image localhost:9876/tanzu-cli/plugins/central:small --to-tar plugin_bundle.tar --group vmware-tkg/default
[!] Skipping the plugins discovery image signature verification for "localhost:9876/tanzu-cli/plugins/central:small"

[i] will be downloading the 7 plugins from group: vmware-tkg/default:v9.9.9
[i] downloading image "localhost:9876/tanzu-cli/plugins/central:small"
[...]

# Download plugins from two groups with and without specifying the version
# Notice the new printout, per group, which includes the version: 
$ tz plugin download-bundle --image localhost:9876/tanzu-cli/plugins/central:small --to-tar plugin_bundle.tar --group vmware-tkg/default,vmware-tkg/default:v0.0.1
[!] Skipping the plugins discovery image signature verification for "localhost:9876/tanzu-cli/plugins/central:small"

[i] will be downloading the 7 plugins from group: vmware-tkg/default:v9.9.9
[i] will be downloading the 7 plugins from group: vmware-tkg/default:v0.0.1
[i] downloading image "localhost:9876/tanzu-cli/plugins/central:small"
[i] copy | exporting 2 images...
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The "tanzu plugin download-bundle" command now prints the number of plugins that will be downloaded and using which plugin group version, if applicable.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
