### PR TITLE
Validate file path for plugin download-bundle

### DIFF
--- a/pkg/airgapped/plugin_bundle_download.go
+++ b/pkg/airgapped/plugin_bundle_download.go
@@ -244,8 +244,17 @@ func (o *DownloadPluginBundleOptions) downloadImagesAsTarFile(pluginEntries []*p
 // validateOptions validates the provided options and returns
 // error if contains invalid option
 func (o *DownloadPluginBundleOptions) validateOptions() error {
-	_, err := os.Stat(filepath.Dir(o.ToTar))
+	dir := filepath.Dir(o.ToTar)
+	_, err := os.Stat(dir)
 	if err != nil {
+		return errors.Wrapf(err, "invalid path for %q", dir)
+	}
+	// Check the input file path for --to-tar is valid
+	var empty []byte
+	err = os.WriteFile(o.ToTar, empty, 0600)
+	if err == nil {
+		os.Remove(o.ToTar)
+	} else {
 		return errors.Wrapf(err, "invalid path for %q", o.ToTar)
 	}
 

--- a/test/e2e/airgapped/airgapped_test.go
+++ b/test/e2e/airgapped/airgapped_test.go
@@ -4,8 +4,10 @@
 package airgapped
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -14,6 +16,8 @@ import (
 	"github.com/vmware-tanzu/tanzu-cli/test/e2e/framework"
 	pluginlifecyclee2e "github.com/vmware-tanzu/tanzu-cli/test/e2e/plugin_lifecycle"
 )
+
+const InvalidPath = "invalid path for \"%s\""
 
 var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Airgapped-Plugin-DownloadBundle-UploadBundle-Lifecycle]", func() {
 
@@ -229,6 +233,25 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Airgapped-Plugin-Download
 			installedPlugins, err := tf.PluginCmd.ListInstalledPlugins()
 			Expect(err).To(BeNil())
 			Expect(framework.CheckAllPluginsExists(installedPlugins, pluginsNotInAnyPG_999)).To(BeTrue())
+		})
+
+		// Test case: (negative use case) empty path for --to-tar
+		It("plugin download-bundle when to-tar path is empty", func() {
+			err := tf.PluginCmd.DownloadPluginBundle(e2eTestLocalCentralRepoImage, []string{}, "")
+			Expect(err).NotTo(BeNil(), "should throw error for incorrect input path")
+			Expect(strings.Contains(err.Error(), fmt.Sprintf(InvalidPath, ""))).To(BeTrue())
+		})
+		// Test case: (negative use case) directory name only for for --to-tar
+		It("plugin download-bundle when to-tar path is a directory", func() {
+			err := tf.PluginCmd.DownloadPluginBundle(e2eTestLocalCentralRepoImage, []string{}, tempDir)
+			Expect(err).NotTo(BeNil(), "should throw error for incorrect input path")
+			Expect(strings.Contains(err.Error(), fmt.Sprintf(InvalidPath, tempDir))).To(BeTrue())
+		})
+		// Test case: (negative use case) current directory only for --to-tar
+		It("plugin download-bundle when to-tar path is current directory", func() {
+			err := tf.PluginCmd.DownloadPluginBundle(e2eTestLocalCentralRepoImage, []string{}, ".")
+			Expect(err).NotTo(BeNil(), "should throw error for incorrect input path")
+			Expect(strings.Contains(err.Error(), fmt.Sprintf(InvalidPath, "."))).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
### What this PR does / why we need it
This pull request aims to validate the input path for the `--to-tar` option in the `tanzu plugin download-bundle `command. Previously, the path was not properly validated before downloading the bundle. With this fix, the input paths are now validated prior to downloading the bundle.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
The E2E tests have been updated and manual testing has been performed to ensure the changes are working as expected.
**After the Fix:**
```
❯ 
❯ t plugin download-bundle --to-tar .
[x] : invalid path for ".": open .: is a directory
❯ 
❯ t plugin download-bundle --to-tar /Users/cpamuluri
[x] : invalid path for "/Users/cpamuluri": open /Users/cpamuluri: is a directory
❯ 
❯ 
```
**Before the Fix:**
```
C:\Users\cpamuluri\Downloads\tanzu-cli-windows-amd64\v0.90.0-rc.0>t plugin download-bundle --to-tar .
[i] will be downloading the 12 plugins from: projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory@sha256:4d9862452d14e8cd8adb5e622b4eced5e22e42d566b97e620a8e30242635fd2f
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory@sha256:9d19d962b7f5ec63a8aa08a2473efaa3c685cc7e5b3d31ea929b93a462d9c428
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (552.8µs)
[i] copy | done: file 'sha256-9602a49ea32962c2d612dd04a88306c0b0e20cb5039fc8e80d24c0740eb417f7.tar.gz' (517.4µs)
[i] copy | done: file 'sha256-1137adaa75ee19dc554f2d1c46b3c55d66308944bb2b3dc143b9a23750516d74.tar.gz' (0s)
[i] copy | done: file 'sha256-9bf0540f3ff26c9b61b5876347911a709771a0e0738c4a66f8d1c73814375d74.tar.gz' (0s)
[i] ---------------------------

[i] copy | done: file 'sha256-db9cb9b786884bafbaddf927164f3b14b1f9b31a9bfb78e5219a05c13fb08252.tar.gz' (3.7882919s)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tzcli/windows/amd64/global/test:v0.90.0-beta.0"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tzcli/windows/amd64/global/test@sha256:a1b88d02fe86b7a90b894933bde60925b61422e80c28df3cd74b7ec3d8f97e81
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tzcli/windows/amd64/global/test@sha256:cc3010342aa99bf2b858a26bc80a2e4984c450e22696699f66a28ba277d1e3a8
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (1.0685ms)
[i] copy | done: file 'sha256-1b82b4fba655601c766c5ea4d0f2556503f85be07bd5b3d329480a4d3e5551ca.tar.gz' (510.8µs)
[i] copy | done: file 'sha256-5f629b3a6695d3c5d0c4b0850a295fd84b0a5e1f90cacdb19423dea6e8846dbb.tar.gz' (1.3757813s)
[i] saving plugin bundle at: .
[x] : error while creating archive file: open .: is a directory
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
