### PR TITLE
Add timeout to k8s client

### DIFF
--- a/pkg/discovery/interface.go
+++ b/pkg/discovery/interface.go
@@ -10,10 +10,13 @@ package discovery
 
 import (
 	"errors"
+	"time"
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/plugininventory"
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
+
+var defaultTimeout = 5 * time.Second
 
 // Discovery is the interface to fetch the list of available plugins
 type Discovery interface {

--- a/pkg/discovery/kubernetes.go
+++ b/pkg/discovery/kubernetes.go
@@ -47,7 +47,7 @@ func (k *KubernetesDiscovery) Name() string {
 // Manifest returns the manifest for a kubernetes repository.
 func (k *KubernetesDiscovery) Manifest() ([]Discovered, error) {
 	// Create cluster client
-	clusterClient, err := cluster.NewClient(k.kubeconfigPath, k.kubecontext, cluster.Options{})
+	clusterClient, err := cluster.NewClient(k.kubeconfigPath, k.kubecontext, cluster.Options{RequestTimeout: defaultTimeout})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/discovery/rest.go
+++ b/pkg/discovery/rest.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/pkg/errors"
 
@@ -19,8 +18,6 @@ import (
 	"github.com/vmware-tanzu/tanzu-cli/pkg/distribution"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/utils"
 )
-
-var defaultTimeout = 5 * time.Second
 
 // Plugin contains information about a Tanzu CLI plugin discovered via a REST API.
 type Plugin struct {

--- a/pkg/fakes/discoveryclusterclient_fake.go
+++ b/pkg/fakes/discoveryclusterclient_fake.go
@@ -122,13 +122,18 @@ type DiscoveryClient struct {
 		result1 *version.Info
 		result2 error
 	}
+	WithLegacyStub        func() discovery.DiscoveryInterface
+	withLegacyMutex       sync.RWMutex
+	withLegacyArgsForCall []struct {
+	}
+	withLegacyReturns struct {
+		result1 discovery.DiscoveryInterface
+	}
+	withLegacyReturnsOnCall map[int]struct {
+		result1 discovery.DiscoveryInterface
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *DiscoveryClient) WithLegacy() discovery.DiscoveryInterface {
-	//TODO implement me
-	panic("implement me")
 }
 
 func (fake *DiscoveryClient) OpenAPISchema() (*openapi_v2.Document, error) {
@@ -640,6 +645,59 @@ func (fake *DiscoveryClient) ServerVersionReturnsOnCall(i int, result1 *version.
 	}{result1, result2}
 }
 
+func (fake *DiscoveryClient) WithLegacy() discovery.DiscoveryInterface {
+	fake.withLegacyMutex.Lock()
+	ret, specificReturn := fake.withLegacyReturnsOnCall[len(fake.withLegacyArgsForCall)]
+	fake.withLegacyArgsForCall = append(fake.withLegacyArgsForCall, struct {
+	}{})
+	stub := fake.WithLegacyStub
+	fakeReturns := fake.withLegacyReturns
+	fake.recordInvocation("WithLegacy", []interface{}{})
+	fake.withLegacyMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *DiscoveryClient) WithLegacyCallCount() int {
+	fake.withLegacyMutex.RLock()
+	defer fake.withLegacyMutex.RUnlock()
+	return len(fake.withLegacyArgsForCall)
+}
+
+func (fake *DiscoveryClient) WithLegacyCalls(stub func() discovery.DiscoveryInterface) {
+	fake.withLegacyMutex.Lock()
+	defer fake.withLegacyMutex.Unlock()
+	fake.WithLegacyStub = stub
+}
+
+func (fake *DiscoveryClient) WithLegacyReturns(result1 discovery.DiscoveryInterface) {
+	fake.withLegacyMutex.Lock()
+	defer fake.withLegacyMutex.Unlock()
+	fake.WithLegacyStub = nil
+	fake.withLegacyReturns = struct {
+		result1 discovery.DiscoveryInterface
+	}{result1}
+}
+
+func (fake *DiscoveryClient) WithLegacyReturnsOnCall(i int, result1 discovery.DiscoveryInterface) {
+	fake.withLegacyMutex.Lock()
+	defer fake.withLegacyMutex.Unlock()
+	fake.WithLegacyStub = nil
+	if fake.withLegacyReturnsOnCall == nil {
+		fake.withLegacyReturnsOnCall = make(map[int]struct {
+			result1 discovery.DiscoveryInterface
+		})
+	}
+	fake.withLegacyReturnsOnCall[i] = struct {
+		result1 discovery.DiscoveryInterface
+	}{result1}
+}
+
 func (fake *DiscoveryClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -661,6 +719,8 @@ func (fake *DiscoveryClient) Invocations() map[string][][]interface{} {
 	defer fake.serverResourcesForGroupVersionMutex.RUnlock()
 	fake.serverVersionMutex.RLock()
 	defer fake.serverVersionMutex.RUnlock()
+	fake.withLegacyMutex.RLock()
+	defer fake.withLegacyMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value


### PR DESCRIPTION
### What this PR does / why we need it
This pull request updates the default timeout for the Kubernetes client. Previously, the client had a timeout of 32 seconds. With this pull request, the default timeout has been reduced to 5 seconds. Having a timeout of 32 seconds was not a great user experience, hence the change.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
I have tested the PR by mocking the http server and running the `tanzu plugin list` before fix and after the fix:
<!-- Example: Created vSphere workload cluster to verify change. -->
**Before Fix:**
Default timeout is 32s before the fix: 
We can see that the `tanzu plugin list` command is hanging for 32.12 seconds (32.120 total)
```
❯ git status
On branch main
Your branch is up to date with 'origin/main'.
nothing added to commit but untracked files present (use "git add" to track)
❯ 
❯ make build
build darwin-amd64 CLI with version: v1.0.0-dev
mkdir -p bin
cp /Users/cpamuluri/tkg/tasks/cli_core_main/tanzu-cli/artifacts/darwin/amd64/cli/core/v1.0.0-dev/tanzu-cli-darwin_amd64 ./bin/tanzu
❯ 
❯ time t plugin list
[!] there was an error while discovering plugins, error information: 'unable to list plugins from discovery source 'default-k11': Failed to invoke API on cluster : Get "http://127.0.0.1:58650/version?timeout=32s": net/http: request canceled (Client.Timeout exceeded while awaiting headers)'
[!] there was an error while getting installed context plugins, error information: 'unable to list plugins from discovery source 'default-k11': Failed to invoke API on cluster : Get "http://127.0.0.1:58650/version?timeout=32s": net/http: request canceled (Client.Timeout exceeded while awaiting headers)'
Standalone Plugins
  NAME     DESCRIPTION              TARGET      VERSION  STATUS     
  builder  Build Tanzu components   global      v0.90.0  installed  
  secret   Tanzu secret management  kubernetes  v0.29.0  installed  
[x] : unable to list plugins from discovery source 'default-k11': Failed to invoke API on cluster : Get "http://127.0.0.1:58650/version?timeout=32s": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
./bin/tanzu plugin list  0.10s user 0.04s system 0% cpu 32.120 total
❯
```
**After the Fix:**
As part of the fix the default timeout has updated as 5 seconds, we can see the same in the below request call "https://127.0.0.1:58650/version?timeout=5s" and the `tanzu plugin list` is ended after 6.040 seconds 
```
❯ 
❯ git checkout topic/chandra/add-timeout-k8s-client
Switched to branch 'topic/chandra/add-timeout-k8s-client'
❯ 
❯ make build
build darwin-amd64 CLI with version: v1.0.0-dev
mkdir -p bin
cp /Users/cpamuluri/tkg/tasks/cli_core_main/tanzu-cli/artifacts/darwin/amd64/cli/core/v1.0.0-dev/tanzu-cli-darwin_amd64 ./bin/tanzu
❯ 
❯ 
❯ time t plugin list                               
[!] there was an error while discovering plugins, error information: 'unable to list plugins from discovery source 'default-k11': Failed to invoke API on cluster : Get "http://127.0.0.1:58650/version?timeout=5s": net/http: request canceled (Client.Timeout exceeded while awaiting headers)'
[!] there was an error while getting installed context plugins, error information: 'unable to list plugins from discovery source 'default-k11': Failed to invoke API on cluster : Get "http://127.0.0.1:58650/version?timeout=5s": net/http: request canceled (Client.Timeout exceeded while awaiting headers)'
Standalone Plugins
  NAME     DESCRIPTION              TARGET      VERSION  STATUS     
  builder  Build Tanzu components   global      v0.90.0  installed  
  secret   Tanzu secret management  kubernetes  v0.29.0  installed  
[x] : unable to list plugins from discovery source 'default-k11': Failed to invoke API on cluster : Get "http://127.0.0.1:58650/version?timeout=5s": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
./bin/tanzu plugin list  0.09s user 0.04s system 2% cpu 6.040 total
❯ 
```
### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
