### PR TITLE
Add building APT packages on a Fedora image

### DIFF
--- a/hack/apt/README.md
+++ b/hack/apt/README.md
@@ -34,6 +34,11 @@ repository will be generated as a directory called `_output/apt` which will
 contain the two built packages. Please see the section on publishing the
 repository for more details.
 
+## Using fedora
+
+The package build scripts support building on a fedora machine.
+This can be done using `make apt-package APT_BUILDER_IMAGE=fedora`.
+
 ## Testing the installation of the Tanzu CLI locally
 
 We can install the Tanzu CLI using the newly built Debian repository locally on

--- a/hack/apt/build_package.sh
+++ b/hack/apt/build_package.sh
@@ -4,9 +4,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set -e
+set -x
 
-if [ $(uname) != "Linux" ] || [ -z "$(command -v apt)" ]; then
-   echo "This script must be run on a Linux system that uses the APT package manager"
+if [ $(uname) != "Linux" ]; then
+   echo "This script must be run on a Linux system"
+   exit 1
+fi
+
+# Use apt-get, but also support dnf/yum
+PKG_MGR=$(command -v apt-get || command -v dnf || command -v yum || true)
+
+if [ -z "$PKG_MGR" ]; then
+   echo "This script requires one of the following package managers: apt-get, dnf or yum"
    exit 1
 fi
 
@@ -24,9 +33,9 @@ OUTPUT_DIR=${BASE_DIR}/_output
 ARTIFACTS_DIR=${BASE_DIR}/../../artifacts
 
 # Install build dependencies
-if ! command -v curl &> /dev/null; then
-   apt-get update
-   apt-get install -y curl
+if ! command -v dpkg-deb &> /dev/null; then
+   ${PKG_MGR} update -y
+   ${PKG_MGR} install -y dpkg
 fi
 
 # Clean any old packages

--- a/hack/apt/build_package_repo.sh
+++ b/hack/apt/build_package_repo.sh
@@ -4,9 +4,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set -e
+set -x
 
-if [ $(uname) != "Linux" ] || [ -z "$(command -v apt)" ]; then
-   echo "This script must be run on a Linux system that uses the APT package manager"
+if [ $(uname) != "Linux" ]; then
+   echo "This script must be run on a Linux system"
+   exit 1
+fi
+
+# Use apt-get, but also support dnf/yum
+PKG_MGR=$(command -v apt-get || command -v dnf || command -v yum || true)
+
+if [ -z "$PKG_MGR" ]; then
+   echo "This script requires one of the following package managers: apt-get, dnf or yum"
    exit 1
 fi
 
@@ -24,8 +33,8 @@ OUTPUT_DIR=${BASE_DIR}/_output
 
 # Install build dependencies
 if ! command -v reprepro &> /dev/null; then
-   apt-get update
-   apt-get install -y reprepro
+   ${PKG_MGR} update -y
+   ${PKG_MGR} install -y reprepro
 fi
 
 # Assumes ${OUTPUT_DIR} is populated from build_package.sh


### PR DESCRIPTION
### What this PR does / why we need it

When building the apt packages we assumed an ubuntu-like image.
It is more flexible to also support a redhat-like image even for apt packages.

This commit makes the apt build script generic so they can use either ubuntu or fedora.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Ran `make apt-package` which uses ubuntu and verified locally that the package built and could be installed.

Ran `make apt-package APT_BUILDER_IMAGE=fedora` which instead uses a fedora image and verified locally that the package built and could be installed.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The APT distribution package can now be built using a Fedora image.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
