### PR TITLE
Update the deprecation message for login and server command

### DIFF
--- a/pkg/cli/usage.go
+++ b/pkg/cli/usage.go
@@ -35,7 +35,7 @@ func (u *MainUsage) UsageFunc() func(*cobra.Command) error {
 func (u *MainUsage) GenerateDescriptor(c *cobra.Command, w io.Writer) error {
 	cmdMap := CmdMap{}
 	for _, cmd := range c.Commands() {
-		if cmd.Hidden {
+		if cmd.Hidden || cmd.Deprecated != "" {
 			continue
 		}
 		group := cmd.Annotations["group"]

--- a/pkg/command/config.go
+++ b/pkg/command/config.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
-	"github.com/vmware-tanzu/tanzu-plugin-runtime/command"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/component"
 	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
@@ -42,7 +41,9 @@ func init() {
 	)
 	serversCmd.AddCommand(listServersCmd)
 	addDeleteServersCmd()
-	command.DeprecateCommandWithAlternative(serversCmd, "1.2.0", "context")
+	// TODO: Update the plugin-runtime library with the new format and use the library method
+	msg := fmt.Sprintf("this was done in the %q release, it will be removed following the deprecation policy (6 months). Use the %q command instead.\n", "v0.90.0", "context")
+	serversCmd.Deprecated = msg
 }
 
 var unattended bool

--- a/pkg/command/login.go
+++ b/pkg/command/login.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
 
-	"github.com/vmware-tanzu/tanzu-plugin-runtime/command"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/component"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
@@ -57,7 +56,10 @@ func init() {
 	loginCmd.Flags().MarkHidden("staging")     // nolint
 	loginCmd.SetUsageFunc(cli.SubCmdUsageFunc)
 	loginCmd.MarkFlagsMutuallyExclusive("endpoint-ca-certificate", "insecure-skip-tls-verify")
-	command.DeprecateCommandWithAlternative(loginCmd, "1.2.0", "context")
+
+	// TODO: Update the plugin-runtime library with the new format and use the library method
+	msg := fmt.Sprintf("this was done in the %q release, it will be removed following the deprecation policy (6 months). Use the %q command instead.\n", "v0.90.0", "context")
+	loginCmd.Deprecated = msg
 
 	loginCmd.Example = `
 	# Login to TKG management cluster using endpoint


### PR DESCRIPTION
### What this PR does / why we need it

This PR updates the deprecation message for `tanzu login` and `tanzu config server` command. Also the tanzu help usage is updated to not show the deprecated commands

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

ran the help for `tanzu -help`, `tanzu login` and `tanzu config server` commands and verified the deprecation message. All the CI and unit tests passed.

```
# you can observer login command is not shown in the help as it is deprecated
❯ ./bin/tanzu
Usage:
  tanzu [command]

Available command groups:

  Admin
    builder                 Build Tanzu components

  System
    ceip-participation      Manage VMware's Customer Experience Improvement Program (CEIP) Participation (subject to change)
    completion              Output shell completion code
    config                  Configuration for the CLI
    context                 Configure and manage contexts for the Tanzu CLI
    init                    Initialize the CLI
    plugin                  Manage CLI plugins
    version                 Version information

  Target
    kubernetes              Tanzu CLI plugins that target a Kubernetes cluster
    mission-control         Tanzu CLI plugins that target a Tanzu Mission Control endpoint


Flags:
  -h, --help   help for tanzu

Use "tanzu [command] --help" for more information about a command.



❯ ./bin/tanzu config server
Command "server" is deprecated, this was done in "0.90.0" release, it will be removed following the deprecation policy (6 months). Use the "context" command instead.

Configured servers

Usage:
  tanzu config server [command]

Available Commands:
  delete      Delete a server from the config
  list        List servers

Flags:
  -h, --help   help for server

Use "tanzu config server [command] --help" for more information about a command.


❯ ./bin/tanzu login
Command "login" is deprecated, this was done in "0.90.0" release, it will be removed following the deprecation policy (6 months). Use the "context" command instead.

? Select a server  [Use arrows to move, type to filter]
> prem-testnewplugin-login-withInsecureSkipTLS(https://10.92.35.70:6443)
  prem-testnewplugin-login-withcert(https://10.92.35.70:6443)
  tkg-aws-cc-capi115-upg-mc()
  tmc                 (unstable.tmc-dev.cloud.vmware.com:443)
  tmc-sm-main.local-dev.7infra.com:443(tmc-sm-main.local-dev.7infra.com:443)
  tt                  (https://10.92.35.70:6443)
  tt-s                (https://10.206.208.104:6443)

```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
