### PR TITLE
Don't download plugin if binary already present

### DIFF
--- a/pkg/pluginmanager/manager.go
+++ b/pkg/pluginmanager/manager.go
@@ -931,14 +931,25 @@ func installOrUpgradePlugin(p *discovery.Discovered, version string, installTest
 		log.Infof("Installing plugin '%v:%v' with target '%v'", p.Name, version, p.Target)
 	}
 
-	binary, err := fetchAndVerifyPlugin(p, version)
-	if err != nil {
-		return err
+	var plugin *cli.PluginInfo
+	if !installTestPlugin {
+		// If we need to install the test plugin we know we are doing a local
+		// installation.  In that case, we don't use the cache as the binary is
+		// already local to the machine.
+		plugin = getPluginFromCache(p, version)
 	}
+	if plugin == nil {
+		binary, err := fetchAndVerifyPlugin(p, version)
+		if err != nil {
+			return err
+		}
 
-	plugin, err := installAndDescribePlugin(p, version, binary)
-	if err != nil {
-		return err
+		plugin, err = installAndDescribePlugin(p, version, binary)
+		if err != nil {
+			return err
+		}
+	} else {
+		log.Infof("Plugin binary for '%v:%v' found in cache", p.Name, version)
 	}
 
 	if installTestPlugin {
@@ -948,6 +959,32 @@ func installOrUpgradePlugin(p *discovery.Discovered, version string, installTest
 	}
 
 	return updatePluginInfoAndInitializePlugin(p, plugin)
+}
+
+func getPluginFromCache(p *discovery.Discovered, version string) *cli.PluginInfo {
+	pluginArtifact, err := p.Distribution.DescribeArtifact(version, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return nil
+	}
+
+	// TODO(khouzam): We should not be checking the presence of the binary directly here,
+	// as it bypasses the plugin catalog abstraction.  Instead, we should ask the plugin
+	// catalog to know if the plugin binary is present already.
+	pluginFileName := fmt.Sprintf("%s_%s_%s", version, pluginArtifact.Digest, p.Target)
+	pluginPath := filepath.Join(common.DefaultPluginRoot, p.Name, pluginFileName)
+
+	if cli.BuildArch().IsWindows() {
+		pluginPath += exe
+	}
+	if _, err := os.Stat(pluginPath); err != nil {
+		return nil
+	}
+
+	plugin, err := describePlugin(p, pluginPath)
+	if err != nil {
+		return nil
+	}
+	return plugin
 }
 
 func fetchAndVerifyPlugin(p *discovery.Discovered, version string) ([]byte, error) {
@@ -989,6 +1026,11 @@ func installAndDescribePlugin(p *discovery.Discovered, version string, binary []
 	if err := os.WriteFile(pluginPath, binary, 0755); err != nil {
 		return nil, errors.Wrap(err, "could not write file")
 	}
+
+	return describePlugin(p, pluginPath)
+}
+
+func describePlugin(p *discovery.Discovered, pluginPath string) (*cli.PluginInfo, error) {
 	bytesInfo, err := execCommand(pluginPath, "info").Output()
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not describe plugin %q", p.Name)


### PR DESCRIPTION
### What this PR does / why we need it

With this PR, when a plugin needs to be installed, the CLI will first check if the plugin binary is already on the machine, and if so, it will re-use it.

The impact of this improvement can be seen in two cases:
1. when installing a plugin as standalone more than once
2. when installing the same version of context-plugins for different contexts

The code for this PR was purposely kept contained in the `manager.go` file in an attempt to reduce the impact of the change.  I posted #323 which a different PR which enhances the plugin catalog to achieve the same result; that second PR is more complex but a better design.  We should discuss what approach to take considering the timeline towards the v0.90.0 release.

In an attempt to include this optimization in the v0.90.0-beta.0 release, we have decided to use this simplified approach.  A cleanup effort along the lines of #323 should be done after the v0.90.0 release.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

```
# Initialize the CLI
$ rm ~/.config/tanzu/config*
$ tz config eula accept && tz ceip set false
[ok] Marking agreement as accepted.
$ tz plugin clean
[ok] successfully cleaned up all plugins
# Download the inventory DB (so it does not count when we compare the installation time in the next commands)
$ tz plugin search >/dev/null
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest", this will take a few seconds.

# Install the builder plugin for the first time.  It it downloaded which takes 10 seconds total.
$ time tz plugin install builder
[i] Installing plugin 'builder:v0.90.0-alpha.2' with target 'global'
[ok] successfully installed 'builder' plugin
/Users/kmarc/git/tanzu-cli/bin/tanzu plugin install builder  1.33s user 0.46s system 16% cpu 10.810 total

# Install the builder plugin again.  This time the binary from the cache is used, which takes 3 seconds.
$ time tz plugin install builder
[i] Installing plugin 'builder:v0.90.0-alpha.2' with target 'global'
[i] Plugin binary for 'builder:v0.90.0-alpha.2' found in cache
[ok] successfully installed 'builder' plugin
/Users/kmarc/git/tanzu-cli/bin/tanzu plugin install builder  0.34s user 0.10s system 14% cpu 2.961 total

# Add another discovery
$ tz config set env.TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest
$ tz plugin search >/dev/null
[i] Reading plugin inventory for "harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest", this will take a few seconds.

# Create a context which will install 3 plugins by downloading .  This takes 61 seconds.
$ time tz context create --name tkg1 --kubecontext tkg1 --kubeconfig /Users/kmarc/.k3d/kubeconfig-tkg1.yaml
[ok] successfully created a kubernetes context using the kubeconfig /Users/kmarc/.k3d/kubeconfig-tkg1.yaml
[i] Checking for required plugins...
[i] Installing plugin 'cluster:v0.28.0' with target 'kubernetes'
[i] Installing plugin 'feature:v0.28.0' with target 'kubernetes'
[i] Installing plugin 'kubernetes-release:v0.28.0' with target 'kubernetes'
[i] Successfully installed all required plugins
/Users/kmarc/git/tanzu-cli/bin/tanzu context create --name tkg1 --kubecontext  8.54s user 3.12s system 18% cpu 1:01.52 total

# Create a new context that will install the exact same 3 plugins.
# With this PR the three cached binaries are used, which takes 15 seconds only.
$ time tz context create --name tkg1-1 --kubecontext tkg1 --kubeconfig /Users/kmarc/.k3d/kubeconfig-tkg1.yaml
[ok] successfully created a kubernetes context using the kubeconfig /Users/kmarc/.k3d/kubeconfig-tkg1.yaml
[i] Checking for required plugins...
[i] Installing plugin 'cluster:v0.28.0' with target 'kubernetes'
[i] Plugin binary for 'cluster:v0.28.0' found in cache
[i] Installing plugin 'feature:v0.28.0' with target 'kubernetes'
[i] Plugin binary for 'feature:v0.28.0' found in cache
[i] Installing plugin 'kubernetes-release:v0.28.0' with target 'kubernetes'
[i] Plugin binary for 'kubernetes-release:v0.28.0' found in cache
[i] Successfully installed all required plugins
/Users/kmarc/git/tanzu-cli/bin/tanzu context create --name tkg1-1  tkg1    0.92s user 0.43s system 8% cpu 15.485 total

# Delete the builder plugin (this does not delete the binary from the cache)
$ tz plugin delete builder
Deleting Plugin 'builder' for target 'global'. Are you sure? [y/N]: y
[ok] successfully deleted plugin 'builder'
$ tz builder
[x] : unknown command "builder" for "tanzu"

# Install the builder plugin again and see the cache being used.
$ time tz plugin install builder
[i] Installing plugin 'builder:v0.90.0-alpha.2' with target 'global'
[i] Plugin binary for 'builder:v0.90.0-alpha.2' found in cache
[ok] successfully installed 'builder' plugin
/Users/kmarc/git/tanzu-cli/bin/tanzu plugin install builder  0.40s user 0.14s system 7% cpu 6.825 total
# Verify the plugin
$ tz builder info
{"name":"builder","description":"Build Tanzu components","target":"global","version":"v0.90.0-alpha.2","buildSHA":"2735d8b7","digest":"","group":"Admin","docURL":"","completionType":0,"pluginRuntimeVersion":"v0.90.0-alpha.2"}

# A plugin clean deletes all the plugin binaries
$ tz plugin clean
[ok] successfully cleaned up all plugins

# Install the builder plugin and see that the cache is not being used (no printout)
$ tz plugin install builder
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Reading plugin inventory for "harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Installing plugin 'builder:v0.90.0-alpha.2' with target 'global'
[ok] successfully installed 'builder' plugin
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The CLI first checks if a plugin binary is already in the cache before downloading it.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
