### PR TITLE
Add plugin discovery options to use cache explicitly

### DIFF
--- a/pkg/command/discovery_source.go
+++ b/pkg/command/discovery_source.go
@@ -285,7 +285,7 @@ func createDiscoverySource(dsType, dsName, uri string) (configtypes.PluginDiscov
 // checkDiscoverySource attempts to access the content of the discovery to
 // confirm it is valid
 func checkDiscoverySource(source configtypes.PluginDiscovery) error {
-	discObject, err := discovery.CreateDiscoveryFromV1alpha1(source, nil)
+	discObject, err := discovery.CreateDiscoveryFromV1alpha1(source)
 	if err != nil {
 		return err
 	}

--- a/pkg/command/plugin_group.go
+++ b/pkg/command/plugin_group.go
@@ -61,7 +61,7 @@ func newSearchCmd() *cobra.Command {
 					Name:      groupIdentifier.Name,
 				}
 			}
-			groups, err := pluginmanager.DiscoverPluginGroups(criteria)
+			groups, err := pluginmanager.DiscoverPluginGroups(discovery.WithGroupDiscoveryCriteria(criteria))
 			if err != nil {
 				return err
 			}
@@ -101,12 +101,13 @@ func newGetCmd() *cobra.Command {
 				groupIdentifier.Version = cli.VersionLatest
 			}
 
-			groups, err := pluginmanager.DiscoverPluginGroups(&discovery.GroupDiscoveryCriteria{
+			criteria := &discovery.GroupDiscoveryCriteria{
 				Vendor:    groupIdentifier.Vendor,
 				Publisher: groupIdentifier.Publisher,
 				Name:      groupIdentifier.Name,
 				Version:   groupIdentifier.Version,
-			})
+			}
+			groups, err := pluginmanager.DiscoverPluginGroups(discovery.WithGroupDiscoveryCriteria(criteria))
 			if err != nil {
 				return err
 			}

--- a/pkg/command/plugin_search.go
+++ b/pkg/command/plugin_search.go
@@ -58,9 +58,11 @@ func newSearchPluginCmd() *cobra.Command {
 				}
 			} else {
 				// Show plugins found in the central repos
-				allPlugins, err = pluginmanager.DiscoverStandalonePlugins(&discovery.PluginDiscoveryCriteria{
+				criteria := &discovery.PluginDiscoveryCriteria{
 					Name:   pluginName,
-					Target: configtypes.StringToTarget(targetStr)})
+					Target: configtypes.StringToTarget(targetStr),
+				}
+				allPlugins, err = pluginmanager.DiscoverStandalonePlugins(discovery.WithPluginDiscoveryCriteria(criteria))
 				if err != nil {
 					errorList = append(errorList, err)
 					log.Warningf("there was an error while discovering standalone plugins, error information: '%v'", err.Error())

--- a/pkg/discovery/interface_test.go
+++ b/pkg/discovery/interface_test.go
@@ -18,7 +18,7 @@ func Test_CreateDiscoveryFromV1alpha1(t *testing.T) {
 
 	// When no discovery type is provided, it should throw error
 	pd := configtypes.PluginDiscovery{}
-	_, err := CreateDiscoveryFromV1alpha1(pd, nil)
+	_, err := CreateDiscoveryFromV1alpha1(pd)
 	assert.NotNil(err)
 	assert.Contains(err.Error(), "unknown plugin discovery source")
 
@@ -26,7 +26,7 @@ func Test_CreateDiscoveryFromV1alpha1(t *testing.T) {
 	pd = configtypes.PluginDiscovery{
 		OCI: &configtypes.OCIDiscovery{Name: "fake-oci", Image: "fake.repo.com/test:v1.0.0"},
 	}
-	discovery, err := CreateDiscoveryFromV1alpha1(pd, nil)
+	discovery, err := CreateDiscoveryFromV1alpha1(pd)
 	assert.Nil(err)
 	assert.Equal(common.DiscoveryTypeOCI, discovery.Type())
 	assert.Equal("fake-oci", discovery.Name())
@@ -35,7 +35,7 @@ func Test_CreateDiscoveryFromV1alpha1(t *testing.T) {
 	pd = configtypes.PluginDiscovery{
 		Local: &configtypes.LocalDiscovery{Name: "fake-local", Path: "test/path"},
 	}
-	discovery, err = CreateDiscoveryFromV1alpha1(pd, nil)
+	discovery, err = CreateDiscoveryFromV1alpha1(pd)
 	assert.Nil(err)
 	assert.Equal(common.DiscoveryTypeLocal, discovery.Type())
 	assert.Equal("fake-local", discovery.Name())
@@ -44,7 +44,7 @@ func Test_CreateDiscoveryFromV1alpha1(t *testing.T) {
 	pd = configtypes.PluginDiscovery{
 		Kubernetes: &configtypes.KubernetesDiscovery{Name: "fake-k8s"},
 	}
-	discovery, err = CreateDiscoveryFromV1alpha1(pd, nil)
+	discovery, err = CreateDiscoveryFromV1alpha1(pd)
 	assert.Nil(err)
 	assert.Equal(common.DiscoveryTypeKubernetes, discovery.Type())
 	assert.Equal("fake-k8s", discovery.Name())
@@ -53,7 +53,7 @@ func Test_CreateDiscoveryFromV1alpha1(t *testing.T) {
 	pd = configtypes.PluginDiscovery{
 		REST: &configtypes.GenericRESTDiscovery{Name: "fake-rest"},
 	}
-	discovery, err = CreateDiscoveryFromV1alpha1(pd, nil)
+	discovery, err = CreateDiscoveryFromV1alpha1(pd)
 	assert.Nil(err)
 	assert.Equal(common.DiscoveryTypeREST, discovery.Type())
 	assert.Equal("fake-rest", discovery.Name())
@@ -64,7 +64,7 @@ func Test_CreateGroupDiscovery(t *testing.T) {
 
 	// When no discovery type is provided, it should throw error
 	pd := configtypes.PluginDiscovery{}
-	_, err := CreateGroupDiscovery(pd, nil)
+	_, err := CreateGroupDiscovery(pd)
 	assert.NotNil(err)
 	assert.Contains(err.Error(), "unknown group discovery source")
 
@@ -72,7 +72,7 @@ func Test_CreateGroupDiscovery(t *testing.T) {
 	pd = configtypes.PluginDiscovery{
 		OCI: &configtypes.OCIDiscovery{Name: "fake-oci", Image: "fake.repo.com/test:v1.0.0"},
 	}
-	discovery, err := CreateGroupDiscovery(pd, nil)
+	discovery, err := CreateGroupDiscovery(pd)
 	assert.Nil(err)
 	assert.Equal("fake-oci", discovery.Name())
 
@@ -85,7 +85,7 @@ func Test_CreateGroupDiscovery(t *testing.T) {
 		Publisher: "tkg",
 		Name:      "fakegroup",
 	}
-	discovery, err = CreateGroupDiscovery(pd, criteria)
+	discovery, err = CreateGroupDiscovery(pd, WithGroupDiscoveryCriteria(criteria))
 	assert.Nil(err)
 	assert.Equal("fake-oci", discovery.Name())
 

--- a/pkg/discovery/oci.go
+++ b/pkg/discovery/oci.go
@@ -32,10 +32,17 @@ type OCIDiscovery struct {
 }
 
 // NewOCIDiscovery returns a new Discovery using the specified OCI image.
-func NewOCIDiscovery(name, image string, criteria *PluginDiscoveryCriteria) Discovery {
+func NewOCIDiscovery(name, image string, options ...DiscoveryOptions) Discovery {
+	// Initialize discovery options
+	opts := NewDiscoveryOpts()
+	for _, option := range options {
+		option(opts)
+	}
+
 	if !config.IsFeatureActivated(constants.FeatureDisableCentralRepositoryForTesting) {
 		discovery := newDBBackedOCIDiscovery(name, image)
-		discovery.pluginCriteria = criteria
+		discovery.pluginCriteria = opts.PluginDiscoveryCriteria
+		discovery.useLocalCacheOnly = opts.UseLocalCacheOnly
 		return discovery
 	}
 
@@ -46,9 +53,17 @@ func NewOCIDiscovery(name, image string, criteria *PluginDiscoveryCriteria) Disc
 }
 
 // NewOCIGroupDiscovery returns a new plugn group Discovery using the specified OCI image.
-func NewOCIGroupDiscovery(name, image string, criteria *GroupDiscoveryCriteria) GroupDiscovery {
+func NewOCIGroupDiscovery(name, image string, options ...DiscoveryOptions) GroupDiscovery {
+	// Initialize discovery options
+	opts := NewDiscoveryOpts()
+	for _, option := range options {
+		option(opts)
+	}
+
 	discovery := newDBBackedOCIDiscovery(name, image)
-	discovery.groupCriteria = criteria
+	discovery.groupCriteria = opts.GroupDiscoveryCriteria
+	discovery.useLocalCacheOnly = opts.UseLocalCacheOnly
+
 	return discovery
 }
 

--- a/pkg/discovery/oci_dbbacked.go
+++ b/pkg/discovery/oci_dbbacked.go
@@ -38,6 +38,8 @@ type DBBackedOCIDiscovery struct {
 	// groupCriteria specifies different conditions that a plugin group must respect to be discovered.
 	// This allows to filter the list of plugins groups that will be returned.
 	groupCriteria *GroupDiscoveryCriteria
+	// useLocalCacheOnly enable to pull the plugins and plugin groups data from the cache
+	useLocalCacheOnly bool
 	// pluginDataDir is the location where the plugin data will be stored once
 	// extracted from the OCI image
 	pluginDataDir string
@@ -59,21 +61,37 @@ func (od *DBBackedOCIDiscovery) Type() string {
 	return common.DiscoveryTypeOCI
 }
 
-// List available plugins.
+// List is a method of the DBBackedOCIDiscovery struct that retrieves the available plugins.
+// It returns a slice of Discovered interfaces and an error if any occurs during the process.
 func (od *DBBackedOCIDiscovery) List() ([]Discovered, error) {
-	err := od.fetchInventoryImage()
-	if err != nil {
-		return nil, errors.Wrapf(err, "unable to fetch the inventory of discovery '%s' for plugins", od.Name())
+	// If useLocalCacheOnly option is not set, fetch the inventory image
+	if !od.useLocalCacheOnly {
+		// Fetch the inventory image
+		err := od.fetchInventoryImage()
+		if err != nil {
+			// Return an error if unable to fetch the inventory image for plugins
+			return nil, errors.Wrapf(err, "unable to fetch the inventory of discovery '%s' for plugins", od.Name())
+		}
 	}
+
+	// List and return the plugins from the inventory
 	return od.listPluginsFromInventory()
 }
 
-// GetGroups returns the plugin groups defined in the discovery
+// GetGroups is a method of the DBBackedOCIDiscovery struct that retrieves the plugin groups defined in the discovery.
+// It returns a slice of PluginGroup pointers and an error if any occurs during the process.
 func (od *DBBackedOCIDiscovery) GetGroups() ([]*plugininventory.PluginGroup, error) {
-	err := od.fetchInventoryImage()
-	if err != nil {
-		return nil, errors.Wrapf(err, "unable to fetch the inventory of discovery '%s' for groups", od.Name())
+	// If useLocalCacheOnly option is not set, fetch the inventory image
+	if !od.useLocalCacheOnly {
+		// Fetch the inventory image
+		err := od.fetchInventoryImage()
+		if err != nil {
+			// Return an error if unable to fetch the inventory image for groups
+			return nil, errors.Wrapf(err, "unable to fetch the inventory of discovery '%s' for groups", od.Name())
+		}
 	}
+
+	// List and return the groups from the inventory
 	return od.listGroupsFromInventory()
 }
 

--- a/pkg/discovery/oci_dbbacked_test.go
+++ b/pkg/discovery/oci_dbbacked_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Unit tests for DB-backed OCI discovery", func() {
 		})
 		Context("Without any criteria", func() {
 			It("should have a filter that only ignores hidden plugins", func() {
-				discovery := NewOCIDiscovery("test-discovery", "test-image:latest", nil)
+				discovery := NewOCIDiscovery("test-discovery", "test-image:latest")
 				Expect(err).To(BeNil(), "unable to create discovery")
 				dbDiscovery, ok := discovery.(*DBBackedOCIDiscovery)
 				Expect(ok).To(BeTrue(), "oci discovery is not of type DBBackedOCIDiscovery")
@@ -102,7 +102,7 @@ var _ = Describe("Unit tests for DB-backed OCI discovery", func() {
 				}))
 			})
 			It("with TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY=1 the filter should include hidden plugins", func() {
-				discovery := NewOCIDiscovery("test-discovery", "test-image:latest", nil)
+				discovery := NewOCIDiscovery("test-discovery", "test-image:latest")
 				Expect(err).To(BeNil(), "unable to create discovery")
 				dbDiscovery, ok := discovery.(*DBBackedOCIDiscovery)
 				Expect(ok).To(BeTrue(), "oci discovery is not of type DBBackedOCIDiscovery")
@@ -134,13 +134,14 @@ var _ = Describe("Unit tests for DB-backed OCI discovery", func() {
 				filteredArch    = "amd64"
 			)
 			It("should have a filter that matches the criteria and ignores hidden plugins", func() {
-				discovery := NewOCIDiscovery("test-discovery", "test-image:latest", &PluginDiscoveryCriteria{
+				criteria := &PluginDiscoveryCriteria{
 					Name:    filteredName,
 					Target:  filteredTarget,
 					Version: filteredVersion,
 					OS:      filteredOS,
 					Arch:    filteredArch,
-				})
+				}
+				discovery := NewOCIDiscovery("test-discovery", "test-image:latest", WithPluginDiscoveryCriteria(criteria))
 				Expect(err).To(BeNil(), "unable to create discovery")
 				dbDiscovery, ok := discovery.(*DBBackedOCIDiscovery)
 				Expect(ok).To(BeTrue(), "oci discovery is not of type DBBackedOCIDiscovery")
@@ -164,13 +165,14 @@ var _ = Describe("Unit tests for DB-backed OCI discovery", func() {
 				}))
 			})
 			It("with TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY=1 the filter should include hidden plugin", func() {
-				discovery := NewOCIDiscovery("test-discovery", "test-image:latest", &PluginDiscoveryCriteria{
+				criteria := &PluginDiscoveryCriteria{
 					Name:    filteredName,
 					Target:  filteredTarget,
 					Version: filteredVersion,
 					OS:      filteredOS,
 					Arch:    filteredArch,
-				})
+				}
+				discovery := NewOCIDiscovery("test-discovery", "test-image:latest", WithPluginDiscoveryCriteria(criteria))
 				Expect(err).To(BeNil(), "unable to create discovery")
 				dbDiscovery, ok := discovery.(*DBBackedOCIDiscovery)
 				Expect(ok).To(BeTrue(), "oci discovery is not of type DBBackedOCIDiscovery")
@@ -222,7 +224,7 @@ var _ = Describe("Unit tests for DB-backed OCI discovery", func() {
 		})
 		Context("Without any criteria", func() {
 			It("should use a filter that ignores hidden groups", func() {
-				discovery := NewOCIDiscovery("test-discovery", "test-image:latest", nil)
+				discovery := NewOCIDiscovery("test-discovery", "test-image:latest")
 				Expect(err).To(BeNil(), "unable to create discovery")
 				dbDiscovery, ok := discovery.(*DBBackedOCIDiscovery)
 				Expect(ok).To(BeTrue(), "oci discovery is not of type DBBackedOCIDiscovery")
@@ -241,7 +243,7 @@ var _ = Describe("Unit tests for DB-backed OCI discovery", func() {
 				}))
 			})
 			It("with TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY=1 the filter should include hidden groups", func() {
-				discovery := NewOCIDiscovery("test-discovery", "test-image:latest", nil)
+				discovery := NewOCIDiscovery("test-discovery", "test-image:latest")
 				Expect(err).To(BeNil(), "unable to create discovery")
 				dbDiscovery, ok := discovery.(*DBBackedOCIDiscovery)
 				Expect(ok).To(BeTrue(), "oci discovery is not of type DBBackedOCIDiscovery")
@@ -271,11 +273,12 @@ var _ = Describe("Unit tests for DB-backed OCI discovery", func() {
 				filteredName      = "groupname"
 			)
 			It("should have a filter that matches the criteria and ignores hidden groups", func() {
-				discovery := NewOCIGroupDiscovery("test-discovery", "test-image:latest", &GroupDiscoveryCriteria{
+				criteria := &GroupDiscoveryCriteria{
 					Vendor:    filteredVendor,
 					Publisher: filteredPublisher,
 					Name:      filteredName,
-				})
+				}
+				discovery := NewOCIGroupDiscovery("test-discovery", "test-image:latest", WithGroupDiscoveryCriteria(criteria))
 				Expect(err).To(BeNil(), "unable to create discovery")
 				dbDiscovery, ok := discovery.(*DBBackedOCIDiscovery)
 				Expect(ok).To(BeTrue(), "oci discovery is not of type DBBackedOCIDiscovery")
@@ -297,11 +300,12 @@ var _ = Describe("Unit tests for DB-backed OCI discovery", func() {
 				}))
 			})
 			It("with TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY=1 the filter should include hidden groups", func() {
-				discovery := NewOCIGroupDiscovery("test-discovery", "test-image:latest", &GroupDiscoveryCriteria{
+				criteria := &GroupDiscoveryCriteria{
 					Vendor:    filteredVendor,
 					Publisher: filteredPublisher,
 					Name:      filteredName,
-				})
+				}
+				discovery := NewOCIGroupDiscovery("test-discovery", "test-image:latest", WithGroupDiscoveryCriteria(criteria))
 				Expect(err).To(BeNil(), "unable to create discovery")
 				dbDiscovery, ok := discovery.(*DBBackedOCIDiscovery)
 				Expect(ok).To(BeTrue(), "oci discovery is not of type DBBackedOCIDiscovery")

--- a/pkg/discovery/oci_test.go
+++ b/pkg/discovery/oci_test.go
@@ -160,10 +160,10 @@ func Test_NewOCIDiscovery(t *testing.T) {
 	discoveryName := "test-discovery"
 	discoveryImage := "test-image:latest"
 	criteriaName := "test-criteria"
-	discoveryCriteria := PluginDiscoveryCriteria{Name: criteriaName}
+	discoveryCriteria := &PluginDiscoveryCriteria{Name: criteriaName}
 
 	// Check that the correct discovery type is returned
-	pd := NewOCIDiscovery(discoveryName, discoveryImage, &discoveryCriteria)
+	pd := NewOCIDiscovery(discoveryName, discoveryImage, WithPluginDiscoveryCriteria(discoveryCriteria))
 	assert.NotNil(pd)
 	assert.Equal(discoveryName, pd.Name())
 	assert.Equal(common.DiscoveryTypeOCI, pd.Type())
@@ -172,7 +172,7 @@ func Test_NewOCIDiscovery(t *testing.T) {
 	assert.True(ok)
 	assert.Equal(discoveryName, dbDiscovery.name)
 	assert.Equal(discoveryImage, dbDiscovery.image)
-	assert.Equal(discoveryCriteria, *dbDiscovery.pluginCriteria)
+	assert.Equal(discoveryCriteria, dbDiscovery.pluginCriteria)
 	assert.Nil(dbDiscovery.groupCriteria)
 
 	// Turn off central repo feature
@@ -181,7 +181,7 @@ func Test_NewOCIDiscovery(t *testing.T) {
 	assert.Nil(err)
 
 	// Check that the correct discovery type is returned
-	pd = NewOCIDiscovery(discoveryName, discoveryImage, &discoveryCriteria)
+	pd = NewOCIDiscovery(discoveryName, discoveryImage, WithPluginDiscoveryCriteria(discoveryCriteria))
 	assert.NotNil(pd)
 	assert.Equal(discoveryName, pd.Name())
 	assert.Equal(common.DiscoveryTypeOCI, pd.Type())
@@ -198,10 +198,10 @@ func Test_NewOCIGroupDiscovery(t *testing.T) {
 	discoveryName := "test-discovery2"
 	discoveryImage := "test-image2:latest"
 	criteriaName := "test-criteria2"
-	groupCriteria := GroupDiscoveryCriteria{Name: criteriaName}
+	groupCriteria := &GroupDiscoveryCriteria{Name: criteriaName}
 
 	// Check that the correct discovery is returned
-	pd := NewOCIGroupDiscovery(discoveryName, discoveryImage, &groupCriteria)
+	pd := NewOCIGroupDiscovery(discoveryName, discoveryImage, WithGroupDiscoveryCriteria(groupCriteria))
 	assert.NotNil(pd)
 	assert.Equal(discoveryName, pd.Name())
 
@@ -209,6 +209,6 @@ func Test_NewOCIGroupDiscovery(t *testing.T) {
 	assert.True(ok)
 	assert.Equal(discoveryName, dbDiscovery.name)
 	assert.Equal(discoveryImage, dbDiscovery.image)
-	assert.Equal(groupCriteria, *dbDiscovery.groupCriteria)
+	assert.Equal(groupCriteria, dbDiscovery.groupCriteria)
 	assert.Nil(dbDiscovery.pluginCriteria)
 }

--- a/pkg/plugininventory/sqlite_inventory.go
+++ b/pkg/plugininventory/sqlite_inventory.go
@@ -159,12 +159,25 @@ func (b *SQLiteInventory) GetPluginGroups(filter PluginGroupFilter) ([]*PluginGr
 }
 
 // getPluginsFromDB returns the plugins found in the DB 'inventoryFile' that match the filter
+//
+//nolint:dupl
 func (b *SQLiteInventory) getPluginsFromDB(filter *PluginInventoryFilter) ([]*PluginInventoryEntry, error) {
+	// Check if the inventory file exists.
+	if _, err := os.Stat(b.inventoryFile); os.IsNotExist(err) {
+		return []*PluginInventoryEntry{}, nil
+	}
+
 	db, err := sql.Open("sqlite", b.inventoryFile)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to open the DB at '%s'", b.inventoryFile)
 	}
 	defer db.Close()
+
+	// Return empty data if db connection is not available
+	err = db.Ping()
+	if err != nil {
+		return []*PluginInventoryEntry{}, err
+	}
 
 	whereClause, err := createPluginWhereClause(filter)
 	if err != nil {
@@ -319,12 +332,25 @@ func (b *SQLiteInventory) extractPluginsFromRows(rows *sql.Rows) ([]*PluginInven
 }
 
 // getGroupsFromDB returns all the plugin groups found in the DB 'inventoryFile' that match the filter
+//
+//nolint:dupl
 func (b *SQLiteInventory) getGroupsFromDB(filter PluginGroupFilter) ([]*PluginGroup, error) {
+	// Check if the inventory file exists.
+	if _, err := os.Stat(b.inventoryFile); os.IsNotExist(err) {
+		return []*PluginGroup{}, nil
+	}
+
 	db, err := sql.Open("sqlite", b.inventoryFile)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to open the DB at '%s' for groups", b.inventoryFile)
 	}
 	defer db.Close()
+
+	// Return empty data if db connection is not available
+	err = db.Ping()
+	if err != nil {
+		return []*PluginGroup{}, err
+	}
 
 	whereClause, err := createGroupWhereClause(filter)
 	if err != nil {


### PR DESCRIPTION
### What this PR does / why we need it

- Added PluginDiscoveryOptions to customise the discovery mechanism. Currently added ForceCache setting to explitly use the cache image and not check or fetch the inventory
- By Default ForceCache is false and doesn't have any impact on tanzu cli commands.
-  This Setting will be used to check and install or update essential plugin group.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Unit tests, E2E tests
Tanzu CLI continue to work as expected

```

mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (add_cache_options_discover_plugins)> tanzu version
version: v1.0.0-dev
buildDate: 2023-07-12
sha: a86ef3a7
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (add_cache_options_discover_plugins)> tanzu plugin group search
  GROUP               DESCRIPTION      LATEST
  vmware-tkg/default  Plugins for TKG  v2.2.0
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (add_cache_options_discover_plugins)> rm -rf ~/.cache/tanzu/plugin_inventory/
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (add_cache_options_discover_plugins)> tanzu plugin list
Standalone Plugins
  NAME   DESCRIPTION   TARGET  VERSION  STATUS
  hello  hello 0.0.10  global  v0.0.10  installed
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (add_cache_options_discover_plugins)> tanzu plugin clean
[ok] successfully cleaned up all plugins
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (add_cache_options_discover_plugins)> clear
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (add_cache_options_discover_plugins)> tanzu
Usage:
  tanzu [command]

Available command groups:

  System
    completion              Output shell completion code
    config                  Configuration for the CLI
    context                 Configure and manage contexts for the Tanzu CLI
    init                    Initialize the CLI
    plugin                  Manage CLI plugins
    version                 Version information

  Target
    kubernetes              Tanzu CLI plugins that target a Kubernetes cluster
    mission-control         Tanzu CLI plugins that target a Tanzu Mission Control endpoint


Flags:
  -h, --help   help for tanzu

Use "tanzu [command] --help" for more information about a command.
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (add_cache_options_discover_plugins)> tanzu plugin list
Standalone Plugins
  NAME  DESCRIPTION  TARGET  VERSION  STATUS
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (add_cache_options_discover_plugins)> tanzu plugin group search
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
  GROUP               DESCRIPTION      LATEST
  vmware-tkg/default  Plugins for TKG  v2.2.0
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (add_cache_options_discover_plugins)> tanzu plugin search
  NAME                  DESCRIPTION                                                                       TARGET           LATEST
  builder               Build Tanzu components                                                            global           v0.90.1
  isolated-cluster      Prepopulating images/bundle for internet-restricted environments                  global           v0.29.0
  pinniped-auth         Pinniped authentication operations (usually not directly invoked)                 global           v0.29.0
  test                  Test the CLI                                                                      global           v0.90.1
  cluster               Kubernetes cluster operations                                                     kubernetes       v0.29.0
  feature               Operate on features and featuregates                                              kubernetes       v0.29.0
  kubernetes-release    Kubernetes release operations                                                     kubernetes       v0.29.0
  management-cluster    Kubernetes management cluster operations                                          kubernetes       v0.29.0
  namespaces            Discover vSphere Supervisor namespaces you have access to                         kubernetes       v1.0.0
  package               Tanzu package management                                                          kubernetes       v0.29.0
  secret                Tanzu secret management                                                           kubernetes       v0.29.0
  telemetry             configure cluster-wide settings for vmware tanzu telemetry                        kubernetes       v0.29.0
  account               TMC account management for the organization                                       mission-control  v0.1.1
  agentartifacts        Image artifacts of all the agents to be made available on the cluster             mission-control  v0.1.1
  aks-cluster           aks-cluster plugin is used to provision and manage the tmc aks clusters.          mission-control  v0.1.1
  apply                 Apply a resource file                                                             mission-control  v0.1.1
  audit                 Run an audit request on an organization                                           mission-control  v0.1.1
  cluster               A TMC managed Kubernetes cluster                                                  mission-control  v0.1.1
  clustergroup          A group of Kubernetes clusters                                                    mission-control  v0.1.1
  continuousdelivery    Manage cluster configurations                                                     mission-control  v0.1.1
  data-protection       Backup, restore, or migrate cluster data.                                         mission-control  v0.1.1
  ekscluster            ekscluster plugin is used to provision and manage the tmc eks clusters.           mission-control  v0.1.1
  events                TMC events for any meaningful user activity or system state change                mission-control  v0.1.1
  helm                  Manage helm deployments                                                           mission-control  v0.1.1
  iam                   IAM Policies for tmc resources                                                    mission-control  v0.1.1
  inspection            Run an inspection on a cluster                                                    mission-control  v0.1.1
  integration           Get available integrations and their information from registry.                   mission-control  v0.1.1
  management-cluster    A TMC registered Management cluster                                               mission-control  v0.1.1
  policy                Policy management for resources                                                   mission-control  v0.1.1
  provider-aks-cluster  provider-aks-cluster plugin is used to manage and unmanage tmc provider aks       mission-control  v0.1.1
                        clusters
  provider-eks-cluster  provider-eks-cluster plugin is used to manage and unmanage tmc provider eks       mission-control  v0.1.1
                        clusters
  secret                Manage kubernetes secrets resource for a cluster                                  mission-control  v0.1.1
  setting               Manage default settings for some tmc features                                     mission-control  v0.1.1
  tanzupackage          Install and manage Tanzu packages. Note: tanzu-standard package repository is     mission-control  v0.1.1
                        unavailable for non-TKG clusters.
  workspace             A group of Kubernetes namespaces                                                  mission-control  v0.1.1
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (add_cache_options_discover_plugins)> tanzu plugin install builder
[i] Installing plugin 'builder:v0.90.1' with target 'global'
[ok] successfully installed 'builder' plugin
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (add_cache_options_discover_plugins)> tanzu plugin list
Standalone Plugins
  NAME     DESCRIPTION             TARGET  VERSION  STATUS
  builder  Build Tanzu components  global  v0.90.1  installed
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (add_cache_options_discover_plugins)>


```

**With ForceCache disabled and using essential plugins**

```
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (cli_essential_plugin_groups)> tanzu version
InstallEssentialPlugins: 34.458µs
version: v1.0.0-dev
buildDate: 2023-07-13
sha: e510c7ae-dirty
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (cli_essential_plugin_groups)> tanzu plugin clean
InstallEssentialPlugins: 49.209µs
[ok] successfully cleaned up all plugins
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (cli_essential_plugin_groups)> rm -rf ~/.cache/tanzu/plugin_inventory
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (cli_essential_plugin_groups)> tanzu plugin list
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Reading plugin inventory for "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest", this will take a few seconds.
[!] Skipping the plugins discovery image signature verification for "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"

DiscoverPluginGroups: 4.952912708s
IsPluginsFromPluginGroupInstalled: 4.95446575s
false false
[i] Looks like you haven't installed essential plugins, installing the essential plugins
[i] Installing plugin 'hello:v0.0.10' with target 'global'
InstallEssentialPlugins: 8.806384666s
Standalone Plugins
  NAME   DESCRIPTION   TARGET  VERSION  STATUS
  hello  hello 0.0.10  global  v0.0.10  installed
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (cli_essential_plugin_groups)> tanzu plugin group get vmware-tzcli/essentials
DiscoverPluginGroups: 1.220797417s
IsPluginsFromPluginGroupInstalled: 1.222619834s
true false
InstallEssentialPlugins: 1.222744209s
Plugins in Group:  vmware-tzcli/essentials:v0.0.10
  NAME   TARGET  VERSION
  hello  global  v0.0.10
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (cli_essential_plugin_groups)> tanzu plugin list
DiscoverPluginGroups: 1.328635625s
IsPluginsFromPluginGroupInstalled: 1.330417792s
true false
InstallEssentialPlugins: 1.33055275s
Standalone Plugins
  NAME   DESCRIPTION   TARGET  VERSION  STATUS
  hello  hello 0.0.10  global  v0.0.10  installed
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (cli_essential_plugin_groups)>


```


**With ForceCache enabled and using essentials**

```
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (cli_essential_plugin_groups) [1]> tz version
InstallEssentialPlugins: 33.792µs
version: v1.0.0-dev
buildDate: 2023-07-13
sha: e510c7ae-dirty
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (cli_essential_plugin_groups)> tz plugin clean
DiscoverPluginGroups: 3.978291ms
IsPluginsFromPluginGroupInstalled: 8.18425ms
false false
InstallEssentialPlugins: 8.310875ms
[ok] successfully cleaned up all plugins
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (cli_essential_plugin_groups)> rm -rf ~/.cache/tanzu/plugin_inventory/
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (cli_essential_plugin_groups)> tz plugin list
DiscoverPluginGroups: 3.748834ms
IsPluginsFromPluginGroupInstalled: 5.973125ms
false false
InstallEssentialPlugins: 6.075834ms
Standalone Plugins
  NAME  DESCRIPTION  TARGET  VERSION  STATUS
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (cli_essential_plugin_groups)> tz plugin group get
[x] : accepts 1 arg(s), received 0
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (cli_essential_plugin_groups) [1]> tz plugin group get vmware-tzcli/essentials
DiscoverPluginGroups: 3.552333ms
IsPluginsFromPluginGroupInstalled: 5.709417ms
false false
InstallEssentialPlugins: 5.819917ms
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Reading plugin inventory for "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest", this will take a few seconds.
[!] Skipping the plugins discovery image signature verification for "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"

Plugins in Group:  vmware-tzcli/essentials:v0.0.10
  NAME   TARGET  VERSION
  hello  global  v0.0.10
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (cli_essential_plugin_groups)> tz plugin list
DiscoverPluginGroups: 32.023625ms
IsPluginsFromPluginGroupInstalled: 33.662916ms
false false
[i] Looks like you haven't installed essential plugins, installing the essential plugins
[i] Installing plugin 'hello:v0.0.10' with target 'global'
InstallEssentialPlugins: 3.117538667s
Standalone Plugins
  NAME   DESCRIPTION   TARGET  VERSION  STATUS
  hello  hello 0.0.10  global  v0.0.10  installed
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (cli_essential_plugin_groups)>


```


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
 Able to customise the plugin discovery process to use cache image
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
