### PR TITLE
update e2e tanzu binary env

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -54,7 +54,7 @@ ContextCmd   ContextCmdOps
 }
 ```
 
-To customize the choice of the Tanzu binary for usage, you have the option to indicate it by utilizing the environment variable `TANZU_CLI_BINARY_PATH`.
+To customize the choice of the Tanzu binary for usage, you have the option to indicate it by utilizing the environment variable `TANZU_CLI_E2E_TEST_BINARY_PATH`.
 Additionally, within the Tests, the `WithTanzuBinary()` helper method allows you to personalize the Tanzu binary selection.
 
 Below are the major interfaces defined and implemented as part of the E2E

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -98,7 +98,7 @@ func init() {
 	TanzuFolderPath = filepath.Join(filepath.Join(TestDirPath, ConfigFolder), TanzuFolder)
 	ConfigFilePath = filepath.Join(TanzuFolderPath, ConfigFile)
 	ConfigNGFilePath = filepath.Join(TanzuFolderPath, ConfigNGFile)
-	TanzuBinary = os.Getenv(TanzuCLIBinaryPath)
+	TanzuBinary = os.Getenv(TanzuCLIE2ETestBinaryPath)
 	// Set `tanzu` as default binary if not specified tanzu cli binary path
 	if TanzuBinary == "" {
 		TanzuBinary = TanzuPrefix

--- a/test/e2e/framework/framework_constants.go
+++ b/test/e2e/framework/framework_constants.go
@@ -186,7 +186,7 @@ const (
 	ConfigNGFile                = "config-ng.yaml"
 	K8SCRDFileName              = "cli.tanzu.vmware.com_cliplugins.yaml"
 	Config                      = "config"
-	TanzuCLIBinaryPath          = "TANZU_CLI_BINARY_PATH"
+	TanzuCLIE2ETestBinaryPath   = "TANZU_CLI_E2E_TEST_BINARY_PATH"
 	WiredMockHTTPServerStartCmd = "docker run --rm -d -p 8080:8080 -p 8443:8443 --name %s -v %s:/home/wiremock rodolpheche/wiremock:2.25.1"
 	HttpMockServerStopCmd       = "docker container stop %s"
 	HttpMockServerName          = "wiremock"


### PR DESCRIPTION
### What this PR does / why we need it
-  Extend the e2e framework  to customize the tanzu binary
- Provided a env variable TANZU_CLI_E2E_TEST_BINARY_PATH to override the tanzu binary used in the e2e tests
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
 
e2e tests passed

```
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (e2e/customize_tanzu_binary)> export TANZU_CLI_E2E_TEST_BINARY_PATH="/usr/local/bin/tz2"
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (e2e/customize_tanzu_binary)> echo $TANZU_CLI_E2E_TEST_BINARY_PATH
/usr/local/bin/tz2

mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (e2e/customize_tanzu_binary)> make e2e-cli-lifecycle
export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="No" ; \
	export TANZU_CLI_EULA_PROMPT_ANSWER="Yes" ; \
	/Users/mpanchajanya/vmw/repository/tanzu-cli/hack/tools/bin/ginkgo --keep-going --output-dir /Users/mpanchajanya/vmw/repository/tanzu-cli/test/e2e/testresults --json-report=results.json --keep-separate-reports --race --nodes=1 -v -r /Users/mpanchajanya/vmw/repository/tanzu-cli/test/e2e/cli_lifecycle  --trace > /tmp/out && { cat /tmp/out | grep -Ev 'STEP:|seconds|.go:'; rm /tmp/out; } || { exit_code=$?; cat /tmp/out | grep -Ev 'STEP:|seconds|.go:'; rm /tmp/out; exit $exit_code; } \

Running Suite: CLI lifecycle E2E Test Suite - /Users/mpanchajanya/vmw/repository/tanzu-cli/test/e2e/cli_lifecycle
=================================================================================================================
Random Seed: 1687528032

Will run 9 of 9 specs
------------------------------
[BeforeSuite]
command /usr/local/bin/tz2 config init
[i] Executing command: /usr/local/bin/tz2 config init
------------------------------
[CLI-Core][Tests:E2E][Feature:Command-init-version] tests for tanzu init and version commands when init command executed should initialize cli successfully
command /usr/local/bin/tz2 init
[i] Executing command: /usr/local/bin/tz2 init
------------------------------
[CLI-Core][Tests:E2E][Feature:Command-init-version] tests for tanzu init and version commands when version command executed should return version info
command /usr/local/bin/tz2 version
[i] Executing command: /usr/local/bin/tz2 version
------------------------------
[CLI-Core][Tests:E2E][Feature:Command-completion] tests for tanzu completion ommand when completion command executed When the completion command is executed without specifying a shell input value
command /usr/local/bin/tz2 completion
[i] Executing command: /usr/local/bin/tz2 completion
[i] failed to run completion command: %s completion, stdout:
------------------------------
[CLI-Core][Tests:E2E][Feature:Command-completion] tests for tanzu completion ommand when completion command executed When the completion command is executed with bash as the input
command /usr/local/bin/tz2 completion bash
[i] Executing command: /usr/local/bin/tz2 completion bash
------------------------------
[CLI-Core][Tests:E2E][Feature:Command-completion] tests for tanzu completion ommand when completion command executed When the completion command is executed with zsh as the input
command /usr/local/bin/tz2 completion zsh
[i] Executing command: /usr/local/bin/tz2 completion zsh
------------------------------
[CLI-Core][Tests:E2E][Feature:Command-completion] tests for tanzu completion ommand when completion command executed When the completion command is executed with fish as the input
command /usr/local/bin/tz2 completion fish
[i] Executing command: /usr/local/bin/tz2 completion fish
------------------------------
[CLI-Core][Tests:E2E][Feature:Command-completion] tests for tanzu completion ommand when completion command executed When the completion command is executed with powershell as the input
command /usr/local/bin/tz2 completion powershell
[i] Executing command: /usr/local/bin/tz2 completion powershell
------------------------------
[CLI-Core][Tests:E2E][Feature:Command-completion] tests for tanzu completion ommand when completion command executed When the completion command is executed with pwsh as the input
command /usr/local/bin/tz2 completion pwsh
[i] Executing command: /usr/local/bin/tz2 completion pwsh
------------------------------
[CLI-Core][Tests:E2E][Feature:Command-completion] tests for tanzu completion ommand when completion command executed When the cobra __complete command is executed
command /usr/local/bin/tz2 __complete ''
[i] Executing command: /usr/local/bin/tz2 __complete ''
------------------------------
[ReportAfterSuite] Autogenerated ReportAfterSuite for --json-report
autogenerated by Ginkgo
------------------------------

SUCCESS! -- 9 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 2.955485667s
Test Suite Passed
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (e2e/customize_tanzu_binary)>

```





<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
