### PR TITLE
Add command invocation metrics collection for telemetry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,10 @@ require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/gnostic v0.6.9
 	github.com/google/go-containerregistry v0.15.2
+	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/imdario/mergo v0.3.13
+	github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b
 	github.com/k14s/kbld v0.32.0
 	github.com/lithammer/dedent v1.1.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
@@ -30,6 +32,7 @@ require (
 	github.com/sigstore/sigstore v1.6.4
 	github.com/spf13/afero v1.9.3
 	github.com/spf13/cobra v1.7.0
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.3
 	github.com/tj/assert v0.0.3
 	github.com/verybluebot/tarinator-go v0.0.0-20190613183509-5ab4e1193986
@@ -37,7 +40,7 @@ require (
 	github.com/vmware-tanzu/carvel-ytt v0.40.0
 	github.com/vmware-tanzu/tanzu-cli/test/e2e/framework v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686
-	github.com/vmware-tanzu/tanzu-plugin-runtime v0.90.0
+	github.com/vmware-tanzu/tanzu-plugin-runtime v1.0.0-dev.0.20230706203022-6b662c0fddaa
 	go.pinniped.dev v0.20.0
 	go.uber.org/multierr v1.11.0
 	golang.org/x/mod v0.10.0
@@ -140,7 +143,6 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20221118152302-e6195bd50e26 // indirect
 	github.com/google/trillian v1.5.2 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.2 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
@@ -151,7 +153,6 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b // indirect
 	github.com/k14s/semver/v4 v4.0.1-0.20210701191048-266d47ac6115 // indirect
 	github.com/k14s/starlark-go v0.0.0-20200720175618-3a5c849cc368 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
@@ -193,7 +194,6 @@ require (
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.15.0 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect

--- a/go.sum
+++ b/go.sum
@@ -690,8 +690,8 @@ github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502eb
 github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502ebf68/go.mod h1:e1Uef+Ux5BIHpYwqbeP2ZZmOzehBcez2vUEWXHe+xHE=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686 h1:VcuXqUXFxm5WDqWkzAlU/6cJXua0ozELnqD59fy7J6E=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686/go.mod h1:AFGOXZD4tH+KhpmtV0VjWjllXhr8y57MvOsIxTtywc4=
-github.com/vmware-tanzu/tanzu-plugin-runtime v0.90.0 h1:MbnTxvqCBOLR8gHpnzwxlcbP16vF71LyV8Tx2ANC57o=
-github.com/vmware-tanzu/tanzu-plugin-runtime v0.90.0/go.mod h1:wMK/qpJjU7hytDAGt3FX5/iGdlUK8TsJLu36pCr+Zvk=
+github.com/vmware-tanzu/tanzu-plugin-runtime v1.0.0-dev.0.20230706203022-6b662c0fddaa h1:jhsuQ5Y9dt7RBODw3/WzqjHF1IqYysNq1Nrd/zUZESE=
+github.com/vmware-tanzu/tanzu-plugin-runtime v1.0.0-dev.0.20230706203022-6b662c0fddaa/go.mod h1:wMK/qpJjU7hytDAGt3FX5/iGdlUK8TsJLu36pCr+Zvk=
 github.com/xanzy/go-gitlab v0.83.0 h1:37p0MpTPNbsTMKX/JnmJtY8Ch1sFiJzVF342+RvZEGw=
 github.com/xanzy/go-gitlab v0.83.0/go.mod h1:5ryv+MnpZStBH8I/77HuQBsMbBGANtVpLWC15qOjWAw=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1616,6 +1616,7 @@ github.com/onsi/ginkgo/v2 v2.1.4/go.mod h1:um6tUpWM/cxCK3/FK8BXqEiUMUwRgSM4JXG47
 github.com/onsi/ginkgo/v2 v2.4.0/go.mod h1:iHkDK1fKGcBoEHT5W7YBq4RFWaQulw+caOMkAt4OrFo=
 github.com/onsi/ginkgo/v2 v2.6.0/go.mod h1:63DOGlLAH8+REH8jUGdL3YpCpu7JODesutUjdENfUAc=
 github.com/onsi/ginkgo/v2 v2.9.1/go.mod h1:FEcmzVcCHl+4o9bQZVab+4dC9+j+91t2FHSzmGAPfuo=
+github.com/onsi/ginkgo/v2 v2.9.2/go.mod h1:WHcJJG2dIlcCqVfBAwUCrJxSPFb6v4azBwgxeMeDuts=
 github.com/onsi/ginkgo/v2 v2.9.7/go.mod h1:cxrmXWykAwTwhQsJOPfdIDiJ+l2RYq7U8hFU+M/1uw0=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
@@ -1628,6 +1629,7 @@ github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+t
 github.com/onsi/gomega v1.23.0/go.mod h1:Z/NWtiqwBrwUt4/2loMmHL63EDLnYHmVbuBpDr2vQAg=
 github.com/onsi/gomega v1.24.1/go.mod h1:3AOiACssS3/MajrniINInwbfOOtfZvplPzuRSmvt1jM=
 github.com/onsi/gomega v1.27.4/go.mod h1:riYq/GJKh8hhoM01HN6Vmuy93AarCXCBGpvFDK3q3fQ=
+github.com/onsi/gomega v1.27.6/go.mod h1:PIQNjfQwkP3aQAH7lf7j87O/5FiNr+ZR8+ipb+qQlhg=
 github.com/onsi/gomega v1.27.7/go.mod h1:1p8OOlwo2iUUDsHnOrjE5UKYJ+e3W8eQ3qSlRahPmr4=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 h1:lDH9UUVJtmYCjyT0CI4q8xvlXPxeZ0gYCVvWbmPlp88=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=

--- a/pkg/cli/plugin_cmd.go
+++ b/pkg/cli/plugin_cmd.go
@@ -28,9 +28,10 @@ func GetCmdForPlugin(p *PluginInfo) *cobra.Command {
 		},
 		DisableFlagParsing: true,
 		Annotations: map[string]string{
-			"group": string(p.Group),
-			"scope": p.Scope,
-			"type":  common.CommandTypePlugin,
+			"group":                  string(p.Group),
+			"scope":                  p.Scope,
+			"type":                   common.CommandTypePlugin,
+			"pluginInstallationPath": p.InstallationPath,
 		},
 		Hidden:  p.Hidden,
 		Aliases: p.Aliases,

--- a/pkg/common/defaults.go
+++ b/pkg/common/defaults.go
@@ -20,6 +20,9 @@ var (
 	// DefaultLocalPluginDistroDir is the default Local plugin distribution root directory
 	// This directory will be used for local discovery and local distribute of plugins
 	DefaultLocalPluginDistroDir = filepath.Join(xdg.Home, ".config", "tanzu-plugins")
+
+	// DefaultCLITelemetryDir is the default telemetry directory
+	DefaultCLITelemetryDir = filepath.Join(xdg.Home, ".config", "tanzu-cli-telemetry")
 )
 
 const (

--- a/pkg/constants/env_variables.go
+++ b/pkg/constants/env_variables.go
@@ -23,4 +23,5 @@ const (
 	E2ETestEnvironment                                = "TANZU_CLI_E2E_TEST_ENVIRONMENT"
 	// ControlPlaneEndpointType is the control-plane endpoint type to be used for "self-managed-tmc"(this list may grow in future)
 	ControlPlaneEndpointType = "TANZU_CLI_CONTROL_PLANE_ENDPOINT_TYPE"
+	ShowTelemetryConsoleLogs = "TANZU_CLI_SHOW_TELEMETRY_CONSOLE_LOGS"
 )

--- a/pkg/telemetry/client.go
+++ b/pkg/telemetry/client.go
@@ -1,0 +1,247 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package telemetry collects the CLI metrics and sends the telemetry data to supercollider
+package telemetry
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/buildinfo"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
+	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
+	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
+)
+
+var once sync.Once
+
+var client MetricsHandler
+
+type MetricsHandler interface {
+	// SetInstalledPlugins adds the installed plugins to the handler used to retrieve
+	// the plugin information
+	SetInstalledPlugins(plugins []cli.PluginInfo)
+	// UpdateCmdPreRunMetrics updates the metrics collected before running the command
+	UpdateCmdPreRunMetrics(cmd *cobra.Command, args []string) error
+	// UpdateCmdPostRunMetrics updates the metrics collected after command execution is completed
+	UpdateCmdPostRunMetrics(metrics *PostRunMetrics) error
+	// SaveMetrics saves the metrics to the metrics store/DB
+	SaveMetrics() error
+	// SendMetrics sends the metrics to the destination(metrics data lake)
+	SendMetrics() error
+}
+
+type telemetryClient struct {
+	currentOperationMetrics *OperationMetricsPayload
+	installedPlugins        []cli.PluginInfo
+	metricsDB               MetricsDB
+}
+
+type PostRunMetrics struct {
+	ExitCode int
+}
+type OperationMetricsPayload struct {
+	CliID         string
+	StartTime     time.Time
+	EndTime       time.Time
+	Args          []string
+	NameArg       string
+	CommandName   string
+	ExitStatus    int
+	PluginName    string
+	Flags         string
+	CliVersion    string
+	PluginVersion string
+	Target        string
+	Endpoint      string
+	Error         string
+}
+
+func Client() MetricsHandler {
+	once.Do(func() {
+		client = newTelemetryClient()
+	})
+	return client
+}
+
+func newTelemetryClient() MetricsHandler {
+	opMetrics := &OperationMetricsPayload{}
+	metricsDB := newSQLiteMetricsDB()
+	return &telemetryClient{
+		currentOperationMetrics: opMetrics,
+		metricsDB:               metricsDB,
+	}
+}
+
+func (tc *telemetryClient) SetInstalledPlugins(plugins []cli.PluginInfo) {
+	tc.installedPlugins = plugins
+}
+
+func (tc *telemetryClient) UpdateCmdPreRunMetrics(cmd *cobra.Command, args []string) error {
+	if err := ensureMetricsSource(); err != nil {
+		return errors.Wrap(err, "failed to ensure metrics source in the configuration file")
+	}
+
+	cliID, err := cliInstanceID()
+	if err != nil {
+		return errors.Wrap(err, "unable to get CLI Instance ID")
+	}
+
+	if isCoreCommand(cmd) {
+		return tc.updateMetricsForCoreCommand(cmd, args, cliID)
+	}
+
+	return tc.updateMetricsForPlugin(cmd, args, cliID)
+}
+
+func (tc *telemetryClient) UpdateCmdPostRunMetrics(metrics *PostRunMetrics) error {
+	if metrics == nil {
+		return errors.New("post metrics data is required for update")
+	}
+	tc.currentOperationMetrics.ExitStatus = metrics.ExitCode
+	tc.currentOperationMetrics.EndTime = time.Now()
+	return nil
+}
+
+func (tc *telemetryClient) SaveMetrics() error {
+	// If cli command fail cobra validation, the PersistentPreRunE() wouldn't be invoked where initialization is done
+	// so, it is safe to ignore the metrics for user errors(like typos) at least to an extent where cobra can validate.
+	if tc.currentOperationMetrics.StartTime.IsZero() {
+		return nil
+	}
+
+	err := tc.metricsDB.CreateSchema()
+	if err != nil {
+		return errors.Wrap(err, "unable to create the telemetry schema")
+	}
+
+	return tc.metricsDB.SaveOperationMetric(tc.currentOperationMetrics)
+}
+
+// SendMetrics sends the local stored metrics to super collider
+// TODO: to be implemented
+func (tc *telemetryClient) SendMetrics() error {
+	return nil
+}
+
+func isCoreCommand(cmd *cobra.Command) bool {
+	if cmd.Annotations != nil && cmd.Annotations["type"] == common.CommandTypePlugin {
+		return false
+	}
+	return true
+}
+func (tc *telemetryClient) updateMetricsForCoreCommand(cmd *cobra.Command, args []string, cliID string) error {
+	tc.currentOperationMetrics.CliID = cliID
+	tc.currentOperationMetrics.CliVersion = buildinfo.Version
+	tc.currentOperationMetrics.StartTime = time.Now()
+	tc.currentOperationMetrics.CommandName = strings.Join(strings.Split(cmd.CommandPath(), " ")[1:], " ")
+
+	// CLI recommendation is to have a single argument for a command
+	if len(args) != 0 {
+		tc.currentOperationMetrics.NameArg = hashString(args[0])
+	}
+
+	flagMap := make(map[string]string)
+	hashRequired := isHashRequiredForCmdFlags(cmd.CommandPath())
+	cmd.Flags().Visit(func(flag *pflag.Flag) {
+		// capture the boolean and empty flag values as is
+		if !hashRequired || flag.Value.String() == "" || flag.Value.Type() == "bool" {
+			flagMap[flag.Name] = flag.Value.String()
+		} else {
+			flagMap[flag.Name] = hashString(flag.Value.String())
+		}
+	})
+	if len(flagMap) != 0 {
+		jsonString, _ := json.Marshal(flagMap)
+		tc.currentOperationMetrics.Flags = string(jsonString)
+	}
+
+	return nil
+}
+
+func (tc *telemetryClient) updateMetricsForPlugin(cmd *cobra.Command, args []string, cliID string) error {
+	tc.currentOperationMetrics.CliID = cliID
+	tc.currentOperationMetrics.CliVersion = buildinfo.Version
+	tc.currentOperationMetrics.StartTime = time.Now()
+
+	flagNames := TraverseFlagNames(args)
+	if len(flagNames) > 0 {
+		tc.currentOperationMetrics.Flags = flagNamesToJSONString(flagNames)
+	}
+
+	plugin := tc.pluginInfoFromCommand(cmd)
+	if plugin != nil {
+		tc.currentOperationMetrics.PluginName = plugin.Name
+		tc.currentOperationMetrics.PluginVersion = plugin.Version
+		tc.currentOperationMetrics.Target = string(plugin.Target)
+		tc.currentOperationMetrics.Endpoint = getEndpointSHA(plugin)
+	}
+
+	// TODO : Fix the command chain for plugins by using command chain cache constructed from generate-all-docs command
+	tc.currentOperationMetrics.CommandName = strings.Join(strings.Split(cmd.CommandPath(), " ")[1:], " ")
+
+	return nil
+}
+func (tc *telemetryClient) pluginInfoFromCommand(cmd *cobra.Command) *cli.PluginInfo {
+	var plugin *cli.PluginInfo
+	if cmd.Annotations == nil || cmd.Annotations["pluginInstallationPath"] == "" {
+		return nil
+	}
+	for i := range tc.installedPlugins {
+		if cmd.Annotations["pluginInstallationPath"] == tc.installedPlugins[i].InstallationPath {
+			return &tc.installedPlugins[i]
+		}
+	}
+
+	return plugin
+}
+
+func cliInstanceID() (string, error) {
+	cliID, err := configlib.GetCLIId()
+	if err != nil {
+		return "", err
+	}
+	return cliID, nil
+}
+
+func ensureMetricsSource() error {
+	telemetryOptions, _ := configlib.GetCLITelemetryOptions()
+	dbFile := filepath.Join(common.DefaultCLITelemetryDir, SQliteDBFileName)
+	if telemetryOptions != nil && telemetryOptions.Source == dbFile {
+		return nil
+	}
+
+	err := configlib.SetCLITelemetryOptions(&configtypes.TelemetryOptions{Source: dbFile})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// isHashRequiredForCmdFlags determines if hashing is required for a core command read from command path
+// currently, for each command we are either hashing all the values or none. A possible enhancement would be
+// to return list of flags whose values need to be hashed.
+func isHashRequiredForCmdFlags(cmdPath string) bool {
+	coreCommandsAllowedWithFlagValues := map[string]struct{}{
+		"plugin": struct{}{},
+	}
+
+	cmds := strings.Split(cmdPath, " ")
+	if len(cmds) < 2 {
+		return false
+	}
+
+	if _, exists := coreCommandsAllowedWithFlagValues[cmds[1]]; exists {
+		return false
+	}
+	return true
+}

--- a/pkg/telemetry/client_test.go
+++ b/pkg/telemetry/client_test.go
@@ -1,0 +1,416 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package telemetry
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
+	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
+	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
+)
+
+func TestClient(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Telemetry plugin test suite")
+}
+
+type mockMetricsDB struct {
+	createSchemaCalled             bool
+	saveOperationMetricCalled      bool
+	createSchemaReturnError        error
+	saveOperationMetricReturnError error
+}
+
+func (mc *mockMetricsDB) CreateSchema() error {
+	mc.createSchemaCalled = true
+	return mc.createSchemaReturnError
+}
+
+func (mc *mockMetricsDB) SaveOperationMetric(payload *OperationMetricsPayload) error {
+	mc.saveOperationMetricCalled = true
+	return mc.saveOperationMetricReturnError
+}
+
+var _ = Describe("Unit tests for UpdateCmdPreRunMetrics()", func() {
+	const True = "true"
+	var (
+		tc           *telemetryClient
+		metricsDB    *mockMetricsDB
+		rootCmd      *cobra.Command
+		cmd          *cobra.Command
+		configFile   *os.File
+		configFileNG *os.File
+		err          error
+	)
+
+	BeforeEach(func() {
+		metricsDB = &mockMetricsDB{}
+		tc = &telemetryClient{
+			currentOperationMetrics: &OperationMetricsPayload{
+				StartTime: time.Time{},
+			},
+			metricsDB: metricsDB,
+		}
+
+		rootCmd = &cobra.Command{
+			Use: "tanzu",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return nil
+			},
+		}
+
+		configFile, err = os.CreateTemp("", "config")
+		Expect(err).To(BeNil())
+		os.Setenv("TANZU_CONFIG", configFile.Name())
+
+		configFileNG, err = os.CreateTemp("", "config_ng")
+		Expect(err).To(BeNil())
+		os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
+
+		err = configlib.SetCLIId("fake-cli-id")
+		Expect(err).ToNot(HaveOccurred(), "failed to set the CLI ID")
+
+	})
+	AfterEach(func() {
+		os.Unsetenv("TANZU_CONFIG")
+		os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
+
+		os.RemoveAll(configFile.Name())
+		os.RemoveAll(configFileNG.Name())
+
+	})
+	Describe("when the command is CLI core command", func() {
+		BeforeEach(func() {
+			cmd = &cobra.Command{
+				Use: "corecommand",
+				RunE: func(cmd *cobra.Command, args []string) error {
+					return nil
+				},
+			}
+			rootCmd.AddCommand(cmd)
+		})
+		Context("when core command has arguments provided but no flags", func() {
+			It("should return success and the metrics should have name arg(first argument) hashed and flags string should be empty", func() {
+				//tc.UpdateCoreCommandMap(cmd)
+				err = tc.UpdateCmdPreRunMetrics(cmd, []string{"arg1"})
+				Expect(err).ToNot(HaveOccurred())
+				metricsPayload := tc.currentOperationMetrics
+				Expect(metricsPayload.CommandName).To(Equal("corecommand"))
+				Expect(metricsPayload.NameArg).To(Equal(hashString("arg1")))
+				Expect(metricsPayload.Flags).To(BeEmpty())
+				Expect(metricsPayload.CliID).ToNot(BeEmpty())
+				Expect(metricsPayload.StartTime.IsZero()).To(BeFalse())
+
+			})
+		})
+		Context("when the core command (requiring hashed values) has arguments and flags provided", func() {
+			It("should return success and the metrics should have name arg(first argument) hashed and flags values should be hashed except boolean type flags", func() {
+				//tc.UpdateCoreCommandMap(cmd)
+				cmd.Flags().String("flag1", "value1", "Flag 1")
+				cmd.Flags().Bool("flag2", false, "Flag 2")
+				err = cmd.Flags().Set("flag1", "value2")
+				Expect(err).ToNot(HaveOccurred())
+				err = cmd.Flags().Set("flag2", True)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = tc.UpdateCmdPreRunMetrics(cmd, []string{"arg1"})
+				Expect(err).ToNot(HaveOccurred())
+				metricsPayload := tc.currentOperationMetrics
+				Expect(metricsPayload.CommandName).To(Equal("corecommand"))
+				Expect(metricsPayload.NameArg).To(Equal(hashString("arg1")))
+				flagMap := make(map[string]string)
+				flagMap["flag1"] = hashString("value2")
+				// boolean flag values should not be hashed
+				flagMap["flag2"] = True
+				flagStr, err := json.Marshal(flagMap)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(metricsPayload.Flags).To(Equal(string(flagStr)))
+				Expect(metricsPayload.CliID).ToNot(BeEmpty())
+				Expect(metricsPayload.StartTime.IsZero()).To(BeFalse())
+
+			})
+		})
+		Context("when the core command (not requiring hashed values) has arguments and flags provided", func() {
+			It("should return success and the metrics should have name arg(first argument) hashed and flags values should be hashed", func() {
+				// change the command name to "plugin" since CLI wouldn't hash the flag values for plugin LCM commands
+				cmd.Use = "plugin"
+				//tc.UpdateCoreCommandMap(cmd)
+				cmd.Flags().String("flag1", "value1", "Flag 1")
+				cmd.Flags().Bool("flag2", false, "Flag 2")
+				err = cmd.Flags().Set("flag1", "value2")
+				Expect(err).ToNot(HaveOccurred())
+				err = cmd.Flags().Set("flag2", True)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(configFileNG).ToNot(BeNil())
+				err = tc.UpdateCmdPreRunMetrics(cmd, []string{"arg1"})
+				Expect(err).ToNot(HaveOccurred())
+				metricsPayload := tc.currentOperationMetrics
+				Expect(metricsPayload.CommandName).To(Equal("plugin"))
+				Expect(metricsPayload.NameArg).To(Equal(hashString("arg1")))
+				Expect(metricsPayload.CliID).ToNot(BeEmpty())
+				Expect(metricsPayload.StartTime.IsZero()).To(BeFalse())
+
+				flagMap := make(map[string]string)
+				flagMap["flag1"] = "value2"
+				flagMap["flag2"] = True
+				flagStr, err := json.Marshal(flagMap)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(metricsPayload.Flags).To(Equal(string(flagStr)))
+
+			})
+		})
+	})
+
+	Describe("when the command is plugin command", func() {
+
+		//Since cobra can only recognize the plugin command in the current plugin architecture, all the subcommands and flags are considered as args for the plugin command
+		Context("when plugin command has only args ", func() {
+			It("should return success and the metrics should have name arg(first argument) empty and flags string should be empty", func() {
+				globalPluginCmd := &cobra.Command{
+					Use: "plugin1",
+					RunE: func(cmd *cobra.Command, args []string) error {
+						return nil
+					},
+					Annotations: map[string]string{
+						"type":                   common.CommandTypePlugin,
+						"pluginInstallationPath": "/path/to/plugin1",
+					},
+				}
+				rootCmd.AddCommand(globalPluginCmd)
+
+				tc.SetInstalledPlugins([]cli.PluginInfo{{
+					Name:             "plugin1",
+					Version:          "1.0.0",
+					InstallationPath: "/path/to/plugin1",
+				}})
+
+				// command: tanzu plugin1 arg1
+				err = tc.UpdateCmdPreRunMetrics(globalPluginCmd, []string{"arg1"})
+
+				Expect(err).ToNot(HaveOccurred())
+				metricsPayload := tc.currentOperationMetrics
+				Expect(metricsPayload.CommandName).To(Equal("plugin1"))
+				Expect(metricsPayload.PluginName).To(Equal("plugin1"))
+				Expect(metricsPayload.PluginVersion).To(Equal("1.0.0"))
+				Expect(metricsPayload.Flags).To(BeEmpty())
+				Expect(metricsPayload.CliID).ToNot(BeEmpty())
+				Expect(metricsPayload.StartTime.IsZero()).To(BeFalse())
+
+			})
+		})
+
+		//Since cobra can only recognize the plugin command in the current plugin architecture, all the subcommands and flags are considered as args for the plugin command
+		Context("when kubernetes plugin command has subcommands, args and flags ", func() {
+			It("should return success and the metrics should have name arg(first argument) empty and flags string should be empty", func() {
+
+				k8sTargetCmd := &cobra.Command{
+					Use: "kubernetes",
+					RunE: func(cmd *cobra.Command, args []string) error {
+						return nil
+					},
+				}
+				k8sPlugincmd := &cobra.Command{
+					Use: "k8s-plugin1",
+					RunE: func(cmd *cobra.Command, args []string) error {
+						return nil
+					},
+					Annotations: map[string]string{
+						"type":                   common.CommandTypePlugin,
+						"pluginInstallationPath": "/path/to/k8s-plugin1",
+					},
+				}
+				k8sTargetCmd.AddCommand(k8sPlugincmd)
+				rootCmd.AddCommand(k8sTargetCmd)
+
+				tc.SetInstalledPlugins([]cli.PluginInfo{{
+					Name:             "k8s-plugin1",
+					Version:          "1.0.0",
+					Target:           configtypes.TargetK8s,
+					InstallationPath: "/path/to/k8s-plugin1",
+				}})
+
+				// command : tanzu kubernetes k8s-plugin1 plugin-subcmd1 -v 6 plugin-subcmd2 -ab --flag1=value1 --flag2 value2 -- --arg1 --arg2
+				err = tc.UpdateCmdPreRunMetrics(k8sPlugincmd, []string{"plugin-subcmd1", "-v", "6", "plugin-subcmd2", "-ab", "--flag1=value1", "--flag2", "value2", "--", "--arg1", "--arg2"})
+
+				Expect(err).ToNot(HaveOccurred())
+				metricsPayload := tc.currentOperationMetrics
+				Expect(metricsPayload.CommandName).To(Equal("kubernetes k8s-plugin1"))
+				Expect(metricsPayload.PluginName).To(Equal("k8s-plugin1"))
+				Expect(metricsPayload.PluginVersion).To(Equal("1.0.0"))
+				Expect(metricsPayload.Target).To(Equal(string(configtypes.TargetK8s)))
+				Expect(metricsPayload.Endpoint).To(BeEmpty())
+				Expect(metricsPayload.NameArg).To(BeEmpty())
+
+				flagMap := make(map[string]string)
+				err = json.Unmarshal([]byte(metricsPayload.Flags), &flagMap)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(flagMap).To(Equal(map[string]string{
+					"v":     "",
+					"a":     "",
+					"b":     "",
+					"flag1": "",
+					"flag2": "",
+				}))
+				Expect(metricsPayload.CliID).ToNot(BeEmpty())
+				Expect(metricsPayload.StartTime.IsZero()).To(BeFalse())
+			})
+		})
+
+	})
+})
+
+func TestClient_Client(t *testing.T) {
+	client := Client()
+
+	// Call Client() multiple times and ensure that the same instance of the MetricsHandler is returned
+	for i := 0; i < 5; i++ {
+		assert.Equal(t, client, Client())
+	}
+}
+
+func TestTelemetryClient_UpdateCmdPostRunMetrics(t *testing.T) {
+	tc := &telemetryClient{
+		currentOperationMetrics: &OperationMetricsPayload{},
+		metricsDB:               &mockMetricsDB{},
+	}
+	metrics := &PostRunMetrics{
+		ExitCode: 1,
+	}
+
+	err := tc.UpdateCmdPostRunMetrics(metrics)
+	if err != nil {
+		t.Errorf("Failed to update post-run metrics: %v", err)
+	}
+
+	payload := tc.currentOperationMetrics
+
+	if payload.ExitStatus != 1 {
+		t.Errorf("Exit status is not set correctly")
+	}
+
+	if payload.EndTime.IsZero() {
+		t.Errorf("End time is not set")
+	}
+
+	// Test when post run metric data is nil (should not update the metrics)
+	if err := tc.UpdateCmdPostRunMetrics(nil); err == nil {
+		t.Errorf("Updating command post run metrics should return error if post run metric data is nil")
+	}
+}
+
+var _ = Describe("Unit tests for SaveMetrics()", func() {
+	var (
+		tc        *telemetryClient
+		metricsDB *mockMetricsDB
+		err       error
+	)
+	BeforeEach(func() {
+		metricsDB = &mockMetricsDB{}
+		tc = &telemetryClient{
+			currentOperationMetrics: &OperationMetricsPayload{
+				StartTime: time.Time{},
+			},
+			metricsDB: metricsDB,
+		}
+	})
+
+	Context("when the start time is zero", func() {
+		It("should return success and not save the metrics to DB", func() {
+			err = tc.SaveMetrics()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metricsDB.createSchemaCalled).To(BeFalse())
+			Expect(metricsDB.saveOperationMetricCalled).To(BeFalse())
+
+		})
+	})
+	Context("when the DB schema creation failed", func() {
+		It("should return failure", func() {
+			tc.currentOperationMetrics.StartTime = time.Now()
+			metricsDB.createSchemaReturnError = errors.New("fake schema creation error")
+
+			err = tc.SaveMetrics()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("unable to create the telemetry schema: fake schema creation error"))
+			Expect(metricsDB.createSchemaCalled).To(BeTrue())
+			Expect(metricsDB.saveOperationMetricCalled).To(BeFalse())
+		})
+	})
+	Context("when DB returns error to save the metrics", func() {
+		It("should return failure", func() {
+			tc.currentOperationMetrics.StartTime = time.Now()
+			metricsDB.saveOperationMetricReturnError = errors.New("fake save metrics error")
+
+			err = tc.SaveMetrics()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("fake save metrics error"))
+			Expect(metricsDB.createSchemaCalled).To(BeTrue())
+			Expect(metricsDB.saveOperationMetricCalled).To(BeTrue())
+		})
+	})
+	Context("when metrics is saved in DB successfully", func() {
+		It("should return success", func() {
+			tc.currentOperationMetrics.StartTime = time.Now()
+			err = tc.SaveMetrics()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metricsDB.createSchemaCalled).To(BeTrue())
+			Expect(metricsDB.saveOperationMetricCalled).To(BeTrue())
+		})
+	})
+
+})
+
+func TestTelemetryClient_SendMetrics(t *testing.T) {
+	tc := &telemetryClient{}
+
+	err := tc.SendMetrics()
+	if err != nil {
+		t.Errorf("Failed to send metrics: %v", err)
+	}
+}
+
+func TestTelemetryClient_isCoreCommand(t *testing.T) {
+	coreCMD := &cobra.Command{
+		Use: "core-command-wo-annotations",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	isCoreCMD := isCoreCommand(coreCMD)
+	if !isCoreCMD {
+		t.Error("isCoreCommand should return true for a command with out annotations")
+	}
+
+	// set the annotation, but without 'type': 'plugin'
+	coreCMD.Annotations = map[string]string{
+		"group": "System",
+	}
+	isCoreCMD = isCoreCommand(coreCMD)
+	if !isCoreCMD {
+		t.Error("isCoreCommand should return true for the command with out plugin annotation")
+	}
+
+	// set the annotation, but without 'type': 'plugin'
+	coreCMD.Annotations = map[string]string{
+		"type": common.CommandTypePlugin,
+	}
+	isCoreCMD = isCoreCommand(coreCMD)
+	if isCoreCMD {
+		t.Error("isCoreCommand should return false for the command with plugin annotation")
+	}
+}

--- a/pkg/telemetry/data/sqlite/create_tables.sql
+++ b/pkg/telemetry/data/sqlite/create_tables.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS "tanzu_cli_operations"
+(
+    "cli_version"       TEXT NOT NULL,
+    "os_name"           TEXT NOT NULL,
+    "os_arch"           TEXT NOT NULL,
+    "plugin_name"       TEXT,
+    "plugin_version"    TEXT,
+    "command"           TEXT NOT NULL,
+    "cli_id"            TEXT NOT NULL,
+    "command_start_ts"  TEXT NOT NULL,
+    "command_end_ts"    TEXT NOT NULL,
+    "csp_org_id"        TEXT,
+    "account_number"    TEXT,
+    "target"            TEXT,
+    "name_arg"          TEXT,
+    "endpoint"          TEXT,
+    "flags"             TEXT,
+    "exit_status"       INTEGER,
+    "is_internal"       TEXT,
+    "error"             TEXT,
+    PRIMARY KEY("cli_id","command","command_start_ts")
+);

--- a/pkg/telemetry/flags.go
+++ b/pkg/telemetry/flags.go
@@ -1,0 +1,70 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package telemetry
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+const doubleHyphen = "--"
+
+func TraverseFlagNames(args []string) []string {
+	flags := []string{}
+Loop:
+	for _, arg := range args {
+		switch {
+		// "--" terminates the flags (everything after is an argument)
+		case arg == doubleHyphen:
+			break Loop
+		// A long flag with a space separated value
+		case strings.HasPrefix(arg, doubleHyphen) && !strings.Contains(arg, "="):
+			flags = append(flags, arg)
+			continue
+		// A short flag with a space separated value
+		case strings.HasPrefix(arg, "-") && !strings.Contains(arg, "=") && len(arg) == 2:
+			flags = append(flags, arg)
+			continue
+		// A flag without a value, or with an `=` separated value
+		case isFlagArg(arg):
+			if strings.Contains(arg, "=") {
+				flags = append(flags, strings.Split(arg, "=")[0])
+			} else {
+				flags = append(flags, arg)
+			}
+			continue
+		}
+	}
+	return processFlagNames(flags)
+}
+
+func flagNamesToJSONString(flagNames []string) string {
+	flagMap := make(map[string]string)
+	for _, flagName := range flagNames {
+		flagMap[flagName] = ""
+	}
+	flagsStr, _ := json.Marshal(flagMap)
+	return string(flagsStr)
+}
+
+func processFlagNames(flags []string) []string {
+	var resultFlags []string
+	for _, flag := range flags {
+		switch {
+		// if flag is -abc , its equivalent to 3 short flags -a,-b, -c
+		case len(flag) >= 3 && flag[0] == '-' && flag[1] != '-':
+			resultFlags = append(resultFlags, strings.Split(flag[1:], "")...)
+			continue
+		default:
+			// strip the "-" or "--" from the flag name
+			resultFlags = append(resultFlags, strings.TrimLeft(flag, "-"))
+		}
+	}
+	return resultFlags
+}
+
+func isFlagArg(arg string) bool {
+	return (len(arg) >= 3 && arg[0:2] == "--") ||
+		(len(arg) >= 2 && arg[0] == '-' && arg[1] != '-')
+}

--- a/pkg/telemetry/flags_test.go
+++ b/pkg/telemetry/flags_test.go
@@ -1,0 +1,70 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package telemetry
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTraverseFlagNames(t *testing.T) {
+	args := []string{"-a", "--flag1", "--flag2=value", "-bc", "--", "--arg1", "--arg2"}
+
+	expectedFlags := []string{"a", "flag1", "flag2", "b", "c"}
+	resultFlags := TraverseFlagNames(args)
+
+	if !reflect.DeepEqual(resultFlags, expectedFlags) {
+		t.Errorf("Expected flags: %v, but got: %v", expectedFlags, resultFlags)
+	}
+
+	// ex: tanzu pluginName -v 6 pluginCmd --flag1 pluginSubcmd --flag1=10 -bc -- arg1 --arg2
+	argsWithPluginCommands := []string{"-v", "6", "pluginCmd", "--flag1", "pluginSubCmd", "--flag2=value", "-bc", "--", "--arg1", "--arg2"}
+
+	expectedFlagsWithoutPluginCommands := []string{"v", "flag1", "flag2", "b", "c"}
+	resultFlags = TraverseFlagNames(argsWithPluginCommands)
+
+	if !reflect.DeepEqual(resultFlags, expectedFlagsWithoutPluginCommands) {
+		t.Errorf("Expected flags excluding the pluginCommand in the args: %v, but got: %v", expectedFlags, resultFlags)
+	}
+}
+
+func TestFlagNamesToJSONString(t *testing.T) {
+	flagNames := []string{"flag1", "flag2", "flag3"}
+
+	expectedJSONString := `{"flag1":"","flag2":"","flag3":""}`
+	resultJSONString := flagNamesToJSONString(flagNames)
+
+	if resultJSONString != expectedJSONString {
+		t.Errorf("Expected JSON string: %s, but got: %s", expectedJSONString, resultJSONString)
+	}
+}
+
+func TestProcessFlagNames(t *testing.T) {
+	flags := []string{"a", "flag1", "flag2", "b", "c"}
+
+	expectedResultFlags := []string{"a", "flag1", "flag2", "b", "c"}
+	resultFlags := processFlagNames(flags)
+
+	if !reflect.DeepEqual(resultFlags, expectedResultFlags) {
+		t.Errorf("Expected flags: %v, but got: %v", expectedResultFlags, resultFlags)
+	}
+}
+
+func TestIsFlagArg(t *testing.T) {
+	flagArg1 := "--flag"
+	flagArg2 := "-a"
+	nonFlagArg := "arg"
+
+	if !isFlagArg(flagArg1) {
+		t.Errorf("Expected %s to be a flag argument", flagArg1)
+	}
+
+	if !isFlagArg(flagArg2) {
+		t.Errorf("Expected %s to be a flag argument", flagArg2)
+	}
+
+	if isFlagArg(nonFlagArg) {
+		t.Errorf("Expected %s not to be a flag argument", nonFlagArg)
+	}
+}

--- a/pkg/telemetry/log.go
+++ b/pkg/telemetry/log.go
@@ -1,0 +1,32 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package telemetry
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
+)
+
+var showTelemetryLog = false
+
+func init() {
+	showLog := os.Getenv(constants.ShowTelemetryConsoleLogs)
+	if isTrue, _ := strconv.ParseBool(showLog); isTrue {
+		showTelemetryLog = true
+	}
+}
+
+func LogError(err error, msg string, kvs ...interface{}) {
+	if showTelemetryLog {
+		log.Error(err, msg, kvs...)
+	}
+}
+func LogWarning(msg string, kvs ...interface{}) {
+	if showTelemetryLog {
+		log.Warning(msg, kvs...)
+	}
+}

--- a/pkg/telemetry/metric_db.go
+++ b/pkg/telemetry/metric_db.go
@@ -1,0 +1,13 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package telemetry
+
+type MetricsDB interface {
+	// CreateSchema creates table schemas to the provided database.
+	// returns error if table creation fails for any reason
+	CreateSchema() error
+
+	// SaveOperationMetric inserts CLI operation metrics collected into database
+	SaveOperationMetric(*OperationMetricsPayload) error
+}

--- a/pkg/telemetry/metrics_db_lock.go
+++ b/pkg/telemetry/metrics_db_lock.go
@@ -1,0 +1,86 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package telemetry
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
+
+	"github.com/juju/fslock"
+)
+
+const (
+	LocalTanzuCLIMetricsDBFileLock = ".cli_metrics_db.lock"
+	// DefaultMetricsDBLockTimeout is the default time waiting on the filelock
+	DefaultMetricsDBLockTimeout = 3 * time.Second
+)
+
+var cliMetricDBLockFile string
+
+// cliMetricDBLock used as a static lock variable that stores fslock
+// This is used for interprocess locking of the tanzu cli metrics DB file
+var cliMetricDBLock *fslock.Lock
+
+// cliMetricDBMutex is used to handle the locking behavior between concurrent calls
+// within the existing process trying to acquire the lock
+var cliMetricDBMutex sync.Mutex
+
+// AcquireTanzuMetricDBLock tries to acquire lock to update tanzu cli metrics DB file with timeout
+func AcquireTanzuMetricDBLock() error {
+	var err error
+
+	if cliMetricDBLockFile == "" {
+		cliMetricDBLockFile = filepath.Join(common.DefaultCLITelemetryDir, LocalTanzuCLIMetricsDBFileLock)
+	}
+
+	// using fslock to handle interprocess locking
+	lock, err := getFileLockWithTimeout(cliMetricDBLockFile, DefaultMetricsDBLockTimeout)
+	if err != nil {
+		return fmt.Errorf("cannot acquire lock for Tanzu CLI metrics DB, reason: %v", err)
+	}
+
+	// Lock the mutex to prevent concurrent calls to acquire and configure the cliMetricDBLock
+	cliMetricDBMutex.Lock()
+	cliMetricDBLock = lock
+	return nil
+}
+
+// ReleaseTanzuMetricDBLock releases the lock if the cliMetricDBLock was acquired
+func ReleaseTanzuMetricDBLock() {
+	if cliMetricDBLock == nil {
+		return
+	}
+	if errUnlock := cliMetricDBLock.Unlock(); errUnlock != nil {
+		panic(fmt.Sprintf("cannot release lock for Tanzu CLI metrics DB, reason: %v", errUnlock))
+	}
+
+	cliMetricDBLock = nil
+	// Unlock the mutex to allow other concurrent calls to acquire and configure the cliMetricDBLock
+	cliMetricDBMutex.Unlock()
+}
+
+// getFileLockWithTimeout returns a file lock with timeout
+func getFileLockWithTimeout(lockPath string, lockDuration time.Duration) (*fslock.Lock, error) {
+	dir := filepath.Dir(lockPath)
+
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return nil, err
+		}
+	}
+
+	lock := fslock.New(lockPath)
+
+	if err := lock.LockWithTimeout(lockDuration); err != nil {
+		return nil, errors.Wrap(err, "failed to acquire a lock with timeout")
+	}
+	return lock, nil
+}

--- a/pkg/telemetry/metrics_helper.go
+++ b/pkg/telemetry/metrics_helper.go
@@ -1,0 +1,57 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package telemetry
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
+	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
+	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
+)
+
+func getEndpointSHA(plugin *cli.PluginInfo) string {
+	cfg, err := configlib.GetClientConfig()
+	if err != nil {
+		return ""
+	}
+	curCtxMap, err := cfg.GetAllCurrentContextsMap()
+	if err != nil || curCtxMap == nil {
+		return ""
+	}
+
+	return computeEndpointSHAForContext(curCtxMap, plugin.Target)
+}
+
+// computeEndpointSHAForContext computes the endpoint SHA for based on the target type(context type) used
+func computeEndpointSHAForContext(curCtx map[configtypes.Target]*configtypes.Context, targetType configtypes.Target) string {
+	switch targetType {
+	case configtypes.TargetK8s:
+		ctx, exists := curCtx[configtypes.TargetK8s]
+		if exists {
+			// returns SHA256 of the complete context
+			ctxBytes, _ := json.Marshal(ctx)
+			return hashString(string(ctxBytes))
+		}
+		return ""
+
+	case configtypes.TargetTMC:
+		ctx, exists := curCtx[configtypes.TargetTMC]
+		if exists {
+			// returns SHA256 of concatenated string of Endpoint and RefreshToken
+			// (usually RefreshToken is valid for long duration, hence it is considered for TMC Context uniqueness for telemetry)
+			return hashString(ctx.GlobalOpts.Endpoint + ctx.GlobalOpts.Auth.RefreshToken)
+		}
+		return ""
+	}
+	return ""
+}
+
+func hashString(str string) string {
+	h := sha256.New()
+	h.Write([]byte(str))
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/pkg/telemetry/sqlite_metrics_db.go
+++ b/pkg/telemetry/sqlite_metrics_db.go
@@ -1,0 +1,155 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package telemetry
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+
+	// Import the sqlite3 driver
+	_ "modernc.org/sqlite"
+
+	"github.com/pkg/errors"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
+)
+
+// sqliteMetricsDB implements the MetricDB interface using SQLite database
+type sqliteMetricsDB struct {
+	// metricsDBFile represents the full path to the SQLite DB file
+	metricsDBFile string
+}
+
+const (
+	// SQliteDBFileName is the name of the DB file that has CLI metrics
+	SQliteDBFileName = "cli_metrics.db"
+
+	// TanzuCLITelemetryMaxRowCount Max metric instances to be accumulated before pausing the collection
+	TanzuCLITelemetryMaxRowCount = 1000
+
+	// cliOperationMetricRowClause is the SELECT section of the SQL query to be used when querying the Metric DB row count.
+	cliOperationMetricRowClause = "SELECT count(*) FROM tanzu_cli_operations"
+)
+
+// Structure of each row of the PluginBinaries table within the SQLite database
+type cliOperationsRow struct {
+	cliVersion         string
+	osName             string
+	osArch             string
+	pluginName         string
+	pluginVersion      string
+	command            string
+	cliID              string
+	commandStartTSMsec string
+	commandEndTSMsec   string
+	cspOrgID           string
+	accountNumber      string
+	target             string
+	nameArg            string
+	endpoint           string
+	flags              string
+	exitStatus         int
+	isInternal         bool
+	error              string
+}
+
+// newSQLiteMetricsDB returns a new PluginInventory connected to the data found at 'metricsDBFile'.
+func newSQLiteMetricsDB() MetricsDB {
+	dbFile := filepath.Join(common.DefaultCLITelemetryDir, SQliteDBFileName)
+	return &sqliteMetricsDB{
+		metricsDBFile: dbFile,
+	}
+}
+
+// CreateSchema creates table schemas to the provided database.
+// returns error if table creation fails for any reason
+func (b *sqliteMetricsDB) CreateSchema() error {
+	dirName := filepath.Dir(b.metricsDBFile)
+	if _, serr := os.Stat(dirName); serr != nil {
+		merr := os.MkdirAll(dirName, os.ModePerm)
+		if merr != nil {
+			return merr
+		}
+	}
+	db, err := sql.Open("sqlite", b.metricsDBFile)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open the DB at '%s'", b.metricsDBFile)
+	}
+	defer db.Close()
+
+	_, err = db.Exec(CreateTablesSchema)
+	if err != nil {
+		return errors.Wrap(err, "error while creating tables to the database")
+	}
+
+	return nil
+}
+
+func (b *sqliteMetricsDB) SaveOperationMetric(entry *OperationMetricsPayload) error {
+	err := AcquireTanzuMetricDBLock()
+	if err != nil {
+		return err
+	}
+	defer ReleaseTanzuMetricDBLock()
+
+	db, err := sql.Open("sqlite", b.metricsDBFile)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open the DB from '%s' file", b.metricsDBFile)
+	}
+	defer db.Close()
+
+	atThreshold, err := isDBRowCountThresholdReached(db)
+	if err != nil {
+		return errors.Wrap(err, "failed to validate the DB size threshold")
+	}
+	if atThreshold {
+		return errors.New("metrics DB size threshold reached")
+	}
+
+	row := cliOperationsRow{
+		cliVersion:         entry.CliVersion,
+		osName:             runtime.GOOS,
+		osArch:             runtime.GOARCH,
+		pluginName:         entry.PluginName,
+		pluginVersion:      entry.PluginVersion,
+		command:            entry.CommandName,
+		cliID:              entry.CliID,
+		commandStartTSMsec: strconv.FormatInt(entry.StartTime.UnixMilli(), 10),
+		commandEndTSMsec:   strconv.FormatInt(entry.EndTime.UnixMilli(), 10),
+		cspOrgID:           "", // TODO:(prkalle) to configure cspOrgID through telemetry plugin
+		accountNumber:      "", // TODO:(prkalle) to configure accountNumber through telemetry plugin
+		target:             entry.Target,
+		nameArg:            entry.NameArg,
+		endpoint:           entry.Endpoint,
+		flags:              entry.Flags,
+		exitStatus:         entry.ExitStatus,
+		isInternal:         true, // TODO:(prkalle) to configure isInternal through build options
+		error:              entry.Error,
+	}
+
+	_, err = db.Exec("INSERT INTO tanzu_cli_operations VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);", row.cliVersion, row.osName, row.osArch, row.pluginName, row.pluginVersion, row.command, row.cliID, row.commandStartTSMsec, row.commandEndTSMsec, row.cspOrgID, row.accountNumber, row.target, row.nameArg, row.endpoint, row.flags, row.exitStatus, row.isInternal, row.error)
+	if err != nil {
+		return errors.Wrapf(err, "unable to insert clioperations row %v", row)
+	}
+
+	return nil
+}
+
+func isDBRowCountThresholdReached(db *sql.DB) (bool, error) {
+	dbQuery := cliOperationMetricRowClause
+	rows, err := db.Query(dbQuery)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to execute the DB query : %v", dbQuery)
+	}
+	defer rows.Close()
+	count := 0
+	if rows.Next() {
+		err = rows.Scan(&count)
+	}
+
+	return count >= TanzuCLITelemetryMaxRowCount, err
+}

--- a/pkg/telemetry/sqlite_metrics_db_test.go
+++ b/pkg/telemetry/sqlite_metrics_db_test.go
@@ -1,0 +1,114 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package telemetry
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/pkg/errors"
+)
+
+var _ = Describe("Inserting CLI metrics to database and verifying it by fetching the metrics from database", func() {
+	var (
+		err    error
+		db     *sqliteMetricsDB
+		dbFile *os.File
+		tmpDir string
+	)
+	BeforeEach(func() {
+		tmpDir, err = os.MkdirTemp(os.TempDir(), "")
+		Expect(err).To(BeNil(), "unable to create temporary directory")
+
+		// Create DB file
+		dbFile, err = os.Create(filepath.Join(tmpDir, SQliteDBFileName))
+		Expect(err).To(BeNil())
+
+		db = &sqliteMetricsDB{metricsDBFile: dbFile.Name()}
+		err = db.CreateSchema()
+		Expect(err).To(BeNil(), "failed to create DB schema for testing")
+	})
+	AfterEach(func() {
+		os.RemoveAll(tmpDir)
+	})
+	Context("When inserting the cli metrics data", func() {
+		It("operation should be successful inserted into the database", func() {
+
+			metricsPayload := &OperationMetricsPayload{
+				CliID:         "fake-cli-cliID",
+				StartTime:     time.Now(),
+				EndTime:       time.Now().Add(10 * time.Millisecond),
+				NameArg:       "fake-name-arg",
+				CommandName:   "fake-cmd-name",
+				ExitStatus:    0,
+				PluginName:    "fake-plugin",
+				Flags:         `{"v":"6","longflag":"lvalue"}`,
+				CliVersion:    "v1.0.0",
+				PluginVersion: "v0.0.1",
+				Target:        "kubernetes",
+				Endpoint:      "fake-endpoint-hash",
+				Error:         "",
+			}
+
+			err = db.SaveOperationMetric(metricsPayload)
+			Expect(err).ToNot(HaveOccurred(), "failed to save the metrics")
+			metricsRows, err := getOperationMetrics(db)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(metricsRows)).To(Equal(1))
+			Expect(metricsRows[0].cliID).To(Equal("fake-cli-cliID"))
+			Expect(metricsRows[0].cliVersion).To(Equal("v1.0.0"))
+			Expect(metricsRows[0].osName).To(Equal(runtime.GOOS))
+			Expect(metricsRows[0].osArch).To(Equal(runtime.GOARCH))
+			Expect(metricsRows[0].nameArg).To(Equal("fake-name-arg"))
+			Expect(metricsRows[0].command).To(Equal("fake-cmd-name"))
+			Expect(metricsRows[0].commandStartTSMsec).ToNot(BeEmpty())
+			Expect(metricsRows[0].commandEndTSMsec).ToNot(BeEmpty())
+			Expect(metricsRows[0].pluginName).To(Equal("fake-plugin"))
+			Expect(metricsRows[0].pluginVersion).To(Equal("v0.0.1"))
+			Expect(metricsRows[0].flags).To(Equal(`{"v":"6","longflag":"lvalue"}`))
+			Expect(metricsRows[0].target).To(Equal("kubernetes"))
+			Expect(metricsRows[0].endpoint).To(Equal("fake-endpoint-hash"))
+			Expect(metricsRows[0].exitStatus).To(Equal(0))
+			Expect(metricsRows[0].error).To(BeEmpty())
+
+		})
+	})
+
+})
+
+const selectAllFromCLIOperationMetrics = "SELECT cli_version,os_name,os_arch,plugin_name,plugin_version,command,cli_id,command_start_ts,command_end_ts,csp_org_id," +
+	"account_number,target,name_arg,endpoint,flags,exit_status,is_internal,error FROM tanzu_cli_operations"
+
+func getOperationMetrics(metricsDB *sqliteMetricsDB) ([]*cliOperationsRow, error) {
+	db, err := sql.Open("sqlite", metricsDB.metricsDBFile)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open the DB from '%s' file", metricsDB.metricsDBFile)
+	}
+	defer db.Close()
+
+	dbQuery := selectAllFromCLIOperationMetrics
+	rows, err := db.Query(dbQuery)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to execute the DB query : %v", dbQuery)
+	}
+	defer rows.Close()
+
+	var metricsRows []*cliOperationsRow
+	for rows.Next() {
+		var row cliOperationsRow
+		err = rows.Scan(&row.cliVersion, &row.osName, &row.osArch, &row.pluginName, &row.pluginVersion, &row.command, &row.cliID, &row.commandStartTSMsec, &row.commandEndTSMsec,
+			&row.cspOrgID, &row.accountNumber, &row.target, &row.nameArg, &row.endpoint, &row.flags, &row.exitStatus, &row.isInternal, &row.error)
+		if err != nil {
+			return nil, errors.New("failed to scan the metrics row")
+		}
+		metricsRows = append(metricsRows, &row)
+	}
+	return metricsRows, nil
+}

--- a/pkg/telemetry/sqlite_metrics_schema.go
+++ b/pkg/telemetry/sqlite_metrics_schema.go
@@ -1,0 +1,16 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package telemetry
+
+import (
+	_ "embed"
+	"strings"
+)
+
+var (
+	// CreateTablesSchema defines the database schema to create sqlite database
+	CreateTablesSchema = strings.TrimSpace(createTablesSchema)
+	//go:embed data/sqlite/create_tables.sql
+	createTablesSchema string
+)


### PR DESCRIPTION
### What this PR does / why we need it
This PR adds command invocation metrics collection for telemetry

Some Key points:
Flags:
- For all the core commands except `plugin` LCM(life cycle management) commands, all the flag values (except boolean flags) should be masked 
- For any command implemented in any plugin, only the flag names would be captured

Arguments:
- For all the core commands, the default argument(arg[0]) would be hashed and stored in `name_arg` in the DB
- For any command implemented in any plugin, the default arguments would not be capture due to the limitation in the existing infrastructure to capture the plugin args reliably. 

Command:
- For core command, the complete command chain(excluding the `tanzu`) would be captured
   eg: For ` tanzu config cert add --host test.host.com --insecure`, the command captured is `config cert add` 
- For any command implemented in any plugin, currently it would only capture the plugin name due to the way CLI invokes the plugins. This would be updated in the follow-up PR. 


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

**Testing core commands:** 
- Ran the tanzu core command `tanzu config get` and the metrics is collected successfully in the DB
```
❯ ./bin/tanzu config get
servers:
    - name: tkg-aws-cc-capi115-upg-mc
      type: managementcluster
      managementClusterOpts:
        path: /Users/pkalle/.kube/config
        context: tkg-aws-cc-capi115-upg-mc-admin@tkg-aws-cc-capi115-upg-mc
<SNAPPED>


❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db
SELECT cli_version,os_name,os_arch,plugin_name,plugin_version,command,cli_id,command_start_ts,command_end_ts,csp_org_id,account_number,target,name_arg,endpoint,flags,exit_status,is_internal,error FROM TanzuCLIOperations;
v1.0.0-dev|darwin|amd64|||config get|aa4c97d5-408e-4cbb-a5f0-986ca5ae79f9|1688581470984|1688581471015|||||||0|1|
```


- Ran the tanzu core command `tanzu config set env.` command. Metrics is collected successfully in the DB and default arg is hashed
```
❯ rm -rf /Users/pkalle/.config/tanzu-cli-telemetry/cli_metrics.db
❯ ./bin/tanzu config set env.TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY localhost:9876/tanzu-cli/plugins/sandbox1:small,localhost:9876/tanzu-cli/plugins/sandbox2:small
❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db
SELECT cli_version,os_name,os_arch,plugin_name,plugin_version,command,cli_id,command_start_ts,command_end_ts,csp_org_id,account_number,target,name_arg,endpoint,flags,exit_status,is_internal,error FROM TanzuCLIOperations;
v1.0.0-dev|darwin|amd64|||config set|aa4c97d5-408e-4cbb-a5f0-986ca5ae79f9|1688581603251|1688581603294||||6b3ec009eeaada86a7a9da005dfa3a13f2af2f1157bb73553c819d8503a18953|||0|1|
```

- Running the tanzu core command with flags , the flag values should be masked (except for `plugin` LCM commands all the core command flag values will be asked other than boolan flags)

```
❯ rm -rf /Users/pkalle/.config/tanzu-cli-telemetry/cli_metrics.db
❯
❯ ./bin/tanzu config cert add --host test.host.com --ca-certificate ~/openssl/server.crt
[ok] successfully added certificate data for host test.host.com

❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db
SELECT cli_version,os_name,os_arch,plugin_name,plugin_version,command,cli_id,command_start_ts,command_end_ts,csp_org_id,account_number,target,name_arg,endpoint,flags,exit_status,is_internal,error FROM TanzuCLIOperations;
v1.0.0-dev|darwin|amd64|||config cert add|aa4c97d5-408e-4cbb-a5f0-986ca5ae79f9|1688583372085|1688583372107||||||{"ca-certificate":"ea4ca78badbf06f493b4710e62171b6796e0f1b7d7092bfa558ea02a849c76ae","host":"d1c5ef9a0984e2877edec4d798450dc2033c68a567fef3761e71167f073f08a7"}|0|1|
```

- Running the plugin LCM command, all the flag values should be in clear text(not hashed)

```
❯ rm -rf /Users/pkalle/.config/tanzu-cli-telemetry/cli_metrics.db
❯ ./bin/tanzu plugin group search --name vmware-tkg/default --show-details
name: vmware-tkg/default
description: Desc for vmware-tkg/default:v22.22.22
latest: v22.22.22
versions:
    - v2.2.0
    - v9.9.9
    - v11.11.11
    - v22.22.22
❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db
SELECT cli_version,os_name,os_arch,plugin_name,plugin_version,command,cli_id,command_start_ts,command_end_ts,csp_org_id,account_number,target,name_arg,endpoint,flags,exit_status,is_internal,error FROM TanzuCLIOperations;
v1.0.0-dev|darwin|amd64|||plugin group search|aa4c97d5-408e-4cbb-a5f0-986ca5ae79f9|1688583670123|1688583670828||||||{"name":"vmware-tkg/default","show-details":"true"}|0|1|


❯ # Installing the plugin group, you can notice the "group" flag value is captured
❯ rm -rf /Users/pkalle/.config/tanzu-cli-telemetry/cli_metrics.db

❯ ./bin/tanzu plugin install --group vmware-tkg/default:v2.2.0
[i] Installing plugin 'isolated-cluster:v0.29.0' with target 'global'
[i] Installing plugin 'management-cluster:v0.29.0' with target 'kubernetes'
[i] Installing plugin 'package:v0.29.0' with target 'kubernetes'
[i] Installing plugin 'pinniped-auth:v0.29.0' with target 'global'
[i] Installing plugin 'secret:v0.29.0' with target 'kubernetes'
[i] Installing plugin 'telemetry:v0.29.0' with target 'kubernetes'
[ok] successfully installed all plugins from group 'vmware-tkg/default:v2.2.0'
❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db
SELECT cli_version,os_name,os_arch,plugin_name,plugin_version,command,cli_id,command_start_ts,command_end_ts,csp_org_id,account_number,target,name_arg,endpoint,flags,exit_status,is_internal,error FROM TanzuCLIOperations;
v1.0.0-dev|darwin|amd64|||plugin install|aa4c97d5-408e-4cbb-a5f0-986ca5ae79f9|1688583805560|1688583850128||||||{"group":"vmware-tkg/default:v2.2.0"}|0|1|
```

- Testing the core command (context plugin)

```
❯ ./bin/tanzu context create tkg-mgmt-vc --kubeconfig ~/temp/tkgCluster_admin.kfg --kubecontext tkg-mgmt-vc-admin@tkg-mgmt-vc
[ok] successfully created a kubernetes context using the kubeconfig /Users/pkalle/temp/tkgCluster_admin.kfg
[i] Checking for required plugins...
[i] All required plugins are already installed and up-to-date
❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db
SELECT cli_version,os_name,os_arch,plugin_name,plugin_version,command,cli_id,command_start_ts,command_end_ts,csp_org_id,account_number,target,name_arg,endpoint,flags,exit_status,is_internal,error FROM TanzuCLIOperations;
v1.0.0-dev|darwin|amd64|||context create|7dbe3b36-f07b-4206-bd77-0f7728e75cc2|1688586232461|1688586233335||||86fde1e81453c0fa397ddee030f932e2e6e4f2a06fc49e53b23bda225860b3a8||{"kubeconfig":"27c1c0f843b185e6faee830432c1e6994f83d2d252d2fa090f16a9fa6c3adfa4","kubecontext":"b1bbb64960ad9c73469b1654e7992846c02cfdc5ddbd4d3b354bbfae54452fd6"}|0|1|
```

- Testing negative case for core command. Metric is captured successfully(including the exit status )
```
❯ ./bin/tanzu context delete invalid-context -y
[i] Deleting entry for cluster invalid-context
[x] : context invalid-context not found
❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db
SELECT cli_version,os_name,os_arch,plugin_name,plugin_version,command,cli_id,command_start_ts,command_end_ts,csp_org_id,account_number,target,name_arg,endpoint,flags,exit_status,is_internal,error FROM TanzuCLIOperations;
v1.0.0-dev|darwin|amd64|||context delete|7dbe3b36-f07b-4206-bd77-0f7728e75cc2|1688587343050|1688587343063||||5e12a27eb2297df878e8124d622837b703e96cb2385d9471a5f878e6bea0c574||{"yes":"true"}|1|1|

```

**Testing the Plugins:**
- Ran `tanzu management-cluster get ` and you can notice the plugin name, plugin verison, target, endpoint(hash of the context), flags  are captured. 
Note:  command name would only show plugin name, to capture the complete command chain, the work is in progress

```
❯ ./bin/tanzu mc get --show-details
  NAME         NAMESPACE   STATUS   CONTROLPLANE  WORKERS  KUBERNETES        ROLES       PLAN  TKR
  tkg-mgmt-vc  tkg-system  running  1/1           1/1      v1.24.9+vmware.1  management  dev   v1.24.9---vmware.1-tkg.1


Details:

NAME                                                                                READY  SEVERITY  REASON  SINCE  MESSAGE
/tkg-mgmt-vc                                                                        True                     40m
├─ClusterInfrastructure - VSphereCluster/tkg-mgmt-vc-9cc9g                          True                     40m
├─ControlPlane - KubeadmControlPlane/tkg-mgmt-vc-lhr9q                              True                     40m
│ └─Machine/tkg-mgmt-vc-lhr9q-4rt4g                                                 True                     40m
│   ├─BootstrapConfig - KubeadmConfig/tkg-mgmt-vc-lhr9q-6cpnt                       True                     40m
│   └─MachineInfrastructure - VSphereMachine/tkg-mgmt-vc-control-plane-bj7fv-kpsjm  True                     40m
└─Workers
  └─MachineDeployment/tkg-mgmt-vc-md-0-nv25l                                        True                     40m
    └─Machine/tkg-mgmt-vc-md-0-nv25l-69896b7486-642qn                               True                     40m
      ├─BootstrapConfig - KubeadmConfig/tkg-mgmt-vc-md-0-bootstrap-xnmtq-5mzdt      True                     40m
      └─MachineInfrastructure - VSphereMachine/tkg-mgmt-vc-md-0-infra-f9tkd-kpgwm   True                     40m


Providers:

  NAMESPACE                          NAME                            TYPE                    PROVIDERNAME     VERSION  WATCHNAMESPACE
  caip-in-cluster-system             infrastructure-ipam-in-cluster  InfrastructureProvider  ipam-in-cluster  v0.1.0
  capi-kubeadm-bootstrap-system      bootstrap-kubeadm               BootstrapProvider       kubeadm          v1.2.8
  capi-kubeadm-control-plane-system  control-plane-kubeadm           ControlPlaneProvider    kubeadm          v1.2.8
  capi-system                        cluster-api                     CoreProvider            cluster-api      v1.2.8
  capv-system                        infrastructure-vsphere          InfrastructureProvider  vsphere          v1.5.1

❯ 
❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db
SELECT cli_version,os_name,os_arch,plugin_name,plugin_version,command,cli_id,command_start_ts,command_end_ts,csp_org_id,account_number,target,name_arg,endpoint,flags,exit_status,is_internal,error FROM TanzuCLIOperations;
v1.0.0-dev|darwin|amd64|management-cluster|v0.28.0|management-cluster|7dbe3b36-f07b-4206-bd77-0f7728e75cc2|1688586542348|1688586544952|||kubernetes||58fabb359b0e763b10e0ca376f00cf89951251e8b8772601ae3cdff14a14e7f6|{"show-details":""}|0|1|
```

- Running the plugin with target specified before the plugin name (specified `k8s` before `mc` in the cli command). Metrics collection was successful
```
❯ ./bin/tanzu k8s mc get --show-details
  NAME         NAMESPACE   STATUS   CONTROLPLANE  WORKERS  KUBERNETES        ROLES       PLAN  TKR
  tkg-mgmt-vc  tkg-system  running  1/1           1/1      v1.24.9+vmware.1  management  dev   v1.24.9---vmware.1-tkg.1


Details:

NAME                                                                                READY  SEVERITY  REASON  SINCE  MESSAGE
/tkg-mgmt-vc                                                                        True                     138m
├─ClusterInfrastructure - VSphereCluster/tkg-mgmt-vc-rhj2j                          True                     138m
├─ControlPlane - KubeadmControlPlane/tkg-mgmt-vc-2nnbx                              True                     138m
│ └─Machine/tkg-mgmt-vc-2nnbx-c58ks                                                 True                     138m
│   ├─BootstrapConfig - KubeadmConfig/tkg-mgmt-vc-2nnbx-9j5fk                       True                     138m
│   └─MachineInfrastructure - VSphereMachine/tkg-mgmt-vc-control-plane-5zhgz-s9wxx  True                     138m
└─Workers
  └─MachineDeployment/tkg-mgmt-vc-md-0-mx474                                        True                     138m
    └─Machine/tkg-mgmt-vc-md-0-mx474-7b85596464-7mg7v                               True                     138m
      ├─BootstrapConfig - KubeadmConfig/tkg-mgmt-vc-md-0-bootstrap-xp24l-lpfmf      True                     138m
      └─MachineInfrastructure - VSphereMachine/tkg-mgmt-vc-md-0-infra-8r8xh-jlsml   True                     138m


Providers:

  NAMESPACE                          NAME                            TYPE                    PROVIDERNAME     VERSION  WATCHNAMESPACE
  caip-in-cluster-system             infrastructure-ipam-in-cluster  InfrastructureProvider  ipam-in-cluster  v0.1.0
  capi-kubeadm-bootstrap-system      bootstrap-kubeadm               BootstrapProvider       kubeadm          v1.2.8
  capi-kubeadm-control-plane-system  control-plane-kubeadm           ControlPlaneProvider    kubeadm          v1.2.8
  capi-system                        cluster-api                     CoreProvider            cluster-api      v1.2.8
  capv-system                        infrastructure-vsphere          InfrastructureProvider  vsphere          v1.5.1
❯
❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db
SELECT cli_version,os_name,os_arch,plugin_name,plugin_version,command,cli_id,command_start_ts,command_end_ts,csp_org_id,account_number,target,name_arg,endpoint,flags,exit_status,is_internal,error FROM TanzuCLIOperations;
v1.0.0-dev|darwin|amd64|management-cluster|v0.28.0|kubernetes management-cluster|7dbe3b36-f07b-4206-bd77-0f7728e75cc2|1688681354197|1688681356139|||kubernetes||58fabb359b0e763b10e0ca376f00cf89951251e8b8772601ae3cdff14a14e7f6|{"show-details":""}|0|1|
```

- Negative test case where the `tanzu cluster create` command failed. The metric is collected successfully including the exit status,flags etc..
```
❯ ./bin/tanzu cluster create testCluster --tkr v1.24.9---vmware.1-tkg.1 -d
Error: required config variable 'CLUSTER_PLAN' not set
❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db
SELECT cli_version,os_name,os_arch,plugin_name,plugin_version,command,cli_id,command_start_ts,command_end_ts,csp_org_id,account_number,target,name_arg,endpoint,flags,exit_status,is_internal,error FROM TanzuCLIOperations;
v1.0.0-dev|darwin|amd64|cluster|v0.28.0|cluster|7dbe3b36-f07b-4206-bd77-0f7728e75cc2|1688587083310|1688587084109|||kubernetes||58fabb359b0e763b10e0ca376f00cf89951251e8b8772601ae3cdff14a14e7f6|{"d":"","tkr":""}|1|1|
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add command invocation metrics collection for telemetry
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

TODO: 
1. For plugins, a parser need to be implemented to identify the complete command chain executed by the user. This is due to the fact that cobra can only recognize the command path upto plugin name due to the plugin architecture, all the subcommand,args and flags after the plugin name are identified as args. So we need special logic to identify the command chain/path executed by the user. [ Done as part of PR: #398 ]
2. Update the metrics with cspOrgID and account number configured by user using the telemetry plugin
3. Configure and update the metrics with `isInternal` flag to determine whether CLI build is production/official release or customer build.


#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
