### PR TITLE
Hide the CEIP prompt and ceip-participation command

### DIFF
--- a/docs/quickstart/install.md
+++ b/docs/quickstart/install.md
@@ -104,15 +104,11 @@ available in the default central plugin repository.
 Note: to review the Terms and decide again on the acceptance, this same
 prompt can also be explicitly invoked with `tanzu config eula show`.
 
-****Customer Experience Improvement Program (CEIP) Prompt**** :
-The Tanzu CLI prompts the user to accept participation in CEIP or not.
-
 Systems and users (via automation scripts, for instance) that expect
-non-interactive use of the CLI can avoid being prompted with either of the
+non-interactive use of the CLI can avoid being prompted with the
 above by running the following before any other CLI commands:
 
 - `tanzu config eula accept` to accept the EULA.
-- `tanzu ceip-participation set <true/false>` to set the CEIP participation status.
 
 ## Installing and using the Tanzu CLI in internet-restricted environments
 

--- a/pkg/command/ceip_participation.go
+++ b/pkg/command/ceip_participation.go
@@ -35,6 +35,7 @@ func newCEIPParticipationCmd() *cobra.Command {
 		Annotations: map[string]string{
 			"group": string(plugin.SystemCmdGroup),
 		},
+		Hidden: true,
 	}
 	ceipParticipationCmd.SetUsageFunc(cli.SubCmdUsageFunc)
 

--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -160,10 +160,10 @@ func newRootCmd() *cobra.Command {
 					fmt.Fprintf(os.Stderr, "The Tanzu CLI is only usable with reduced functionality until the General Terms are agreed to.\nPlease use `tanzu config eula show` to review the terms, or `tanzu config eula accept` to accept them directly\n")
 					return errors.New("terms not accepted")
 				}
-
-				if err := cliconfig.ConfigureCEIPOptIn(); err != nil {
-					return err
-				}
+				// TODO(prkalle): uncomment when the CEIP implementation is done in future release
+				// if err := cliconfig.ConfigureCEIPOptIn(); err != nil {
+				//	return err
+				// }
 			}
 			return nil
 		},


### PR DESCRIPTION
### What this PR does / why we need it
This PR hides the CEIP prompt and `tanzu ceip-participation` command as the implementation is not complete yet.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #346 

### Describe testing done for PR

Tested with clean config files to verify the ceip prompt wouldn't show up. It only shows EULA prompt and didn't show CEIP prompt as expected
```
❯ ./bin/tanzu plugin search
? You must agree to the VMware General Terms in order to download, install, or
use software from this registry via Tanzu CLI. Acceptance of the VMware General
Terms covers all software installed via the Tanzu CLI during any Session.
“Session” means the period from acceptance until any of the following occurs:
(1) a change to VMware General Terms, (2) a new major release of the Tanzu CLI
is installed, (3) software is accessed in a separate software distribution
registry, or (4) re-acceptance of the General Terms is prompted by VMware.

To view the VMware General Terms, please see https://www.vmware.com/vmware-general-terms.html

Do you agree to the VMware General Terms?
 Yes
  NAME                DESCRIPTION                                                      TARGET           LATEST
  builder             Build Tanzu components                                           global           v0.90.0-alpha.2
```

Checked the `tanzu ` command help and it doesn't show ceip-participation command

```
❯ ./bin/tanzu -h
Usage:
  tanzu [command]

Available command groups:

  Admin
    builder                 Build Tanzu components

  System
    completion              Output shell completion code
    config                  Configuration for the CLI
    context                 Configure and manage contexts for the Tanzu CLI
    init                    Initialize the CLI
    plugin                  Manage CLI plugins
    version                 Version information

  Target
    kubernetes              Tanzu CLI plugins that target a Kubernetes cluster
    mission-control         Tanzu CLI plugins that target a Tanzu Mission Control endpoint


Flags:
  -h, --help   help for tanzu

Use "tanzu [command] --help" for more information about a command.
```


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
