### PR TITLE
Use the `tanzu plugin download-bundle --dry-run` to get list of images

### DIFF
--- a/test/e2e/airgapped/airgapped_test.go
+++ b/test/e2e/airgapped/airgapped_test.go
@@ -239,7 +239,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Airgapped-Plugin-Download
 		It("plugin download-bundle when to-tar path is empty", func() {
 			err := tf.PluginCmd.DownloadPluginBundle(e2eTestLocalCentralRepoImage, []string{}, "")
 			Expect(err).NotTo(BeNil(), "should throw error for incorrect input path")
-			Expect(strings.Contains(err.Error(), fmt.Sprintf(InvalidPath, ""))).To(BeTrue())
+			Expect(strings.Contains(err.Error(), "flag '--to-tar' is required")).To(BeTrue())
 		})
 		// Test case: (negative use case) directory name only for for --to-tar
 		It("plugin download-bundle when to-tar path is a directory", func() {


### PR DESCRIPTION
### What this PR does / why we need it

This PR adds a `--dry-run` option to the `tanzu plugin download-bundle` command which allows users to get the list of images that will be downloaded as part of the `tanzu plugin download-bundle` command.

The PR writes the list of images that will be downloaded as a yaml to the standard output. This means, if any user wants to get the yaml file, the output of the command can be piped to a file.

Please note: The `--dry-run` flag introduced with `tanzu plugin download-bundle` is a hidden command to help the user get the list of images for evaluation purposes only. The users should not expect to migrate just the listed images to the air-gapped repository.
This is because when tanzu cli migrates the plugins to an air-gapped repository an additional metadata image gets created dynamically based on the existing state of the plugin repository.


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
```
$ tz plugin download-bundle --dry-run
[i] Getting selected plugin information...
[i] will be downloading the 35 plugins from: projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest
[i] Saving the list of images to download...
images:
    - projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest
    - projects.registry.vmware.com/tanzu_cli/plugins/vmware/tmc/darwin/amd64/mission-control/account:v0.1.1
    - projects.registry.vmware.com/tanzu_cli/plugins/vmware/tmc/linux/amd64/mission-control/account:v0.1.1
    - projects.registry.vmware.com/tanzu_cli/plugins/vmware/tmc/windows/amd64/mission-control/account:v0.1.1
    ...
    - projects.registry.vmware.com/tanzu_cli/plugins/vmware/tmc/windows/amd64/mission-control/workspace:v0.1.1
```

```
$ tz plugin download-bundle --dry-run --group vmware-tkg/default:v2.2.0 > /tmp/images.yaml
[i] Getting selected plugin information...
[i] will be downloading the 9 plugins from group: vmware-tkg/default:v2.2.0
[i] Saving the list of images to download...

$ cat /tmp/images.yaml
images:
    - projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest
    - projects.registry.vmware.com/tanzu_cli/plugins/vmware/tkg/darwin/amd64/kubernetes/cluster:v0.29.0
    - projects.registry.vmware.com/tanzu_cli/plugins/vmware/tkg/linux/amd64/kubernetes/cluster:v0.29.0
    - projects.registry.vmware.com/tanzu_cli/plugins/vmware/tkg/windows/amd64/kubernetes/cluster:v0.29.0
    - projects.registry.vmware.com/tanzu_cli/plugins/vmware/tkg/darwin/amd64/kubernetes/feature:v0.29.0
    - projects.registry.vmware.com/tanzu_cli/plugins/vmware/tkg/linux/amd64/kubernetes/feature:v0.29.0
    ...
```



<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
None
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
