### PR TITLE
Use a binary built locally for APT/RPM

### DIFF
--- a/hack/apt/README.md
+++ b/hack/apt/README.md
@@ -9,9 +9,20 @@ how to install the CLI from that repository.
 Executing the `hack/apt/build_package.sh` script will build the Debian packages
 under `hack/apt/_output`. The `hack/apt/build_package.sh` script is meant to
 be run on a Linux machine that has `apt` installed. This can be done in
-docker. To facilitate this operation, the new `apt-package` Makefile target has
-been added; this Makefile target will first start a docker container and then
-run the `hack/apt/build_package.sh` script.
+docker.
+
+Then the `hack/apt/build_package_repo.sh` needs to be executed to build the
+Debian repository containing the packages.
+
+To facilitate this operation, the `apt-package` Makefile target can be used;
+this Makefile target will first start a docker container and then
+run the `hack/apt/build_package*.sh` scripts.
+
+### Pre-requisite
+
+`make cross-build` should be run first to build the `tanzu` binary for linux
+in the location expected by the scripts.  To save time, the shorter
+`make build-cli-linux-amd64` target can be used.
 
 ```bash
 cd tanzu-cli

--- a/hack/apt/build_package.sh
+++ b/hack/apt/build_package.sh
@@ -21,6 +21,7 @@ VERSION=${VERSION#v}
 
 BASE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}"); pwd)
 OUTPUT_DIR=${BASE_DIR}/_output
+ARTIFACTS_DIR=${BASE_DIR}/../../artifacts
 
 # Install build dependencies
 if ! command -v curl &> /dev/null; then
@@ -44,15 +45,12 @@ for arch in amd64 arm64; do
    echo "Building debian package for $arch..."
    echo "===================================="
 
-   mkdir -p ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}/usr/bin
-
    # For now, we don't have an ARM64 build, so we get the AMD64 one and use it for ARM64.
    # This is for Apple M1 machines which normally have an emulator.
-   # TODO: Replace all instances of "amd64" with "${arch}"
-   curl -sLo tanzu-cli-linux-${arch}.tar.gz https://github.com/vmware-tanzu/tanzu-cli/releases/download/v${VERSION}/tanzu-cli-linux-amd64.tar.gz
-
-   tar xzf tanzu-cli-linux-${arch}.tar.gz --strip-components=1 v${VERSION}/tanzu-cli-linux_amd64
-   mv tanzu-cli-linux_amd64 ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}/usr/bin/tanzu
+   # TODO: Replace all instances of "${fakeArch}" with "${arch}"
+   fakeArch=amd64
+   mkdir -p ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}/usr/bin
+   cp ${ARTIFACTS_DIR}/linux/${fakeArch}/cli/core/v${VERSION}/tanzu-cli-linux_${fakeArch} ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}/usr/bin/tanzu
 
    # Create the control file
    mkdir -p ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}/DEBIAN

--- a/hack/rpm/README.md
+++ b/hack/rpm/README.md
@@ -14,6 +14,12 @@ operation, the new `rpm-package` Makefile target has been added; this Makefile
 target will first start a docker container and then run the
 `hack/rpm/build_package.sh` script.
 
+### Pre-requisite
+
+`make cross-build` should be run first to build the `tanzu` binary for linux
+in the location expected by the scripts.  To save time, the shorter
+`make build-cli-linux-amd64` target can be used.
+
 ```bash
 cd tanzu-cli
 make rpm-package
@@ -31,8 +37,8 @@ Linux machine with `yum` or `dnf` installed or using a docker container. For
 example, using `yum`:
 
 ```bash
-cd tanzu-cli
-docker run --rm -it -v $(pwd)/hack/rpm/_output/rpm:/tmp/rpm fedora
+$ cd tanzu-cli
+$ docker run --rm -it -v $(pwd)/hack/rpm/_output/rpm:/tmp/rpm fedora
 cat << EOF | sudo tee /etc/yum.repos.d/tanzu-cli.repo
 [tanzu-cli]
 name=Tanzu CLI
@@ -60,7 +66,7 @@ can be installed publicly as described in the next section.
 ## Installing the Tanzu CLI
 
 ```bash
-docker run --rm -it fedora
+$ docker run --rm -it fedora
 cat << EOF | sudo tee /etc/yum.repos.d/tanzu-cli.repo
 [tanzu-cli]
 name=Tanzu CLI

--- a/hack/rpm/build_package.sh
+++ b/hack/rpm/build_package.sh
@@ -28,6 +28,7 @@ VERSION=${VERSION#v}
 
 BASE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}"); pwd)
 OUTPUT_DIR=${BASE_DIR}/_output/rpm/tanzu-cli
+ROOT_DIR=${BASE_DIR}/../..
 
 # Install build dependencies
 if ! command -v rpmlint &> /dev/null; then
@@ -42,6 +43,8 @@ mkdir -p ${HOME}/rpmbuild/SOURCES
 # Create the .rpm packages
 rm -rf ${OUTPUT_DIR}
 mkdir -p ${OUTPUT_DIR}
+cd ${ROOT_DIR}
+
 # RPM does not like - in the its package version
 PACKAGE_VERSION=${VERSION//-/_}
 rpmbuild --define "package_version ${PACKAGE_VERSION}" --define "release_version ${VERSION}" -bb ${BASE_DIR}/tanzu-cli.spec --target x86_64
@@ -61,8 +64,8 @@ fi
 createrepo ${OUTPUT_DIR}
 
 if [[ ! -z "${RPM_SIGNER}" ]]; then
- # instead of ... gpg --detach-sign --armor repodata/repomd.xml
- ${RPM_SIGNER} ${OUTPUT_DIR}/repodata/repomd.xml
+  # instead of ... gpg --detach-sign --armor repodata/repomd.xml
+  ${RPM_SIGNER} ${OUTPUT_DIR}/repodata/repomd.xml
 else
   echo skip rpmsigning repo
 fi

--- a/hack/rpm/tanzu-cli.spec
+++ b/hack/rpm/tanzu-cli.spec
@@ -17,8 +17,7 @@ Obsoletes:  tanzu-cli  < %{package_version}
 %define arch amd64
 %endif
 
-%undefine _disable_source_fetch
-Source0:    https://github.com/vmware-tanzu/tanzu-cli/releases/download/v%{release_version}/tanzu-cli-linux-%{arch}.tar.gz
+Source0:    %{expand:%%(pwd)/artifacts/linux/%{arch}/cli/core/v%{release_version}/tanzu-cli-linux_%{arch}}
 
 %description
 VMware Tanzu is a modular, cloud native application platform that enables vital DevSecOps outcomes
@@ -31,16 +30,10 @@ in a multi-cloud world.  The Tanzu CLI allows you to control VMware Tanzu from t
 # This is required to avoid some missing debug file errors
 %define debug_package %nil
 
-%prep
-%setup -q -n v%{release_version}
-
-%build
-# Nothing to build
-
 %install
 rm -rf $RPM_BUILD_ROOT
-mkdir -p $RPM_BUILD_ROOT/%{_bindir}
-mv tanzu-cli-linux_%{arch} $RPM_BUILD_ROOT/%{_bindir}/tanzu
+mkdir -p $RPM_BUILD_ROOT%{_bindir}
+cp -af %{SOURCEURL0} $RPM_BUILD_ROOT%{_bindir}/tanzu
 
 %post
 # Setup bash completion


### PR DESCRIPTION
### What this PR does / why we need it

Before this PR, the scripts to build APT and RPM packages would download the `tanzu` binary from Github.  This was meant to use an SRP-compliant binary in the packages (VMware secure build process).

We plan on adding the building of the APT/RPM packages to the SRP-compliant build itself.  To prepare for this, this PR no longer downloads the binary from Github but uses the one built locally.  This means that when building these packages in an SRP-compliant environment at the same time as when the SRP-compliant binaries are built, the resulting packages will also be SRP-compliant.

This implies that when such packages are built on a developer's machine, they will not be SRP-compliant since they no longer use the SRP-compliant binary from Github.  This is not such a problem because it is already not possible to properly sign such packages on a developer's machine, so we already have to rely on the SRP-environment to build and sign these APT/RPM packages.

On a developer's machine, before running either `make apt-package` or `make rpm-package`, the CLI binary must be built (for linux) first by using `make cross-build` (or the quicker `make build-cli-linux-amd64`).  This is not enforced by the makefile (yet?) because the binary build is triggered differently when doing the full SRP-compliant build.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Build `apt-package` without an `artifacts` directory should fail as the local build is not used:
```
$ \rm -rf artifacts
$ make apt-package
docker run --rm -e VERSION=v1.0.0-dev -e DEB_SIGNER= -v /Users/kmarc/git/tanzu-cli:/Users/kmarc/git/tanzu-cli ubuntu /Users/kmarc/git/tanzu-cli/hack/apt/build_package.sh
Get:1 http://ports.ubuntu.com/ubuntu-ports jammy InRelease [270 kB]
Get:2 http://ports.ubuntu.com/ubuntu-ports jammy-updates InRelease [119 kB]
Get:3 http://ports.ubuntu.com/ubuntu-ports jammy-backports InRelease [108 kB]
[...]
====================================
Building debian package for amd64...
====================================
cp: cannot stat '/Users/kmarc/git/tanzu-cli/hack/apt/../../artifacts/linux/amd64/cli/core/v1.0.0-dev/tanzu-cli-linux_amd64': No such file or directory
make: *** [apt-package-only] Error 1
```

Build `rpm-package` without an `artifacts` directory should fail as the local build is not used:
```
$ \rm -rf artifacts
$ make rpm-package
docker run --rm -e VERSION=v1.0.0-dev -e RPM_SIGNER= -v /Users/kmarc/git/tanzu-cli:/Users/kmarc/git/tanzu-cli fedora /Users/kmarc/git/tanzu-cli/hack/rpm/build_package.sh
Fedora 38 - aarch64                             4.8 MB/s |  79 MB     00:16
Fedora 38 openh264 (From Cisco) - aarch64       1.9 kB/s | 2.5 kB     00:01
Fedora Modular 38 - aarch64                     3.1 MB/s | 2.7 MB     00:00
Fedora 38 - aarch64 - Updates                   3.7 MB/s |  23 MB     00:06
Fedora Modular 38 - aarch64 - Updates           2.3 MB/s | 2.0 MB     00:00
Dependencies resolved.
================================================================================
 Package                       Arch      Version                Repo       Size
================================================================================
Installing:
 createrepo_c                  aarch64   0.21.1-1.fc38          updates    76 k
 rpm-build                     aarch64   4.18.1-3.fc38          updates    77 k
[...]
+ rm -rf /root/rpmbuild/BUILDROOT/tanzu-cli-1.0.0_dev-1.x86_64
+ mkdir -p /root/rpmbuild/BUILDROOT/tanzu-cli-1.0.0_dev-1.x86_64/usr/bin
+ cp -af /Users/kmarc/git/tanzu-cli/artifacts/linux/amd64/cli/core/v1.0.0-dev/tanzu-cli-linux_amd64 /root/rpmbuild/BUILDROOT/tanzu-cli-1.0.0_dev-1.x86_64/usr/bin/tanzu
cp: cannot stat '/Users/kmarc/git/tanzu-cli/artifacts/linux/amd64/cli/core/v1.0.0-dev/tanzu-cli-linux_amd64': No such file or directory
error: Bad exit status from /var/tmp/rpm-tmp.hYIR73 (%install)
    source_date_epoch_from_changelog set but %changelog is missing
    Bad exit status from /var/tmp/rpm-tmp.hYIR73 (%install)

RPM build warnings:

RPM build errors:
make: *** [rpm-package] Error 1
```

Build `apt-package` and install it locally:
```
$ \rm -rf hack/apt/_output/
$ make build-cli-linux-amd64
build linux-amd64 CLI with version: v1.0.0-dev

$ make apt-package
docker run --rm -e VERSION=v1.0.0-dev -e DEB_SIGNER= -v /Users/kmarc/git/tanzu-cli:/Users/kmarc/git/tanzu-cli ubuntu /Users/kmarc/git/tanzu-cli/hack/apt/build_package.sh
Get:1 http://ports.ubuntu.com/ubuntu-ports jammy InRelease [270 kB]
Get:2 http://ports.ubuntu.com/ubuntu-ports jammy-updates InRelease [119 kB]
Get:3 http://ports.ubuntu.com/ubuntu-ports jammy-backports InRelease [108 kB]
[...]
====================================
Building debian package for amd64...
====================================
dpkg-deb: building package 'tanzu-cli' in '/Users/kmarc/git/tanzu-cli/hack/apt/_output/tanzu-cli_1.0.0-dev_linux_amd64.deb'.
====================================
Building debian package for arm64...
====================================
dpkg-deb: building package 'tanzu-cli' in '/Users/kmarc/git/tanzu-cli/hack/apt/_output/tanzu-cli_1.0.0-dev_linux_arm64.deb'.
skip debsigning
docker run --rm -e VERSION=v1.0.0-dev -e DEB_SIGNER= -v /Users/kmarc/git/tanzu-cli:/Users/kmarc/git/tanzu-cli ubuntu /Users/kmarc/git/tanzu-cli/hack/apt/build_package_repo.sh
Get:1 http://ports.ubuntu.com/ubuntu-ports jammy InRelease [270 kB]
Get:2 http://ports.ubuntu.com/ubuntu-ports jammy-updates InRelease [119 kB]
[...]
====================================
Building debian package repo for amd64...
====================================
Exporting indices...
====================================
Building debian package repo for arm64...
====================================
Exporting indices...
skip debsigning

# Test the resulting package
$ docker run --rm -it -v $(pwd)/hack/apt/_output/apt:/tmp/apt ubuntu

root@f5f1fdade059:/# echo "deb file:///tmp/apt tanzu-cli-jessie main" | tee /etc/apt/sources.list.d/tanzu.list
deb file:///tmp/apt tanzu-cli-jessie main
root@f5f1fdade059:/# apt-get update --allow-insecure-repositories
Get:1 file:/tmp/apt tanzu-cli-jessie InRelease
Ign:1 file:/tmp/apt tanzu-cli-jessie InRelease
[...]
Get:22 http://ports.ubuntu.com/ubuntu-ports jammy-security/main arm64 Packages [564 kB]
Fetched 23.8 MB in 4s (5714 kB/s)
Reading package lists... Done
W: The repository 'file:/tmp/apt tanzu-cli-jessie Release' is not signed.
N: Data from such a repository can't be authenticated and is therefore potentially dangerous to use.
N: See apt-secure(8) manpage for repository creation and user configuration details.

root@f5f1fdade059:/# apt install -y tanzu-cli --allow-unauthenticated
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following NEW packages will be installed:
  tanzu-cli
0 upgraded, 1 newly installed, 0 to remove and 13 not upgraded.
Need to get 0 B/39.9 MB of archives.
After this operation, 0 B of additional disk space will be used.
WARNING: The following packages cannot be authenticated!
  tanzu-cli
Authentication warning overridden.
Get:1 file:/tmp/apt tanzu-cli-jessie/main arm64 tanzu-cli arm64 1.0.0-dev [39.9 MB]
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package tanzu-cli.
(Reading database ... 4389 files and directories currently installed.)
Preparing to unpack .../tanzu-cli_1.0.0-dev_arm64.deb ...
Unpacking tanzu-cli (1.0.0-dev) ...
Setting up tanzu-cli (1.0.0-dev) ...

root@f5f1fdade059:/# tanzu version
version: v1.0.0-dev
buildDate: 2023-06-23
sha: c2d0c0163
```

Build `rpm-package` and install it locally:
```
$ make build-cli-linux-amd64
build linux-amd64 CLI with version: v1.0.0-dev
$ \rm -rf hack/rpm/_output/

$ make rpm-package
docker run --rm -e VERSION=v1.0.0-dev -e RPM_SIGNER= -v /Users/kmarc/git/tanzu-cli:/Users/kmarc/git/tanzu-cli fedora /Users/kmarc/git/tanzu-cli/hack/rpm/build_package.sh
Fedora 38 - aarch64                             6.2 MB/s |  79 MB     00:12
Fedora 38 openh264 (From Cisco) - aarch64       2.8 kB/s | 2.5 kB     00:00
Fedora Modular 38 - aarch64                     1.4 MB/s | 2.7 MB     00:01
Fedora 38 - aarch64 - Updates                   3.9 MB/s |  23 MB     00:06
Fedora Modular 38 - aarch64 - Updates           1.1 MB/s | 2.0 MB     00:01
[...]
+ rm -rf /root/rpmbuild/BUILDROOT/tanzu-cli-1.0.0_dev-1.x86_64
+ mkdir -p /root/rpmbuild/BUILDROOT/tanzu-cli-1.0.0_dev-1.x86_64/usr/bin
+ cp -af /Users/kmarc/git/tanzu-cli/artifacts/linux/amd64/cli/core/v1.0.0-dev/tanzu-cli-linux_amd64 /root/rpmbuild/BUILDROOT/tanzu-cli-1.0.0_dev-1.x86_64/usr/bin/tanzu
[...]
RPM build warnings:
    source_date_epoch_from_changelog set but %changelog is missing
    Missing build-id in /root/rpmbuild/BUILDROOT/tanzu-cli-1.0.0_dev-1.aarch64/usr/bin/tanzu
skip rpmsigning packages
Directory walk started
Directory walk done - 2 packages
Temporary output repo path: /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/.repodata/
Preparing sqlite DBs
Pool started (with 5 workers)
Pool finished
skip rpmsigning repo

# Install the built RPM package
$ docker run --rm -it -v $(pwd)/hack/rpm/_output/rpm:/tmp/rpm fedora

[root@9021800e5542 /]# cat << EOF | sudo tee /etc/yum.repos.d/tanzu-cli.repo
[tanzu-cli]
name=Tanzu CLI
baseurl=file:///tmp/rpm/tanzu-cli
enabled=1
gpgcheck=0
EOF

[root@9021800e5542 /]# yum install -y tanzu-cli
Fedora 38 - aarch64                                                                                                          7.1 MB/s |  79 MB     00:11
[...]

Installed:
  tanzu-cli-1.0.0_dev-1.aarch64

Complete!

[root@9021800e5542 /]# tanzu version
version: v1.0.0-dev
buildDate: 2023-06-23
sha: c2d0c0163
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Building local APT/RPM packages now uses a local build of the `tanzu` binary.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
