### PR TITLE
Build the RPM repository incrementally and provide 'unstable' package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ rpm-package: ## Build an RPM package
 		echo "Docker required to build rpm package" ;\
 		exit 1 ;\
 	fi
-	docker run --rm -e VERSION=$(BUILD_VERSION) -e RPM_SIGNER=$(RPM_SIGNER) -v $(ROOT_DIR):$(ROOT_DIR) $(RPM_IMAGE) $(ROOT_DIR)/hack/rpm/build_package.sh
+	docker run --rm -e VERSION=$(BUILD_VERSION) -e RPM_SIGNER=$(RPM_SIGNER) -e RPM_METADATA_BASE_URI=$(RPM_METADATA_BASE_URI) -v $(ROOT_DIR):$(ROOT_DIR) $(RPM_IMAGE) $(ROOT_DIR)/hack/rpm/build_package.sh
 
 .PHONY: rpm-package-in-docker
 rpm-package-in-docker: ## Build an RPM package from within a container already

--- a/hack/rpm/README.md
+++ b/hack/rpm/README.md
@@ -4,6 +4,16 @@ YUM and DNF (the replacement for YUM) use RPM packages for installation. This
 document describes how to build such packages for the Tanzu CLI, how to push
 them to a public repository and how to install the CLI from that repository.
 
+There are two package names that can be built:
+
+1. "tanzu-cli" for official releases
+2. "tanzu-cli-unstable" for pre-releases
+
+The name of the packages built is chosen automatically based on the version
+used; a version with a `-` in it is considered a pre-release and will use the
+`tanzu-cli-unstable` package name, while other versions will use the
+official `tanzu-cli` package name.
+
 ## Building the RPM package
 
 Executing the `hack/rpm/build_package.sh` script will build the RPM packages
@@ -56,6 +66,15 @@ tanzu
 
 Note that when building locally, the repository isn't signed, so you may see warnings during installation.
 
+### Testing a pre-release installation
+
+To install a pre-release package, the same procedure must be used as described above
+but for the actual installation the command should be:
+
+```bash
+yum install -y tanzu-cli-unstable
+```
+
 ## Publishing the package to GCloud
 
 The GCloud bucket dedicated to hosting the Tanzu CLI OS packages is
@@ -83,6 +102,8 @@ directory located locally at `hack/rpm/_output/rpm` to the root of the *new* buc
 Note that it is the second `rpm` directory that must be uploaded. You can do this manually.
 Once uploaded, the Tanzu CLI can be installed publicly as described in the next section.
 
+The above procedure applies just as much to the `tanzu-cli-unstable` packages.
+
 ## Installing the Tanzu CLI
 
 ```bash
@@ -97,4 +118,13 @@ repo_gpgcheck=1
 gpgkey=https://packages.vmware.com/tools/keys/VMWARE-PACKAGING-GPG-RSA-KEY.pub
 EOF
 yum install -y tanzu-cli
+```
+
+### Installing a pre-release
+
+To install a pre-release package, the same procedure must be used as described above
+but for the actual installation the command should be:
+
+```bash
+yum install -y tanzu-cli-unstable
 ```

--- a/hack/rpm/build_package.sh
+++ b/hack/rpm/build_package.sh
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set -e
+set -x
 
 if [ $(uname) != "Linux" ]; then
    echo "This script must be run on a Linux system"
@@ -28,11 +29,13 @@ VERSION=${VERSION#v}
 
 BASE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}"); pwd)
 OUTPUT_DIR=${BASE_DIR}/_output/rpm/tanzu-cli
+# Directory where the packages will be stored
+PKG_DIR=${OUTPUT_DIR}
 ROOT_DIR=${BASE_DIR}/../..
 
 # Install build dependencies
 if ! command -v rpmlint &> /dev/null; then
-   $DNF install -y rpmdevtools rpmlint createrepo rpm-build rpm-sign
+   $DNF install -y rpmlint createrepo rpm-build yum-utils
 fi
 
 rpmlint ${BASE_DIR}/tanzu-cli.spec
@@ -43,25 +46,89 @@ mkdir -p ${HOME}/rpmbuild/SOURCES
 # Create the .rpm packages
 rm -rf ${OUTPUT_DIR}
 mkdir -p ${OUTPUT_DIR}
+mkdir -p ${PKG_DIR}
 cd ${ROOT_DIR}
 
-# RPM does not like - in the its package version
-PACKAGE_VERSION=${VERSION//-/_}
-rpmbuild --define "package_version ${PACKAGE_VERSION}" --define "release_version ${VERSION}" -bb ${BASE_DIR}/tanzu-cli.spec --target x86_64
-mv ${HOME}/rpmbuild/RPMS/x86_64/* ${OUTPUT_DIR}/
+# Transform the CLI version into RPM-compatible package version and release numbers.
+if [[ ${VERSION} == *-* ]]; then 
+   # When there is a - in the version, we are dealing with a pre-release
+   # e.g., 1.0.0-dev, 1.0.0-alpha.0, 1.0.0.rc.1, etc
+   # Such versions should be marked as RPM pre-releases by using a package release
+   # number of the form 0.1...
+   # See https://serverfault.com/a/867567
 
-rpmbuild --define "package_version ${PACKAGE_VERSION}" --define "release_version ${VERSION}" -bb ${BASE_DIR}/tanzu-cli.spec --target aarch64
-mv ${HOME}/rpmbuild/RPMS/aarch64/* ${OUTPUT_DIR}/
-
-if [[ ! -z "${RPM_SIGNER}" ]]; then
-  ${RPM_SIGNER} ${OUTPUT_DIR}/tanzu-cli*aarch64.rpm
-  ${RPM_SIGNER} ${OUTPUT_DIR}/tanzu-cli*x86_64.rpm
+   # For the package version 1.0.0-rc-1 becomes 1.0.0
+   RPM_PACKAGE_VERSION="${VERSION%%-*}"
+   # while the release version becomes 0.1-rc-1
+   RPM_RELEASE_VERSION="0.1_${VERSION#*-}"
+   # RPM does not like having the - character in the version of the package
+   RPM_RELEASE_VERSION=${RPM_RELEASE_VERSION//-/_}
+   # For a full version of 1.0.0-0.1_rc_1
 else
-  echo skip rpmsigning packages
+   RPM_PACKAGE_VERSION="${VERSION}"
+   RPM_RELEASE_VERSION="1"
+fi
+
+######################
+# Build the packages
+######################
+
+# Build the package for each architecture
+for arch in x86_64 aarch64; do
+   rpmbuild --define "rpm_package_version ${RPM_PACKAGE_VERSION}" \
+            --define "rpm_release_version ${RPM_RELEASE_VERSION}" \
+            --define "cli_version v${VERSION}" \
+            -bb ${BASE_DIR}/tanzu-cli.spec \
+            --target ${arch}
+   mv ${HOME}/rpmbuild/RPMS/${arch}/* ${PKG_DIR}/
+
+   if [[ ! -z "${RPM_SIGNER}" ]]; then
+     ${RPM_SIGNER} ${PKG_DIR}/tanzu-cli*${arch}.rpm
+   else
+     echo skip rpmsigning packages for ${arch}
+   fi
+done
+
+######################
+# Build the repository
+######################
+
+# Prepare the existing repository info so we can sync from it
+RPM_METADATA_BASE_URI=${RPM_METADATA_BASE_URI:=https://storage.googleapis.com/tanzu-cli-os-packages}
+if [ "${RPM_METADATA_BASE_URI}" = "new" ]; then
+   echo
+   echo "Building a brand new repository"
+   echo
+else
+   cat << EOF | tee /tmp/tanzu-cli.repo
+[tanzu-cli]
+name=Tanzu CLI
+baseurl=${RPM_METADATA_BASE_URI}/rpm/tanzu-cli
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.vmware.com/tools/keys/VMWARE-PACKAGING-GPG-RSA-KEY.pub
+EOF
+   
+   # Sync the metadata so we can update it
+   # Use the --source flag to avoid downloading the actual RPMs
+   reposync --repoid=tanzu-cli --download-metadata -p ${OUTPUT_DIR} -c /tmp/tanzu-cli.repo --norepopath --source -y
+   # Remove the old signature, which won't be valid anymore
+   rm -f ${OUTPUT_DIR}/repodata/repomd.xml.asc
+   
+   # Now list the existing RPMs so we can pretend to have them locally
+   for p in $(reposync --repoid=tanzu-cli -c /tmp/tanzu-cli.repo -u -y | grep ${RPM_METADATA_BASE_URI}); do
+      echo "Found package: $p"
+      touch ${PKG_DIR}/$(basename $p)
+   done
 fi
 
 # Create the repository metadata
-createrepo ${OUTPUT_DIR}
+createrepo --update --skip-stat ${OUTPUT_DIR}
+
+# Now that the repo is created, remove the fake empty packages so they don't
+# risk being copied over the real ones in the final repository.
+find ${PKG_DIR} -type f -empty -delete
 
 if [[ ! -z "${RPM_SIGNER}" ]]; then
   # instead of ... gpg --detach-sign --armor repodata/repomd.xml

--- a/hack/rpm/build_package.sh
+++ b/hack/rpm/build_package.sh
@@ -49,8 +49,11 @@ mkdir -p ${OUTPUT_DIR}
 mkdir -p ${PKG_DIR}
 cd ${ROOT_DIR}
 
+UNSTABLE="false"
 # Transform the CLI version into RPM-compatible package version and release numbers.
 if [[ ${VERSION} == *-* ]]; then 
+   UNSTABLE="true"
+
    # When there is a - in the version, we are dealing with a pre-release
    # e.g., 1.0.0-dev, 1.0.0-alpha.0, 1.0.0.rc.1, etc
    # Such versions should be marked as RPM pre-releases by using a package release
@@ -78,6 +81,7 @@ for arch in x86_64 aarch64; do
    rpmbuild --define "rpm_package_version ${RPM_PACKAGE_VERSION}" \
             --define "rpm_release_version ${RPM_RELEASE_VERSION}" \
             --define "cli_version v${VERSION}" \
+            --define "unstable ${UNSTABLE}" \
             -bb ${BASE_DIR}/tanzu-cli.spec \
             --target ${arch}
    mv ${HOME}/rpmbuild/RPMS/${arch}/* ${PKG_DIR}/

--- a/hack/rpm/tanzu-cli.spec
+++ b/hack/rpm/tanzu-cli.spec
@@ -1,12 +1,12 @@
 Name:       tanzu-cli
-Version:    %{package_version}
-Release:    1
+Version:    %{rpm_package_version}
+Release:    %{rpm_release_version}
 License:    Apache 2.0
 URL:        https://github.com/vmware-tanzu/tanzu-cli
 Vendor:     VMware
 Summary:    The core Tanzu CLI
 Provides:   tanzu-cli
-Obsoletes:  tanzu-cli  < %{package_version}
+Obsoletes:  tanzu-cli  < %{rpm_package_version}
 
 %ifarch x86_64
 %define arch amd64
@@ -17,7 +17,7 @@ Obsoletes:  tanzu-cli  < %{package_version}
 %define arch amd64
 %endif
 
-Source0:    %{expand:%%(pwd)/artifacts/linux/%{arch}/cli/core/v%{release_version}/tanzu-cli-linux_%{arch}}
+Source0:    %{expand:%%(pwd)/artifacts/linux/%{arch}/cli/core/%{cli_version}/tanzu-cli-linux_%{arch}}
 
 %description
 VMware Tanzu is a modular, cloud native application platform that enables vital DevSecOps outcomes

--- a/hack/rpm/tanzu-cli.spec
+++ b/hack/rpm/tanzu-cli.spec
@@ -1,12 +1,19 @@
+%if "%{unstable}" == "false"
 Name:       tanzu-cli
+Provides:   tanzu-cli
+Obsoletes:  tanzu-cli  < %{rpm_package_version}
+%else
+Name:       tanzu-cli-unstable
+Provides:   tanzu-cli-unstable
+Obsoletes:  tanzu-cli-unstable  < %{rpm_package_version}
+%endif
+
 Version:    %{rpm_package_version}
 Release:    %{rpm_release_version}
 License:    Apache 2.0
 URL:        https://github.com/vmware-tanzu/tanzu-cli
 Vendor:     VMware
 Summary:    The core Tanzu CLI
-Provides:   tanzu-cli
-Obsoletes:  tanzu-cli  < %{rpm_package_version}
 
 %ifarch x86_64
 %define arch amd64


### PR DESCRIPTION
### What this PR does / why we need it

**First commit**
A requirement that we have is that our repo is on a GCP bucket (at least for the moment).  Therefore, all existing versions of the CLI packages are on the bucket and not on the machine where we build the repo.  We don't want to have to download every package from the bucket to be able to build a new repo as this would take more and more time as we accumulate versions.  Instead we want to build the repo incrementally by simply adding a new package version to it.

After investigation, the best we I found to do this was to download the existing repo metadata, locally create empty packages for the existing packages, and the rebuild the metadata with using:
  createrepo --update --skip-stat

This approach re-uses the previous metadata but adds to it the new package versions.

This commit also numbers pre-releases appropriately for RPM. In case we ever put pre-release packages in a repo along with final releases, it is important that the pre-releases be numbered as such for RPM to prioritize the final releases.

The commit also does a little cleanup to use a loop per architecture.

**Second commit**

The second commit (part of this PR because it needs to be based on the first) detects when the version is a pre-release and in that case builds an `tanzu-cli-unstable` package.  This allows to publish pre-release without having final users install them automatically.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Build the RPM repo:
```
$ \rm -rf hack/rpm/_output/
$ make rpm-package
docker run --rm -e VERSION=v1.0.0-dev -e RPM_SIGNER= -e RPM_METADATA_BASE_URI= -v /Users/kmarc/git/tanzu-cli:/Users/kmarc/git/tanzu-cli fedora /Users/kmarc/git/tanzu-cli/hack/rpm/build_package.sh
++ uname
+ '[' Linux '!=' Linux ']'

[...]

RPM build warnings:
    source_date_epoch_from_changelog set but %changelog is missing
    Missing build-id in /root/rpmbuild/BUILDROOT/tanzu-cli-1.0.0-0.1_dev.aarch64/usr/bin/tanzu
+ mv /root/rpmbuild/RPMS/aarch64/tanzu-cli-1.0.0-0.1_dev.aarch64.rpm /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/
skip rpmsigning packages for aarch64
+ [[ ! -z '' ]]
+ echo skip rpmsigning packages for aarch64

# This is where we start building the repository
+ RPM_METADATA_BASE_URI=https://storage.googleapis.com/tanzu-cli-os-packages
+ '[' https://storage.googleapis.com/tanzu-cli-os-packages = new ']'
+ cat
+ sudo tee /etc/yum.repos.d/tanzu-cli.repo
[tanzu-cli]
name=Tanzu CLI
baseurl=https://storage.googleapis.com/tanzu-cli-os-packages/rpm/tanzu-cli
enabled=1
gpgcheck=1
repo_gpgcheck=1
gpgkey=https://packages.vmware.com/tools/keys/VMWARE-PACKAGING-GPG-RSA-KEY.pub
+ reposync --repoid=tanzu-cli --download-metadata -p /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli --norepopath --source -y
Tanzu CLI                                       692  B/s | 481  B     00:00
Tanzu CLI                                       5.4 kB/s | 987  B     00:00
Importing GPG key 0x001E5CC9:
 Userid     : "VMware, Inc. (Linux Packaging Key) <linux-packages@vmware.com>"
 Fingerprint: 3127 82BD 40F5 4908 346A 9BEB 9154 93E7 001E 5CC9
 From       : https://packages.vmware.com/tools/keys/VMWARE-PACKAGING-GPG-RSA-KEY.pub
Tanzu CLI                                       1.2 kB/s | 1.2 kB     00:00
Tanzu CLI                                       5.1 kB/s | 5.3 kB     00:01
+ rm /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/repodata/repomd.xml.asc
++ reposync --repoid=tanzu-cli -u -y
++ grep https://storage.googleapis.com/tanzu-cli-os-packages
Found package: https://storage.googleapis.com/tanzu-cli-os-packages/rpm/tanzu-cli/tanzu-cli-0.90.1-1.aarch64.rpm
+ for p in $(reposync --repoid=tanzu-cli -u -y | grep ${RPM_METADATA_BASE_URI})
+ echo 'Found package: https://storage.googleapis.com/tanzu-cli-os-packages/rpm/tanzu-cli/tanzu-cli-0.90.1-1.aarch64.rpm'
++ basename https://storage.googleapis.com/tanzu-cli-os-packages/rpm/tanzu-cli/tanzu-cli-0.90.1-1.aarch64.rpm
+ touch /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/tanzu-cli-0.90.1-1.aarch64.rpm
+ for p in $(reposync --repoid=tanzu-cli -u -y | grep ${RPM_METADATA_BASE_URI})
+ echo 'Found package: https://storage.googleapis.com/tanzu-cli-os-packages/rpm/tanzu-cli/tanzu-cli-0.90.1-1.x86_64.rpm'
Found package: https://storage.googleapis.com/tanzu-cli-os-packages/rpm/tanzu-cli/tanzu-cli-0.90.1-1.x86_64.rpm
++ basename https://storage.googleapis.com/tanzu-cli-os-packages/rpm/tanzu-cli/tanzu-cli-0.90.1-1.x86_64.rpm
+ touch /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/tanzu-cli-0.90.1-1.x86_64.rpm
+ createrepo --update --skip-stat /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli
Directory walk started
Directory walk done - 4 packages
Loaded information about 2 packages
Temporary output repo path: /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/.repodata/
Preparing sqlite DBs
Pool started (with 5 workers)
Pool finished
+ [[ ! -z '' ]]
+ echo skip rpmsigning repo
skip rpmsigning repo
```

Now try to install the CLI using this local repo:
```
$ docker run --rm -it -v $(pwd)/hack/rpm/_output/rpm:/tmp/rpm fedora
[root@c679a8087080 /]# cat << EOF | sudo tee /etc/yum.repos.d/tanzu-cli.repo
[tanzu-cli]
name=Tanzu CLI
baseurl=file:///tmp/rpm/tanzu-cli
enabled=1
gpgcheck=0
EOF
[tanzu-cli]
name=Tanzu CLI
baseurl=file:///tmp/rpm/tanzu-cli
enabled=1
gpgcheck=0
[root@c679a8087080 /]# yum install tanzu-cli
Fedora 38 - aarch64                                                                                                          9.1 MB/s |  79 MB     00:08
[...]
=============================================================================================================================================================
 Package                              Architecture                       Version                                  Repository                            Size
=============================================================================================================================================================
Installing:
 tanzu-cli                            aarch64                            1.0.0-0.1_dev                            tanzu-cli                             16 M

Transaction Summary
=============================================================================================================================================================
Install  1 Package

Total size: 16 M
Installed size: 67 M
Is this ok [y/N]: y
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                     1/1
  Installing       : tanzu-cli-1.0.0-0.1_dev.aarch64                                                                                                     1/1
  Running scriptlet: tanzu-cli-1.0.0-0.1_dev.aarch64                                                                                                     1/1
  Verifying        : tanzu-cli-1.0.0-0.1_dev.aarch64                                                                                                     1/1

Installed:
  tanzu-cli-1.0.0-0.1_dev.aarch64

Complete!

[root@c679a8087080 /]# tanzu version
version: v1.0.0-dev
buildDate: 2023-07-17
sha: 2a54b31f0

# Now check what versions are available in the new repo.
# Nice!  Both the new 1.0.0-0.1_dev and old 0.90.1-1 are listed.
# Note that the 0.90.1-1 version is not installable locally since we
# did not actually download the package.  But it will be installable
# when this metadata is uploaded to the GCP bucket.
[root@c679a8087080 /]# yum list tanzu-cli --showduplicate
Last metadata expiration check: 0:00:20 ago on Mon Jul 17 13:11:46 2023.
Installed Packages
tanzu-cli.aarch64                                                          1.0.0-0.1_dev                                                           @tanzu-cli
Available Packages
tanzu-cli.aarch64                                                          0.90.1-1                                                                tanzu-cli
tanzu-cli.x86_64                                                           0.90.1-1                                                                tanzu-cli
tanzu-cli.aarch64                                                          1.0.0-0.1_dev                                                           tanzu-cli
tanzu-cli.x86_64                                                           1.0.0-0.1_dev                                                           tanzu-cli

```

I also tested this using `make rpm-package RPM_METADATA_BASE_URI=new`


### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Allow to incrementally build the RPM (YUM/DNF) repository for the Tanzu CLI.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
