### PR TITLE
Add a delimiter after the eula prompt

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,6 +5,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -155,6 +156,11 @@ func promptForEULA() (bool, error) {
 	if err != nil {
 		return false, errors.Wrapf(err, "prompt failed")
 	}
+
+	// Put a delimiter after the prompt as it can be followed by
+	// standard CLI output
+	fmt.Println("")
+	fmt.Println("==")
 
 	return strings.EqualFold(eulaAccepted, "Yes"), nil
 }


### PR DESCRIPTION
### What this PR does / why we need it

This PR simply adds a delimiter after the EULA prompt to clearly separate the prompt part from the CLI output of the command that triggered the prompt.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Before the PR, notice that the CLI output is right below the `No/Yes` answer to the prompt, which makes it hard to separate for the user.
```
$ rm ~/.config/tanzu/config*
$ tz plugin list
? You must agree to the VMware General Terms in order to download, install, or
use software from this registry via Tanzu CLI. Acceptance of the VMware General
Terms covers all software installed via the Tanzu CLI during any Session.
“Session” means the period from acceptance until any of the following occurs:
(1) a change to VMware General Terms, (2) a new major release of the Tanzu CLI
is installed, (3) software is accessed in a separate software distribution
registry, or (4) re-acceptance of the General Terms is prompted by VMware.

To view the VMware General Terms, please see https://www.vmware.com/vmware-general-terms.html

Do you agree to the VMware General Terms?
 No
The Tanzu CLI is only usable with reduced functionality until the General Terms are agreed to.
Please use `tanzu config eula show` to review the terms, or `tanzu config eula accept` to accept them directly
[x] : terms not accepted


$ tz plugin list
? You must agree to the VMware General Terms in order to download, install, or
use software from this registry via Tanzu CLI. Acceptance of the VMware General
Terms covers all software installed via the Tanzu CLI during any Session.
“Session” means the period from acceptance until any of the following occurs:
(1) a change to VMware General Terms, (2) a new major release of the Tanzu CLI
is installed, (3) software is accessed in a separate software distribution
registry, or (4) re-acceptance of the General Terms is prompted by VMware.

To view the VMware General Terms, please see https://www.vmware.com/vmware-general-terms.html

Do you agree to the VMware General Terms?
 Yes
Standalone Plugins
  NAME     DESCRIPTION             TARGET  VERSION     STATUS
  builder  Build Tanzu components  global  v1.0.0-dev  installed
```

With the delimiter of this PR:
```
$ rm ~/.config/tanzu/config*
$ tz plugin list
? You must agree to the VMware General Terms in order to download, install, or
use software from this registry via Tanzu CLI. Acceptance of the VMware General
Terms covers all software installed via the Tanzu CLI during any Session.
“Session” means the period from acceptance until any of the following occurs:
(1) a change to VMware General Terms, (2) a new major release of the Tanzu CLI
is installed, (3) software is accessed in a separate software distribution
registry, or (4) re-acceptance of the General Terms is prompted by VMware.

To view the VMware General Terms, please see https://www.vmware.com/vmware-general-terms.html

Do you agree to the VMware General Terms?
 No

==
The Tanzu CLI is only usable with reduced functionality until the General Terms are agreed to.
Please use `tanzu config eula show` to review the terms, or `tanzu config eula accept` to accept them directly
[x] : terms not accepted


$ tz plugin list
? You must agree to the VMware General Terms in order to download, install, or
use software from this registry via Tanzu CLI. Acceptance of the VMware General
Terms covers all software installed via the Tanzu CLI during any Session.
“Session” means the period from acceptance until any of the following occurs:
(1) a change to VMware General Terms, (2) a new major release of the Tanzu CLI
is installed, (3) software is accessed in a separate software distribution
registry, or (4) re-acceptance of the General Terms is prompted by VMware.

To view the VMware General Terms, please see https://www.vmware.com/vmware-general-terms.html

Do you agree to the VMware General Terms?
 Yes

==
Standalone Plugins
  NAME     DESCRIPTION             TARGET  VERSION     STATUS
  builder  Build Tanzu components  global  v1.0.0-dev  installed


$ rm ~/.config/tanzu/config*
$ tz plugin clean
? You must agree to the VMware General Terms in order to download, install, or
use software from this registry via Tanzu CLI. Acceptance of the VMware General
Terms covers all software installed via the Tanzu CLI during any Session.
“Session” means the period from acceptance until any of the following occurs:
(1) a change to VMware General Terms, (2) a new major release of the Tanzu CLI
is installed, (3) software is accessed in a separate software distribution
registry, or (4) re-acceptance of the General Terms is prompted by VMware.

To view the VMware General Terms, please see https://www.vmware.com/vmware-general-terms.html

Do you agree to the VMware General Terms?
 Yes

==
[ok] successfully cleaned up all plugins
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
A delimiter is now printed after the EULA prompt to separate it from the CLI output.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

I'm open to suggestion on the format I choose in my attempt to make the output more clear for the user.