### PR TITLE
Hide 'delete' command under 'plugin source'

### DIFF
--- a/pkg/command/discovery_source.go
+++ b/pkg/command/discovery_source.go
@@ -213,9 +213,10 @@ func newUpdateDiscoverySourceCmd() *cobra.Command {
 
 func newDeleteDiscoverySourceCmd() *cobra.Command {
 	var deleteDiscoverySourceCmd = &cobra.Command{
-		Use:   "delete SOURCE_NAME",
-		Short: "Delete a discovery source",
-		Args:  cobra.ExactArgs(1),
+		Use:    "delete SOURCE_NAME",
+		Short:  "Delete a discovery source",
+		Args:   cobra.ExactArgs(1),
+		Hidden: true,
 		Example: `
     # Delete a discovery source
     tanzu plugin discovery delete default`,


### PR DESCRIPTION
### What this PR does / why we need it
This pull request hides the delete command under tanzu plugin source and adds an output message when there are no plugin sources available. This change aims to provide clarity to end-users when there are no plugin sources available.
All below use cases covered as part of this fix:
```
tanzu plugin search
tanzu plugin install
tanzu plugin install --group
tanzu plugin group search
tanzu plugin sync
tanzu plugin context use
```
 
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
**After Fix:**
```
❯ t plugin source lidy
Manage plugin discovery sources. Discovery source provides metadata about the list of available plugins, their supported versions and how to download them.

Usage:
  tanzu plugin source [command]

Available Commands:
  init        Initialize the discovery source to its default value
  list        List available discovery sources
  update      Update a discovery source configuration

Flags:
  -h, --help   help for source

Use "tanzu plugin source [command] --help" for more information about a command.
❯ t plugin source list
  NAME     IMAGE                                                                   
  default  projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest  
❯ t plugin source delete default
[ok] deleted discovery source default
❯ t plugin source list
  NAME  IMAGE  
❯ 
❯ 
❯ t plugin search
[!] there was an error while discovering standalone plugins, error information: 'there are no plugin discovery sources available. Please run 'tanzu plugin source init''
  NAME  DESCRIPTION  TARGET  LATEST  
[x] : there are no plugin discovery sources available. Please run 'tanzu plugin source init'
❯ 
❯ 
❯ t plugin install pn
[x] : there are no plugin discovery sources available. Please run 'tanzu plugin source init'
❯ 
❯
❯ t plugin install --group pg
[x] : there are no plugin discovery sources available. Please run 'tanzu plugin source init'
❯ 
❯ 
❯ 
❯ t plugin group search
[x] : there are no plugin discovery sources available. Please run 'tanzu plugin source init'
❯ 
❯ 
❯ t context use tmc1
[i] Checking for required plugins...
[!] unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually, error: 'there are no plugin discovery sources available. Please run 'tanzu plugin source init''
❯ 
❯ 
❯ 
❯ t plugin sync
[i] Checking for required plugins...
[x] : there are no plugin discovery sources available. Please run 'tanzu plugin source init'
❯ 
```
**Before Fix:**
```
 t plugin source
Manage plugin discovery sources. Discovery source provides metadata about the list of available plugins, their supported versions and how to download them.

Usage:
  tanzu plugin source [command]

Available Commands:
  delete      Delete a discovery source
  init        Initialize the discovery source to its default value
  list        List available discovery sources
  update      Update a discovery source configuration

Flags:
  -h, --help   help for source

Use "tanzu plugin source [command] --help" for more information about a command.

❯ t plugin source list
  NAME     IMAGE                                                                   
  default  projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest  
❯ t plugin source delete default
[ok] deleted discovery source default
❯ t plugin source list          
  NAME  IMAGE  
❯ t plugin search
  NAME  DESCRIPTION  TARGET  LATEST  
❯ 
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
