### PR TITLE
Run OCI image package building and publishing concurrently

### DIFF
--- a/cmd/plugin/builder/command/cli_compile.go
+++ b/cmd/plugin/builder/command/cli_compile.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -24,6 +23,7 @@ import (
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 	rtplugin "github.com/vmware-tanzu/tanzu-plugin-runtime/plugin"
 
+	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/helpers"
 	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/types"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
@@ -72,7 +72,6 @@ type PluginCompileArgs struct {
 
 const local = "local"
 
-var minConcurrent = 2
 var identifiers = []string{
 	string('\U0001F435'),
 	string('\U0001F43C'),
@@ -111,14 +110,6 @@ func getBuildArch(arch []string) []cli.Arch {
 		}
 	}
 	return arrArch
-}
-
-func getMaxParallelism() int {
-	maxConcurrent := runtime.NumCPU() - 2
-	if maxConcurrent < minConcurrent {
-		maxConcurrent = minConcurrent
-	}
-	return maxConcurrent
 }
 
 type errInfo struct {
@@ -160,7 +151,7 @@ func Compile(compileArgs *PluginCompileArgs) error {
 	}
 
 	// Limit the number of concurrent operations we perform so we don't overwhelm the system.
-	maxConcurrent := getMaxParallelism()
+	maxConcurrent := helpers.GetMaxParallelism()
 	guard := make(chan struct{}, maxConcurrent)
 
 	// Mix up IDs so we don't always get the same set.

--- a/cmd/plugin/builder/helpers/helper.go
+++ b/cmd/plugin/builder/helpers/helper.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/pkg/errors"
 
@@ -20,8 +19,6 @@ import (
 	"github.com/vmware-tanzu/tanzu-cli/pkg/utils"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
-
-var minConcurrent = 2
 
 // ReadPluginManifest reads the PluginManifest file and returns Manifest object
 func ReadPluginManifest(pluginManifestFile string) (*cli.Manifest, error) {
@@ -77,8 +74,8 @@ func GetDigest(filePath string) (string, error) {
 // ValidatePluginBinary validates the plugin binary file
 // Checks the binary file size if its empty
 // returns true if file is not empty and false if file is empty
-func ValidatePluginBinary(pluginBinaryFilePath string) (bool, error) {
-	log.Infof("Validating Plugin Binary file: %v", pluginBinaryFilePath)
+func ValidatePluginBinary(pluginBinaryFilePath, threadID string) (bool, error) {
+	log.Infof("%s Validating Plugin Binary file: %v", threadID, pluginBinaryFilePath)
 	// Check whether the plugin binary is empty by verifying if size is zero
 	fileEmpty, err := utils.IsFileEmpty(pluginBinaryFilePath)
 
@@ -87,36 +84,4 @@ func ValidatePluginBinary(pluginBinaryFilePath string) (bool, error) {
 	}
 
 	return !fileEmpty, nil
-}
-
-func GetMaxParallelism() int {
-	maxConcurrent := runtime.NumCPU() - 2
-	if maxConcurrent < minConcurrent {
-		maxConcurrent = minConcurrent
-	}
-	return maxConcurrent
-}
-
-var Identifiers = []string{
-	string("=> T01]"),
-	string("=> T02]"),
-	string("=> T03]"),
-	string("=> T04]"),
-	string("=> T05]"),
-	string("=> T06]"),
-	string("=> T07]"),
-	string("=> T08]"),
-	string("=> T09]"),
-	string("=> T10]"),
-	string("=> T11]"),
-	string("=> T12]"),
-}
-
-func GetID(i int) string {
-	index := i
-	if i >= len(Identifiers) {
-		// Well aren't you lucky
-		index = i % len(Identifiers)
-	}
-	return Identifiers[index]
 }

--- a/cmd/plugin/builder/helpers/helper.go
+++ b/cmd/plugin/builder/helpers/helper.go
@@ -85,3 +85,15 @@ func ValidatePluginBinary(pluginBinaryFilePath, threadID string) (bool, error) {
 
 	return !fileEmpty, nil
 }
+
+// GetNumberOfIndividualPluginBinariesFromManifest returns the number of plugin binaries
+// into consideration based on the plugin manifest file
+// This includes plugin binaries for all supported os architectures as well as
+// all versions mentioned for the specific plugin.
+func GetNumberOfIndividualPluginBinariesFromManifest(pluginManifest *cli.Manifest) int {
+	numberOfPluginPackages := 0
+	for i := range pluginManifest.Plugins {
+		numberOfPluginPackages += len(pluginManifest.Plugins[i].Versions)
+	}
+	return numberOfPluginPackages * len(cli.AllOSArch)
+}

--- a/cmd/plugin/builder/helpers/helper.go
+++ b/cmd/plugin/builder/helpers/helper.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/pkg/errors"
 
@@ -19,6 +20,8 @@ import (
 	"github.com/vmware-tanzu/tanzu-cli/pkg/utils"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
+
+var minConcurrent = 2
 
 // ReadPluginManifest reads the PluginManifest file and returns Manifest object
 func ReadPluginManifest(pluginManifestFile string) (*cli.Manifest, error) {
@@ -84,4 +87,36 @@ func ValidatePluginBinary(pluginBinaryFilePath string) (bool, error) {
 	}
 
 	return !fileEmpty, nil
+}
+
+func GetMaxParallelism() int {
+	maxConcurrent := runtime.NumCPU() - 2
+	if maxConcurrent < minConcurrent {
+		maxConcurrent = minConcurrent
+	}
+	return maxConcurrent
+}
+
+var Identifiers = []string{
+	string("=> T01]"),
+	string("=> T02]"),
+	string("=> T03]"),
+	string("=> T04]"),
+	string("=> T05]"),
+	string("=> T06]"),
+	string("=> T07]"),
+	string("=> T08]"),
+	string("=> T09]"),
+	string("=> T10]"),
+	string("=> T11]"),
+	string("=> T12]"),
+}
+
+func GetID(i int) string {
+	index := i
+	if i >= len(Identifiers) {
+		// Well aren't you lucky
+		index = i % len(Identifiers)
+	}
+	return Identifiers[index]
 }

--- a/cmd/plugin/builder/helpers/helpers_test.go
+++ b/cmd/plugin/builder/helpers/helpers_test.go
@@ -33,7 +33,7 @@ func TestNonEmptyValidatePluginBinary(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Test a non-empty plugin binary file
-	valid, err := ValidatePluginBinary(tmpFile.Name())
+	valid, err := ValidatePluginBinary(tmpFile.Name(), "")
 	assert.Nil(t, err)
 	assert.Equal(t, true, valid)
 }
@@ -55,7 +55,7 @@ func TestEmptyValidatePluginBinary(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Test an empty plugin binary file
-	valid, err := ValidatePluginBinary(tmpFile.Name())
+	valid, err := ValidatePluginBinary(tmpFile.Name(), "")
 	assert.Nil(t, err)
 	assert.Equal(t, false, valid)
 }

--- a/cmd/plugin/builder/helpers/parallel.go
+++ b/cmd/plugin/builder/helpers/parallel.go
@@ -1,0 +1,51 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package helpers
+
+import "runtime"
+
+var minConcurrent = 2
+
+// ErrInfo is used to return error information for
+type ErrInfo struct {
+	Err  error
+	Path string
+	ID   string
+}
+
+// GetMaxParallelism return the maximum concurrent threads to use.
+// Limit the number of concurrent operations we perform so we don't overwhelm the system.
+func GetMaxParallelism() int {
+	maxConcurrent := runtime.NumCPU() - 2
+	if maxConcurrent < minConcurrent {
+		maxConcurrent = minConcurrent
+	}
+	return maxConcurrent
+}
+
+// Identifiers are the emoji symbols to specify progress happening on different threads
+var Identifiers = []string{
+	string('\U0001F435'),
+	string('\U0001F43C'),
+	string('\U0001F436'),
+	string('\U0001F430'),
+	string('\U0001F98A'),
+	string('\U0001F431'),
+	string('\U0001F981'),
+	string('\U0001F42F'),
+	string('\U0001F42E'),
+	string('\U0001F437'),
+	string('\U0001F42D'),
+	string('\U0001F428'),
+}
+
+// GetID return a unique ID based on the identifiers
+func GetID(i int) string {
+	index := i
+	if i >= len(Identifiers) {
+		// Well aren't you lucky
+		index = i % len(Identifiers)
+	}
+	return Identifiers[index]
+}

--- a/cmd/plugin/builder/plugin/build-packages.go
+++ b/cmd/plugin/builder/plugin/build-packages.go
@@ -52,7 +52,7 @@ func (bpo *BuildPluginPackageOptions) BuildPluginPackages() error {
 	maxConcurrent := helpers.GetMaxParallelism()
 	guard := make(chan struct{}, maxConcurrent)
 	var wg sync.WaitGroup
-	fatalErrors := make(chan helpers.ErrInfo, len(pluginManifest.Plugins)*len(cli.AllOSArch))
+	fatalErrors := make(chan helpers.ErrInfo, helpers.GetNumberOfIndividualPluginBinariesFromManifest(pluginManifest))
 
 	generatePluginPackage := func(p cli.Plugin, osArch cli.Arch, version, threadID string) {
 		defer func() {

--- a/cmd/plugin/builder/plugin/build-packages.go
+++ b/cmd/plugin/builder/plugin/build-packages.go
@@ -6,10 +6,13 @@ package plugin
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 
@@ -47,48 +50,79 @@ func (bpo *BuildPluginPackageOptions) BuildPluginPackages() error {
 
 	log.Infof("Using plugin binary artifacts from %q", bpo.BinaryArtifactDir)
 
+	// Limit the number of concurrent operations we perform so we don't overwhelm the system.
+	maxConcurrent := helpers.GetMaxParallelism()
+	guard := make(chan struct{}, maxConcurrent)
+	var wg sync.WaitGroup
+	// Mix up IDs so we don't always get the same set.
+	randSkew := rand.Intn(len(helpers.Identifiers)) // nolint:gosec
+	errorList := []error{}
+
+	generatePluginPackage := func(p cli.Plugin, osArch cli.Arch, version, id string) {
+		defer func() {
+			<-guard
+			wg.Done()
+		}()
+
+		pluginBinaryFilePath := filepath.Join(bpo.BinaryArtifactDir, osArch.OS(), osArch.Arch(),
+			p.Target, p.Name, version,
+			cli.MakeArtifactName(p.Name, osArch))
+
+		if !utils.PathExists(pluginBinaryFilePath) {
+			return
+		}
+
+		// Check whether the binary exec file is valid
+		valid, err := helpers.ValidatePluginBinary(pluginBinaryFilePath)
+
+		// Return err if plugin binary file validation fails
+		if err != nil {
+			errorList = append(errorList, err)
+			return
+		}
+
+		// Return err if plugin binary file is not valid
+		if !valid {
+			errorList = append(errorList, fmt.Errorf("invalid plugin binary :%v", pluginBinaryFilePath))
+			return
+		}
+
+		pluginTarFilePath := filepath.Join(bpo.PackageArtifactDir, helpers.GetPluginArchiveRelativePath(p, osArch, version))
+		image := fmt.Sprintf("%s/plugins/%s/%s/%s:%s", bpo.LocalOCIRegistry, osArch.OS(), osArch.Arch(), p.Name, version)
+
+		log.Infof("Generating plugin package for 'plugin:%s' 'target:%s' 'os:%s' 'arch:%s' 'version:%s'", p.Name, p.Target, osArch.OS(), osArch.Arch(), version)
+
+		err = carvelhelpers.NewImageOperationsImpl().PushImage(image, []string{pluginBinaryFilePath})
+		if err != nil {
+			errorList = append(errorList, errors.Wrapf(err, "unable to push package to temporary registry for plugin: %s, target: %s, os: %s, arch: %s, version: %s", p.Name, p.Target, osArch.OS(), osArch.Arch(), version))
+			return
+		}
+
+		err = bpo.CraneOptions.SaveImage(image, pluginTarFilePath)
+		if err != nil {
+			errorList = append(errorList, errors.Wrapf(err, "unable to generate package for plugin: %s, target: %s, os: %s, arch: %s, version: %s", p.Name, p.Target, osArch.OS(), osArch.Arch(), version))
+			return
+		}
+
+		log.Infof("Generated plugin package at %q", pluginTarFilePath)
+	}
+
+	id := 0
 	for i := range pluginManifest.Plugins {
 		for _, osArch := range cli.AllOSArch {
 			for _, version := range pluginManifest.Plugins[i].Versions {
-				pluginBinaryFilePath := filepath.Join(bpo.BinaryArtifactDir, osArch.OS(), osArch.Arch(),
-					pluginManifest.Plugins[i].Target, pluginManifest.Plugins[i].Name, version,
-					cli.MakeArtifactName(pluginManifest.Plugins[i].Name, osArch))
-
-				if !utils.PathExists(pluginBinaryFilePath) {
-					continue
-				}
-
-				// Check whether the binary exec file is valid
-				valid, err := helpers.ValidatePluginBinary(pluginBinaryFilePath)
-
-				// Return err if plugin binary file validation fails
-				if err != nil {
-					return err
-				}
-
-				// Return err if plugin binary file is not valid
-				if !valid {
-					return fmt.Errorf("invalid plugin binary :%v", pluginBinaryFilePath)
-				}
-
-				pluginTarFilePath := filepath.Join(bpo.PackageArtifactDir, helpers.GetPluginArchiveRelativePath(pluginManifest.Plugins[i], osArch, version))
-				image := fmt.Sprintf("%s/plugins/%s/%s/%s:%s", bpo.LocalOCIRegistry, osArch.OS(), osArch.Arch(), pluginManifest.Plugins[i].Name, version)
-
-				log.Infof("Generating plugin package for 'plugin:%s' 'target:%s' 'os:%s' 'arch:%s' 'version:%s'", pluginManifest.Plugins[i].Name, pluginManifest.Plugins[i].Target, osArch.OS(), osArch.Arch(), version)
-
-				err = carvelhelpers.NewImageOperationsImpl().PushImage(image, []string{pluginBinaryFilePath})
-				if err != nil {
-					return errors.Wrapf(err, "unable to push package to temporary registry for plugin: %s, target: %s, os: %s, arch: %s, version: %s", pluginManifest.Plugins[i].Name, pluginManifest.Plugins[i].Target, osArch.OS(), osArch.Arch(), version)
-				}
-
-				err = bpo.CraneOptions.SaveImage(image, pluginTarFilePath)
-				if err != nil {
-					return errors.Wrapf(err, "unable to generate package for plugin: %s, target: %s, os: %s, arch: %s, version: %s", pluginManifest.Plugins[i].Name, pluginManifest.Plugins[i].Target, osArch.OS(), osArch.Arch(), version)
-				}
-
-				log.Infof("Generated plugin package at %q", pluginTarFilePath)
+				wg.Add(1)
+				guard <- struct{}{}
+				go generatePluginPackage(pluginManifest.Plugins[i], osArch, version, helpers.GetID(id+randSkew))
+				id++
 			}
 		}
+	}
+
+	wg.Wait()
+
+	if len(errorList) != 0 {
+		return kerrors.NewAggregate(errorList)
 	}
 
 	// copy plugin_manifest.yaml to PackageArtifactDir

--- a/cmd/plugin/builder/plugin/build-packages.go
+++ b/cmd/plugin/builder/plugin/build-packages.go
@@ -6,13 +6,11 @@ package plugin
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"sync"
 
 	"github.com/pkg/errors"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 
@@ -54,11 +52,9 @@ func (bpo *BuildPluginPackageOptions) BuildPluginPackages() error {
 	maxConcurrent := helpers.GetMaxParallelism()
 	guard := make(chan struct{}, maxConcurrent)
 	var wg sync.WaitGroup
-	// Mix up IDs so we don't always get the same set.
-	randSkew := rand.Intn(len(helpers.Identifiers)) // nolint:gosec
-	errorList := []error{}
+	fatalErrors := make(chan helpers.ErrInfo, len(pluginManifest.Plugins)*len(cli.AllOSArch))
 
-	generatePluginPackage := func(p cli.Plugin, osArch cli.Arch, version, id string) {
+	generatePluginPackage := func(p cli.Plugin, osArch cli.Arch, version, threadID string) {
 		defer func() {
 			<-guard
 			wg.Done()
@@ -68,43 +64,10 @@ func (bpo *BuildPluginPackageOptions) BuildPluginPackages() error {
 			p.Target, p.Name, version,
 			cli.MakeArtifactName(p.Name, osArch))
 
-		if !utils.PathExists(pluginBinaryFilePath) {
-			return
-		}
-
-		// Check whether the binary exec file is valid
-		valid, err := helpers.ValidatePluginBinary(pluginBinaryFilePath)
-
-		// Return err if plugin binary file validation fails
+		err := bpo.generatePluginPackage(pluginBinaryFilePath, p, osArch, version, threadID)
 		if err != nil {
-			errorList = append(errorList, err)
-			return
+			fatalErrors <- helpers.ErrInfo{Err: err, ID: threadID, Path: pluginBinaryFilePath}
 		}
-
-		// Return err if plugin binary file is not valid
-		if !valid {
-			errorList = append(errorList, fmt.Errorf("invalid plugin binary :%v", pluginBinaryFilePath))
-			return
-		}
-
-		pluginTarFilePath := filepath.Join(bpo.PackageArtifactDir, helpers.GetPluginArchiveRelativePath(p, osArch, version))
-		image := fmt.Sprintf("%s/plugins/%s/%s/%s:%s", bpo.LocalOCIRegistry, osArch.OS(), osArch.Arch(), p.Name, version)
-
-		log.Infof("Generating plugin package for 'plugin:%s' 'target:%s' 'os:%s' 'arch:%s' 'version:%s'", p.Name, p.Target, osArch.OS(), osArch.Arch(), version)
-
-		err = carvelhelpers.NewImageOperationsImpl().PushImage(image, []string{pluginBinaryFilePath})
-		if err != nil {
-			errorList = append(errorList, errors.Wrapf(err, "unable to push package to temporary registry for plugin: %s, target: %s, os: %s, arch: %s, version: %s", p.Name, p.Target, osArch.OS(), osArch.Arch(), version))
-			return
-		}
-
-		err = bpo.CraneOptions.SaveImage(image, pluginTarFilePath)
-		if err != nil {
-			errorList = append(errorList, errors.Wrapf(err, "unable to generate package for plugin: %s, target: %s, os: %s, arch: %s, version: %s", p.Name, p.Target, osArch.OS(), osArch.Arch(), version))
-			return
-		}
-
-		log.Infof("Generated plugin package at %q", pluginTarFilePath)
 	}
 
 	id := 0
@@ -113,16 +76,22 @@ func (bpo *BuildPluginPackageOptions) BuildPluginPackages() error {
 			for _, version := range pluginManifest.Plugins[i].Versions {
 				wg.Add(1)
 				guard <- struct{}{}
-				go generatePluginPackage(pluginManifest.Plugins[i], osArch, version, helpers.GetID(id+randSkew))
+				go generatePluginPackage(pluginManifest.Plugins[i], osArch, version, helpers.GetID(id))
 				id++
 			}
 		}
 	}
 
 	wg.Wait()
+	close(fatalErrors)
 
-	if len(errorList) != 0 {
-		return kerrors.NewAggregate(errorList)
+	hasFailed := false
+	for err := range fatalErrors {
+		hasFailed = true
+		log.Errorf("%s - building plugin package for %q failed - %v", err.ID, err.Path, err.Err)
+	}
+	if hasFailed {
+		os.Exit(1)
 	}
 
 	// copy plugin_manifest.yaml to PackageArtifactDir
@@ -132,5 +101,42 @@ func (bpo *BuildPluginPackageOptions) BuildPluginPackages() error {
 	}
 	log.Infof("Saved plugin manifest at %q", filepath.Join(bpo.PackageArtifactDir, cli.PluginManifestFileName))
 
+	return nil
+}
+
+func (bpo *BuildPluginPackageOptions) generatePluginPackage(pluginBinaryFilePath string, p cli.Plugin, osArch cli.Arch, version, threadID string) error {
+	if !utils.PathExists(pluginBinaryFilePath) {
+		return nil
+	}
+
+	// Check whether the binary exec file is valid
+	valid, err := helpers.ValidatePluginBinary(pluginBinaryFilePath, threadID)
+
+	// Return err if plugin binary file validation fails
+	if err != nil {
+		return err
+	}
+
+	// Return err if plugin binary file is not valid
+	if !valid {
+		return fmt.Errorf("invalid plugin binary :%v", pluginBinaryFilePath)
+	}
+
+	pluginTarFilePath := filepath.Join(bpo.PackageArtifactDir, helpers.GetPluginArchiveRelativePath(p, osArch, version))
+	image := fmt.Sprintf("%s/plugins/%s/%s/%s:%s", bpo.LocalOCIRegistry, osArch.OS(), osArch.Arch(), p.Name, version)
+
+	log.Infof("%s Generating plugin package for 'plugin:%s' 'target:%s' 'os:%s' 'arch:%s' 'version:%s'", threadID, p.Name, p.Target, osArch.OS(), osArch.Arch(), version)
+
+	err = carvelhelpers.NewImageOperationsImpl().PushImage(image, []string{pluginBinaryFilePath})
+	if err != nil {
+		return errors.Wrapf(err, "unable to push package to temporary registry for plugin: %s, target: %s, os: %s, arch: %s, version: %s", p.Name, p.Target, osArch.OS(), osArch.Arch(), version)
+	}
+
+	err = bpo.CraneOptions.SaveImage(image, pluginTarFilePath)
+	if err != nil {
+		return errors.Wrapf(err, "unable to generate package for plugin: %s, target: %s, os: %s, arch: %s, version: %s", p.Name, p.Target, osArch.OS(), osArch.Arch(), version)
+	}
+
+	log.Infof("%s Generated plugin package at %q", threadID, pluginTarFilePath)
 	return nil
 }

--- a/cmd/plugin/builder/plugin/publish-packages.go
+++ b/cmd/plugin/builder/plugin/publish-packages.go
@@ -5,12 +5,11 @@ package plugin
 
 import (
 	"fmt"
-	"math/rand"
+	"os"
 	"path/filepath"
 	"sync"
 
 	"github.com/pkg/errors"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 
@@ -50,33 +49,19 @@ func (ppo *PublishPluginPackageOptions) PublishPluginPackages() error {
 	maxConcurrent := helpers.GetMaxParallelism()
 	guard := make(chan struct{}, maxConcurrent)
 	var wg sync.WaitGroup
-	// Mix up IDs so we don't always get the same set.
-	randSkew := rand.Intn(len(helpers.Identifiers)) // nolint:gosec
-	errorList := []error{}
+	fatalErrors := make(chan helpers.ErrInfo, len(pluginManifest.Plugins)*len(cli.AllOSArch))
 
-	publishPluginPackage := func(p cli.Plugin, osArch cli.Arch, version, id string) {
+	publishPluginPackage := func(p cli.Plugin, osArch cli.Arch, version, threadID string) {
 		defer func() {
 			<-guard
 			wg.Done()
 		}()
 
 		pluginTarFilePath := filepath.Join(ppo.PackageArtifactDir, helpers.GetPluginArchiveRelativePath(p, osArch, version))
-		if !utils.PathExists(pluginTarFilePath) {
-			return
-		}
 
-		imageToPush := fmt.Sprintf("%s/%s/%s/%s/%s/%s/%s:%s", ppo.Repository, ppo.Vendor, ppo.Publisher, osArch.OS(), osArch.Arch(), p.Target, p.Name, version)
-
-		if ppo.DryRun {
-			log.Infof("command: 'crane push %s %s'", pluginTarFilePath, imageToPush)
-		} else {
-			log.Infof("publishing plugin 'name:%s' 'target:%s' 'os:%s' 'arch:%s' 'version:%s'", p.Name, p.Target, osArch.OS(), osArch.Arch(), version)
-			err = ppo.CraneOptions.PushImage(pluginTarFilePath, imageToPush)
-			if err != nil {
-				errorList = append(errorList, errors.Wrapf(err, "unable to publish plugin (name:%s, target:%s, os:%s, arch:%s, version:%s)", p.Name, p.Target, osArch.OS(), osArch.Arch(), version))
-				return
-			}
-			log.Infof("published plugin at '%s'", imageToPush)
+		err = ppo.publishPluginPackage(pluginTarFilePath, p, osArch, version, threadID)
+		if err != nil {
+			fatalErrors <- helpers.ErrInfo{Err: err, ID: threadID, Path: pluginTarFilePath}
 		}
 	}
 
@@ -86,7 +71,7 @@ func (ppo *PublishPluginPackageOptions) PublishPluginPackages() error {
 			for _, version := range pluginManifest.Plugins[i].Versions {
 				wg.Add(1)
 				guard <- struct{}{}
-				go publishPluginPackage(pluginManifest.Plugins[i], osArch, version, helpers.GetID(id+randSkew))
+				go publishPluginPackage(pluginManifest.Plugins[i], osArch, version, helpers.GetID(id))
 				id++
 			}
 		}
@@ -94,6 +79,36 @@ func (ppo *PublishPluginPackageOptions) PublishPluginPackages() error {
 
 	// wait for all WaitGroup to complete before continuing
 	wg.Wait()
+	close(fatalErrors)
 
-	return kerrors.NewAggregate(errorList)
+	hasFailed := false
+	for err := range fatalErrors {
+		hasFailed = true
+		log.Errorf("%s - publishing plugin package for %q failed - %v", err.ID, err.Path, err.Err)
+	}
+	if hasFailed {
+		os.Exit(1)
+	}
+
+	return nil
+}
+
+func (ppo *PublishPluginPackageOptions) publishPluginPackage(pluginTarFilePath string, p cli.Plugin, osArch cli.Arch, version, threadID string) error {
+	if !utils.PathExists(pluginTarFilePath) {
+		return nil
+	}
+
+	imageToPush := fmt.Sprintf("%s/%s/%s/%s/%s/%s/%s:%s", ppo.Repository, ppo.Vendor, ppo.Publisher, osArch.OS(), osArch.Arch(), p.Target, p.Name, version)
+
+	if ppo.DryRun {
+		log.Infof("%s command: 'crane push %s %s'", threadID, pluginTarFilePath, imageToPush)
+	} else {
+		log.Infof("%s publishing plugin 'name:%s' 'target:%s' 'os:%s' 'arch:%s' 'version:%s'", threadID, p.Name, p.Target, osArch.OS(), osArch.Arch(), version)
+		err := ppo.CraneOptions.PushImage(pluginTarFilePath, imageToPush)
+		if err != nil {
+			return errors.Wrapf(err, "unable to publish plugin (name:%s, target:%s, os:%s, arch:%s, version:%s)", p.Name, p.Target, osArch.OS(), osArch.Arch(), version)
+		}
+		log.Infof("%s published plugin at '%s'", threadID, imageToPush)
+	}
+	return nil
 }

--- a/cmd/plugin/builder/plugin/publish-packages.go
+++ b/cmd/plugin/builder/plugin/publish-packages.go
@@ -49,7 +49,7 @@ func (ppo *PublishPluginPackageOptions) PublishPluginPackages() error {
 	maxConcurrent := helpers.GetMaxParallelism()
 	guard := make(chan struct{}, maxConcurrent)
 	var wg sync.WaitGroup
-	fatalErrors := make(chan helpers.ErrInfo, len(pluginManifest.Plugins)*len(cli.AllOSArch))
+	fatalErrors := make(chan helpers.ErrInfo, helpers.GetNumberOfIndividualPluginBinariesFromManifest(pluginManifest))
 
 	publishPluginPackage := func(p cli.Plugin, osArch cli.Arch, version, threadID string) {
 		defer func() {


### PR DESCRIPTION
### What this PR does / why we need it

- As part of the builder plugin we are generating an OCI image package for the plugins and using that package to publish OCI images to the destination container registry.
- Before this change, the building and publishing of the OCI image were happening sequentially. This change uses go concurrency to run multiple things using go routines to speed up the building and publishing process.

**Performance comparison:**
- The OCI image build to build 7 plugins for 3 os-arch took `40.27s` compared to `164.53s` earlier which is approx **4** times faster.
- The OCI image publishing to publish 7 plugins for 3 os-arch took `21.64s` compared to `195.62s` earlier which is approx **9** times faster.
- The OCI image build and publishing combined of 7 plugins for 3 os-arch took `107.22s` compared to `360.87s` earlier which is approx **3.5** times faster.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #378

### Describe testing done for PR

```
Building Plugin Packages: (make plugin-build-packages)

   Without Parallel Execution: 164.53 secs
   With Parallel Execution: 40.27 secs

Publishing Plugin Packages: (make plugin-plugin-packages) (excluding the building packages)
    
   Without Parallel Execution: 195.62 secs
   With Parallel Execution: 21.64 secs

Building & Publishing Plugin Packages Combined: (make plugin-plugin-packages) 

   Without Parallel Execution: 360.87 secs
   With Parallel Execution: 107.22 secs

```


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Run OCI image package building and publishing concurrently when using `builder` plugin
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
