### PR TITLE
take 2: Don't download plugin if binary already present

### DIFF
--- a/pkg/catalog/catalog_types.go
+++ b/pkg/catalog/catalog_types.go
@@ -41,8 +41,8 @@ type Catalog struct {
 
 	// IndexByPath of PluginInfos for all installed plugins by installation path.
 	IndexByPath map[string]cli.PluginInfo `json:"indexByPath,omitempty" yaml:"indexByPath,omitempty"`
-	// IndeByName of all plugin installation paths by name.
-	IndexByName map[string][]string `json:"indexByName,omitempty" yaml:"indexByName,omitempty"`
+	// IndexByVersionName of all plugin installation paths by name.
+	IndexByVersionName map[string]string `json:"indexByVersionName,omitempty" yaml:"indexByVersionName,omitempty"`
 	// StandAlonePlugins is a set of stand-alone plugin installations aggregated across all context types.
 	// Note: Shall be reduced to only those stand-alone plugins that are common to all context types.
 	StandAlonePlugins PluginAssociation `json:"standAlonePlugins,omitempty" yaml:"standAlonePlugins,omitempty"`


### PR DESCRIPTION
This is a better design of #322 but it introduces more risk.

### What this PR does / why we need it

With this PR, when a plugin needs to be installed, the CLI will first check if the plugin binary is already on the machine, and if so, it will re-use it.

The impact of this improvement can be seen in two cases:
1. when installing a plugin as standalone more than once
1. when installing the same version of context-plugins for different contexts

The PR changes the catalog cache in b doing the following:
WILL BE ADDED LATER

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

```
# Initialize the CLI
$ rm ~/.config/tanzu/config*
$ tz config eula accept && tz ceip set false
[ok] Marking agreement as accepted.
$ tz plugin clean
[ok] successfully cleaned up all plugins
# Download the inventory DB (so it does not count when we compare the installation time in the next commands)
$ tz plugin search >/dev/null
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Reading plugin inventory for "harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest", this will take a few seconds.

# Install the builder plugin for the first time.  It it downloaded which takes 15 seconds total.
$ time tz plugin install builder
[i] Installing plugin 'builder:v0.90.0-alpha.2' with target 'global'
[ok] successfully installed 'builder' plugin
/Users/kmarc/git/tanzu-cli/bin/tanzu plugin install builder  1.41s user 0.46s system 12% cpu 14.667 total

# Install the builder plugin again.  This time the binary from the cache is used, which takes 5 seconds.
$ time tz plugin install builder
[i] Installing plugin 'builder:v0.90.0-alpha.2' with target 'global'
[i] Plugin binary for 'builder:v0.90.0-alpha.2' found in cache
[ok] successfully installed 'builder' plugin
/Users/kmarc/git/tanzu-cli/bin/tanzu plugin install builder  0.32s user 0.10s system 8% cpu 4.698 total

# Create a context which will install 3 plugins by downloading .  This takes 62 seconds.
$ time tz context create --name tkg1 --kubecontext tkg1 --kubeconfig /Users/kmarc/.k3d/kubeconfig-tkg1.yaml
[ok] successfully created a kubernetes context using the kubeconfig /Users/kmarc/.k3d/kubeconfig-tkg1.yaml
[i] Checking for required plugins...
[i] Installing plugin 'cluster:v0.28.0' with target 'kubernetes'
[i] Installing plugin 'feature:v0.28.0' with target 'kubernetes'
[i] Installing plugin 'kubernetes-release:v0.28.0' with target 'kubernetes'
[i] Successfully installed all required plugins
/Users/kmarc/git/tanzu-cli/bin/tanzu context create --name tkg1 --kubecontext  8.43s user 3.10s system 18% cpu 1:02.37 total

# Create a new context that will install the exact same 3 plugins.
# With this PR the three cached binaries are used, which takes 21 seconds only.
$ time tz context create --name tkg1-1 --kubecontext tkg1 --kubeconfig /Users/kmarc/.k3d/kubeconfig-tkg1.yaml
[ok] successfully created a kubernetes context using the kubeconfig /Users/kmarc/.k3d/kubeconfig-tkg1.yaml
[i] Checking for required plugins...
[i] Installing plugin 'cluster:v0.28.0' with target 'kubernetes'
[i] Plugin binary for 'cluster:v0.28.0' found in cache
[i] Installing plugin 'feature:v0.28.0' with target 'kubernetes'
[i] Plugin binary for 'feature:v0.28.0' found in cache
[i] Installing plugin 'kubernetes-release:v0.28.0' with target 'kubernetes'
[i] Plugin binary for 'kubernetes-release:v0.28.0' found in cache
[i] Successfully installed all required plugins
/Users/kmarc/git/tanzu-cli/bin/tanzu context create --name tkg1-1  tkg1    0.69s user 0.31s system 4% cpu 21.268 total

# Delete the builder plugin (this does not delete the binary from the cache)
$ tz plugin delete builder
Deleting Plugin 'builder' for target 'global'. Are you sure? [y/N]: y
[ok] successfully deleted plugin 'builder'
$ tz builder
[x] : unknown command "builder" for "tanzu"

# Install the builder plugin again and see the cache being used.
$ time tz plugin install builder
[i] Installing plugin 'builder:v0.90.0-alpha.2' with target 'global'
[i] Plugin binary for 'builder:v0.90.0-alpha.2' found in cache
[ok] successfully installed 'builder' plugin
/Users/kmarc/git/tanzu-cli/bin/tanzu plugin install builder  0.37s user 0.11s system 6% cpu 7.015 total
# Verify the plugin
$ tz builder info
{"name":"builder","description":"Build Tanzu components","target":"global","version":"v0.90.0-alpha.2","buildSHA":"2735d8b7","digest":"","group":"Admin","docURL":"","completionType":0,"pluginRuntimeVersion":"v0.90.0-alpha.2"}

# A plugin clean deletes all the plugin binaries
$ tz plugin clean
[ok] successfully cleaned up all plugins

# Install the builder plugin and see that the cache is not being used (no printout)
$ time tz plugin install builder
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Reading plugin inventory for "harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Installing plugin 'builder:v0.90.0-alpha.2' with target 'global'
[ok] successfully installed 'builder' plugin
/Users/kmarc/git/tanzu-cli/bin/tanzu plugin install builder  1.50s user 0.53s system 6% cpu 31.066 total

# Install the builder plugin again using the cache
$ time tz plugin install builder
[i] Installing plugin 'builder:v0.90.0-alpha.2' with target 'global'
[i] Plugin binary for 'builder:v0.90.0-alpha.2' found in cache
[ok] successfully installed 'builder' plugin
/Users/kmarc/git/tanzu-cli/bin/tanzu plugin install builder  0.37s user 0.12s system 5% cpu 9.257 total```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
