### PR TITLE
Remove logged in status from usage info

### DIFF
--- a/pkg/cli/usage.go
+++ b/pkg/cli/usage.go
@@ -50,25 +50,12 @@ func (u *MainUsage) GenerateDescriptor(c *cobra.Command, w io.Writer) error {
 		cmdMap[group] = g
 	}
 
-	serverString := "Not logged in"
-
-	// TODO(vuil): Re-add server endpoint access.
-	//nolint
-	/*
-		s, err := config.GetCurrentServer()
-		if err == nil {
-			serverString = fmt.Sprintf("Logged in to %s", component.Underline(s.Name))
-		}
-	*/
-
 	d := struct {
 		*cobra.Command
-		CmdMap       CmdMap
-		ServerString string
+		CmdMap CmdMap
 	}{
 		c,
 		cmdMap,
-		serverString,
 	}
 
 	t := template.Must(template.New("usage").Funcs(TemplateFuncs).Parse(u.Template()))
@@ -96,9 +83,7 @@ func (u *MainUsage) Template() string {
 {{ bold "Flags:" }}
 {{.LocalFlags.FlagUsages  | trimTrailingWhitespaces}}
 
-Use "{{.CommandPath}} [command] --help" for more information about a command. {{ if ne .ServerString "" }}
-
-{{ .ServerString }}{{end}}
+Use "{{.CommandPath}} [command] --help" for more information about a command.
 `
 }
 


### PR DESCRIPTION
### What this PR does / why we need it
- Remove login info from the usage text

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Before the fix:
```
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main)> tanzu
Usage:
  tanzu [command]

Available command groups:

  Admin
    builder                 Build Tanzu components

  Build
    accelerator             Manage accelerators in a Kubernetes cluster

  System
    ceip-participation      Manage VMware's Customer Experience Improvement Program (CEIP) Participation (subject to change)
    completion              Output shell completion code
    config                  Configuration for the CLI
    context                 Configure and manage contexts for the Tanzu CLI
    init                    Initialize the CLI
    login                   Login to the platform
    plugin                  Manage CLI plugins
    version                 Version information

  Target
    kubernetes              Tanzu CLI plugins that target a Kubernetes cluster
    mission-control         Tanzu CLI plugins that target a Tanzu Mission Control endpoint


Flags:
  -h, --help   help for tanzu

Use "tanzu [command] --help" for more information about a command.

Not logged in

```

After the fix:

```
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main)> tanzu
Usage:
  tanzu [command]

Available command groups:

  Admin
    builder                 Build Tanzu components

  Build
    accelerator             Manage accelerators in a Kubernetes cluster

  System
    ceip-participation      Manage VMware's Customer Experience Improvement Program (CEIP) Participation (subject to change)
    completion              Output shell completion code
    config                  Configuration for the CLI
    context                 Configure and manage contexts for the Tanzu CLI
    init                    Initialize the CLI
    login                   Login to the platform
    plugin                  Manage CLI plugins
    version                 Version information

  Target
    kubernetes              Tanzu CLI plugins that target a Kubernetes cluster
    mission-control         Tanzu CLI plugins that target a Tanzu Mission Control endpoint


Flags:
  -h, --help   help for tanzu

Use "tanzu [command] --help" for more information about a command.

```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
log in status is not displayed in the tanzu usage since login command is deprecated use tanzu context
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
