### PR TITLE
E2E: Boolean flags must use the `=` format

### DIFF
--- a/test/e2e/framework/cmd_exec_operations.go
+++ b/test/e2e/framework/cmd_exec_operations.go
@@ -76,7 +76,7 @@ func (co *cmdOps) Exec(command string, opts ...E2EOption) (stdOut, stdErr *bytes
 	cmd.Stderr = &stderr
 	err = cmd.Run()
 	if err != nil {
-		return &stdout, &stderr, fmt.Errorf("error while running '%s', stdOut: %s, stdErr: %s, err: %s", command, stdout.String(), stderr.String(), err.Error())
+		return &stdout, &stderr, fmt.Errorf("error while running '%s' (detailed arguments: %q), stdOut: %s, stdErr: %s, err: %s", command, cmdArgs, stdout.String(), stderr.String(), err.Error())
 	}
 	return &stdout, &stderr, err
 }

--- a/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_suite_test.go
+++ b/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_suite_test.go
@@ -43,7 +43,7 @@ const routesFileName = "routes.json"
 const tmcPluginsMockFile = "tmcPluginsMock.json"
 const numberOfPluginsToInstall = 3
 
-const forceCSPFlag = " --force-csp true"
+const forceCSPFlag = "--force-csp=true"
 const tmcConfigFolderName = "tmc"
 const numberOfPluginsSameAsNoOfPluginsInfoMocked = "number of plugins should be same as number of plugins mocked in tmc endpoint response"
 const pluginsInstalledAndMockedShouldBeSame = "plugins being installed and plugins being mocked in tmc endpoint response should be same"


### PR DESCRIPTION
### What this PR does / why we need it

Fix E2E test from TMC

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Let CI run

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
