### PR TITLE
[Release-0.90] Fix plugin sync and plugin list not considering updates available state

### DIFF
--- a/pkg/pluginmanager/manager.go
+++ b/pkg/pluginmanager/manager.go
@@ -1205,7 +1205,7 @@ func SyncPlugins() error {
 
 	installed := false
 	for idx := range plugins {
-		if plugins[idx].Status == common.PluginStatusNotInstalled {
+		if plugins[idx].Status == common.PluginStatusNotInstalled || plugins[idx].Status == common.PluginStatusUpdateAvailable {
 			installed = true
 			p := plugins[idx]
 			err = InstallPluginFromContext(p.Name, p.RecommendedVersion, p.Target, p.ContextName)


### PR DESCRIPTION
Cherry-pick: #356

### What this PR does / why we need it
This fixes the bug when context-scoped plugins are already installed and newer version of the same plugins are recommended by the context, running `tanzu plugin sync` does not upgrade the plugins to the latest version and `tanzu plugin list` does not show the updates are available

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
Please check #356
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix `tanzu plugin sync` and `tanzu plugin list` not accounting for the `updates available` state for context-scoped plugins
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
