### PR TITLE
Help message updated for consistency

### DIFF
--- a/pkg/command/cert.go
+++ b/pkg/command/cert.go
@@ -147,7 +147,7 @@ func newAddCertCmd() *cobra.Command {
 
 func newUpdateCertCmd() *cobra.Command {
 	var updateCertCmd = &cobra.Command{
-		Use:   "update [host]",
+		Use:   "update HOST",
 		Short: "Update certificate configuration for a host",
 		Args:  cobra.ExactArgs(1),
 		Example: `
@@ -201,7 +201,7 @@ func newUpdateCertCmd() *cobra.Command {
 
 func newDeleteCertCmd() *cobra.Command {
 	var deleteCertCmd = &cobra.Command{
-		Use:   "delete [host]",
+		Use:   "delete HOST",
 		Short: "Delete certificate configuration for a host",
 		Args:  cobra.ExactArgs(1),
 		Example: `

--- a/pkg/command/discovery_source.go
+++ b/pkg/command/discovery_source.go
@@ -164,7 +164,7 @@ func newAddDiscoverySourceCmd() *cobra.Command {
 
 func newUpdateDiscoverySourceCmd() *cobra.Command {
 	var updateDiscoverySourceCmd = &cobra.Command{
-		Use:   "update [name]",
+		Use:   "update SOURCE_NAME",
 		Short: "Update a discovery source configuration",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -213,7 +213,7 @@ func newUpdateDiscoverySourceCmd() *cobra.Command {
 
 func newDeleteDiscoverySourceCmd() *cobra.Command {
 	var deleteDiscoverySourceCmd = &cobra.Command{
-		Use:   "delete [name]",
+		Use:   "delete SOURCE_NAME",
 		Short: "Delete a discovery source",
 		Args:  cobra.ExactArgs(1),
 		Example: `

--- a/pkg/command/plugin_group.go
+++ b/pkg/command/plugin_group.go
@@ -84,7 +84,7 @@ func newSearchCmd() *cobra.Command {
 
 func newGetCmd() *cobra.Command {
 	var getCmd = &cobra.Command{
-		Use:   "get <group>",
+		Use:   "get GROUP_NAME",
 		Short: "Get the content of the specified plugin-group",
 		Long:  "Get the content of the specified plugin-group.  A plugin-group provides a list of plugin name/version combinations which can be installed in one step.  This command allows to see the list of plugins included in the specified group.",
 		Args:  cobra.ExactArgs(1),


### PR DESCRIPTION
### What this PR does / why we need it

Continue update of help text for other commands that take arguments.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Check the changed help messages
```
$ tz config cert update -h
Update certificate configuration for a host

Usage:
tanzu config cert update HOST [flags]

Examples:

    # Update CA certificate for a host,
    tanzu config cert update test.vmware.com --ca-certificate path/to/ca/ert

    # Update CA certificate for a host:port,
    tanzu config cert update test.vmware.com:5443 --ca-certificate path/to/ca/ert

    # Update whether to skip verifying the certificate while interacting with host
    tanzu config cert update test.vmware.com  --skip-cert-verify true

	# Update whether to allow insecure (http) connection while interacting with host
	tanzu config cert update test.vmware.com  --insecure true

Flags:
      --ca-certificate string     path to the public certificate
  -h, --help                      help for update
      --insecure string           allow the use of http when interacting with the host (true|false)
      --skip-cert-verify string   skip server's TLS certificate verification (true|false)
$ tz config cert delete -h
Delete certificate configuration for a host

Usage:
tanzu config cert delete HOST [flags]

Examples:

    # Delete a certificate for host
    tanzu config cert delete test.vmware.com

    # Delete a certificate for host:port
    tanzu config cert delete test.vmware.com:5443

Flags:
  -h, --help   help for delete
$ tz plugin source update -h
Update a discovery source configuration

Usage:
tanzu plugin source update SOURCE_NAME [flags]

Examples:

    # Update the discovery source for an air-gapped scenario. The URI must be an OCI image.
    tanzu plugin source update default --uri registry.example.com/tanzu/plugin-inventory:latest

Flags:
  -h, --help         help for update
  -u, --uri string   URI for discovery source. The URI must be of an OCI image
$ tz plugin source delete -h
Delete a discovery source

Usage:
tanzu plugin source delete SOURCE_NAME [flags]

Examples:

    # Delete a discovery source
    tanzu plugin discovery delete default

Flags:
  -h, --help   help for delete
$ tz plugin group get -h
Get the content of the specified plugin-group.  A plugin-group provides a list of plugin name/version combinations which can be installed in one step.  This command allows to see the list of plugins included in the specified group.

Usage:
tanzu plugin group get GROUP_NAME [flags]

Flags:
  -h, --help            help for get
  -o, --output string   output format (yaml|json|table)
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
