### PR TITLE
List test discovery source in plugin source list

### DIFF
--- a/pkg/command/plugin_search.go
+++ b/pkg/command/plugin_search.go
@@ -18,7 +18,6 @@ import (
 	"github.com/vmware-tanzu/tanzu-cli/pkg/pluginmanager"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/component"
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
-	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
 
 var (
@@ -53,8 +52,7 @@ func newSearchPluginCmd() *cobra.Command {
 				}
 				allPlugins, err = pluginmanager.DiscoverPluginsFromLocalSource(local)
 				if err != nil {
-					errorList = append(errorList, err)
-					log.Warningf("there was an error while discovering plugins from local source, error information: '%v'", err.Error())
+					errorList = append(errorList, fmt.Errorf("there was an error while discovering plugins from local source, error information: '%w'", err))
 				}
 			} else {
 				// Show plugins found in the central repos
@@ -64,8 +62,7 @@ func newSearchPluginCmd() *cobra.Command {
 				}
 				allPlugins, err = pluginmanager.DiscoverStandalonePlugins(discovery.WithPluginDiscoveryCriteria(criteria))
 				if err != nil {
-					errorList = append(errorList, err)
-					log.Warningf("there was an error while discovering standalone plugins, error information: '%v'", err.Error())
+					errorList = append(errorList, fmt.Errorf("there was an error while discovering standalone plugins, error information: '%w'", err))
 				}
 			}
 			sort.Sort(discovery.DiscoveredSorter(allPlugins))

--- a/pkg/pluginmanager/manager.go
+++ b/pkg/pluginmanager/manager.go
@@ -146,15 +146,11 @@ func DiscoverStandalonePlugins(options ...discovery.DiscoveryOptions) ([]discove
 	}
 
 	plugins, err := discoverSpecificPlugins(discoveries, options...)
-	if err != nil {
-		log.Warningf(errorWhileDiscoveringPlugins, err.Error())
-	}
-
 	for i := range plugins {
 		plugins[i].Scope = common.PluginScopeStandalone
 		plugins[i].Status = common.PluginStatusNotInstalled
 	}
-	return mergeDuplicatePlugins(plugins), nil
+	return mergeDuplicatePlugins(plugins), err
 }
 
 // DiscoverPluginGroups returns the available plugin groups
@@ -174,13 +170,13 @@ func DiscoverPluginGroups(options ...discovery.DiscoveryOptions) ([]*plugininven
 	return groups, err
 }
 
-// getAdditionalTestPluginDiscoveries returns an array of plugin discoveries that
+// GetAdditionalTestPluginDiscoveries returns an array of plugin discoveries that
 // are meant to be used for testing new plugin version.  The comma-separated list of
 // such discoveries can be specified through the environment variable
 // "TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY".
 // Each entry in the variable should be the URI of an OCI image of the DB of the
 // discovery in question.
-func getAdditionalTestPluginDiscoveries() []configtypes.PluginDiscovery {
+func GetAdditionalTestPluginDiscoveries() []configtypes.PluginDiscovery {
 	var testDiscoveries []configtypes.PluginDiscovery
 	testDiscoveryImages := config.GetAdditionalTestDiscoveryImages()
 	for idx, image := range testDiscoveryImages {
@@ -1609,7 +1605,7 @@ func getPluginDiscoveries() ([]configtypes.PluginDiscovery, error) {
 	var testDiscoveries []configtypes.PluginDiscovery
 	if !configlib.IsFeatureActivated(constants.FeatureDisableCentralRepositoryForTesting) {
 		// Look for testing discoveries.  Those should be stored and searched AFTER the central repo.
-		testDiscoveries = getAdditionalTestPluginDiscoveries()
+		testDiscoveries = GetAdditionalTestPluginDiscoveries()
 	}
 
 	// The configured discoveries should be searched BEFORE the test discoveries.

--- a/pkg/pluginmanager/manager_test.go
+++ b/pkg/pluginmanager/manager_test.go
@@ -1321,7 +1321,7 @@ func TestGetAdditionalTestPluginDiscoveries(t *testing.T) {
 	err := os.Setenv(constants.ConfigVariableAdditionalDiscoveryForTesting, "")
 	assertions.Nil(err)
 
-	discoveries := getAdditionalTestPluginDiscoveries()
+	discoveries := GetAdditionalTestPluginDiscoveries()
 	assertions.Nil(err)
 	assertions.Equal(0, len(discoveries))
 
@@ -1330,7 +1330,7 @@ func TestGetAdditionalTestPluginDiscoveries(t *testing.T) {
 	err = os.Setenv(constants.ConfigVariableAdditionalDiscoveryForTesting, expectedDiscovery)
 	assertions.Nil(err)
 
-	discoveries = getAdditionalTestPluginDiscoveries()
+	discoveries = GetAdditionalTestPluginDiscoveries()
 	assertions.Nil(err)
 	assertions.Equal(1, len(discoveries))
 	assertions.Equal(expectedDiscovery, discoveries[0].OCI.Image)
@@ -1347,7 +1347,7 @@ func TestGetAdditionalTestPluginDiscoveries(t *testing.T) {
 		expectedDiscoveries[0]+","+expectedDiscoveries[1]+"   ,"+expectedDiscoveries[2]+"  ,  "+expectedDiscoveries[3])
 	assertions.Nil(err)
 
-	discoveries = getAdditionalTestPluginDiscoveries()
+	discoveries = GetAdditionalTestPluginDiscoveries()
 	assertions.Equal(len(expectedDiscoveries), len(discoveries))
 	assertions.Equal(expectedDiscoveries[0], discoveries[0].OCI.Image)
 	assertions.Equal(expectedDiscoveries[1], discoveries[1].OCI.Image)


### PR DESCRIPTION
### What this PR does / why we need it
This pull request addresses two issues:

1. It lists the test-only plugin discovery sources along with default plugin source for the `tanzu plugin source list` command, ensuring that only relevant sources are displayed.

2. It removes the repeated error message that occurs for the `tanzu plugin search` command, enhancing the user experience by eliminating unnecessary redundancy.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
tanzu plugin source list output before and after fix:

```
❯ t plugin source list                                            
  NAME     IMAGE                                                                   
  default  projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest  
❯ 
❯ export TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY="harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest,localhost:9876/tanzu-cli/plugins/sandbox1:small"
❯ 
❯ t plugin source list
  NAME                IMAGE                                                                   
  default             projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest  
  disc_0 (test only)  harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest  
  disc_1 (test only)  localhost:9876/tanzu-cli/plugins/sandbox1:small                         
❯ 
```

tanzu plugin search output before and after fix:
```
❯ t plugin search | wc -l
[!] there was an error while discovering standalone plugins, error information: '[unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "localhost:9876/tanzu-cli/plugins/sandbox1:small" is correct , unable to list plugins from discovery source 'disc_1': unable to fetch the inventory of discovery 'disc_1' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "localhost:9876/tanzu-cli/plugins/central:small" is correct ]'
[x] : [unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "localhost:9876/tanzu-cli/plugins/sandbox1:small" is correct , unable to list plugins from discovery source 'disc_1': unable to fetch the inventory of discovery 'disc_1' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "localhost:9876/tanzu-cli/plugins/central:small" is correct ]
      39
❯ 
❯ make build
build darwin-amd64 CLI with version: v1.0.0-dev
mkdir -p bin
cp /Users/cpamuluri/tkg/tasks/cli_core_main/tanzu-cli/artifacts/darwin/amd64/cli/core/v1.0.0-dev/tanzu-cli-darwin_amd64 ./bin/tanzu
❯ t plugin search | wc -l
[x] : there was an error while discovering standalone plugins, error information: '[unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "localhost:9876/tanzu-cli/plugins/sandbox1:small" is correct , unable to list plugins from discovery source 'disc_1': unable to fetch the inventory of discovery 'disc_1' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "localhost:9876/tanzu-cli/plugins/central:small" is correct ]'
      39
❯ git status
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The `tanzu plugin source list` lists the test only plugin sources along with default plugin source.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
