### PR TITLE
E2E test: Fix tanzu plugin sync and tanzu plugin list not accounting for the updates available state for context-scoped plugins 

### DIFF
--- a/pkg/command/plugin.go
+++ b/pkg/command/plugin.go
@@ -690,7 +690,7 @@ func displayInstalledAndMissingListView(installedStandalonePlugins []cli.PluginI
 			installedStandalonePlugins[index].Description,
 			string(installedStandalonePlugins[index].Target),
 			installedStandalonePlugins[index].Version,
-			common.PluginStatusInstalled,
+			installedStandalonePlugins[index].Status,
 			"", // No context
 		)
 	}
@@ -701,8 +701,8 @@ func displayInstalledAndMissingListView(installedStandalonePlugins []cli.PluginI
 			installedContextPlugins[i].Name,
 			installedContextPlugins[i].Description,
 			string(installedContextPlugins[i].Target),
-			installedContextPlugins[i].RecommendedVersion,
-			common.PluginStatusInstalled,
+			installedContextPlugins[i].InstalledVersion,
+			installedContextPlugins[i].Status,
 			installedContextPlugins[i].ContextName,
 		)
 	}

--- a/test/e2e/framework/framework_constants.go
+++ b/test/e2e/framework/framework_constants.go
@@ -78,10 +78,11 @@ const (
 	CLIE2ETestEnvironment = "TANZU_CLI_E2E_TEST_ENVIRONMENT"
 
 	// General constants
-	True         = "true"
-	Installed    = "installed"
-	NotInstalled = "not installed"
-	JSONOtuput   = "-o json"
+	True            = "true"
+	Installed       = "installed"
+	UpdateAvailable = "update available"
+	NotInstalled    = "not installed"
+	JSONOtuput      = "-o json"
 
 	// Context commands
 	CreateContextWithEndPoint              = "%s context create --endpoint %s %s"

--- a/test/e2e/framework/plugin_lifecycle_operations.go
+++ b/test/e2e/framework/plugin_lifecycle_operations.go
@@ -156,7 +156,7 @@ func (po *pluginCmdOps) ListPluginsForGivenContext(context string, installedOnly
 	for i := range plugins {
 		if plugins[i].Context == context {
 			if installedOnly {
-				if plugins[i].Status == Installed {
+				if plugins[i].Status == Installed || plugins[i].Status == UpdateAvailable {
 					contextSpecificPlugins = append(contextSpecificPlugins, plugins[i])
 				}
 			} else {


### PR DESCRIPTION
### What this PR does / why we need it
- E2E test: Fix tanzu plugin sync and tanzu plugin list not accounting for the updates available state for context-scoped plugins 

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Related to #358

### Describe testing done for PR
- Added E2E tests.

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
None
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
