### PR TITLE
Update the tanzu config init help text to include default feature flags

### DIFF
--- a/pkg/command/config.go
+++ b/pkg/command/config.go
@@ -208,7 +208,7 @@ func setEdition(cfg *configtypes.ClientConfig, edition string) error {
 var initConfigCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize config with defaults",
-	Long:  "Initialize config with defaults including plugin specific defaults for all active and installed plugins",
+	Long:  "Initialize config with defaults including plugin specific defaults such as default feature flags for all active and installed plugins",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Acquire tanzu config lock
 		configlib.AcquireTanzuConfigLock()


### PR DESCRIPTION
### What this PR does / why we need it
- Update the tanzu config init help text to include default feature flags

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
Before the fix:
```
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main)> tanzu config init --help
Initialize config with defaults including plugin specific defaults for all active and installed plugins

Usage:
tanzu config init [flags]

Flags:
  -h, --help   help for init

```
After the fix:

```
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bugfix/update_config_init_help_text)> tanzu config init --help
Initialize config with defaults including plugin specific defaults such as default feature flags for all active and installed plugins

Usage:
tanzu config init [flags]

Flags:
  -h, --help   help for init

```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
