### PR TITLE
Rename the --local flag to --local-source

### DIFF
--- a/pkg/command/plugin_search.go
+++ b/pkg/command/plugin_search.go
@@ -82,7 +82,22 @@ func newSearchPluginCmd() *cobra.Command {
 	f.BoolVar(&showDetails, "show-details", false, "show the details of the specified plugin, including all available versions")
 	f.StringVarP(&pluginName, "name", "n", "", "limit the search to plugins with the specified name")
 	f.StringVarP(&outputFormat, "output", "o", "", "output format (yaml|json|table)")
-	f.StringVarP(&local, "local", "l", "", "path to local plugin source")
+
+	f.StringVarP(&local, "local", "", "", "path to local plugin source")
+	msg := fmt.Sprintf("this was done in the %q release, it will be removed following the deprecation policy (6 months). Use the %q flag instead.\n", "v1.0.0", "--local-source")
+	if err := f.MarkDeprecated("local", msg); err != nil {
+		// Will only fail if the flag does not exist, which would indicate a coding error,
+		// so let's panic so we notice immediately.
+		panic(err)
+	}
+	f.StringVarP(&local, "local-source", "l", "", "path to local plugin source")
+	// We hide the "local-source" flag because installing from a local-source is not supported in production.
+	// See the "local-source" flag of the "plugin install" command.
+	if err := f.MarkHidden("local-source"); err != nil {
+		// Will only fail if the flag does not exist, which would indicate a coding error,
+		// so let's panic so we notice immediately.
+		panic(err)
+	}
 	f.StringVarP(&targetStr, "target", "t", "", fmt.Sprintf("limit the search to plugins of the specified target (%s)", common.TargetList))
 
 	searchCmd.MarkFlagsMutuallyExclusive("local", "name")

--- a/pkg/command/plugin_test.go
+++ b/pkg/command/plugin_test.go
@@ -82,7 +82,7 @@ func TestPluginList(t *testing.T) {
 			centralRepoFeature: true,
 			args:               []string{"plugin", "list", "--local", "someDirectory"},
 			expectedFailure:    true,
-			expected:           "the '--local' flag does not apply to this command. Please use 'tanzu plugin search --local'",
+			expected:           "the '--local' flag does not apply to this command. Please use 'tanzu plugin search --local-source'",
 		},
 		{
 			test:               "With empty config file(no discovery sources added) and no plugins installed",


### PR DESCRIPTION
### What this PR does / why we need it

This is a UX improvement that was recommended by our UX team.
It renames the `--local` flag to `--local-source` for both `tanzu plugin install` and `tanzu plugin search` in a backwards compatible fashion.

For backwards-compatibility the "--local" form is kept but is marked deprecated.

Further the "--local-source" flag is now hidden for "plugin search". Since the same flag is hidden for "plugin install" because that scenario is not supported in production, I felt the same approach should be taken for "plugin search".

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

```
# Notice that both `--local` and `--local-source` are hidden in the help
$ tz plugin install -h
Install a specific plugin by name or specify all to install all plugins of a group

Usage:
tanzu plugin install [PLUGIN_NAME] [flags]

Examples:

    # Install all plugins of the vmware-tkg/default plugin group version v2.1.0
    tanzu plugin install --group vmware-tkg/default:v2.1.0

    # Install all plugins of the latest version of the vmware-tkg/default plugin group
    tanzu plugin install --group vmware-tkg/default

    # Install the latest version of plugin "myPlugin"
	# If the plugin exists for more than one target, an error will be thrown
    tanzu plugin install myPlugin

    # Install the latest version of plugin "myPlugin" for target kubernetes
    tanzu plugin install myPlugin --target k8s

    # Install version v1.0.0 of plugin "myPlugin"
    tanzu plugin install myPlugin --version v1.0.0

Flags:
      --group string     install the plugins specified by a plugin-group version
  -h, --help             help for install
  -t, --target string    target of the plugin (kubernetes[k8s]/mission-control[tmc]/global)
  -v, --version string   version of the plugin (default "latest")

# Notice that both `--local` and `--local-source` are hidden in the help
$ tz plugin search -h
Search provides the ability to search for plugins that can be installed.
The command lists all plugins currently available for installation.
The search command also provides flags to limit the scope of the search.

Usage:
tanzu plugin search [flags]

Flags:
  -h, --help            help for search
  -n, --name string     limit the search to plugins with the specified name
  -o, --output string   output format (yaml|json|table)
      --show-details    show the details of the specified plugin, including all available versions
  -t, --target string   limit the search to plugins of the specified target (kubernetes[k8s]/mission-control[tmc]/global)

# Test the new flag
$ tz plugin install --local-source artifacts/plugins/darwin/amd64 builder
[i] Installing plugin 'builder:v1.0.0-dev' with target 'global'
[ok] successfully installed 'builder' plugin

# Test the deprecated flag
$ tz plugin install --local artifacts/plugins/darwin/amd64 builder
Flag --local has been deprecated, this was done in the v1.0.0 release, it will be removed following the deprecation policy (6 months). Use the --local-source flag instead.

[i] Installing plugin 'builder:v1.0.0-dev' with target 'global'
[ok] successfully installed 'builder' plugin

# Test the new flag
$ tz plugin search --local-source artifacts/plugins/darwin/amd64
  NAME     DESCRIPTION             TARGET  LATEST
  builder  Build Tanzu components  global  v1.0.0-dev
  test     Test the CLI            global  v1.0.0-dev

# Test the deprecated flag
$ tz plugin search --local artifacts/plugins/darwin/amd64
Flag --local has been deprecated, this was done in the "v1.0.0" release, it will be removed following the deprecation policy (6 months). Use the "--local-source" flag instead.

  NAME     DESCRIPTION             TARGET  LATEST
  builder  Build Tanzu components  global  v1.0.0-dev
  test     Test the CLI            global  v1.0.0-dev
```

Test our helpful comment if the user tries to use `tz plugin list --local` as it was supported in the TKG cli.
Maybe we should remove this printout altogether and even remove the flag now?
```
$ tz plugin list --local a
[x] : the '--local' flag does not apply to this command. Please use 'tanzu plugin search --local-source'
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The hidden `--local` flag for the `tanzu plugin install` command has been renamed to `--local-source`.  The same has been done for the `tanzu plugin search` command and this renamed `--local-source` flag is now hidden.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

Now that v0.90.0 is out, should we remove the special handling of the `--local` flag from `tz plugin list --local`?
```
$ tz plugin list --local a
[x] : the '--local' flag does not apply to this command. Please use 'tanzu plugin search --local-source'
```
As shown in the example above the special handling has the cli detect that the`--local` flag was called with `plugin list` and redirects the user to use `plugin search` instead through a warning. But technically there is no `--local` flag on `plugin list`. We added this special detection to help users that were familiar with the pre-independent CLI behavior.