### PR TITLE
Make apt/rpm package builds more configurable

### DIFF
--- a/hack/apt/build_package_repo.sh
+++ b/hack/apt/build_package_repo.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+if [ $(uname) != "Linux" ] || [ -z "$(command -v apt)" ]; then
+   echo "This script must be run on a Linux system that uses the APT package manager"
+   exit 1
+fi
+
+# VERSION should be set when calling this script
+if [ -z "${VERSION}" ]; then
+   echo "\$VERSION must be set before calling this script"
+   exit 1
+fi
+
+# Strip 'v' prefix as an apt package version must start with an integer
+VERSION=${VERSION#v}
+
+BASE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}"); pwd)
+OUTPUT_DIR=${BASE_DIR}/_output
+
+# Install build dependencies
+if ! command -v reprepo &> /dev/null; then
+   apt-get update
+   apt-get install -y reprepro
+fi
+
+# Assumes ${OUTPUT_DIR} is populated from build_package.sh
+
+# Download the SRP-compliant CLI build from github and copy it to the package directory
+for arch in amd64 arm64; do
+   echo "===================================="
+   echo "Building debian package repo for $arch..."
+   echo "===================================="
+
+   # Expects signed file to be present
+   if [ ! -f "${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}.deb" ]; then
+      echo "Not found: ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}.deb"
+      exit 1
+   fi
+
+   # Create repository
+   reprepro -b ${OUTPUT_DIR}/apt includedeb tanzu-cli-jessie ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}.deb
+
+   # Cleanup
+   rm -f ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}.deb
+done
+
+# Global cleanup
+rm -rf ${OUTPUT_DIR}/apt/conf
+rm -rf ${OUTPUT_DIR}/apt/db


### PR DESCRIPTION

### What this PR does / why we need it

This is largely to accomodate the different build setup where the container to run the scripts in are pre-prepped and provided.

- Optionally sign apt repo with gpg key

- apt-package target will attempt to sign repo created using the key id if it is provided via the $GPGKEY env var.

- rpm-package target will attempt to sign repo and artifacts created using the key id if it is provided via the $GPGKEY env var.

- Make os package builder image configurable via the following 3 env vars: {APT,RPM,CHOCO}_BUILDER_IMAGE

- Decompose build_package.sh into it and build_package_repo.sh ... to accomodate out-of-banding signing of deb artifacts. TODO : this might turn out to be unnecessary, so will revisit to to reunify the scripts.

- Accept RPM_SIGNER and DEB_SIGNER env vars These are used in the packaging scripts to invoke signing functionality on package artifacts

- Add *-package-in-docker targets to be used when build is invoked from within the container already.

- Conditionally install package dependencies in rpm/apt build scripts In one use case the container is prepped so the deps do not need to be installed.


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

ensure `make apt-package` and `make rpm-package` continues to work
while continuing to test using pre-prepped containers

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
None
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
