### PR TITLE
Don't use reprepro for building the apt repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ apt-package-repo: ## Build a debian package repo
 		echo "Docker required to build apt package" ;\
 		exit 1 ;\
 	fi
-	docker run --rm -e VERSION=$(BUILD_VERSION) -e DEB_SIGNER=$(DEB_SIGNER) -v $(ROOT_DIR):$(ROOT_DIR) $(APT_IMAGE) $(ROOT_DIR)/hack/apt/build_package_repo.sh
+	docker run --rm -e VERSION=$(BUILD_VERSION) -e DEB_SIGNER=$(DEB_SIGNER) -e DEB_METADATA_BASE_URI=$(DEB_METADATA_BASE_URI) -v $(ROOT_DIR):$(ROOT_DIR) $(APT_IMAGE) $(ROOT_DIR)/hack/apt/build_package_repo.sh
 
 .PHONY: apt-package-in-docker
 apt-package-in-docker: ## Build a debian package from within a container already

--- a/hack/apt/README.md
+++ b/hack/apt/README.md
@@ -4,6 +4,16 @@ APT uses Debian packages for installation. This document describes how to build
 such packages for the Tanzu CLI, how to push them to a public repository and
 how to install the CLI from that repository.
 
+There are two package names that can be built:
+
+1. "tanzu-cli" for official releases
+2. "tanzu-cli-unstable" for pre-releases
+
+The name of the packages built is chosen automatically based on the version
+used; a version with a `-` in it is considered a pre-release and will use the
+`tanzu-cli-unstable` package name, while other versions will use the
+official `tanzu-cli` package name.
+
 ## Building the Debian package
 
 Executing the `hack/apt/build_package.sh` script will build the Debian packages
@@ -60,6 +70,15 @@ tanzu
 Note that when building locally, the repository isn't signed, so you may see warnings
 during installation.
 
+### Testing a pre-release installation
+
+To install a pre-release package, the same procedure must be used as described above
+but for the actual installation the command should be:
+
+```bash
+apt install -y tanzu-cli-unstable --allow-unauthenticated
+```
+
 ## Publishing the package to GCloud
 
 The GCloud bucket dedicated to hosting the Tanzu CLI OS packages is
@@ -87,6 +106,8 @@ directory located locally at `hack/apt/_output/apt` to the root of the *new* buc
 Note that it is the second `apt` directory that must be uploaded. You can do this manually.
 Once uploaded, the Tanzu CLI can be installed publicly as described in the next section.
 
+The above procedure applies just as much to the `tanzu-cli-unstable` packages.
+
 ## Installing the Tanzu CLI
 
 ```bash
@@ -97,4 +118,13 @@ curl -fsSL https://packages.vmware.com/tools/keys/VMWARE-PACKAGING-GPG-RSA-KEY.p
 echo "deb [signed-by=/etc/apt/keyrings/tanzu-archive-keyring.gpg] https://storage.googleapis.com/tanzu-cli-os-packages/apt tanzu-cli-jessie main" | tee /etc/apt/sources.list.d/tanzu.list
 apt update
 apt install -y tanzu-cli
+```
+
+### Installing a pre-release
+
+To install a pre-release package, the same procedure must be used as described above
+but for the actual installation the command should be:
+
+```bash
+apt install -y tanzu-cli-unstable
 ```

--- a/hack/apt/build_package.sh
+++ b/hack/apt/build_package.sh
@@ -41,14 +41,7 @@ fi
 # Clean any old packages
 rm -rf ${OUTPUT_DIR}
 
-# Prepare repository that will be published
-mkdir -p ${OUTPUT_DIR}/apt/conf
-echo "Codename: tanzu-cli-jessie
-Components: main
-Architectures: amd64 arm64" \
-   > ${OUTPUT_DIR}/apt/conf/distributions 
-
-# Download the SRP-compliant CLI build from github and copy it to the package directory
+# Copy the CLI build from ARTIFACTS_DIR to the package directory
 for arch in amd64 arm64; do
    echo "===================================="
    echo "Building debian package for $arch..."

--- a/hack/apt/build_package.sh
+++ b/hack/apt/build_package.sh
@@ -28,6 +28,11 @@ fi
 # Strip 'v' prefix as an apt package version must start with an integer
 VERSION=${VERSION#v}
 
+UNSTABLE=""
+if [[ ${VERSION} == *-* ]]; then 
+   UNSTABLE="-unstable"
+fi
+
 BASE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}"); pwd)
 OUTPUT_DIR=${BASE_DIR}/_output
 ARTIFACTS_DIR=${BASE_DIR}/../../artifacts
@@ -51,12 +56,12 @@ for arch in amd64 arm64; do
    # This is for Apple M1 machines which normally have an emulator.
    # TODO: Replace all instances of "${fakeArch}" with "${arch}"
    fakeArch=amd64
-   mkdir -p ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}/usr/bin
-   cp ${ARTIFACTS_DIR}/linux/${fakeArch}/cli/core/v${VERSION}/tanzu-cli-linux_${fakeArch} ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}/usr/bin/tanzu
+   mkdir -p ${OUTPUT_DIR}/tanzu-cli${UNSTABLE}_${VERSION}_linux_${arch}/usr/bin
+   cp ${ARTIFACTS_DIR}/linux/${fakeArch}/cli/core/v${VERSION}/tanzu-cli-linux_${fakeArch} ${OUTPUT_DIR}/tanzu-cli${UNSTABLE}_${VERSION}_linux_${arch}/usr/bin/tanzu
 
    # Create the control file
-   mkdir -p ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}/DEBIAN
-   echo "Package: tanzu-cli
+   mkdir -p ${OUTPUT_DIR}/tanzu-cli${UNSTABLE}_${VERSION}_linux_${arch}/DEBIAN
+   echo "Package: tanzu-cli${UNSTABLE}
 Version: ${VERSION}
 Maintainer: Tanzu CLI project team
 Architecture: ${arch}
@@ -64,7 +69,7 @@ Section: main
 Priority: optional
 Homepage: https://github.com/vmware-tanzu/tanzu-cli
 Description: The core Tanzu CLI" \
-      > ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}/DEBIAN/control
+      > ${OUTPUT_DIR}/tanzu-cli${UNSTABLE}_${VERSION}_linux_${arch}/DEBIAN/control
 
    # Add a postinstall script to setup shell completion
    echo "#!/bin/bash
@@ -80,13 +85,13 @@ chmod a+r /usr/local/share/zsh/site-functions/_tanzu
 mkdir -p /usr/share/fish/vendor_completions.d
 tanzu completion fish > /usr/share/fish/vendor_completions.d/tanzu.fish
 chmod a+r /usr/share/fish/vendor_completions.d/tanzu.fish" \
-      > ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}/DEBIAN/postinst
-   chmod a+x ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}/DEBIAN/postinst
+      > ${OUTPUT_DIR}/tanzu-cli${UNSTABLE}_${VERSION}_linux_${arch}/DEBIAN/postinst
+   chmod a+x ${OUTPUT_DIR}/tanzu-cli${UNSTABLE}_${VERSION}_linux_${arch}/DEBIAN/postinst
 
    # Create the .deb package
-   dpkg-deb --build -Zgzip ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}
+   dpkg-deb --build -Zgzip ${OUTPUT_DIR}/tanzu-cli${UNSTABLE}_${VERSION}_linux_${arch}
 
-   rm -rf ${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}
+   rm -rf ${OUTPUT_DIR}/tanzu-cli${UNSTABLE}_${VERSION}_linux_${arch}
 done
 
 if [[ ! -z "${DEB_SIGNER}" ]]; then

--- a/hack/apt/build_package_repo.sh
+++ b/hack/apt/build_package_repo.sh
@@ -28,6 +28,11 @@ fi
 # Strip 'v' prefix as an apt package version must start with an integer
 VERSION=${VERSION#v}
 
+UNSTABLE=""
+if [[ ${VERSION} == *-* ]]; then 
+   UNSTABLE="-unstable"
+fi
+
 BASE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}"); pwd)
 OUTPUT_DIR=${BASE_DIR}/_output
 
@@ -43,7 +48,7 @@ for arch in amd64 arm64; do
    FINAL_DIR=${DIST_DIR}/main/binary-${arch}
 
    # Assumes ${OUTPUT_DIR} is populated with the new deb packages from build_package.sh
-   PKG="${OUTPUT_DIR}/tanzu-cli_${VERSION}_linux_${arch}.deb"
+   PKG="${OUTPUT_DIR}/tanzu-cli${UNSTABLE}_${VERSION}_linux_${arch}.deb"
    if [ ! -f ${PKG} ]; then
       echo "Not found: ${PKG}"
       exit 1
@@ -64,14 +69,14 @@ for arch in amd64 arm64; do
 
    # Generate the new entry for the new package and add it to the existing file of packages
    cat << EOF >> ${FINAL_DIR}/Packages
-Package: tanzu-cli
+Package: tanzu-cli${UNSTABLE}
 Version: ${VERSION}
 Maintainer: Tanzu CLI project team
 Architecture: ${arch}
 Homepage: https://github.com/vmware-tanzu/tanzu-cli
 Priority: optional
 Section: main
-Filename: pool/main/t/tanzu-cli/$(basename ${PKG})
+Filename: pool/main/t/tanzu-cli${UNSTABLE}/$(basename ${PKG})
 Size: $(ls -l ${PKG} | awk '{print $5}')
 SHA256: $(sha256sum ${PKG} | cut -f1 -d' ')
 SHA1: $(sha1sum ${PKG} | cut -f1 -d' ')
@@ -91,8 +96,8 @@ Architecture: ${arch}
 EOF
 
    # Move the new package into its final location
-   mkdir -p ${OUTPUT_DIR}/apt/pool/main/t/tanzu-cli
-   mv ${PKG} ${OUTPUT_DIR}/apt/pool/main/t/tanzu-cli
+   mkdir -p ${OUTPUT_DIR}/apt/pool/main/t/tanzu-cli${UNSTABLE}
+   mv ${PKG} ${OUTPUT_DIR}/apt/pool/main/t/tanzu-cli${UNSTABLE}
 done
 
 # Finally, re-generate the dists/tanzu-cli-jessie/Release file


### PR DESCRIPTION
### What this PR does / why we need it

**First commit**

Reprepro does not allow to have more than one version of a package in the same repo.  Since we want to keep multiple version of the CLI packages available, we can no longer use reprepro.

Another requirement that we have is that our repo is on a GCP bucket (at least for the moment).  Therefore, all existing versions of the CLI packages are on the bucket and not on the machine where we build the repo.  We don't want to have to download every package from the bucket to be able to build a new repo as this would take more and more time as we accumulate versions.  Instead we want to build the repo incrementally by simply adding a new package version to it.

After investigating different alternatives, mostly `aptly`, it became apparent that building a repository incrementally was not easy to do with existing tools.  On the other hand, building the repo manually ourselves turned out to be relatively easy.

Therefore, this commit replaces `reprepro` with a homemade script that allows us to add a new version to an existing repo without having to have the entire set of packages on the local machine.

**Second commit**

The second commit (part of this PR because it needs to be based on the first) detects when the version is a pre-release and in that case builds an `tanzu-cli-unstable` package. This allows to publish pre-releases without having final users install them automatically.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Build the APT repo using a fedora image:
```
$ \rm -rf artifacts hack/apt/_output
$ make build-cli-linux-amd64
build linux-amd64 CLI with version: v1.0.0-dev

$ make apt-package APT_BUILDER_IMAGE=fedora
docker run --rm -e VERSION=v1.0.0-dev -e DEB_SIGNER= -v /Users/kmarc/git/tanzu-cli:/Users/kmarc/git/tanzu-cli fedora /Users/kmarc/git/tanzu-cli/hack/apt/build_package.sh
++ uname
+ '[' Linux '!=' Linux ']'
++ command -v apt-get
++ command -v dnf
+ PKG_MGR=/usr/bin/dnf
+ '[' -z /usr/bin/dnf ']'
+ '[' -z v1.0.0-dev ']'
+ VERSION=1.0.0-dev

[...]

+ echo skip debsigning
skip debsigning

# This part is where we build the repository
docker run --rm -e VERSION=v1.0.0-dev -e DEB_SIGNER= -e DEB_METADATA_BASE_URI= -v /Users/kmarc/git/tanzu-cli:/Users/kmarc/git/tanzu-cli fedora /Users/kmarc/git/tanzu-cli/hack/apt/build_package_repo.sh
++ uname
+ '[' Linux '!=' Linux ']'
++ command -v apt-get
++ command -v dnf
[...]
+ echo skip debsigning

# Now we look that what we built looks like it should.  It does.
$ find hack/apt/_output
hack/apt/_output
hack/apt/_output/apt
hack/apt/_output/apt/pool
hack/apt/_output/apt/pool/main
hack/apt/_output/apt/pool/main/t
hack/apt/_output/apt/pool/main/t/tanzu-cli
hack/apt/_output/apt/pool/main/t/tanzu-cli/tanzu-cli_1.0.0-dev_linux_arm64.deb
hack/apt/_output/apt/pool/main/t/tanzu-cli/tanzu-cli_1.0.0-dev_linux_amd64.deb
hack/apt/_output/apt/dists
hack/apt/_output/apt/dists/tanzu-cli-jessie
hack/apt/_output/apt/dists/tanzu-cli-jessie/Release
hack/apt/_output/apt/dists/tanzu-cli-jessie/main
hack/apt/_output/apt/dists/tanzu-cli-jessie/main/binary-arm64
hack/apt/_output/apt/dists/tanzu-cli-jessie/main/binary-arm64/Packages.gz
hack/apt/_output/apt/dists/tanzu-cli-jessie/main/binary-arm64/Release
hack/apt/_output/apt/dists/tanzu-cli-jessie/main/binary-arm64/Packages.bz2
hack/apt/_output/apt/dists/tanzu-cli-jessie/main/binary-arm64/Packages
hack/apt/_output/apt/dists/tanzu-cli-jessie/main/binary-amd64
hack/apt/_output/apt/dists/tanzu-cli-jessie/main/binary-amd64/Packages.gz
hack/apt/_output/apt/dists/tanzu-cli-jessie/main/binary-amd64/Release
hack/apt/_output/apt/dists/tanzu-cli-jessie/main/binary-amd64/Packages.bz2
hack/apt/_output/apt/dists/tanzu-cli-jessie/main/binary-amd64/Packages

# Notice that the metadata Packages file also contains the existing v0.90.1 info
# although that package is not downloaded locally
$ cat hack/apt/_output/apt/dists/tanzu-cli-jessie/main/binary-arm64/Packages
Package: tanzu-cli
Version: 0.90.1
Maintainer: Tanzu CLI project team
Architecture: arm64
Homepage: https://github.com/vmware-tanzu/tanzu-cli
Priority: optional
Section: main
Filename: pool/main/t/tanzu-cli/tanzu-cli_0.90.1_arm64.deb
Size: 39490748
SHA256: fe74e6c175e0ca2252cd299e05cf7be1f2027bea96a1923e78ebf447a7f7dfe7
SHA1: 26de20863262c8a1f5adb13cca0057e75225221b
MD5sum: e9b863a8d5f49fd0ed818358aa5c0e75
Description: The core Tanzu CLI

Package: tanzu-cli
Version: 1.0.0-dev
Maintainer: Tanzu CLI project team
Architecture: arm64
Homepage: https://github.com/vmware-tanzu/tanzu-cli
Priority: optional
Section: main
Filename: pool/main/t/tanzu-cli/tanzu-cli_1.0.0-dev_linux_arm64.deb
Size: 39486168
SHA256: 863cb9fb53d89ed4e2f4580419d6cbee74bb0469eb9ce8e2e94ffee5a6e4e233
SHA1: 54ad06a908dc324c206b0ac2aac1d9d3bdf1b0c5
MD5sum: 3dd07af9df6728b5047b6eb870ddbfe4
SHA512: bbcbff185e911cdd1326fb3745fd02e16a51f6674834cf1e51099f9b5f33769622731d804f9d0800e895c2e458d658da2e5647d3cbedaef8dbfa9f2febce5ea5
Description: The core Tanzu CLI
```

Now try to install the CLI using this local repo:
```
$ docker run --rm -it -v $(pwd)/hack/apt/_output/apt:/tmp/apt ubuntu
root@789c887c0e24:/# echo "deb file:///tmp/apt tanzu-cli-jessie main" | tee /etc/apt/sources.list.d/tanzu.list
deb file:///tmp/apt tanzu-cli-jessie main
root@789c887c0e24:/# apt-get update --allow-insecure-repositories
Get:1 file:/tmp/apt tanzu-cli-jessie InRelease
Ign:1 file:/tmp/apt tanzu-cli-jessie InRelease
Get:2 file:/tmp/apt tanzu-cli-jessie Release [3414 B]
Get:2 file:/tmp/apt tanzu-cli-jessie Release [3414 B]
Get:3 file:/tmp/apt tanzu-cli-jessie Release.gpg
Ign:3 file:/tmp/apt tanzu-cli-jessie Release.gpg
Get:4 file:/tmp/apt tanzu-cli-jessie/main arm64 Packages [544 B]
Get:5 http://ports.ubuntu.com/ubuntu-ports jammy InRelease [270 kB]
Get:6 http://ports.ubuntu.com/ubuntu-ports jammy-updates InRelease [119 kB]
Get:7 http://ports.ubuntu.com/ubuntu-ports jammy-backports InRelease [108 kB]
Get:8 http://ports.ubuntu.com/ubuntu-ports jammy-security InRelease [110 kB]
Get:9 http://ports.ubuntu.com/ubuntu-ports jammy/multiverse arm64 Packages [224 kB]
Get:10 http://ports.ubuntu.com/ubuntu-ports jammy/main arm64 Packages [1758 kB]
Get:11 http://ports.ubuntu.com/ubuntu-ports jammy/universe arm64 Packages [17.2 MB]
Get:12 http://ports.ubuntu.com/ubuntu-ports jammy/restricted arm64 Packages [24.2 kB]
Get:13 http://ports.ubuntu.com/ubuntu-ports jammy-updates/main arm64 Packages [915 kB]
Get:14 http://ports.ubuntu.com/ubuntu-ports jammy-updates/multiverse arm64 Packages [27.8 kB]
Get:15 http://ports.ubuntu.com/ubuntu-ports jammy-updates/restricted arm64 Packages [431 kB]
Get:16 http://ports.ubuntu.com/ubuntu-ports jammy-updates/universe arm64 Packages [1080 kB]
Get:17 http://ports.ubuntu.com/ubuntu-ports jammy-backports/universe arm64 Packages [23.6 kB]
Get:18 http://ports.ubuntu.com/ubuntu-ports jammy-backports/main arm64 Packages [49.0 kB]
Get:19 http://ports.ubuntu.com/ubuntu-ports jammy-security/multiverse arm64 Packages [23.4 kB]
Get:20 http://ports.ubuntu.com/ubuntu-ports jammy-security/universe arm64 Packages [828 kB]
Get:21 http://ports.ubuntu.com/ubuntu-ports jammy-security/restricted arm64 Packages [430 kB]
Get:22 http://ports.ubuntu.com/ubuntu-ports jammy-security/main arm64 Packages [637 kB]
Fetched 24.3 MB in 5s (5390 kB/s)
Reading package lists... Done
W: The repository 'file:/tmp/apt tanzu-cli-jessie Release' is not signed.
N: Data from such a repository can't be authenticated and is therefore potentially dangerous to use.
N: See apt-secure(8) manpage for repository creation and user configuration details.

# Let's look at what version our repo provides.
# Nice!  We have the old and new versions (the old version cannot be installed though
# because the actually package is not present in our local build)
root@789c887c0e24:/# apt list tanzu-cli -a
Listing... Done
tanzu-cli/tanzu-cli-jessie 1.0.0-dev arm64
tanzu-cli/tanzu-cli-jessie 0.90.1 arm64

root@789c887c0e24:/# apt install -y tanzu-cli --allow-unauthenticated
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following NEW packages will be installed:
  tanzu-cli
0 upgraded, 1 newly installed, 0 to remove and 1 not upgraded.
Need to get 0 B/39.5 MB of archives.
After this operation, 0 B of additional disk space will be used.
WARNING: The following packages cannot be authenticated!
  tanzu-cli
Authentication warning overridden.
Get:1 file:/tmp/apt tanzu-cli-jessie/main arm64 tanzu-cli arm64 1.0.0-dev [39.5 MB]
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package tanzu-cli.
(Reading database ... 4389 files and directories currently installed.)
Preparing to unpack .../tanzu-cli_1.0.0-dev_linux_arm64.deb ...
Unpacking tanzu-cli (1.0.0-dev) ...
Setting up tanzu-cli (1.0.0-dev) ...

root@789c887c0e24:/# tanzu version
version: v1.0.0-dev
buildDate: 2023-07-17
sha: 2a54b31f0
```

I also successfully ran the same tests using an `ubuntu` image by doing `make apt-package`.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Allow to incrementally build the Debian (APT) repository for the Tanzu CLI.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
