### PR TITLE
Update plugin describe command

### DIFF
--- a/pkg/command/plugin.go
+++ b/pkg/command/plugin.go
@@ -209,7 +209,7 @@ func newDescribePluginCmd() *cobra.Command {
 		Short: "Describe a plugin",
 		Long:  "Displays detailed information for a plugin",
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			output := component.NewOutputWriter(cmd.OutOrStdout(), outputFormat, "name", "description", "version", "buildSHA", "digest", "group", "docURL", "completionType", "installationPath", "discovery", "scope", "status", "discoveredRecommendedVersion", "target", "defaultFeatureFlags")
+			output := component.NewOutputWriter(cmd.OutOrStdout(), outputFormat, "name", "version", "status", "target", "description", "installationPath")
 			if len(args) != 1 {
 				return fmt.Errorf("must provide plugin name as positional argument")
 			}
@@ -223,8 +223,7 @@ func newDescribePluginCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			output.AddRow(pd.Name, pd.Description, pd.Version, pd.BuildSHA, pd.Digest, pd.Group, pd.DocURL, pd.CompletionType, pd.InstallationPath,
-				pd.Discovery, pd.Scope, pd.Status, pd.DiscoveredRecommendedVersion, pd.Target, pd.DefaultFeatureFlags)
+			output.AddRow(pd.Name, pd.Version, pd.Status, pd.Target, pd.Description, pd.InstallationPath)
 			output.Render()
 			return nil
 		},

--- a/pkg/command/plugin_test.go
+++ b/pkg/command/plugin_test.go
@@ -140,7 +140,7 @@ func TestPluginList(t *testing.T) {
 			targets:            []configtypes.Target{configtypes.TargetK8s},
 			args:               []string{"plugin", "describe", "foo", "-o", "json"},
 			expectedFailure:    false,
-			expected:           `[ { "buildsha": "", "completiontype": "0", "defaultfeatureflags": "map[]", "description": "some foo description", "digest": "", "discoveredrecommendedversion": "", "discovery": "", "docurl": "", "group": "System", "installationpath": "%v", "name": "foo", "scope": "", "status": "installed", "target": "kubernetes", "version": "v0.1.0" } ]`,
+			expected:           `[ { "description": "some foo description", "installationpath": "%v", "name": "foo", "status": "installed", "target": "kubernetes", "version": "v0.1.0" } ]`,
 		},
 	}
 


### PR DESCRIPTION
### What this PR does / why we need it
This pull request aims to update the output of the `tanzu plugin description` command. Prior to this fix, the command output contained too many columns, resulting in an poor user experience. As part of this PR, the output has been modified by removing non-essential columns, improving the readability and usability of the command.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

The unit test cases have been updated and manual testing has been performed. 
Here is the output **After Fix:**
```
❯ t plugin describe builder
  NAME     VERSION  STATUS     TARGET  DESCRIPTION             INSTALLATIONPATH                                                                                           
  builder  v0.90.0  installed  global  Build Tanzu components  /Users/cpamuluri/Library/Application                                                                       
                                                               Support/tanzu-cli/builder/v0.90.0_4811d1c5c5aebca83731de83b92d4e51268bf345b753b7d44a188fade95f3653_global  
❯ t plugin describe builder -o json
[
  {
    "description": "Build Tanzu components",
    "installationpath": "/Users/cpamuluri/Library/Application Support/tanzu-cli/builder/v0.90.0_4811d1c5c5aebca83731de83b92d4e51268bf345b753b7d44a188fade95f3653_global",
    "name": "builder",
    "status": "installed",
    "target": "global",
    "version": "v0.90.0"
  }
]%                                                                                                                      
❯ 
```
**Before Fix:**
```
❯ t plugin list
Standalone Plugins
  NAME     DESCRIPTION              TARGET      VERSION  STATUS     
  builder  Build Tanzu components   global      v0.90.0  installed  
  secret   Tanzu secret management  kubernetes  v0.29.0  installed  
❯ t plugin describe builder
  NAME     DESCRIPTION             VERSION  BUILDSHA  DIGEST  GROUP  DOCURL  COMPLETIONTYPE  INSTALLATIONPATH                                                                                           DISCOVERY  SCOPE       STATUS     DISCOVEREDRECOMMENDEDVERSION  TARGET  DEFAULTFEATUREFLAGS  
  builder  Build Tanzu components  v0.90.0  ce0e1cdf          Admin          0               /Users/cpamuluri/Library/Application                                                                       default    Standalone  installed  v0.90.0                       global  map[]                
                                                                                             Support/tanzu-cli/builder/v0.90.0_4811d1c5c5aebca83731de83b92d4e51268bf345b753b7d44a188fade95f3653_global                                                                                               
❯ t plugin describe builder -o json
[
  {
    "buildsha": "ce0e1cdf",
    "completiontype": "0",
    "defaultfeatureflags": "map[]",
    "description": "Build Tanzu components",
    "digest": "",
    "discoveredrecommendedversion": "v0.90.0",
    "discovery": "default",
    "docurl": "",
    "group": "Admin",
    "installationpath": "/Users/cpamuluri/Library/Application Support/tanzu-cli/builder/v0.90.0_4811d1c5c5aebca83731de83b92d4e51268bf345b753b7d44a188fade95f3653_global",
    "name": "builder",
    "scope": "Standalone",
    "status": "installed",
    "target": "global",
    "version": "v0.90.0"
  }
]%                                                                                                                      
❯
```

 
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
