### PR TITLE
Remove warning messages

### DIFF
--- a/pkg/discovery/oci_dbbacked.go
+++ b/pkg/discovery/oci_dbbacked.go
@@ -254,7 +254,6 @@ func (od *DBBackedOCIDiscovery) checkImageCache() (string, string, error) {
 	_, hashHexValInventoryImage, err := carvelhelpers.GetImageDigest(od.image)
 	if err != nil {
 		// This will happen when the user has configured an invalid image discovery URI
-		log.Warningf("Unable to resolve the plugin discovery image: %v", err)
 		return "", "", fmt.Errorf("plugins discovery image resolution failed. Please check that the repository image URL %q is correct ", od.image)
 	}
 


### PR DESCRIPTION
### What this PR does / why we need it
This Pull request removes the repeated error messages to have better user experience.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
After Fix:
```
 t context create --name tmc3 --endpoint unstable.tmc-dev.cloud.vmware.com --staging
Flag --name has been deprecated, it has been replaced by using an argument to the command
[i] API token env var is set

[ok] successfully created a TMC context
[i] Checking for required plugins...
[!] unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually, error: '[unable to find plugin 'setting' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'aks-cluster' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'data-protection' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'inspection' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'integration' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'workspace' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'helm' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'iam' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'secret' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'agentartifacts' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'provider-eks-cluster' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'clustergroup' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'account' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'audit' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'cluster' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'continuousdelivery' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'apply' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'ekscluster' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'events' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'management-cluster' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'tanzupackage' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'policy' with version 'v0.0.1' for target 'mission-control']'
❯ 
❯ t plugin sync
[i] Checking for required plugins...
[x] : [unable to find plugin 'agentartifacts' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'cluster' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'secret' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'workspace' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'account' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'events' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'audit' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'continuousdelivery' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'clustergroup' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'ekscluster' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'helm' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'iam' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'policy' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'inspection' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'management-cluster' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'setting' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'aks-cluster' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'data-protection' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'provider-eks-cluster' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'apply' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'integration' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'tanzupackage' with version 'v0.0.1' for target 'mission-control']
❯
```
Before fix:
```
❯ export TANZU_API_TOKEN=8bczHt0X4G5rPoVzFnkgM8p5s7YE5FngQ9sqCqc6UrQWBTGMyPP_Jsu6k7xATffV
❯ t context create --name tmc2 --endpoint unstable.tmc-dev.cloud.vmware.com --staging    
Flag --name has been deprecated, it has been replaced by using an argument to the command
[i] API token env var is set

[ok] successfully created a TMC context
[i] Checking for required plugins...
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually, error: '[unable to find plugin 'ekscluster' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'policy' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'workspace' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'aks-cluster' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'clustergroup' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'audit' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'management-cluster' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'agentartifacts' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'continuousdelivery' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'helm' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'inspection' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'cluster' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'setting' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'provider-eks-cluster' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'tanzupackage' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'apply' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'secret' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'iam' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'integration' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'data-protection' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'events' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'account' with version 'v0.0.1' for target 'mission-control']'
❯ t plugin sync
[i] Checking for required plugins...
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[!] Unable to resolve the plugin discovery image: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused; Get "http://192.168.1.131:9876/v2/": dial tcp 192.168.1.131:9876: connect: connection refused
[!] There was an error while discovering plugins. Error information: 'unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "192.168.1.131:9876/tanzu-cli/plugins/central:small" is correct '
[x] : [unable to find plugin 'continuousdelivery' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'inspection' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'account' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'cluster' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'events' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'secret' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'helm' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'integration' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'workspace' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'agentartifacts' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'clustergroup' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'iam' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'setting' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'provider-eks-cluster' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'tanzupackage' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'data-protection' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'management-cluster' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'policy' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'audit' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'ekscluster' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'aks-cluster' with version 'v0.0.1' for target 'mission-control', unable to find plugin 'apply' with version 'v0.0.1' for target 'mission-control']
❯ t plugin sync --help
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
