### PR TITLE
E2E : customize which tanzu binary to use

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -54,6 +54,9 @@ ContextCmd   ContextCmdOps
 }
 ```
 
+To customize the choice of the Tanzu binary for usage, you have the option to indicate it by utilizing the environment variable `TANZU_CLI_BINARY_PATH`.
+Additionally, within the Tests, the `WithTanzuBinary()` helper method allows you to personalize the Tanzu binary selection.
+
 Below are the major interfaces defined and implemented as part of the E2E
 Framework (which are part of the `Framework` struct type). These interfaces are
 used to write E2E test cases using the Ginkgo test framework. The interfaces

--- a/test/e2e/coexistence/cli_coexistence_test.go
+++ b/test/e2e/coexistence/cli_coexistence_test.go
@@ -40,7 +40,7 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 			gomega.Expect(err).To(gomega.BeNil())
 
 			ginkgo.By("Verify the installed version of new Tanzu CLI")
-			version, err = tf.CLIVersion(framework.WithTanzuCommandPrefix(framework.TzPrefix))
+			version, err = tf.CLIVersion(framework.WithTanzuBinary(framework.TzPrefix))
 			gomega.Expect(version).To(gomega.ContainSubstring(newTanzuCLIVersion))
 			gomega.Expect(err).To(gomega.BeNil())
 
@@ -85,22 +85,22 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 			gomega.Expect(err).To(gomega.BeNil())
 
 			ginkgo.By("Verify the installed version of new Tanzu CLI")
-			version, err = tf.CLIVersion(framework.WithTanzuCommandPrefix(framework.TzPrefix))
+			version, err = tf.CLIVersion(framework.WithTanzuBinary(framework.TzPrefix))
 			gomega.Expect(version).To(gomega.ContainSubstring(newTanzuCLIVersion))
 			gomega.Expect(err).To(gomega.BeNil())
 
 			// set up the test local central repository host CA cert in the config file
-			setTestLocalCentralRepoCertConfig([]framework.E2EOption{framework.WithTanzuCommandPrefix(framework.TzPrefix)})
+			setTestLocalCentralRepoCertConfig([]framework.E2EOption{framework.WithTanzuBinary(framework.TzPrefix)})
 
 			// set up the local central repository discovery image signature public key path
 			os.Setenv(framework.TanzuCliPluginDiscoveryImageSignaturePublicKeyPath, e2eTestLocalCentralRepoPluginDiscoveryImageSignaturePublicKeyPath)
 
 			ginkgo.By("Update plugin discovery source with test central repo")
-			_, err = tf.PluginCmd.UpdatePluginDiscoverySource(&framework.DiscoveryOptions{Name: "default", SourceType: framework.SourceType, URI: e2eTestLocalCentralRepoURL}, framework.WithTanzuCommandPrefix(framework.TzPrefix))
+			_, err = tf.PluginCmd.UpdatePluginDiscoverySource(&framework.DiscoveryOptions{Name: "default", SourceType: framework.SourceType, URI: e2eTestLocalCentralRepoURL}, framework.WithTanzuBinary(framework.TzPrefix))
 			gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin source update")
 
 			ginkgo.By("Search plugins and make sure there are plugins available using new Tanzu CLI")
-			pluginsSearchList, err := pluginlifecyclee2e.SearchAllPlugins(tf, framework.WithTanzuCommandPrefix(framework.TzPrefix))
+			pluginsSearchList, err := pluginlifecyclee2e.SearchAllPlugins(tf, framework.WithTanzuBinary(framework.TzPrefix))
 			gomega.Expect(err).To(gomega.BeNil(), framework.NoErrorForPluginSearch)
 			gomega.Expect(len(pluginsSearchList)).Should(gomega.BeNumerically(">", 0))
 
@@ -110,15 +110,15 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 				if plugin.Target == framework.GlobalTarget { // currently target "global" is not supported as target for install command
 					target = ""
 				}
-				err := tf.PluginCmd.InstallPlugin(plugin.Name, target, plugin.Version, framework.WithTanzuCommandPrefix(framework.TzPrefix))
+				err := tf.PluginCmd.InstallPlugin(plugin.Name, target, plugin.Version, framework.WithTanzuBinary(framework.TzPrefix))
 				gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin install for new tanzu cli")
-				str, err := tf.PluginCmd.DescribePlugin(plugin.Name, plugin.Target, framework.WithTanzuCommandPrefix(framework.TzPrefix), framework.GetJsonOutputFormatAdditionalFlagFunction())
+				str, err := tf.PluginCmd.DescribePlugin(plugin.Name, plugin.Target, framework.WithTanzuBinary(framework.TzPrefix), framework.GetJsonOutputFormatAdditionalFlagFunction())
 				gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin describe for new tanzu cli")
 				gomega.Expect(str).NotTo(gomega.BeNil(), "there should be output for plugin describe for new tanzu cli")
 			}
 
 			ginkgo.By("Installing few plugins using new Tanzu CLI")
-			pluginsList, _, _, err = tf.PluginCmd.ListPlugins(framework.WithTanzuCommandPrefix(framework.TzPrefix))
+			pluginsList, _, _, err = tf.PluginCmd.ListPlugins(framework.WithTanzuBinary(framework.TzPrefix))
 			gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin list for new tanzu cli")
 			gomega.Expect(framework.CheckAllPluginsExists(pluginsList, PluginsForNewTanzuCLICoexistenceTests)).Should(gomega.BeTrue(), "the plugin list output using new tanzu cli is not same as the plugins being installed using new tanzu cli")
 
@@ -314,22 +314,22 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 			gomega.Expect(err).To(gomega.BeNil())
 
 			ginkgo.By("Verify the installed version of new Tanzu CLI")
-			version, err = tf.CLIVersion(framework.WithTanzuCommandPrefix(framework.TzPrefix))
+			version, err = tf.CLIVersion(framework.WithTanzuBinary(framework.TzPrefix))
 			gomega.Expect(version).To(gomega.ContainSubstring(newTanzuCLIVersion))
 			gomega.Expect(err).To(gomega.BeNil())
 
 			// set up the test local central repository host CA cert in the config file
-			setTestLocalCentralRepoCertConfig([]framework.E2EOption{framework.WithTanzuCommandPrefix(framework.TzPrefix)})
+			setTestLocalCentralRepoCertConfig([]framework.E2EOption{framework.WithTanzuBinary(framework.TzPrefix)})
 
 			// set up the local central repository discovery image signature public key path
 			os.Setenv(framework.TanzuCliPluginDiscoveryImageSignaturePublicKeyPath, e2eTestLocalCentralRepoPluginDiscoveryImageSignaturePublicKeyPath)
 
 			ginkgo.By("Update plugin discovery source with test central repo")
-			_, err = tf.PluginCmd.UpdatePluginDiscoverySource(&framework.DiscoveryOptions{Name: "default", SourceType: framework.SourceType, URI: e2eTestLocalCentralRepoURL}, framework.WithTanzuCommandPrefix(framework.TzPrefix))
+			_, err = tf.PluginCmd.UpdatePluginDiscoverySource(&framework.DiscoveryOptions{Name: "default", SourceType: framework.SourceType, URI: e2eTestLocalCentralRepoURL}, framework.WithTanzuBinary(framework.TzPrefix))
 			gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin source update")
 
 			ginkgo.By("search plugins and make sure there are plugins available")
-			pluginsSearchList, err := pluginlifecyclee2e.SearchAllPlugins(tf, framework.WithTanzuCommandPrefix(framework.TzPrefix))
+			pluginsSearchList, err := pluginlifecyclee2e.SearchAllPlugins(tf, framework.WithTanzuBinary(framework.TzPrefix))
 			gomega.Expect(err).To(gomega.BeNil(), framework.NoErrorForPluginSearch)
 			gomega.Expect(len(pluginsSearchList)).Should(gomega.BeNumerically(">", 0))
 
@@ -339,15 +339,15 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 				if plugin.Target == framework.GlobalTarget { // currently target "global" is not supported as target for install command
 					target = ""
 				}
-				err := tf.PluginCmd.InstallPlugin(plugin.Name, target, plugin.Version, framework.WithTanzuCommandPrefix(framework.TzPrefix))
+				err := tf.PluginCmd.InstallPlugin(plugin.Name, target, plugin.Version, framework.WithTanzuBinary(framework.TzPrefix))
 				gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin install using new tanzu cli")
-				str, err := tf.PluginCmd.DescribePlugin(plugin.Name, plugin.Target, framework.WithTanzuCommandPrefix(framework.TzPrefix), framework.GetJsonOutputFormatAdditionalFlagFunction())
+				str, err := tf.PluginCmd.DescribePlugin(plugin.Name, plugin.Target, framework.WithTanzuBinary(framework.TzPrefix), framework.GetJsonOutputFormatAdditionalFlagFunction())
 				gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin describe using new tanzu cli")
 				gomega.Expect(str).NotTo(gomega.BeNil(), "there should be output for plugin describe using new tanzu cli")
 			}
 
 			ginkgo.By("Verify the installed plugins using new Tanzu CLI")
-			pluginsList, _, _, err = tf.PluginCmd.ListPlugins(framework.WithTanzuCommandPrefix(framework.TzPrefix))
+			pluginsList, _, _, err = tf.PluginCmd.ListPlugins(framework.WithTanzuBinary(framework.TzPrefix))
 			gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin list using new tanzu cli")
 			gomega.Expect(framework.CheckAllPluginsExists(pluginsList, PluginsForNewTanzuCLICoexistenceTests)).Should(gomega.BeTrue(), "the plugin list output using new tanzu cli is not same as the plugins being installed using new tanzu cli")
 
@@ -356,7 +356,7 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 			gomega.Expect(err).To(gomega.BeNil())
 
 			ginkgo.By("Verify the installed plugins using reinstalled new Tanzu CLI")
-			pluginsList, _, _, err = tf.PluginCmd.ListPlugins(framework.WithTanzuCommandPrefix(framework.TzPrefix))
+			pluginsList, _, _, err = tf.PluginCmd.ListPlugins(framework.WithTanzuBinary(framework.TzPrefix))
 			gomega.Expect(err).To(gomega.BeNil(), "should not get any error for plugin list using new tanzu cli")
 			gomega.Expect(framework.CheckAllPluginsExists(pluginsList, PluginsForNewTanzuCLICoexistenceTests)).Should(gomega.BeTrue(), "the plugin list output using new tanzu cli is not same as the plugins being installed using new tanzu cli")
 			gomega.Expect(pluginlifecyclee2e.CheckAllLegacyPluginsExists(pluginsList, PluginsForLegacyTanzuCLICoexistenceTests)).Should(gomega.BeTrue(), "the plugin list output using new tanzu cli is not same as the plugins being installed using legacy tanzu cli")
@@ -460,7 +460,7 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 			gomega.Expect(err).To(gomega.BeNil())
 
 			ginkgo.By("Verify the installed version of new Tanzu CLI")
-			version, err = tf.CLIVersion(framework.WithTanzuCommandPrefix(framework.TzPrefix))
+			version, err = tf.CLIVersion(framework.WithTanzuBinary(framework.TzPrefix))
 			gomega.Expect(version).To(gomega.ContainSubstring(newTanzuCLIVersion))
 			gomega.Expect(err).To(gomega.BeNil())
 
@@ -477,12 +477,12 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 			gomega.Expect(val).Should(gomega.Equal(framework.True))
 
 			ginkgo.By("Validate the value of random feature flag set in previous step using new Tanzu CLI")
-			val, err = tf.Config.ConfigGetFeatureFlag(randomFeatureFlagPath, framework.WithTanzuCommandPrefix(framework.TzPrefix))
+			val, err = tf.Config.ConfigGetFeatureFlag(randomFeatureFlagPath, framework.WithTanzuBinary(framework.TzPrefix))
 			gomega.Expect(err).To(gomega.BeNil())
 			gomega.Expect(val).Should(gomega.Equal(framework.True))
 
 			ginkgo.By("Unset random feature flag which was set in previous step using new Tanzu CLI")
-			err = tf.Config.ConfigUnsetFeature(randomFeatureFlagPath, framework.WithTanzuCommandPrefix(framework.TzPrefix))
+			err = tf.Config.ConfigUnsetFeature(randomFeatureFlagPath, framework.WithTanzuBinary(framework.TzPrefix))
 			gomega.Expect(err).To(gomega.BeNil())
 
 			ginkgo.By("Validate the unset random feature flag in previous step using legacy Tanzu CLI")
@@ -491,7 +491,7 @@ var _ = ginkgo.Describe("CLI Coexistence Tests", func() {
 			gomega.Expect(val).Should(gomega.Equal(""))
 
 			ginkgo.By("Validate the unset random feature flag in previous step using new Tanzu CLI")
-			val, err = tf.Config.ConfigGetFeatureFlag(randomFeatureFlagPath, framework.WithTanzuCommandPrefix(framework.TzPrefix))
+			val, err = tf.Config.ConfigGetFeatureFlag(randomFeatureFlagPath, framework.WithTanzuBinary(framework.TzPrefix))
 			gomega.Expect(err).To(gomega.BeNil())
 			gomega.Expect(val).Should(gomega.Equal(""))
 		})

--- a/test/e2e/framework/cli_lifecycle_operations.go
+++ b/test/e2e/framework/cli_lifecycle_operations.go
@@ -158,7 +158,7 @@ func (co *cliOps) RollbackToLegacyTanzuCLI(tf *Framework, opts ...E2EOption) err
 	log.Info("Executing Rollback instructions to legacy Tanzu CLI")
 	// Default options
 	options := NewE2EOptions(
-		WithTanzuCommandPrefix(TanzuPrefix),
+		WithTanzuBinary(TanzuPrefix),
 	)
 
 	// Apply provided options
@@ -261,7 +261,7 @@ func (co *cliOps) InstallNewTanzuCLI(opts ...E2EOption) error {
 
 	// Default options
 	options := NewE2EOptions(
-		WithTanzuCommandPrefix(TzPrefix),
+		WithTanzuBinary(TzPrefix),
 		WithOverride(false),
 		WithFilePath(newTanzuCLIFilePath),
 	)
@@ -307,7 +307,7 @@ func (co *cliOps) InstallNewTanzuCLI(opts ...E2EOption) error {
 		log.Info("New Tanzu CLI to coexist along with Old Tanzu CLI")
 
 		// Create a copy of new tanzu with name tz
-		stdOut, stdErr, err := co.cmdExe.Exec(fmt.Sprintf("cp -r %s/tanzu %s/%s", options.FilePath, options.FilePath, options.TanzuCommandPrefix))
+		stdOut, stdErr, err := co.cmdExe.Exec(fmt.Sprintf("cp -r %s/tanzu %s/%s", options.FilePath, options.FilePath, options.TanzuBinary))
 		log.Info(stdOut.String())
 
 		if stdErr != nil {
@@ -319,7 +319,7 @@ func (co *cliOps) InstallNewTanzuCLI(opts ...E2EOption) error {
 		}
 
 		// Move tz binary to /usr/bin
-		stdOut, stdErr, err = co.cmdExe.Exec(fmt.Sprintf("cp -r %s/%s /usr/bin", options.FilePath, options.TanzuCommandPrefix))
+		stdOut, stdErr, err = co.cmdExe.Exec(fmt.Sprintf("cp -r %s/%s /usr/bin", options.FilePath, options.TanzuBinary))
 		log.Info(stdOut.String())
 
 		if stdErr != nil {

--- a/test/e2e/framework/cmd_exec_operations.go
+++ b/test/e2e/framework/cmd_exec_operations.go
@@ -35,8 +35,9 @@ func NewCmdOps() CmdOps {
 // TanzuCmdExec executes the tanzu command by default uses `tanzu` prefix
 func (co *cmdOps) TanzuCmdExec(command string, opts ...E2EOption) (stdOut, stdErr *bytes.Buffer, err error) {
 	// Get Default options, and initialize Tanzu Command Prefix value as 'tanzu'
-	options := NewE2EOptions(
-		WithTanzuCommandPrefix(TanzuPrefix),
+	var options *E2EOptions
+	options = NewE2EOptions(
+		WithTanzuBinary(TanzuBinary),
 	)
 
 	// Apply the options provided, which allow the user to override the Tanzu command prefix value, such as 'tz'
@@ -44,10 +45,11 @@ func (co *cmdOps) TanzuCmdExec(command string, opts ...E2EOption) (stdOut, stdEr
 		opt(options)
 	}
 
-	// Verify whether the Tanzu prefix is set and if not, set it to the default Tanzu prefix value
+	// Verify whether the Tanzu prefix or binary is set and if not, set the tanzu binary if tanzu binary path is specified or default to tanzu prefix available at PATH variable
 	if strings.Index(command, "%s") == 0 {
-		command = fmt.Sprintf(command, options.TanzuCommandPrefix)
+		command = fmt.Sprintf(command, options.TanzuBinary)
 	}
+
 	// If any additional flags are added, then append them to the command
 	if options.AdditionalFlags != "" {
 		command += options.AdditionalFlags

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -24,6 +24,7 @@ var (
 	// ConfigFilePath represents config-ng.yaml file path which under $HOME/.tanzu-cli-e2e/.config/tanzu
 	ConfigNGFilePath string
 	TanzuFolderPath  string
+	TanzuBinary      string // Tanzu binary name if available in PATH variable or full path to binary with tanzu name
 )
 
 // PluginsForLifeCycleTests is list of plugins (which are published in local central repo) used in plugin life cycle test cases
@@ -49,9 +50,9 @@ type Framework struct {
 }
 
 // E2EOptions used to configure certain options to customize the E2E framework
-// TanzuCommandPrefix should be set to customize the tanzu command prefix; default is tanzu
+
 type E2EOptions struct {
-	TanzuCommandPrefix string
+	TanzuBinary string // TanzuBinary should be set to customize the tanzu binary either the binary name if available with PATH variable or full binary path with name ; default is tanzu from PATH variable
 	CLIOptions
 	AdditionalFlags string
 }
@@ -97,6 +98,11 @@ func init() {
 	TanzuFolderPath = filepath.Join(filepath.Join(TestDirPath, ConfigFolder), TanzuFolder)
 	ConfigFilePath = filepath.Join(TanzuFolderPath, ConfigFile)
 	ConfigNGFilePath = filepath.Join(TanzuFolderPath, ConfigNGFile)
+	TanzuBinary = os.Getenv(TanzuCLIBinaryPath)
+	// Set `tanzu` as default binary if not specified tanzu cli binary path
+	if TanzuBinary == "" {
+		TanzuBinary = TanzuPrefix
+	}
 	// Create a directory (if not exists) $HOME/.tanzu-cli-e2e/.config/tanzu-plugins/discovery/standalone
 	TestStandalonePluginsPath = filepath.Join(filepath.Join(filepath.Join(filepath.Join(TestDirPath, ConfigFolder), TanzuPluginsFolder), "discovery"), "standalone")
 	_ = CreateDir(TestStandalonePluginsPath)

--- a/test/e2e/framework/framework_constants.go
+++ b/test/e2e/framework/framework_constants.go
@@ -179,14 +179,14 @@ const (
 	// TempDirInTestDirPath is the directory under $HOME/$TestDir, to create temporary files (if any) for E2E test execution
 	TempDirInTestDirPath = "temp"
 
-	ConfigFolder       = ".config"
-	TanzuFolder        = "tanzu"
-	TanzuPluginsFolder = "tanzu-plugins"
-	ConfigFile         = "config.yaml"
-	ConfigNGFile       = "config-ng.yaml"
-	K8SCRDFileName     = "cli.tanzu.vmware.com_cliplugins.yaml"
-	Config             = "config"
-
+	ConfigFolder                = ".config"
+	TanzuFolder                 = "tanzu"
+	TanzuPluginsFolder          = "tanzu-plugins"
+	ConfigFile                  = "config.yaml"
+	ConfigNGFile                = "config-ng.yaml"
+	K8SCRDFileName              = "cli.tanzu.vmware.com_cliplugins.yaml"
+	Config                      = "config"
+	TanzuCLIBinaryPath          = "TANZU_CLI_BINARY_PATH"
 	WiredMockHTTPServerStartCmd = "docker run --rm -d -p 8080:8080 -p 8443:8443 --name %s -v %s:/home/wiremock rodolpheche/wiremock:2.25.1"
 	HttpMockServerStopCmd       = "docker container stop %s"
 	HttpMockServerName          = "wiremock"

--- a/test/e2e/framework/framework_helper.go
+++ b/test/e2e/framework/framework_helper.go
@@ -24,10 +24,10 @@ import (
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
 
-// WithTanzuCommandPrefix is to set the tanzu command prefix; default is tanzu
-func WithTanzuCommandPrefix(prefix string) E2EOption {
+// WithTanzuBinary is to set the tanzu binary location; default is tanzu from PATH variable
+func WithTanzuBinary(tanzuBinary string) E2EOption {
 	return func(opts *E2EOptions) {
-		opts.TanzuCommandPrefix = prefix
+		opts.TanzuBinary = tanzuBinary
 	}
 }
 


### PR DESCRIPTION
### What this PR does / why we need it
-  Extend the e2e framework  to customize the tanzu binary
- Provided a env variable TANZU_CLI_BINARY_PATH to override the tanzu binary used in the e2e tests
- Added a WithTanzuBinary() helper method to customize which tanzu binary to use
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
 
e2e tests passed

```
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (e2e/customize_tanzu_binary)> export TANZU_CLI_BINARY_PATH="/usr/local/bin/tz2"
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (e2e/customize_tanzu_binary)> echo $TANZU_CLI_BINARY_PATH
/usr/local/bin/tz2

mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (e2e/customize_tanzu_binary)> make e2e-cli-lifecycle
export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="No" ; \
	export TANZU_CLI_EULA_PROMPT_ANSWER="Yes" ; \
	/Users/mpanchajanya/vmw/repository/tanzu-cli/hack/tools/bin/ginkgo --keep-going --output-dir /Users/mpanchajanya/vmw/repository/tanzu-cli/test/e2e/testresults --json-report=results.json --keep-separate-reports --race --nodes=1 -v -r /Users/mpanchajanya/vmw/repository/tanzu-cli/test/e2e/cli_lifecycle  --trace > /tmp/out && { cat /tmp/out | grep -Ev 'STEP:|seconds|.go:'; rm /tmp/out; } || { exit_code=$?; cat /tmp/out | grep -Ev 'STEP:|seconds|.go:'; rm /tmp/out; exit $exit_code; } \

Running Suite: CLI lifecycle E2E Test Suite - /Users/mpanchajanya/vmw/repository/tanzu-cli/test/e2e/cli_lifecycle
=================================================================================================================
Random Seed: 1687528032

Will run 9 of 9 specs
------------------------------
[BeforeSuite]
command /usr/local/bin/tz2 config init
[i] Executing command: /usr/local/bin/tz2 config init
------------------------------
[CLI-Core][Tests:E2E][Feature:Command-init-version] tests for tanzu init and version commands when init command executed should initialize cli successfully
command /usr/local/bin/tz2 init
[i] Executing command: /usr/local/bin/tz2 init
------------------------------
[CLI-Core][Tests:E2E][Feature:Command-init-version] tests for tanzu init and version commands when version command executed should return version info
command /usr/local/bin/tz2 version
[i] Executing command: /usr/local/bin/tz2 version
------------------------------
[CLI-Core][Tests:E2E][Feature:Command-completion] tests for tanzu completion ommand when completion command executed When the completion command is executed without specifying a shell input value
command /usr/local/bin/tz2 completion
[i] Executing command: /usr/local/bin/tz2 completion
[i] failed to run completion command: %s completion, stdout:
------------------------------
[CLI-Core][Tests:E2E][Feature:Command-completion] tests for tanzu completion ommand when completion command executed When the completion command is executed with bash as the input
command /usr/local/bin/tz2 completion bash
[i] Executing command: /usr/local/bin/tz2 completion bash
------------------------------
[CLI-Core][Tests:E2E][Feature:Command-completion] tests for tanzu completion ommand when completion command executed When the completion command is executed with zsh as the input
command /usr/local/bin/tz2 completion zsh
[i] Executing command: /usr/local/bin/tz2 completion zsh
------------------------------
[CLI-Core][Tests:E2E][Feature:Command-completion] tests for tanzu completion ommand when completion command executed When the completion command is executed with fish as the input
command /usr/local/bin/tz2 completion fish
[i] Executing command: /usr/local/bin/tz2 completion fish
------------------------------
[CLI-Core][Tests:E2E][Feature:Command-completion] tests for tanzu completion ommand when completion command executed When the completion command is executed with powershell as the input
command /usr/local/bin/tz2 completion powershell
[i] Executing command: /usr/local/bin/tz2 completion powershell
------------------------------
[CLI-Core][Tests:E2E][Feature:Command-completion] tests for tanzu completion ommand when completion command executed When the completion command is executed with pwsh as the input
command /usr/local/bin/tz2 completion pwsh
[i] Executing command: /usr/local/bin/tz2 completion pwsh
------------------------------
[CLI-Core][Tests:E2E][Feature:Command-completion] tests for tanzu completion ommand when completion command executed When the cobra __complete command is executed
command /usr/local/bin/tz2 __complete ''
[i] Executing command: /usr/local/bin/tz2 __complete ''
------------------------------
[ReportAfterSuite] Autogenerated ReportAfterSuite for --json-report
autogenerated by Ginkgo
------------------------------

SUCCESS! -- 9 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 2.955485667s
Test Suite Passed
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (e2e/customize_tanzu_binary)>

```





<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
