### PR TITLE
Remove custom key used for cosign verification

### DIFF
--- a/pkg/cosignhelper/cosignverify.go
+++ b/pkg/cosignhelper/cosignverify.go
@@ -79,7 +79,7 @@ func (vo *CosignVerifyOptions) Verify(ctx context.Context, images []string) erro
 		}
 
 	default:
-		for _, raw := range [][]byte{tanzuCLIPluginDBImageSignPublicKey, tanzuCLIPluginDBImageSignPublicKeyOfficial} {
+		for _, raw := range [][]byte{tanzuCLIPluginDBImageSignPublicKeyOfficial} {
 			// PEM encoded file.
 			key, err := cryptoutils.UnmarshalPEMToPublicKey(raw)
 			if err != nil {

--- a/pkg/cosignhelper/tanzu_cli_cert.go
+++ b/pkg/cosignhelper/tanzu_cli_cert.go
@@ -3,13 +3,6 @@
 
 package cosignhelper
 
-var tanzuCLIPluginDBImageSignPublicKey = []byte(`
------BEGIN PUBLIC KEY-----
-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEAqmPz99XIt7P8OG5v9fmUjcCx0AI
-HZPkw/YmuDeV9ki0wT6USut6OcOml9pku+x3Np9eZD30TMlzRTbjdbM8kQ==
------END PUBLIC KEY-----
-`)
-
 var tanzuCLIPluginDBImageSignPublicKeyOfficial = []byte(`
 -----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtDdBg1A2wJQ4IH7PP9Ke3IjyT2kO


### PR DESCRIPTION
### What this PR does / why we need it

- Before this change, Tanzu CLI uses the `tanzuCLIPluginDBImageSignPublicKeyOfficial` and `tanzuCLIPluginDBImageSignPublicKey` keys for cosign verifications.

- `tanzuCLIPluginDBImageSignPublicKey` was used for alpha and beta releases where a custom private key was used to sign the images. We no longer need to use a custom key for cosign verification and we should just use the official key for verification.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
None
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
