### PR TITLE
"group get" should only show mandatory plugins

### DIFF
--- a/pkg/command/plugin_group.go
+++ b/pkg/command/plugin_group.go
@@ -22,7 +22,8 @@ import (
 )
 
 var (
-	groupID string
+	groupID          string
+	showNonMandatory bool
 )
 
 func newPluginGroupCmd() *cobra.Command {
@@ -128,6 +129,8 @@ func newGetCmd() *cobra.Command {
 
 	f := getCmd.Flags()
 	f.StringVarP(&outputFormat, "output", "o", "", "output format (yaml|json|table)")
+	f.BoolVarP(&showNonMandatory, "all", "", false, "include the non-mandatory plugins")
+	_ = f.MarkHidden("all")
 
 	return getCmd
 }
@@ -205,7 +208,9 @@ func displayGroupContentAsTable(group *plugininventory.PluginGroup, writer io.Wr
 	_, _ = cyanBold.Println("Plugins in Group: ", cyanBoldItalic.Sprintf("%s:%s", groupID, group.RecommendedVersion))
 
 	for _, plugin := range group.Versions[group.RecommendedVersion] {
-		output.AddRow(plugin.Name, plugin.Target, plugin.Version)
+		if showNonMandatory || plugin.Mandatory {
+			output.AddRow(plugin.Name, plugin.Target, plugin.Version)
+		}
 	}
 	output.Render()
 }
@@ -215,7 +220,9 @@ func displayGroupContentAsList(group *plugininventory.PluginGroup, writer io.Wri
 
 	groupID := fmt.Sprintf("%s:%s", plugininventory.PluginGroupToID(group), group.RecommendedVersion)
 	for _, plugin := range group.Versions[group.RecommendedVersion] {
-		output.AddRow(groupID, plugin.Name, plugin.Target, plugin.Version)
+		if showNonMandatory || plugin.Mandatory {
+			output.AddRow(groupID, plugin.Name, plugin.Target, plugin.Version)
+		}
 	}
 	output.Render()
 }


### PR DESCRIPTION
### What this PR does / why we need it

`tanzu plugin group get` was showing all mandatory and non-mandatory plugins but when we install from a group it only installs mandatory plugins.  This was confusing.

This PR only lists mandatory plugins by default.
The new HIDDEN "--all" flag can be used to show all plugins in the group.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

```
$ tz plugin group get vmware-tkg/default
Plugins in Group:  vmware-tkg/default:v2.2.0
  NAME                TARGET      VERSION
  isolated-cluster    global      v0.29.0
  management-cluster  kubernetes  v0.29.0
  package             kubernetes  v0.29.0
  pinniped-auth       global      v0.29.0
  secret              kubernetes  v0.29.0
  telemetry           kubernetes  v0.29.0
$ tz plugin group get vmware-tkg/default --all
Plugins in Group:  vmware-tkg/default:v2.2.0
  NAME                TARGET      VERSION
  cluster             kubernetes  v0.29.0
  feature             kubernetes  v0.29.0
  isolated-cluster    global      v0.29.0
  kubernetes-release  kubernetes  v0.29.0
  management-cluster  kubernetes  v0.29.0
  package             kubernetes  v0.29.0
  pinniped-auth       global      v0.29.0
  secret              kubernetes  v0.29.0
  telemetry           kubernetes  v0.29.0
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
