### PR TITLE
Fix "Examples" string for different commands

### DIFF
--- a/cmd/plugin/builder/plugin.go
+++ b/cmd/plugin/builder/plugin.go
@@ -61,14 +61,15 @@ func newPluginBuildCmd() *cobra.Command {
 		Use:          "build",
 		Short:        "Build plugins",
 		SilenceUsage: true,
-		Example: `# Build all plugins under 'cmd/plugin' directory for local host os and arch
-  tanzu builder plugin build --path ./cmd/plugin --version v0.0.2 --os-arch local
+		Example: `
+    # Build all plugins under 'cmd/plugin' directory for local host os and arch
+    tanzu builder plugin build --path ./cmd/plugin --version v0.0.2 --os-arch local
 
-  # Build all plugins under 'cmd/plugin' directory for os-arch 'darwin_amd64', 'linux_amd64', 'windows_amd64'
-  tanzu builder plugin build --path ./cmd/plugin --version v0.0.2 --os-arch darwin_amd64 --os-arch linux_amd64 --os-arch windows_amd64
+    # Build all plugins under 'cmd/plugin' directory for os-arch 'darwin_amd64', 'linux_amd64', 'windows_amd64'
+    tanzu builder plugin build --path ./cmd/plugin --version v0.0.2 --os-arch darwin_amd64 --os-arch linux_amd64 --os-arch windows_amd64
 
-  # Build only foo plugin under 'cmd/plugin' directory for all supported os-arch
-  tanzu builder plugin build --path ./cmd/plugin --version v0.0.2 --os-arch all --match foo`,
+    # Build only foo plugin under 'cmd/plugin' directory for all supported os-arch
+    tanzu builder plugin build --path ./cmd/plugin --version v0.0.2 --os-arch all --match foo`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			compileArgs := &command.PluginCompileArgs{
 				Match:                      pbFlags.Match,

--- a/pkg/command/cert.go
+++ b/pkg/command/cert.go
@@ -107,7 +107,6 @@ func newAddCertCmd() *cobra.Command {
 
     # Set to allow insecure (http) connection while interacting with host
     tanzu config cert add --host test.vmware.com  --insecure true`,
-
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if skipCertVerifyForAdd != "" {
 				if !strings.EqualFold(skipCertVerifyForAdd, "true") && !strings.EqualFold(skipCertVerifyForAdd, "false") {
@@ -160,9 +159,8 @@ func newUpdateCertCmd() *cobra.Command {
     # Update whether to skip verifying the certificate while interacting with host
     tanzu config cert update test.vmware.com  --skip-cert-verify true
 
-	# Update whether to allow insecure (http) connection while interacting with host
-	tanzu config cert update test.vmware.com  --insecure true`,
-
+    # Update whether to allow insecure (http) connection while interacting with host
+    tanzu config cert update test.vmware.com  --insecure true`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if skipCertVerifyForUpdate != "" {
 				if !strings.EqualFold(skipCertVerifyForUpdate, "true") && !strings.EqualFold(skipCertVerifyForUpdate, "false") {

--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -94,27 +94,26 @@ var createCtxCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	RunE:  createCtx,
 	Example: `
-	# Create a TKG management cluster context using endpoint
-	tanzu context create mgmt-cluster --endpoint "https://k8s.example.com[:port]"
+    # Create a TKG management cluster context using endpoint
+    tanzu context create mgmt-cluster --endpoint "https://k8s.example.com[:port]"
 
-	# Create a TKG management cluster context using kubeconfig path and context
-	tanzu context create mgmt-cluster --kubeconfig path/to/kubeconfig --kubecontext kubecontext
+    # Create a TKG management cluster context using kubeconfig path and context
+    tanzu context create mgmt-cluster --kubeconfig path/to/kubeconfig --kubecontext kubecontext
 
- 	#  Create a TKG management cluster context by using the provided CA Bundle for TLS verification:
+    # Create a TKG management cluster context by using the provided CA Bundle for TLS verification:
     tanzu context create --endpoint https://k8s.example.com[:port] --endpoint-ca-certificate /path/to/ca/ca-cert
 
- 	# Create a TKG management cluster context by explicit request to skip TLS verification, which is insecure:
-  	tanzu context create --endpoint https://k8s.example.com[:port] --insecure-skip-tls-verify
+    # Create a TKG management cluster context by explicit request to skip TLS verification, which is insecure:
+    tanzu context create --endpoint https://k8s.example.com[:port] --insecure-skip-tls-verify
 
-	# Create a TKG management cluster context using default kubeconfig path and a kubeconfig context
-	tanzu context create mgmt-cluster --kubecontext kubecontext
+    # Create a TKG management cluster context using default kubeconfig path and a kubeconfig context
+    tanzu context create mgmt-cluster --kubecontext kubecontext
 
-	[*] : User has two options to create a kubernetes cluster context. User can choose the control
-	plane option by providing 'endpoint', or use the kubeconfig for the cluster by providing
-	'kubeconfig' and 'context'. If only '--context' is set and '--kubeconfig' is not set
-	$KUBECONFIG env variable would be used and, if $KUBECONFIG env is also not set default
-	kubeconfig($HOME/.kube/config) would be used.
-	`,
+    [*] : Users have two options to create a kubernetes cluster context. They can choose the control
+    plane option by providing 'endpoint', or use the kubeconfig for the cluster by providing
+    'kubeconfig' and 'context'. If only '--context' is set and '--kubeconfig' is not, the
+    $KUBECONFIG env variable will be used and, if the $KUBECONFIG env is also not set, the default
+    kubeconfig file ($HOME/.kube/config) will be used.`,
 }
 
 func initCreateCtxCmd() {

--- a/pkg/command/discovery_source.go
+++ b/pkg/command/discovery_source.go
@@ -143,7 +143,6 @@ func newAddDiscoverySourceCmd() *cobra.Command {
 
     # Add an OCI discovery source. URI should be an OCI image.
     tanzu plugin source add --name standalone-oci --type oci --uri projects.registry.vmware.com/tkg/tanzu-plugins/standalone:latest`,
-
 		RunE: func(cmd *cobra.Command, args []string) error {
 			newDiscoverySource, err := createDiscoverySource(discoverySourceType, discoverySourceName, uri)
 			if err != nil {

--- a/pkg/command/login.go
+++ b/pkg/command/login.go
@@ -62,30 +62,29 @@ func init() {
 	loginCmd.Deprecated = msg
 
 	loginCmd.Example = `
-	# Login to TKG management cluster using endpoint
-	tanzu login --endpoint "https://login.example.com"  --name mgmt-cluster
+    # Login to TKG management cluster using endpoint
+    tanzu login --endpoint "https://login.example.com"  --name mgmt-cluster
 
- 	#  Login to TKG management cluster by using the provided CA Bundle for TLS verification:
+    #  Login to TKG management cluster by using the provided CA Bundle for TLS verification:
     tanzu login --endpoint https://k8s.example.com[:port] --endpoint-ca-certificate /path/to/ca/ca-cert
 
- 	# Login to TKG management cluster by explicit request to skip TLS verification, which is insecure:
-  	tanzu login --endpoint https://k8s.example.com[:port] --insecure-skip-tls-verify
+    # Login to TKG management cluster by explicit request to skip TLS verification, which is insecure:
+    tanzu login --endpoint https://k8s.example.com[:port] --insecure-skip-tls-verify
 
-	# Login to TKG management cluster by using kubeconfig path and context for the management cluster
-	tanzu login --kubeconfig path/to/kubeconfig --context path/to/context --name mgmt-cluster
+    # Login to TKG management cluster by using kubeconfig path and context for the management cluster
+    tanzu login --kubeconfig path/to/kubeconfig --context path/to/context --name mgmt-cluster
 
-	# Login to TKG management cluster by using default kubeconfig path and context for the management cluster
-	tanzu login  --context path/to/context --name mgmt-cluster
+    # Login to TKG management cluster by using default kubeconfig path and context for the management cluster
+    tanzu login  --context path/to/context --name mgmt-cluster
 
-	# Login to an existing server
-	tanzu login --server mgmt-cluster
+    # Login to an existing server
+    tanzu login --server mgmt-cluster
 
-	[*] : User has two options to login to TKG. User can choose the login endpoint option
-	by providing 'endpoint', or user can choose to use the kubeconfig for the management cluster by
-	providing 'kubeconfig' and 'context'. If only '--context' is set and '--kubeconfig' is unset
-	$KUBECONFIG env variable would be used and, if $KUBECONFIG env is also unset default 
-	kubeconfig($HOME/.kube/config) would be used
-	`
+    [*] : Users have two options to login to TKG. They can choose the login endpoint option
+    by providing 'endpoint', or can choose to use the kubeconfig for the management cluster by
+    providing 'kubeconfig' and 'context'. If only '--context' is set and '--kubeconfig' is not,
+    the $KUBECONFIG env variable will be used and, if the $KUBECONFIG env is also not set, the
+    default kubeconfig file ($HOME/.kube/config) will be used.`
 }
 
 func login(cmd *cobra.Command, args []string) (err error) {

--- a/pkg/command/plugin.go
+++ b/pkg/command/plugin.go
@@ -320,13 +320,13 @@ func newInstallPluginCmd() *cobra.Command {
     tanzu plugin install --group vmware-tkg/default
 
     # Install the latest version of plugin "myPlugin"
-	# If the plugin exists for more than one target, an error will be thrown
+    # If the plugin exists for more than one target, an error will be thrown
     tanzu plugin install myPlugin
 
     # Install the latest version of plugin "myPlugin" for target kubernetes
     tanzu plugin install myPlugin --target k8s
 
-    # Install version v1.0.0 of plugin "myPlugin" 
+    # Install version v1.0.0 of plugin "myPlugin"
     tanzu plugin install myPlugin --version v1.0.0`
 		installCmd.Long = "Install a specific plugin by name or specify all to install all plugins of a group"
 	}

--- a/pkg/command/plugin_bundle.go
+++ b/pkg/command/plugin_bundle.go
@@ -26,12 +26,11 @@ func newDownloadBundlePluginCmd() *cobra.Command {
 		Long: `Download a plugin bundle to the local file system to be used when migrating plugins
 to an internet-restricted environment. Please also see the "upload-bundle" command.`,
 		Example: `
-# Download a plugin bundle for a specific group version from the default discovery source
-tanzu plugin download-bundle --to-tar /tmp/plugin_bundle_vmware_tkg_default_v1.0.0.tar.gz --group vmware-tkg/default:v1.0.0
+    # Download a plugin bundle for a specific group version from the default discovery source
+    tanzu plugin download-bundle --to-tar /tmp/plugin_bundle_vmware_tkg_default_v1.0.0.tar.gz --group vmware-tkg/default:v1.0.0
 
-# Download a plugin bundle with the entire plugin repository from a custom discovery source
-tanzu plugin download-bundle --image custom.registry.vmware.com/tkg/tanzu-plugins/plugin-inventory:latest --to-tar /tmp/plugin_bundle_complete.tar.gz
-		`,
+    # Download a plugin bundle with the entire plugin repository from a custom discovery source
+    tanzu plugin download-bundle --image custom.registry.vmware.com/tkg/tanzu-plugins/plugin-inventory:latest --to-tar /tmp/plugin_bundle_complete.tar.gz`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options := airgapped.DownloadPluginBundleOptions{
 				PluginInventoryImage: dpbo.pluginDiscoveryOCIImage,
@@ -67,9 +66,9 @@ func newUploadBundlePluginCmd() *cobra.Command {
 		Long: `Upload a plugin bundle to an alternate container registry for use in an internet-restricted
 environment. The plugin bundle is obtained using the "download-bundle" command.`,
 		Example: `
-# Upload the plugin bundle to the remote repository
-tanzu plugin upload-bundle --tar /tmp/plugin_bundle_vmware_tkg_default_v1.0.0.tar.gz --to-repo custom.registry.company.com/tanzu-plugins/
-tanzu plugin upload-bundle --tar /tmp/plugin_bundle_complete.tar.gz --to-repo custom.registry.company.com/tanzu-plugins/`,
+    # Upload the plugin bundle to the remote repository
+    tanzu plugin upload-bundle --tar /tmp/plugin_bundle_vmware_tkg_default_v1.0.0.tar.gz --to-repo custom.registry.company.com/tanzu-plugins/
+    tanzu plugin upload-bundle --tar /tmp/plugin_bundle_complete.tar.gz --to-repo custom.registry.company.com/tanzu-plugins/`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options := airgapped.UploadPluginBundleOptions{
 				Tar:             upbo.sourceTar,


### PR DESCRIPTION
### What this PR does / why we need it

This PR simply make sure the indentation for all "Examples" section of commands are all formatted the same (indentation, empty lines).

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Looked at the help of all modified commands.
```
$ make prepare-builder
cd cmd/plugin/builder && go build -o /Users/kmarc/git/tanzu-cli/bin/builder .
$ ./bin/builder plugin build -h
Build plugins

Usage:
builder plugin build [flags]

Examples:

    # Build all plugins under 'cmd/plugin' directory for local host os and arch
    tanzu builder plugin build --path ./cmd/plugin --version v0.0.2 --os-arch local

    # Build all plugins under 'cmd/plugin' directory for os-arch 'darwin_amd64', 'linux_amd64', 'windows_amd64'
    tanzu builder plugin build --path ./cmd/plugin --version v0.0.2 --os-arch darwin_amd64 --os-arch linux_amd64 --os-arch windows_amd64

    # Build only foo plugin under 'cmd/plugin' directory for all supported os-arch
    tanzu builder plugin build --path ./cmd/plugin --version v0.0.2 --os-arch all --match foo

Flags:
      --binary-artifacts string                path to output artifacts directory (default "./artifacts")
      --goflags string                         goflags to set on build
  -h, --help                                   help for build
      --ldflags string                         ldflags to set on build
      --match string                           match a plugin name to build, supports globbing (default "*")
      --os-arch stringArray                    compile for specific os-arch, use 'local' for host os, use '<os>_<arch>' for specific (default [all])
      --path string                            path of plugin directory (default "./cmd/plugin")
      --plugin-scope-association-file string   file specifying plugin scope association
  -v, --version string                         version of the plugins
$ make build
build darwin-arm64 CLI with version: v1.0.0-dev


======================================
! darwin-arm64 is not an officially supported platform!
======================================

mkdir -p bin
cp /Users/kmarc/git/tanzu-cli/artifacts/darwin/arm64/cli/core/v1.0.0-dev/tanzu-cli-darwin_arm64 ./bin/tanzu
$ tz config cert update -h
Update certificate configuration for a host

Usage:
tanzu config cert update HOST [flags]

Examples:

    # Update CA certificate for a host,
    tanzu config cert update test.vmware.com --ca-certificate path/to/ca/ert

    # Update CA certificate for a host:port,
    tanzu config cert update test.vmware.com:5443 --ca-certificate path/to/ca/ert

    # Update whether to skip verifying the certificate while interacting with host
    tanzu config cert update test.vmware.com  --skip-cert-verify true

    # Update whether to allow insecure (http) connection while interacting with host
    tanzu config cert update test.vmware.com  --insecure true

Flags:
      --ca-certificate string     path to the public certificate
  -h, --help                      help for update
      --insecure string           allow the use of http when interacting with the host (true|false)
      --skip-cert-verify string   skip server's TLS certificate verification (true|false)
$ tz context create -h
Create a Tanzu CLI context

Usage:
tanzu context create CONTEXT_NAME [flags]

Examples:

    # Create a TKG management cluster context using endpoint
    tanzu context create mgmt-cluster --endpoint "https://k8s.example.com[:port]"

    # Create a TKG management cluster context using kubeconfig path and context
    tanzu context create mgmt-cluster --kubeconfig path/to/kubeconfig --kubecontext kubecontext

    # Create a TKG management cluster context by using the provided CA Bundle for TLS verification:
    tanzu context create --endpoint https://k8s.example.com[:port] --endpoint-ca-certificate /path/to/ca/ca-cert

    # Create a TKG management cluster context by explicit request to skip TLS verification, which is insecure:
    tanzu context create --endpoint https://k8s.example.com[:port] --insecure-skip-tls-verify

    # Create a TKG management cluster context using default kubeconfig path and a kubeconfig context
    tanzu context create mgmt-cluster --kubecontext kubecontext

    [*] : Users have two options to create a kubernetes cluster context. They can choose the control
    plane option by providing 'endpoint', or use the kubeconfig for the cluster by providing
    'kubeconfig' and 'context'. If only '--context' is set and '--kubeconfig' is not, the
    $KUBECONFIG env variable will be used and, if the $KUBECONFIG env is also not set, the default
    kubeconfig file ($HOME/.kube/config) will be used.

Flags:
      --endpoint string                  endpoint to create a context for
      --endpoint-ca-certificate string   path to the endpoint public certificate
  -h, --help                             help for create
      --insecure-skip-tls-verify         skip endpoint's TLS certificate verification
      --kubeconfig string                path to the kubeconfig file; valid only if user doesn't choose 'endpoint' option.(See [*])
      --kubecontext string               the context in the kubeconfig to use; valid only if user doesn't choose 'endpoint' option.(See [*])
$ tz login -h
Command "login" is deprecated, this was done in the "v0.90.0" release, it will be removed following the deprecation policy (6 months). Use the "context" command instead.

Login to the platform

Usage:
tanzu login [flags]

Aliases:
  login, lo, logins

Examples:

    # Login to TKG management cluster using endpoint
    tanzu login --endpoint "https://login.example.com"  --name mgmt-cluster

    #  Login to TKG management cluster by using the provided CA Bundle for TLS verification:
    tanzu login --endpoint https://k8s.example.com[:port] --endpoint-ca-certificate /path/to/ca/ca-cert

    # Login to TKG management cluster by explicit request to skip TLS verification, which is insecure:
    tanzu login --endpoint https://k8s.example.com[:port] --insecure-skip-tls-verify

    # Login to TKG management cluster by using kubeconfig path and context for the management cluster
    tanzu login --kubeconfig path/to/kubeconfig --context path/to/context --name mgmt-cluster

    # Login to TKG management cluster by using default kubeconfig path and context for the management cluster
    tanzu login  --context path/to/context --name mgmt-cluster

    # Login to an existing server
    tanzu login --server mgmt-cluster

    [*] : Users have two options to login to TKG. They can choose the login endpoint option
    by providing 'endpoint', or can choose to use the kubeconfig for the management cluster by
    providing 'kubeconfig' and 'context'. If only '--context' is set and '--kubeconfig' is not,
    the $KUBECONFIG env variable will be used and, if the $KUBECONFIG env is also not set, the
    default kubeconfig file ($HOME/.kube/config) will be used.

Flags:
      --apiToken string                  API token for global login
      --context string                   the context in the kubeconfig to use for management cluster. Valid only if user doesn't choose 'endpoint' option.(See [*])
      --endpoint string                  endpoint to login to
      --endpoint-ca-certificate string   path to the endpoint public certificate
  -h, --help                             help for login
      --insecure-skip-tls-verify         skip endpoint's TLS certificate verification
      --kubeconfig string                path to kubeconfig management cluster. Valid only if user doesn't choose 'endpoint' option.(See [*])
      --name string                      name of the server
      --server string                    login to the given server
$ tz plugin install -h
Install a specific plugin by name or specify all to install all plugins of a group

Usage:
tanzu plugin install [PLUGIN_NAME] [flags]

Examples:

    # Install all plugins of the vmware-tkg/default plugin group version v2.1.0
    tanzu plugin install --group vmware-tkg/default:v2.1.0

    # Install all plugins of the latest version of the vmware-tkg/default plugin group
    tanzu plugin install --group vmware-tkg/default

    # Install the latest version of plugin "myPlugin"
    # If the plugin exists for more than one target, an error will be thrown
    tanzu plugin install myPlugin

    # Install the latest version of plugin "myPlugin" for target kubernetes
    tanzu plugin install myPlugin --target k8s

    # Install version v1.0.0 of plugin "myPlugin"
    tanzu plugin install myPlugin --version v1.0.0

Flags:
      --group string     install the plugins specified by a plugin-group version
  -h, --help             help for install
  -t, --target string    target of the plugin (kubernetes[k8s]/mission-control[tmc]/global)
  -v, --version string   version of the plugin (default "latest")
$ tz plugin download-bundle -h
Download a plugin bundle to the local file system to be used when migrating plugins
to an internet-restricted environment. Please also see the "upload-bundle" command.

Usage:
tanzu plugin download-bundle [flags]

Examples:

    # Download a plugin bundle for a specific group version from the default discovery source
    tanzu plugin download-bundle --to-tar /tmp/plugin_bundle_vmware_tkg_default_v1.0.0.tar.gz --group vmware-tkg/default:v1.0.0

    # Download a plugin bundle with the entire plugin repository from a custom discovery source
    tanzu plugin download-bundle --image custom.registry.vmware.com/tkg/tanzu-plugins/plugin-inventory:latest --to-tar /tmp/plugin_bundle_complete.tar.gz

Flags:
      --group strings   only download the plugins specified in the plugin-group version (can specify multiple)
  -h, --help            help for download-bundle
      --image string    URI of the plugin discovery image providing the plugins (default "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest")
      --to-tar string   local tar file path to store the plugin images
$ tz plugin upload-bundle -h
Upload a plugin bundle to an alternate container registry for use in an internet-restricted
environment. The plugin bundle is obtained using the "download-bundle" command.

Usage:
tanzu plugin upload-bundle [flags]

Examples:

    # Upload the plugin bundle to the remote repository
    tanzu plugin upload-bundle --tar /tmp/plugin_bundle_vmware_tkg_default_v1.0.0.tar.gz --to-repo custom.registry.company.com/tanzu-plugins/
    tanzu plugin upload-bundle --tar /tmp/plugin_bundle_complete.tar.gz --to-repo custom.registry.company.com/tanzu-plugins/

Flags:
  -h, --help             help for upload-bundle
      --tar string       source tar file
      --to-repo string   destination repository for publishing plugins
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
