### PR TITLE
Build plugins for ARM64

### DIFF
--- a/cmd/plugin/builder/helpers/helper.go
+++ b/cmd/plugin/builder/helpers/helper.go
@@ -97,3 +97,14 @@ func GetNumberOfIndividualPluginBinariesFromManifest(pluginManifest *cli.Manifes
 	}
 	return numberOfPluginPackages * len(cli.AllOSArch)
 }
+
+// IsRequiredOSArch returns true if 'osArch' is one of the require OSArch
+// combinations that a plugin must support.
+func IsRequiredOSArch(osArch cli.Arch) bool {
+	for _, requiredOSArch := range cli.MinOSArch {
+		if osArch == requiredOSArch {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/plugin/builder/template/plugintemplates/plugin-tooling.mk.tmpl
+++ b/cmd/plugin/builder/template/plugintemplates/plugin-tooling.mk.tmpl
@@ -23,7 +23,7 @@ PLUGIN_LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/build
 PLUGIN_GO_FLAGS ?=
 
 # Add supported OS-ARCHITECTURE combinations here
-PLUGIN_BUILD_OS_ARCH ?= linux-amd64 windows-amd64 darwin-amd64
+PLUGIN_BUILD_OS_ARCH ?= linux-amd64 windows-amd64 darwin-amd64 darwin-arm64 linux-arm64
 
 # Paths and Directory information
 ROOT_DIR := $(shell git rev-parse --show-toplevel)

--- a/plugin-tooling.mk
+++ b/plugin-tooling.mk
@@ -27,7 +27,7 @@ PLUGIN_LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/build
 PLUGIN_GO_FLAGS ?=
 
 # Add supported OS-ARCHITECTURE combinations here
-PLUGIN_BUILD_OS_ARCH ?= linux-amd64 windows-amd64 darwin-amd64
+PLUGIN_BUILD_OS_ARCH ?= linux-amd64 windows-amd64 darwin-amd64 darwin-arm64 linux-arm64
 
 # Paths and Directory information
 ROOT_DIR := $(shell git rev-parse --show-toplevel)


### PR DESCRIPTION
This is kept as a draft for the moment, to discuss to approach.

### What this PR does / why we need it

This small change starts building the 'builder' and 'test' plugins for ARM64 for both darwin and linux.
At the same time, new plugin projects will also be building for ARM64 by default.

Unlike the AMD64 arch which must be provided by a plugin build, the arm64 one is kept optional.  This is in case some plugins are not able to build for ARM64 for an unexpected reason; in such a case, the plugin developer can remove the two instances of ARM64 from the `plugin-tooling.mk` file.  Later on, we can choose to make the two ARM64 instances mandatory like the AMD64 ones are.

If the ARM64 binaries are found, the `builder` plugin will publish them and include them in the plugin inventory DB.  If they are not present, the `builder` plugin will ignore them with a printout.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Partly #357

### Describe testing done for PR

Building and publish all osarch (including ARM64):

```
$ export PLUGIN_NAME=builder
$ make cross-build-publish-plugins
cd cmd/plugin/builder && go build -o /Users/kmarc/git/tanzu-cli/bin/builder .
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.0.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev'" \
		--goflags "" \
		--os-arch linux_amd64 \
		--match "builder" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-08-01T11:04:29-04:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.0.0-dev, [linux_amd64]
2023-08-01T11:04:29-04:00 [i] 🐭 - building plugin at path "cmd/plugin/builder"
2023-08-01T11:04:31-04:00 [i] 🐭 - $ /usr/local/go/bin/go build -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/linux/amd64/global/builder/v1.0.0-dev/tanzu-builder-linux_amd64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -tags  ./cmd/plugin/builder
2023-08-01T11:04:34-04:00 [i] ========
2023-08-01T11:04:34-04:00 [i] saving plugin group manifest...
2023-08-01T11:04:34-04:00 [ok] successfully built local repository
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.0.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev'" \
		--goflags "" \
		--os-arch windows_amd64 \
		--match "builder" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-08-01T11:04:34-04:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.0.0-dev, [windows_amd64]
2023-08-01T11:04:34-04:00 [i] 🐱 - building plugin at path "cmd/plugin/builder"
2023-08-01T11:04:36-04:00 [i] 🐱 - $ /usr/local/go/bin/go build -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/windows/amd64/global/builder/v1.0.0-dev/tanzu-builder-windows_amd64.exe -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -tags  ./cmd/plugin/builder
2023-08-01T11:04:39-04:00 [i] ========
2023-08-01T11:04:39-04:00 [i] saving plugin group manifest...
2023-08-01T11:04:39-04:00 [ok] successfully built local repository
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.0.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev'" \
		--goflags "" \
		--os-arch darwin_amd64 \
		--match "builder" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-08-01T11:04:39-04:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.0.0-dev, [darwin_amd64]
2023-08-01T11:04:39-04:00 [i] 🐵 - building plugin at path "cmd/plugin/builder"
2023-08-01T11:04:41-04:00 [i] 🐵 - $ /usr/local/go/bin/go build -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/amd64/global/builder/v1.0.0-dev/tanzu-builder-darwin_amd64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -tags  ./cmd/plugin/builder
2023-08-01T11:04:43-04:00 [i] ========
2023-08-01T11:04:43-04:00 [i] saving plugin group manifest...
2023-08-01T11:04:43-04:00 [ok] successfully built local repository
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.0.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev'" \
		--goflags "" \
		--os-arch darwin_arm64 \
		--match "builder" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-08-01T11:04:44-04:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.0.0-dev, [darwin_arm64]
2023-08-01T11:04:44-04:00 [i] 🐼 - building plugin at path "cmd/plugin/builder"
2023-08-01T11:04:46-04:00 [i] 🐼 - $ /usr/local/go/bin/go build -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/arm64/global/builder/v1.0.0-dev/tanzu-builder-darwin_arm64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -tags  ./cmd/plugin/builder
2023-08-01T11:04:49-04:00 [i] ========
2023-08-01T11:04:49-04:00 [i] saving plugin group manifest...
2023-08-01T11:04:49-04:00 [ok] successfully built local repository
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.0.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev'" \
		--goflags "" \
		--os-arch linux_arm64 \
		--match "builder" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-08-01T11:04:49-04:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.0.0-dev, [linux_arm64]
2023-08-01T11:04:49-04:00 [i] 🐶 - building plugin at path "cmd/plugin/builder"
2023-08-01T11:04:52-04:00 [i] 🐶 - $ /usr/local/go/bin/go build -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/linux/arm64/global/builder/v1.0.0-dev/tanzu-builder-linux_arm64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -tags  ./cmd/plugin/builder
2023-08-01T11:04:54-04:00 [i] ========
2023-08-01T11:04:54-04:00 [i] saving plugin group manifest...
2023-08-01T11:04:54-04:00 [ok] successfully built local repository
cd /Users/kmarc/git/tanzu-cli/artifacts/plugins && tar -czvf ../plugin_bundle.tar.gz .
a .
a ./plugin_group_manifest.yaml
a ./plugin_manifest.yaml
a ./linux
a ./darwin
a ./windows
a ./windows/amd64
a ./windows/amd64/plugin_manifest.yaml
a ./windows/amd64/global
a ./windows/amd64/global/builder
a ./windows/amd64/global/builder/v1.0.0-dev
a ./windows/amd64/global/builder/v1.0.0-dev/tanzu-builder-windows_amd64.exe
a ./darwin/amd64
a ./darwin/arm64
a ./darwin/arm64/plugin_manifest.yaml
a ./darwin/arm64/global
a ./darwin/arm64/global/builder
a ./darwin/arm64/global/builder/v1.0.0-dev
a ./darwin/arm64/global/builder/v1.0.0-dev/tanzu-builder-darwin_arm64
a ./darwin/amd64/plugin_manifest.yaml
a ./darwin/amd64/global
a ./darwin/amd64/global/builder
a ./darwin/amd64/global/builder/v1.0.0-dev
a ./darwin/amd64/global/builder/v1.0.0-dev/tanzu-builder-darwin_amd64
a ./linux/amd64
a ./linux/arm64
a ./linux/arm64/plugin_manifest.yaml
a ./linux/arm64/global
a ./linux/arm64/global/builder
a ./linux/arm64/global/builder/v1.0.0-dev
a ./linux/arm64/global/builder/v1.0.0-dev/tanzu-builder-linux_arm64
a ./linux/amd64/plugin_manifest.yaml
a ./linux/amd64/global
a ./linux/amd64/global/builder
a ./linux/amd64/global/builder/v1.0.0-dev
a ./linux/amd64/global/builder/v1.0.0-dev/tanzu-builder-linux_amd64
/Users/kmarc/git/tanzu-cli/bin/builder plugin build-package \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--package-artifacts /Users/kmarc/git/tanzu-cli/artifacts/packages
2023-08-01T11:05:00-04:00 [i] starting local registry server on port 54831, logs available at /var/folders/k0/lwnx9y_n7393cfx7mj7dct580000gq/T/2924162334
2023-08-01T11:05:00-04:00 [i] Using plugin binary artifacts from "/Users/kmarc/git/tanzu-cli/artifacts/plugins"
2023-08-01T11:05:00-04:00 [i] 🐵 Validating Plugin Binary file: /Users/kmarc/git/tanzu-cli/artifacts/plugins/linux/amd64/global/builder/v1.0.0-dev/tanzu-builder-linux_amd64
2023-08-01T11:05:00-04:00 [i] 🐵 Generating plugin package for 'plugin:builder' 'target:global' 'os:linux' 'arch:amd64' 'version:v1.0.0-dev'
2023-08-01T11:05:00-04:00 [i] 🐶 Validating Plugin Binary file: /Users/kmarc/git/tanzu-cli/artifacts/plugins/windows/amd64/global/builder/v1.0.0-dev/tanzu-builder-windows_amd64.exe
2023-08-01T11:05:00-04:00 [i] 🦊 Validating Plugin Binary file: /Users/kmarc/git/tanzu-cli/artifacts/plugins/linux/arm64/global/builder/v1.0.0-dev/tanzu-builder-linux_arm64
2023-08-01T11:05:00-04:00 [i] 🦊 Generating plugin package for 'plugin:builder' 'target:global' 'os:linux' 'arch:arm64' 'version:v1.0.0-dev'
2023-08-01T11:05:00-04:00 [i] 🐶 Generating plugin package for 'plugin:builder' 'target:global' 'os:windows' 'arch:amd64' 'version:v1.0.0-dev'
2023-08-01T11:05:00-04:00 [i] 🐰 Validating Plugin Binary file: /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/arm64/global/builder/v1.0.0-dev/tanzu-builder-darwin_arm64
2023-08-01T11:05:00-04:00 [i] 🐰 Generating plugin package for 'plugin:builder' 'target:global' 'os:darwin' 'arch:arm64' 'version:v1.0.0-dev'
2023-08-01T11:05:00-04:00 [i] 🐼 Validating Plugin Binary file: /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/amd64/global/builder/v1.0.0-dev/tanzu-builder-darwin_amd64
2023-08-01T11:05:00-04:00 [i] 🐼 Generating plugin package for 'plugin:builder' 'target:global' 'os:darwin' 'arch:amd64' 'version:v1.0.0-dev'
2023-08-01T11:05:05-04:00 [i] 🦊 Generated plugin package at "/Users/kmarc/git/tanzu-cli/artifacts/packages/linux/arm64/global/builder/v1.0.0-dev/builder-linux_arm64.tar"
2023-08-01T11:05:06-04:00 [i] 🐵 Generated plugin package at "/Users/kmarc/git/tanzu-cli/artifacts/packages/linux/amd64/global/builder/v1.0.0-dev/builder-linux_amd64.tar"
2023-08-01T11:05:07-04:00 [i] 🐰 Generated plugin package at "/Users/kmarc/git/tanzu-cli/artifacts/packages/darwin/arm64/global/builder/v1.0.0-dev/builder-darwin_arm64.tar"
2023-08-01T11:05:08-04:00 [i] 🐶 Generated plugin package at "/Users/kmarc/git/tanzu-cli/artifacts/packages/windows/amd64/global/builder/v1.0.0-dev/builder-windows_amd64.tar"
2023-08-01T11:05:09-04:00 [i] 🐼 Generated plugin package at "/Users/kmarc/git/tanzu-cli/artifacts/packages/darwin/amd64/global/builder/v1.0.0-dev/builder-darwin_amd64.tar"
2023-08-01T11:05:09-04:00 [i] Saved plugin manifest at "/Users/kmarc/git/tanzu-cli/artifacts/packages/plugin_manifest.yaml"
2023-08-01T11:05:09-04:00 [i] shutting down local registry server...
docker stop temp-package-registry && docker rm -v temp-package-registry || true
temp-package-registry
temp-package-registry
docker run -d -p 5001:5000 --name temp-package-registry library/registry:2
06a98f07429c59188fb3a18d6916425b31da0a027b171c210535c6d0234fb5d3
/Users/kmarc/git/tanzu-cli/bin/builder plugin publish-package \
		--package-artifacts /Users/kmarc/git/tanzu-cli/artifacts/packages \
		--publisher tanzucli \
		--vendor vmware \
		--repository localhost:5001/test/v1/tanzu-cli/plugins
2023-08-01T11:05:10-04:00 [i] using plugin package artifacts from "/Users/kmarc/git/tanzu-cli/artifacts/packages"
2023-08-01T11:05:10-04:00 [i] 🦊 publishing plugin 'name:builder' 'target:global' 'os:linux' 'arch:arm64' 'version:v1.0.0-dev'
2023-08-01T11:05:10-04:00 [i] 🐵 publishing plugin 'name:builder' 'target:global' 'os:linux' 'arch:amd64' 'version:v1.0.0-dev'
2023-08-01T11:05:10-04:00 [i] 🐶 publishing plugin 'name:builder' 'target:global' 'os:windows' 'arch:amd64' 'version:v1.0.0-dev'
2023-08-01T11:05:10-04:00 [i] 🐼 publishing plugin 'name:builder' 'target:global' 'os:darwin' 'arch:amd64' 'version:v1.0.0-dev'
2023-08-01T11:05:10-04:00 [i] 🐰 publishing plugin 'name:builder' 'target:global' 'os:darwin' 'arch:arm64' 'version:v1.0.0-dev'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/arm64/global/builder@sha256:28dcc5311afbf70657258f6443cb92833d209c417495f7c0a7d3a4683c957f5d
2023-08-01T11:05:11-04:00 [i] 🦊 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/arm64/global/builder:v1.0.0-dev'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/amd64/global/builder@sha256:ee26acca8d81b4d641ddde93b1c7546710deeb29df89a22403dc2218ee7ff475
2023-08-01T11:05:12-04:00 [i] 🐼 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/amd64/global/builder:v1.0.0-dev'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/amd64/global/builder@sha256:18eb2c33b742d2888c9514583f4a8a4c64075a57805c94595e67daed5df8bd6e
2023-08-01T11:05:13-04:00 [i] 🐶 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/amd64/global/builder:v1.0.0-dev'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/amd64/global/builder@sha256:dedf081f88001299cc498faba0e285f1dbb69075aca51e1b55cf81a9bd77e81a
2023-08-01T11:05:14-04:00 [i] 🐵 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/amd64/global/builder:v1.0.0-dev'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/arm64/global/builder@sha256:5c1e4b9410881c2d2d6456837f9a3e2185a18b8d6f0261d32b2770dc48c2ab6e
2023-08-01T11:05:14-04:00 [i] 🐰 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/arm64/global/builder:v1.0.0-dev'
/Users/kmarc/git/tanzu-cli/bin/builder inventory init \
		--repository localhost:5001/test/v1/tanzu-cli/plugins \
		--plugin-inventory-image-tag latest \

2023-08-01T11:05:14-04:00 [i] created database locally at: "/var/folders/k0/lwnx9y_n7393cfx7mj7dct580000gq/T/plugin_inventory.db"
2023-08-01T11:05:14-04:00 [i] publishing database at: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
2023-08-01T11:05:16-04:00 [i] successfully published plugin inventory database
/Users/kmarc/git/tanzu-cli/bin/builder inventory plugin add \
		--repository localhost:5001/test/v1/tanzu-cli/plugins \
		--plugin-inventory-image-tag latest \
		--publisher tanzucli \
		--vendor vmware \
		--manifest /Users/kmarc/git/tanzu-cli/artifacts/packages/plugin_manifest.yaml \
		--plugin-inventory-db-file ""
2023-08-01T11:05:16-04:00 [i] pulling plugin inventory database from: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
2023-08-01T11:05:16-04:00 [i] 🐼 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/amd64/global/builder:v1.0.0-dev'
2023-08-01T11:05:16-04:00 [i] 🦊 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/arm64/global/builder:v1.0.0-dev'
2023-08-01T11:05:16-04:00 [i] 🐰 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/arm64/global/builder:v1.0.0-dev'
2023-08-01T11:05:16-04:00 [i] 🐶 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/amd64/global/builder:v1.0.0-dev'
2023-08-01T11:05:16-04:00 [i] 🐵 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/amd64/global/builder:v1.0.0-dev'
2023-08-01T11:05:17-04:00 [i] publishing plugin inventory database
2023-08-01T11:05:18-04:00 [i] successfully published plugin inventory database at: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
```

Building and publishing WITHOUT the new ARM64:

1. remove the string `darwin-arm64 linux-arm64` from the `plugin-tooling.mk` file

```
$ make cross-build-publish-plugins
cd cmd/plugin/builder && go build -o /Users/kmarc/git/tanzu-cli/bin/builder .
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.0.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev'" \
		--goflags "" \
		--os-arch linux_amd64 \
		--match "builder" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-08-01T11:08:57-04:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.0.0-dev, [linux_amd64]
2023-08-01T11:08:57-04:00 [i] 🐷 - building plugin at path "cmd/plugin/builder"
2023-08-01T11:08:59-04:00 [i] 🐷 - $ /usr/local/go/bin/go build -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/linux/amd64/global/builder/v1.0.0-dev/tanzu-builder-linux_amd64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -tags  ./cmd/plugin/builder
2023-08-01T11:09:01-04:00 [i] ========
2023-08-01T11:09:01-04:00 [i] saving plugin group manifest...
2023-08-01T11:09:01-04:00 [ok] successfully built local repository
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.0.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev'" \
		--goflags "" \
		--os-arch windows_amd64 \
		--match "builder" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-08-01T11:09:01-04:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.0.0-dev, [windows_amd64]
2023-08-01T11:09:01-04:00 [i] 🐭 - building plugin at path "cmd/plugin/builder"
2023-08-01T11:09:04-04:00 [i] 🐭 - $ /usr/local/go/bin/go build -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/windows/amd64/global/builder/v1.0.0-dev/tanzu-builder-windows_amd64.exe -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -tags  ./cmd/plugin/builder
2023-08-01T11:09:06-04:00 [i] ========
2023-08-01T11:09:06-04:00 [i] saving plugin group manifest...
2023-08-01T11:09:06-04:00 [ok] successfully built local repository
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.0.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev'" \
		--goflags "" \
		--os-arch darwin_amd64 \
		--match "builder" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-08-01T11:09:06-04:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.0.0-dev, [darwin_amd64]
2023-08-01T11:09:06-04:00 [i] 🐯 - building plugin at path "cmd/plugin/builder"
2023-08-01T11:09:09-04:00 [i] 🐯 - $ /usr/local/go/bin/go build -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/amd64/global/builder/v1.0.0-dev/tanzu-builder-darwin_amd64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -tags  ./cmd/plugin/builder
2023-08-01T11:09:10-04:00 [i] ========
2023-08-01T11:09:10-04:00 [i] saving plugin group manifest...
2023-08-01T11:09:10-04:00 [ok] successfully built local repository
cd /Users/kmarc/git/tanzu-cli/artifacts/plugins && tar -czvf ../plugin_bundle.tar.gz .
a .
a ./plugin_group_manifest.yaml
a ./plugin_manifest.yaml
a ./linux
a ./darwin
a ./windows
a ./windows/amd64
a ./windows/amd64/plugin_manifest.yaml
a ./windows/amd64/global
a ./windows/amd64/global/builder
a ./windows/amd64/global/builder/v1.0.0-dev
a ./windows/amd64/global/builder/v1.0.0-dev/tanzu-builder-windows_amd64.exe
a ./darwin/amd64
a ./darwin/amd64/plugin_manifest.yaml
a ./darwin/amd64/global
a ./darwin/amd64/global/builder
a ./darwin/amd64/global/builder/v1.0.0-dev
a ./darwin/amd64/global/builder/v1.0.0-dev/tanzu-builder-darwin_amd64
a ./linux/amd64
a ./linux/amd64/plugin_manifest.yaml
a ./linux/amd64/global
a ./linux/amd64/global/builder
a ./linux/amd64/global/builder/v1.0.0-dev
a ./linux/amd64/global/builder/v1.0.0-dev/tanzu-builder-linux_amd64
/Users/kmarc/git/tanzu-cli/bin/builder plugin build-package \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--package-artifacts /Users/kmarc/git/tanzu-cli/artifacts/packages
2023-08-01T11:09:14-04:00 [i] starting local registry server on port 54990, logs available at /var/folders/k0/lwnx9y_n7393cfx7mj7dct580000gq/T/1000187899
2023-08-01T11:09:14-04:00 [i] Using plugin binary artifacts from "/Users/kmarc/git/tanzu-cli/artifacts/plugins"
2023-08-01T11:09:14-04:00 [i] 🐶 Validating Plugin Binary file: /Users/kmarc/git/tanzu-cli/artifacts/plugins/windows/amd64/global/builder/v1.0.0-dev/tanzu-builder-windows_amd64.exe
2023-08-01T11:09:14-04:00 [i] 🐶 Generating plugin package for 'plugin:builder' 'target:global' 'os:windows' 'arch:amd64' 'version:v1.0.0-dev'
2023-08-01T11:09:14-04:00 [i] 🐵 Validating Plugin Binary file: /Users/kmarc/git/tanzu-cli/artifacts/plugins/linux/amd64/global/builder/v1.0.0-dev/tanzu-builder-linux_amd64
2023-08-01T11:09:14-04:00 [i] 🐵 Generating plugin package for 'plugin:builder' 'target:global' 'os:linux' 'arch:amd64' 'version:v1.0.0-dev'
2023-08-01T11:09:14-04:00 [i] 🐼 Validating Plugin Binary file: /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/amd64/global/builder/v1.0.0-dev/tanzu-builder-darwin_amd64
2023-08-01T11:09:14-04:00 [i] 🐼 Generating plugin package for 'plugin:builder' 'target:global' 'os:darwin' 'arch:amd64' 'version:v1.0.0-dev'
2023-08-01T11:09:17-04:00 [i] 🐼 Generated plugin package at "/Users/kmarc/git/tanzu-cli/artifacts/packages/darwin/amd64/global/builder/v1.0.0-dev/builder-darwin_amd64.tar"
2023-08-01T11:09:18-04:00 [i] 🐵 Generated plugin package at "/Users/kmarc/git/tanzu-cli/artifacts/packages/linux/amd64/global/builder/v1.0.0-dev/builder-linux_amd64.tar"
2023-08-01T11:09:19-04:00 [i] 🐶 Generated plugin package at "/Users/kmarc/git/tanzu-cli/artifacts/packages/windows/amd64/global/builder/v1.0.0-dev/builder-windows_amd64.tar"
2023-08-01T11:09:19-04:00 [i] Saved plugin manifest at "/Users/kmarc/git/tanzu-cli/artifacts/packages/plugin_manifest.yaml"
2023-08-01T11:09:19-04:00 [i] shutting down local registry server...
docker stop temp-package-registry && docker rm -v temp-package-registry || true
temp-package-registry
temp-package-registry
docker run -d -p 5001:5000 --name temp-package-registry library/registry:2
663ab51455f8adb1a56a893395614cb393dc5485de0ced497f72e73dca2982ea
/Users/kmarc/git/tanzu-cli/bin/builder plugin publish-package \
		--package-artifacts /Users/kmarc/git/tanzu-cli/artifacts/packages \
		--publisher tanzucli \
		--vendor vmware \
		--repository localhost:5001/test/v1/tanzu-cli/plugins
2023-08-01T11:09:19-04:00 [i] using plugin package artifacts from "/Users/kmarc/git/tanzu-cli/artifacts/packages"
2023-08-01T11:09:19-04:00 [i] 🐶 publishing plugin 'name:builder' 'target:global' 'os:windows' 'arch:amd64' 'version:v1.0.0-dev'
2023-08-01T11:09:19-04:00 [i] 🐼 publishing plugin 'name:builder' 'target:global' 'os:darwin' 'arch:amd64' 'version:v1.0.0-dev'
2023-08-01T11:09:19-04:00 [i] 🐵 publishing plugin 'name:builder' 'target:global' 'os:linux' 'arch:amd64' 'version:v1.0.0-dev'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/amd64/global/builder@sha256:e79b3225314ebb11d5a4524d01dbfbb8034ecedb8169755e5576d1d80bed7586
2023-08-01T11:09:21-04:00 [i] 🐶 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/amd64/global/builder:v1.0.0-dev'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/amd64/global/builder@sha256:f084bc53392df8deda700734930dc9008e43991e0aca3474e781169bc1a40e22
2023-08-01T11:09:21-04:00 [i] 🐼 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/amd64/global/builder:v1.0.0-dev'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/amd64/global/builder@sha256:5ef3e081a5520b71f99aee9fad872a4f70f38ce389315263b7880a4cb438d046
2023-08-01T11:09:22-04:00 [i] 🐵 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/amd64/global/builder:v1.0.0-dev'
/Users/kmarc/git/tanzu-cli/bin/builder inventory init \
		--repository localhost:5001/test/v1/tanzu-cli/plugins \
		--plugin-inventory-image-tag latest \

2023-08-01T11:09:22-04:00 [i] created database locally at: "/var/folders/k0/lwnx9y_n7393cfx7mj7dct580000gq/T/plugin_inventory.db"
2023-08-01T11:09:22-04:00 [i] publishing database at: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
2023-08-01T11:09:23-04:00 [i] successfully published plugin inventory database
/Users/kmarc/git/tanzu-cli/bin/builder inventory plugin add \
		--repository localhost:5001/test/v1/tanzu-cli/plugins \
		--plugin-inventory-image-tag latest \
		--publisher tanzucli \
		--vendor vmware \
		--manifest /Users/kmarc/git/tanzu-cli/artifacts/packages/plugin_manifest.yaml \
		--plugin-inventory-db-file ""
2023-08-01T11:09:23-04:00 [i] pulling plugin inventory database from: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
2023-08-01T11:09:23-04:00 [i] 🦊 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/arm64/global/builder:v1.0.0-dev'
2023-08-01T11:09:23-04:00 [i] 🐶 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/amd64/global/builder:v1.0.0-dev'
2023-08-01T11:09:23-04:00 [i] 🐼 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/amd64/global/builder:v1.0.0-dev'
2023-08-01T11:09:23-04:00 [i] 🐰 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/arm64/global/builder:v1.0.0-dev'
2023-08-01T11:09:23-04:00 [i] 🐵 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/amd64/global/builder:v1.0.0-dev'
2023-08-01T11:09:23-04:00 [i] 🐰 ignoring unavailable plugin for optional os/arch: darwin_arm64
2023-08-01T11:09:23-04:00 [i] 🦊 ignoring unavailable plugin for optional os/arch: linux_arm64
2023-08-01T11:09:23-04:00 [i] publishing plugin inventory database
2023-08-01T11:09:24-04:00 [i] successfully published plugin inventory database at: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
```

**Notice above the new `ignoring unavailable plugin for optional os/arch`**

Check when just doing validation after building all osarch (including ARM64):
```
$ make plugin-build-and-publish-packages
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.0.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev'" \
		--goflags "" \
		--os-arch linux_amd64 \
		--match "builder" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-08-01T11:20:26-04:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.0.0-dev, [linux_amd64]
2023-08-01T11:20:26-04:00 [i] 🦊 - building plugin at path "cmd/plugin/builder"
2023-08-01T11:20:29-04:00 [i] 🦊 - $ /usr/local/go/bin/go build -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/linux/amd64/global/builder/v1.0.0-dev/tanzu-builder-linux_amd64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -tags  ./cmd/plugin/builder
2023-08-01T11:20:31-04:00 [i] ========
2023-08-01T11:20:31-04:00 [i] saving plugin group manifest...
2023-08-01T11:20:31-04:00 [ok] successfully built local repository
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.0.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev'" \
		--goflags "" \
		--os-arch windows_amd64 \
		--match "builder" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-08-01T11:20:31-04:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.0.0-dev, [windows_amd64]
2023-08-01T11:20:31-04:00 [i] 🐯 - building plugin at path "cmd/plugin/builder"
2023-08-01T11:20:34-04:00 [i] 🐯 - $ /usr/local/go/bin/go build -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/windows/amd64/global/builder/v1.0.0-dev/tanzu-builder-windows_amd64.exe -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -tags  ./cmd/plugin/builder
2023-08-01T11:20:36-04:00 [i] ========
2023-08-01T11:20:36-04:00 [i] saving plugin group manifest...
2023-08-01T11:20:36-04:00 [ok] successfully built local repository
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.0.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev'" \
		--goflags "" \
		--os-arch darwin_amd64 \
		--match "builder" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-08-01T11:20:36-04:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.0.0-dev, [darwin_amd64]
2023-08-01T11:20:36-04:00 [i] 🐨 - building plugin at path "cmd/plugin/builder"
2023-08-01T11:20:38-04:00 [i] 🐨 - $ /usr/local/go/bin/go build -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/amd64/global/builder/v1.0.0-dev/tanzu-builder-darwin_amd64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -tags  ./cmd/plugin/builder
2023-08-01T11:20:40-04:00 [i] ========
2023-08-01T11:20:40-04:00 [i] saving plugin group manifest...
2023-08-01T11:20:40-04:00 [ok] successfully built local repository
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.0.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev'" \
		--goflags "" \
		--os-arch darwin_arm64 \
		--match "builder" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-08-01T11:20:40-04:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.0.0-dev, [darwin_arm64]
2023-08-01T11:20:40-04:00 [i] 🐼 - building plugin at path "cmd/plugin/builder"
2023-08-01T11:20:43-04:00 [i] 🐼 - $ /usr/local/go/bin/go build -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/arm64/global/builder/v1.0.0-dev/tanzu-builder-darwin_arm64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -tags  ./cmd/plugin/builder
2023-08-01T11:20:45-04:00 [i] ========
2023-08-01T11:20:45-04:00 [i] saving plugin group manifest...
2023-08-01T11:20:45-04:00 [ok] successfully built local repository
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.0.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev'" \
		--goflags "" \
		--os-arch linux_arm64 \
		--match "builder" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-08-01T11:20:46-04:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.0.0-dev, [linux_arm64]
2023-08-01T11:20:46-04:00 [i] 🐼 - building plugin at path "cmd/plugin/builder"
2023-08-01T11:20:48-04:00 [i] 🐼 - $ /usr/local/go/bin/go build -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/linux/arm64/global/builder/v1.0.0-dev/tanzu-builder-linux_arm64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -tags  ./cmd/plugin/builder
2023-08-01T11:20:50-04:00 [i] ========
2023-08-01T11:20:50-04:00 [i] saving plugin group manifest...
2023-08-01T11:20:50-04:00 [ok] successfully built local repository
cd /Users/kmarc/git/tanzu-cli/artifacts/plugins && tar -czvf ../plugin_bundle.tar.gz .
a .
a ./plugin_group_manifest.yaml
a ./plugin_manifest.yaml
a ./linux
a ./darwin
a ./windows
a ./windows/amd64
a ./windows/amd64/plugin_manifest.yaml
a ./windows/amd64/global
a ./windows/amd64/global/builder
a ./windows/amd64/global/builder/v1.0.0-dev
a ./windows/amd64/global/builder/v1.0.0-dev/tanzu-builder-windows_amd64.exe
a ./darwin/amd64
a ./darwin/arm64
a ./darwin/arm64/plugin_manifest.yaml
a ./darwin/arm64/global
a ./darwin/arm64/global/builder
a ./darwin/arm64/global/builder/v1.0.0-dev
a ./darwin/arm64/global/builder/v1.0.0-dev/tanzu-builder-darwin_arm64
a ./darwin/amd64/plugin_manifest.yaml
a ./darwin/amd64/global
a ./darwin/amd64/global/builder
a ./darwin/amd64/global/builder/v1.0.0-dev
a ./darwin/amd64/global/builder/v1.0.0-dev/tanzu-builder-darwin_amd64
a ./linux/amd64
a ./linux/arm64
a ./linux/arm64/plugin_manifest.yaml
a ./linux/arm64/global
a ./linux/arm64/global/builder
a ./linux/arm64/global/builder/v1.0.0-dev
a ./linux/arm64/global/builder/v1.0.0-dev/tanzu-builder-linux_arm64
a ./linux/amd64/plugin_manifest.yaml
a ./linux/amd64/global
a ./linux/amd64/global/builder
a ./linux/amd64/global/builder/v1.0.0-dev
a ./linux/amd64/global/builder/v1.0.0-dev/tanzu-builder-linux_amd64
/Users/kmarc/git/tanzu-cli/bin/builder plugin build-package \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--package-artifacts /Users/kmarc/git/tanzu-cli/artifacts/packages
2023-08-01T11:20:56-04:00 [i] starting local registry server on port 55194, logs available at /var/folders/k0/lwnx9y_n7393cfx7mj7dct580000gq/T/2518549359
2023-08-01T11:20:56-04:00 [i] Using plugin binary artifacts from "/Users/kmarc/git/tanzu-cli/artifacts/plugins"
2023-08-01T11:20:56-04:00 [i] 🐵 Validating Plugin Binary file: /Users/kmarc/git/tanzu-cli/artifacts/plugins/linux/amd64/global/builder/v1.0.0-dev/tanzu-builder-linux_amd64
2023-08-01T11:20:56-04:00 [i] 🐵 Generating plugin package for 'plugin:builder' 'target:global' 'os:linux' 'arch:amd64' 'version:v1.0.0-dev'
2023-08-01T11:20:56-04:00 [i] 🐼 Validating Plugin Binary file: /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/amd64/global/builder/v1.0.0-dev/tanzu-builder-darwin_amd64
2023-08-01T11:20:56-04:00 [i] 🐼 Generating plugin package for 'plugin:builder' 'target:global' 'os:darwin' 'arch:amd64' 'version:v1.0.0-dev'
2023-08-01T11:20:56-04:00 [i] 🦊 Validating Plugin Binary file: /Users/kmarc/git/tanzu-cli/artifacts/plugins/linux/arm64/global/builder/v1.0.0-dev/tanzu-builder-linux_arm64
2023-08-01T11:20:56-04:00 [i] 🦊 Generating plugin package for 'plugin:builder' 'target:global' 'os:linux' 'arch:arm64' 'version:v1.0.0-dev'
2023-08-01T11:20:56-04:00 [i] 🐰 Validating Plugin Binary file: /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/arm64/global/builder/v1.0.0-dev/tanzu-builder-darwin_arm64
2023-08-01T11:20:56-04:00 [i] 🐰 Generating plugin package for 'plugin:builder' 'target:global' 'os:darwin' 'arch:arm64' 'version:v1.0.0-dev'
2023-08-01T11:20:56-04:00 [i] 🐶 Validating Plugin Binary file: /Users/kmarc/git/tanzu-cli/artifacts/plugins/windows/amd64/global/builder/v1.0.0-dev/tanzu-builder-windows_amd64.exe
2023-08-01T11:20:56-04:00 [i] 🐶 Generating plugin package for 'plugin:builder' 'target:global' 'os:windows' 'arch:amd64' 'version:v1.0.0-dev'
2023-08-01T11:21:00-04:00 [i] 🐵 Generated plugin package at "/Users/kmarc/git/tanzu-cli/artifacts/packages/linux/amd64/global/builder/v1.0.0-dev/builder-linux_amd64.tar"
2023-08-01T11:21:01-04:00 [i] 🐼 Generated plugin package at "/Users/kmarc/git/tanzu-cli/artifacts/packages/darwin/amd64/global/builder/v1.0.0-dev/builder-darwin_amd64.tar"
2023-08-01T11:21:01-04:00 [i] 🦊 Generated plugin package at "/Users/kmarc/git/tanzu-cli/artifacts/packages/linux/arm64/global/builder/v1.0.0-dev/builder-linux_arm64.tar"
2023-08-01T11:21:02-04:00 [i] 🐰 Generated plugin package at "/Users/kmarc/git/tanzu-cli/artifacts/packages/darwin/arm64/global/builder/v1.0.0-dev/builder-darwin_arm64.tar"
2023-08-01T11:21:02-04:00 [i] 🐶 Generated plugin package at "/Users/kmarc/git/tanzu-cli/artifacts/packages/windows/amd64/global/builder/v1.0.0-dev/builder-windows_amd64.tar"
2023-08-01T11:21:02-04:00 [i] Saved plugin manifest at "/Users/kmarc/git/tanzu-cli/artifacts/packages/plugin_manifest.yaml"
2023-08-01T11:21:02-04:00 [i] shutting down local registry server...
docker stop temp-package-registry && docker rm -v temp-package-registry || true
temp-package-registry
temp-package-registry
docker run -d -p 5001:5000 --name temp-package-registry library/registry:2
eafbb734744f103b0f870a80041d04f058866cb284d35354e8631325a130e0b6
/Users/kmarc/git/tanzu-cli/bin/builder plugin publish-package \
		--package-artifacts /Users/kmarc/git/tanzu-cli/artifacts/packages \
		--publisher tanzucli \
		--vendor vmware \
		--repository localhost:5001/test/v1/tanzu-cli/plugins
2023-08-01T11:21:03-04:00 [i] using plugin package artifacts from "/Users/kmarc/git/tanzu-cli/artifacts/packages"
2023-08-01T11:21:03-04:00 [i] 🐰 publishing plugin 'name:builder' 'target:global' 'os:darwin' 'arch:arm64' 'version:v1.0.0-dev'
2023-08-01T11:21:03-04:00 [i] 🦊 publishing plugin 'name:builder' 'target:global' 'os:linux' 'arch:arm64' 'version:v1.0.0-dev'
2023-08-01T11:21:03-04:00 [i] 🐼 publishing plugin 'name:builder' 'target:global' 'os:darwin' 'arch:amd64' 'version:v1.0.0-dev'
2023-08-01T11:21:03-04:00 [i] 🐵 publishing plugin 'name:builder' 'target:global' 'os:linux' 'arch:amd64' 'version:v1.0.0-dev'
2023-08-01T11:21:03-04:00 [i] 🐶 publishing plugin 'name:builder' 'target:global' 'os:windows' 'arch:amd64' 'version:v1.0.0-dev'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/amd64/global/builder@sha256:dedf081f88001299cc498faba0e285f1dbb69075aca51e1b55cf81a9bd77e81a
2023-08-01T11:21:04-04:00 [i] 🐵 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/amd64/global/builder:v1.0.0-dev'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/amd64/global/builder@sha256:ee26acca8d81b4d641ddde93b1c7546710deeb29df89a22403dc2218ee7ff475
2023-08-01T11:21:05-04:00 [i] 🐼 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/amd64/global/builder:v1.0.0-dev'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/arm64/global/builder@sha256:5c1e4b9410881c2d2d6456837f9a3e2185a18b8d6f0261d32b2770dc48c2ab6e
2023-08-01T11:21:05-04:00 [i] 🐰 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/arm64/global/builder:v1.0.0-dev'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/amd64/global/builder@sha256:18eb2c33b742d2888c9514583f4a8a4c64075a57805c94595e67daed5df8bd6e
2023-08-01T11:21:06-04:00 [i] 🐶 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/amd64/global/builder:v1.0.0-dev'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/arm64/global/builder@sha256:28dcc5311afbf70657258f6443cb92833d209c417495f7c0a7d3a4683c957f5d
2023-08-01T11:21:07-04:00 [i] 🦊 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/arm64/global/builder:v1.0.0-dev'
$ make inventory-init
/Users/kmarc/git/tanzu-cli/bin/builder inventory init \
		--repository localhost:5001/test/v1/tanzu-cli/plugins \
		--plugin-inventory-image-tag latest \

2023-08-01T11:22:02-04:00 [i] created database locally at: "/var/folders/k0/lwnx9y_n7393cfx7mj7dct580000gq/T/plugin_inventory.db"
2023-08-01T11:22:02-04:00 [i] publishing database at: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
2023-08-01T11:22:02-04:00 [i] successfully published plugin inventory database
$ bin/builder inventory plugin add \
                --repository localhost:5001/test/v1/tanzu-cli/plugins \
                --plugin-inventory-image-tag latest \
                --publisher tzcli \
                --vendor vmware \
                --manifest ./artifacts/packages/plugin_manifest.yaml --validate
2023-08-01T11:22:08-04:00 [i] pulling plugin inventory database from: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
2023-08-01T11:22:08-04:00 [i] validation successful
```

Check when just doing validation after building WITHOUT the new ARM64:
1. remove the string `darwin-arm64 linux-arm64` from the `plugin-tooling.mk` file
```
$ make plugin-build-and-publish-packages
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.0.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev'" \
		--goflags "" \
		--os-arch linux_amd64 \
		--match "builder" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-08-01T11:13:49-04:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.0.0-dev, [linux_amd64]
2023-08-01T11:13:49-04:00 [i] 🐭 - building plugin at path "cmd/plugin/builder"
2023-08-01T11:13:52-04:00 [i] 🐭 - $ /usr/local/go/bin/go build -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/linux/amd64/global/builder/v1.0.0-dev/tanzu-builder-linux_amd64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -tags  ./cmd/plugin/builder
2023-08-01T11:13:52-04:00 [i] ========
2023-08-01T11:13:52-04:00 [i] saving plugin group manifest...
2023-08-01T11:13:52-04:00 [ok] successfully built local repository
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.0.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev'" \
		--goflags "" \
		--os-arch windows_amd64 \
		--match "builder" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-08-01T11:13:53-04:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.0.0-dev, [windows_amd64]
2023-08-01T11:13:53-04:00 [i] 🐷 - building plugin at path "cmd/plugin/builder"
2023-08-01T11:13:55-04:00 [i] 🐷 - $ /usr/local/go/bin/go build -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/windows/amd64/global/builder/v1.0.0-dev/tanzu-builder-windows_amd64.exe -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -tags  ./cmd/plugin/builder
2023-08-01T11:13:56-04:00 [i] ========
2023-08-01T11:13:56-04:00 [i] saving plugin group manifest...
2023-08-01T11:13:56-04:00 [ok] successfully built local repository
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.0.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev'" \
		--goflags "" \
		--os-arch darwin_amd64 \
		--match "builder" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-08-01T11:13:56-04:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.0.0-dev, [darwin_amd64]
2023-08-01T11:13:56-04:00 [i] 🐨 - building plugin at path "cmd/plugin/builder"
2023-08-01T11:13:58-04:00 [i] 🐨 - $ /usr/local/go/bin/go build -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/amd64/global/builder/v1.0.0-dev/tanzu-builder-darwin_amd64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-01' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=34ee06d79-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -tags  ./cmd/plugin/builder
2023-08-01T11:13:59-04:00 [i] ========
2023-08-01T11:13:59-04:00 [i] saving plugin group manifest...
2023-08-01T11:13:59-04:00 [ok] successfully built local repository
cd /Users/kmarc/git/tanzu-cli/artifacts/plugins && tar -czvf ../plugin_bundle.tar.gz .
a .
a ./plugin_group_manifest.yaml
a ./plugin_manifest.yaml
a ./linux
a ./darwin
a ./windows
a ./windows/amd64
a ./windows/amd64/plugin_manifest.yaml
a ./windows/amd64/global
a ./windows/amd64/global/builder
a ./windows/amd64/global/builder/v1.0.0-dev
a ./windows/amd64/global/builder/v1.0.0-dev/tanzu-builder-windows_amd64.exe
a ./darwin/amd64
a ./darwin/amd64/plugin_manifest.yaml
a ./darwin/amd64/global
a ./darwin/amd64/global/builder
a ./darwin/amd64/global/builder/v1.0.0-dev
a ./darwin/amd64/global/builder/v1.0.0-dev/tanzu-builder-darwin_amd64
a ./linux/amd64
a ./linux/amd64/plugin_manifest.yaml
a ./linux/amd64/global
a ./linux/amd64/global/builder
a ./linux/amd64/global/builder/v1.0.0-dev
a ./linux/amd64/global/builder/v1.0.0-dev/tanzu-builder-linux_amd64
/Users/kmarc/git/tanzu-cli/bin/builder plugin build-package \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--package-artifacts /Users/kmarc/git/tanzu-cli/artifacts/packages
2023-08-01T11:14:02-04:00 [i] starting local registry server on port 55093, logs available at /var/folders/k0/lwnx9y_n7393cfx7mj7dct580000gq/T/1563092590
2023-08-01T11:14:02-04:00 [i] Using plugin binary artifacts from "/Users/kmarc/git/tanzu-cli/artifacts/plugins"
2023-08-01T11:14:02-04:00 [i] 🐵 Validating Plugin Binary file: /Users/kmarc/git/tanzu-cli/artifacts/plugins/linux/amd64/global/builder/v1.0.0-dev/tanzu-builder-linux_amd64
2023-08-01T11:14:02-04:00 [i] 🐵 Generating plugin package for 'plugin:builder' 'target:global' 'os:linux' 'arch:amd64' 'version:v1.0.0-dev'
2023-08-01T11:14:02-04:00 [i] 🐶 Validating Plugin Binary file: /Users/kmarc/git/tanzu-cli/artifacts/plugins/windows/amd64/global/builder/v1.0.0-dev/tanzu-builder-windows_amd64.exe
2023-08-01T11:14:02-04:00 [i] 🐶 Generating plugin package for 'plugin:builder' 'target:global' 'os:windows' 'arch:amd64' 'version:v1.0.0-dev'
2023-08-01T11:14:02-04:00 [i] 🐼 Validating Plugin Binary file: /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/amd64/global/builder/v1.0.0-dev/tanzu-builder-darwin_amd64
2023-08-01T11:14:02-04:00 [i] 🐼 Generating plugin package for 'plugin:builder' 'target:global' 'os:darwin' 'arch:amd64' 'version:v1.0.0-dev'
2023-08-01T11:14:05-04:00 [i] 🐼 Generated plugin package at "/Users/kmarc/git/tanzu-cli/artifacts/packages/darwin/amd64/global/builder/v1.0.0-dev/builder-darwin_amd64.tar"
2023-08-01T11:14:06-04:00 [i] 🐵 Generated plugin package at "/Users/kmarc/git/tanzu-cli/artifacts/packages/linux/amd64/global/builder/v1.0.0-dev/builder-linux_amd64.tar"
2023-08-01T11:14:06-04:00 [i] 🐶 Generated plugin package at "/Users/kmarc/git/tanzu-cli/artifacts/packages/windows/amd64/global/builder/v1.0.0-dev/builder-windows_amd64.tar"
2023-08-01T11:14:06-04:00 [i] Saved plugin manifest at "/Users/kmarc/git/tanzu-cli/artifacts/packages/plugin_manifest.yaml"
2023-08-01T11:14:06-04:00 [i] shutting down local registry server...
docker stop temp-package-registry && docker rm -v temp-package-registry || true
temp-package-registry
temp-package-registry
docker run -d -p 5001:5000 --name temp-package-registry library/registry:2
93e48c8fa409fef54794bd5c7dff904fdb725818f4d1578781f331628a4f3bf7
/Users/kmarc/git/tanzu-cli/bin/builder plugin publish-package \
		--package-artifacts /Users/kmarc/git/tanzu-cli/artifacts/packages \
		--publisher tanzucli \
		--vendor vmware \
		--repository localhost:5001/test/v1/tanzu-cli/plugins
2023-08-01T11:14:07-04:00 [i] using plugin package artifacts from "/Users/kmarc/git/tanzu-cli/artifacts/packages"
2023-08-01T11:14:07-04:00 [i] 🐼 publishing plugin 'name:builder' 'target:global' 'os:darwin' 'arch:amd64' 'version:v1.0.0-dev'
2023-08-01T11:14:07-04:00 [i] 🐶 publishing plugin 'name:builder' 'target:global' 'os:windows' 'arch:amd64' 'version:v1.0.0-dev'
2023-08-01T11:14:07-04:00 [i] 🐵 publishing plugin 'name:builder' 'target:global' 'os:linux' 'arch:amd64' 'version:v1.0.0-dev'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/amd64/global/builder@sha256:e79b3225314ebb11d5a4524d01dbfbb8034ecedb8169755e5576d1d80bed7586
2023-08-01T11:14:08-04:00 [i] 🐶 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/amd64/global/builder:v1.0.0-dev'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/amd64/global/builder@sha256:5ef3e081a5520b71f99aee9fad872a4f70f38ce389315263b7880a4cb438d046
2023-08-01T11:14:09-04:00 [i] 🐵 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/amd64/global/builder:v1.0.0-dev'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/amd64/global/builder@sha256:f084bc53392df8deda700734930dc9008e43991e0aca3474e781169bc1a40e22
2023-08-01T11:14:09-04:00 [i] 🐼 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/amd64/global/builder:v1.0.0-dev'
$ make inventory-init
/Users/kmarc/git/tanzu-cli/bin/builder inventory init \
		--repository localhost:5001/test/v1/tanzu-cli/plugins \
		--plugin-inventory-image-tag latest \

2023-08-01T11:19:20-04:00 [i] created database locally at: "/var/folders/k0/lwnx9y_n7393cfx7mj7dct580000gq/T/plugin_inventory.db"
2023-08-01T11:19:20-04:00 [i] publishing database at: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
2023-08-01T11:19:21-04:00 [i] successfully published plugin inventory database
$ bin/builder inventory plugin add \
                --repository localhost:5001/test/v1/tanzu-cli/plugins \
                --plugin-inventory-image-tag latest \
                --publisher tzcli \
                --vendor vmware \
                --manifest ./artifacts/packages/plugin_manifest.yaml --validate
2023-08-01T11:19:40-04:00 [i] pulling plugin inventory database from: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
2023-08-01T11:19:40-04:00 [i] validation successful
```

Now install a plugin from an ARM64 CLI

```
$ make build
build darwin-arm64 CLI with version: v1.0.0-dev


======================================
! darwin-arm64 is not an officially supported platform!
======================================

mkdir -p bin
cp /Users/kmarc/git/tanzu-cli/artifacts/darwin/arm64/cli/core/v1.0.0-dev/tanzu-cli-darwin_arm64 ./bin/tanzu


# Use the local central repo where we just published ARM64 binaries
$ tz config set env.TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest
$ tz config set env.TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest

# Remove the default central repo to avoid extra noise
$ tz plugin source delete default
[ok] deleted discovery source default

$ tz plugin clean
[ok] successfully cleaned up all plugins
$ tz plugin search
[i] Reading plugin inventory for "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest", this will take a few seconds.
[!] Skipping the plugins discovery image signature verification for "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"

  NAME     DESCRIPTION             TARGET  LATEST
  builder  Build Tanzu components  global  v1.0.0-dev
  test     Test the CLI            global  v1.0.0-dev

# Install the builder using ARM64
$ tz plugin install builder
[i] Installing plugin 'builder:v1.0.0-dev' with target 'global'
[ok] successfully installed 'builder' plugin

# Just to be sure, try to install the builder plugin from the
# main central repo and see that it fails since there is no
# ARM64 version in that repo
$ tz config unset env.TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY
$ tz plugin source init
[ok] successfully initialized discovery source
$ tz plugin search --name builder
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
  NAME     DESCRIPTION             TARGET  LATEST
  builder  Build Tanzu components  global  v0.90.1
$ tz plugin install builder
[x] : unable to find plugin 'builder' with version 'latest'
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The `tanzu builder` plugin now supports building for ARM64 by default.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
