### PR TITLE
UX: Plugin commands help message updated

### DIFF
--- a/pkg/command/plugin.go
+++ b/pkg/command/plugin.go
@@ -42,6 +42,7 @@ const (
 	invalidTargetMsg                = "invalid target specified. Please specify a correct value for the `--target/-t` flag from '" + common.TargetList + "'"
 	errorWhileDiscoveringPlugins    = "there was an error while discovering plugins, error information: '%v'"
 	errorWhileGettingContextPlugins = "there was an error while getting installed context plugins, error information: '%v'"
+	pluginNameCaps                  = "PLUGIN_NAME"
 )
 
 func newPluginCmd() *cobra.Command {
@@ -204,7 +205,7 @@ func newListPluginCmd() *cobra.Command {
 
 func newDescribePluginCmd() *cobra.Command {
 	var describeCmd = &cobra.Command{
-		Use:   "describe [name]",
+		Use:   "describe " + pluginNameCaps,
 		Short: "Describe a plugin",
 		Long:  "Displays detailed information for a plugin",
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
@@ -234,7 +235,7 @@ func newDescribePluginCmd() *cobra.Command {
 
 func newInstallPluginCmd() *cobra.Command {
 	var installCmd = &cobra.Command{
-		Use:   "install [name]",
+		Use:   "install [" + pluginNameCaps + "]",
 		Short: "Install a plugin",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -386,7 +387,7 @@ func legacyPluginInstall(cmd *cobra.Command, args []string) error {
 
 func newUpgradePluginCmd() *cobra.Command {
 	var upgradeCmd = &cobra.Command{
-		Use:   "upgrade [name]",
+		Use:   "upgrade " + pluginNameCaps,
 		Short: "Upgrade a plugin",
 		Long:  "Installs the latest version available for the specified plugin",
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
@@ -425,7 +426,7 @@ func newUpgradePluginCmd() *cobra.Command {
 
 func newDeletePluginCmd() *cobra.Command {
 	var deleteCmd = &cobra.Command{
-		Use:   "delete [name]",
+		Use:   "delete " + pluginNameCaps,
 		Short: "Delete a plugin",
 		Long:  "Uninstalls the specified plugin",
 		RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/test/e2e/framework/framework_constants.go
+++ b/test/e2e/framework/framework_constants.go
@@ -49,6 +49,7 @@ const (
 	pluginSyncCmd                       = "%s plugin sync"
 	PluginDownloadBundleCmd             = "%s plugin download-bundle"
 	PluginUploadBundleCmd               = "%s plugin upload-bundle"
+	PluginCmdWithOptions                = "%s plugin "
 	JSONOutput                          = " -o json"
 	TestPluginsPrefix                   = "test-plugin-"
 	PluginSubCommand                    = "%s %s"

--- a/test/e2e/framework/plugin_lifecycle_operations.go
+++ b/test/e2e/framework/plugin_lifecycle_operations.go
@@ -39,6 +39,8 @@ type PluginBasicOps interface {
 	ExecuteSubCommand(pluginWithSubCommand string, opts ...E2EOption) (string, error)
 	// CleanPlugins executes the plugin clean command to delete all existing plugins
 	CleanPlugins(opts ...E2EOption) error
+	// RunPluginCmd runs plugin command with provided options
+	RunPluginCmd(options string, opts ...E2EOption) (string, string, error)
 }
 
 // PluginSourceOps helps 'plugin source' commands
@@ -296,6 +298,19 @@ func (po *pluginCmdOps) CleanPlugins(opts ...E2EOption) error {
 		log.Errorf(ErrorLogForCommandWithErrStdErrAndStdOut, CleanPluginsCmd, err.Error(), stdErr.String(), out.String())
 	}
 	return err
+}
+
+func (po *pluginCmdOps) RunPluginCmd(options string, opts ...E2EOption) (string, string, error) {
+	cmd := PluginCmdWithOptions
+	if options != "" {
+		cmd += options
+	}
+	stdOut, stdErr, err := po.cmdExe.TanzuCmdExec(cmd, opts...)
+	if err != nil {
+		log.Errorf(ErrorLogForCommandWithErrStdErrAndStdOut, CleanPluginsCmd, err.Error(), stdErr.String(), stdOut.String())
+		return stdOut.String(), stdErr.String(), nil
+	}
+	return stdOut.String(), stdErr.String(), nil
 }
 
 func (po *pluginCmdOps) DownloadPluginBundle(image string, groups []string, toTar string, opts ...E2EOption) error {

--- a/test/e2e/plugin_lifecycle/plugin_lifecycle_test.go
+++ b/test/e2e/plugin_lifecycle/plugin_lifecycle_test.go
@@ -209,4 +209,36 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-lifecycle]", func(
 			}
 		})
 	})
+
+	// use case: test plugin commands help message
+	// a. plugin install help message
+	// b. plugin describe help message
+	// c. plugin upgrade help message
+	// d. plugin delete help message
+	Context("plugin use cases: negative test cases for plugin install and plugin delete commands", func() {
+		// Test case: a. plugin install help message
+		It("tanzu plugin install help message", func() {
+			out, _, err := tf.PluginCmd.RunPluginCmd("install -h")
+			Expect(err).To(BeNil())
+			Expect(out).To(ContainSubstring("tanzu plugin install [PLUGIN_NAME] [flags]"))
+		})
+		// Test case: b. plugin describe help message
+		It("tanzu plugin describe help message", func() {
+			out, _, err := tf.PluginCmd.RunPluginCmd("describe -h")
+			Expect(err).To(BeNil())
+			Expect(out).To(ContainSubstring("tanzu plugin describe PLUGIN_NAME [flags]"))
+		})
+		// Test case: c. plugin upgrade help message
+		It("tanzu plugin upgrade help message", func() {
+			out, _, err := tf.PluginCmd.RunPluginCmd("upgrade -h")
+			Expect(err).To(BeNil())
+			Expect(out).To(ContainSubstring("tanzu plugin upgrade PLUGIN_NAME [flags]"))
+		})
+		// Test case: d. plugin delete help message
+		It("tanzu plugin delete help message", func() {
+			out, _, err := tf.PluginCmd.RunPluginCmd("delete -h")
+			Expect(err).To(BeNil())
+			Expect(out).To(ContainSubstring("tanzu plugin delete PLUGIN_NAME [flags]"))
+		})
+	})
 })


### PR DESCRIPTION
### What this PR does / why we need it

This PR fixes the CLI UX help message for the plugin sub-commands. Before this fix, the mandatory plugin name was referred to as [name], which typically indicates an option input parameter. As part of this fix, the help message for the mandatory plugin name has been updated to PLUGIN_NAME (a qualified string in capital letters, without square brackets). 

This fix applies to the following commands:
`tanzu plugin describe`
`tanzu plugin install`
`tanzu plugin upgrade`
`tanzu plugin delete`

### Which issue(s) this PR fixes
1. E2E test cases have been added as part of this PR to validate the plugin commands' help message.
2. Manual testing has been conducted, and the following is the output:

**Before the fix, help message for the plugin install/describe/upgrade/delete commands:**
```
❯ to plugin describe -h
Displays detailed information for a plugin

Usage:
tanzu plugin describe [name] [flags]

Flags:
  -h, --help            help for describe
  -o, --output string   Output format (yaml|json|table)
  -t, --target string   target of the plugin (kubernetes[k8s]/mission-control[tmc]/global)
❯ to plugin install -h
Install a specific plugin by name or specify all to install all plugins of a group

Usage:
tanzu plugin install [name] [flags]

Examples:

    # Install all plugins of the vmware-tkg/default plugin group version v2.1.0
    tanzu plugin install --group vmware-tkg/default:v2.1.0

    # Install all plugins of the latest version of the vmware-tkg/default plugin group
    tanzu plugin install --group vmware-tkg/default

    # Install the latest version of plugin "myPlugin"
	# If the plugin exists for more than one target, an error will be thrown
    tanzu plugin install myPlugin

    # Install the latest version of plugin "myPlugin" for target kubernetes
    tanzu plugin install myPlugin --target k8s

    # Install version v1.0.0 of plugin "myPlugin"
    tanzu plugin install myPlugin --version v1.0.0

Flags:
      --group string     install the plugins specified by a plugin-group version
  -h, --help             help for install
  -t, --target string    target of the plugin (kubernetes[k8s]/mission-control[tmc]/global)
  -v, --version string   version of the plugin (default "latest")
❯ to plugin upgrade -h
Installs the latest version available for the specified plugin

Usage:
tanzu plugin upgrade [name] [flags]

Flags:
  -h, --help            help for upgrade
  -t, --target string   target of the plugin (kubernetes[k8s]/mission-control[tmc]/global)
❯ to plugin delete -h
Uninstalls the specified plugin

Usage:
tanzu plugin delete [name] [flags]

Flags:
  -h, --help            help for delete
  -t, --target string   target of the plugin (kubernetes[k8s]/mission-control[tmc]/global)
  -y, --yes             delete the plugin without asking for confirmation
❯
❯
```
**After the fix, help message for the plugin install/describe/upgrade/delete commands::**
```
❯
❯ tf plugin describe -h
Displays detailed information for a plugin

Usage:
tanzu plugin describe PLUGIN_NAME [flags]

Flags:
  -h, --help            help for describe
  -o, --output string   Output format (yaml|json|table)
  -t, --target string   target of the plugin (kubernetes[k8s]/mission-control[tmc]/global)
❯ tf plugin install -h
Install a specific plugin by name or specify all to install all plugins of a group

Usage:
tanzu plugin install PLUGIN_NAME [flags]

Examples:

    # Install all plugins of the vmware-tkg/default plugin group version v2.1.0
    tanzu plugin install --group vmware-tkg/default:v2.1.0

    # Install all plugins of the latest version of the vmware-tkg/default plugin group
    tanzu plugin install --group vmware-tkg/default

    # Install the latest version of plugin "myPlugin"
	# If the plugin exists for more than one target, an error will be thrown
    tanzu plugin install myPlugin

    # Install the latest version of plugin "myPlugin" for target kubernetes
    tanzu plugin install myPlugin --target k8s

    # Install version v1.0.0 of plugin "myPlugin"
    tanzu plugin install myPlugin --version v1.0.0

Flags:
      --group string     install the plugins specified by a plugin-group version
  -h, --help             help for install
  -t, --target string    target of the plugin (kubernetes[k8s]/mission-control[tmc]/global)
  -v, --version string   version of the plugin (default "latest")
❯ tf plugin upgrade -h
Installs the latest version available for the specified plugin

Usage:
tanzu plugin upgrade PLUGIN_NAME [flags]

Flags:
  -h, --help            help for upgrade
  -t, --target string   target of the plugin (kubernetes[k8s]/mission-control[tmc]/global)
❯ tf plugin delete -h
Uninstalls the specified plugin

Usage:
tanzu plugin delete PLUGIN_NAME [flags]

Flags:
  -h, --help            help for delete
  -t, --target string   target of the plugin (kubernetes[k8s]/mission-control[tmc]/global)
  -y, --yes             delete the plugin without asking for confirmation
```
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
