### PR TITLE
Fix `tanzu plugin upload-bundle` failing on windows because of incorrect image path

### DIFF
--- a/pkg/airgapped/plugin_bundle_upload.go
+++ b/pkg/airgapped/plugin_bundle_upload.go
@@ -37,6 +37,7 @@ func (o *UploadPluginBundleOptions) UploadPluginBundle() error {
 	defer os.RemoveAll(tempDir)
 
 	// Untar the specified plugin bundle to the temp directory
+	log.Infof("extracting %q for processing...", o.Tar)
 	err = tarinator.UnTarinate(tempDir, o.Tar)
 	if err != nil {
 		return errors.Wrap(err, "unable to extract provided file")
@@ -57,7 +58,7 @@ func (o *UploadPluginBundleOptions) UploadPluginBundle() error {
 	// Iterate through all the images and publish them to the remote repository
 	for _, ic := range manifest.ImagesToCopy {
 		imageTar := filepath.Join(pluginBundleDir, ic.SourceTarFilePath)
-		repoImagePath := filepath.Join(o.DestinationRepo, ic.RelativeImagePath)
+		repoImagePath := utils.JoinURL(o.DestinationRepo, ic.RelativeImagePath)
 		log.Infof("---------------------------")
 		log.Infof("uploading image %q", repoImagePath)
 		err = o.ImageProcessor.CopyImageFromTar(imageTar, repoImagePath)
@@ -71,7 +72,7 @@ func (o *UploadPluginBundleOptions) UploadPluginBundle() error {
 	// Publish plugin inventory metadata image after merging inventory metadata
 	log.Infof("publishing plugin inventory metadata image...")
 	bundledPluginInventoryMetadataDBFilePath := filepath.Join(pluginBundleDir, manifest.InventoryMetadataImage.SourceFilePath)
-	pluginInventoryMetadataImageWithTag := filepath.Join(o.DestinationRepo, manifest.InventoryMetadataImage.RelativeImagePathWithTag)
+	pluginInventoryMetadataImageWithTag := utils.JoinURL(o.DestinationRepo, manifest.InventoryMetadataImage.RelativeImagePathWithTag)
 	err = o.mergePluginInventoryMetadata(pluginInventoryMetadataImageWithTag, bundledPluginInventoryMetadataDBFilePath, tempDir)
 	if err != nil {
 		return errors.Wrap(err, "error while merging the plugin inventory metadata database before uploading metadata image")


### PR DESCRIPTION
### What this PR does / why we need it

This was because `filepath.Join` was used to join the repository and the relative path of image instead of joining using utils.JoinURL which does the url join.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #342

### Describe testing done for PR

* Manually built the Windows binary and tested the fix on the Windows machine and it seems to be working as expected.
* Same has been verified on the Mac machine as well after the change to make sure no regression happens there.

```
PS C:\Users\anujc\Downloads> .\tanzu-cli-windows_amd64.exe plugin upload-bundle --tar C:\Users\anujc\Downloads\tanzu-cli-windows-amd64\v0.90.0-rc.0\downloads\bundle_tkg_v2.1.0.tar.gz --to-repo harbor-repo.vmware.com/tanzu_cli/test/v1/
[i] extracting "C:\Users\anujc\Downloads\tanzu-cli-windows-amd64\v0.90.0-rc.0\downloads\bundle_tkg_v2.1.0.tar.gz" for processing...
[i] ---------------------------
[i] uploading image "harbor-repo.vmware.com/tanzu_cli/test/v1/plugin-inventory"
[i] copy | importing 2 images...
.
.
.
[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "harbor-repo.vmware.com/tanzu_cli/test/v1/vmware/tkg/linux/amd64/kubernetes/telemetry"
[i] copy | importing 2 images...

[i] copy |
copy | done uploading images
[i] copy | Tagging images
[i] ---------------------------
[i] uploading image "harbor-repo.vmware.com/tanzu_cli/test/v1/vmware/tkg/windows/amd64/kubernetes/telemetry"
[i] copy | importing 2 images...

6.81 MiB / 6.84 MiB [---------------------------------------------------------------------------->] 99.64% 2.12 MiB p/s
[i] copy |
copy | done uploading images
6.81 MiB / 6.84 MiB [---------------------------------------------------------------------------->] 99.64% 2.12 MiB p/s
[i] copy | Tagging images
[i] ---------------------------
[i] ---------------------------
[i] publishing plugin inventory metadata image...
[i] plugin inventory metadata image "harbor-repo.vmware.com/tanzu_cli/test/v1/plugin-inventory-metadata:latest" is not present. Skipping merging of the plugin inventory metadata
[i] uploading image "harbor-repo.vmware.com/tanzu_cli/test/v1/plugin-inventory-metadata:latest"
[i] ---------------------------
[i] successfully published all plugin images to "harbor-repo.vmware.com/tanzu_cli/test/v1/plugin-inventory:latest"


PS C:\Users\anujc\Downloads>
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix `tanzu plugin upload-bundle` failing on windows because of incorrect image path
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
