### PR TITLE
Implement telemetry send operation using telemetry plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/vmware-tanzu/carvel-ytt v0.40.0
 	github.com/vmware-tanzu/tanzu-cli/test/e2e/framework v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686
-	github.com/vmware-tanzu/tanzu-plugin-runtime v1.0.0-dev.0.20230706203022-6b662c0fddaa
+	github.com/vmware-tanzu/tanzu-plugin-runtime v1.0.0-dev.0.20230712185745-27ac1d59d87f
 	go.pinniped.dev v0.20.0
 	go.uber.org/multierr v1.11.0
 	golang.org/x/mod v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -690,8 +690,8 @@ github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502eb
 github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502ebf68/go.mod h1:e1Uef+Ux5BIHpYwqbeP2ZZmOzehBcez2vUEWXHe+xHE=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686 h1:VcuXqUXFxm5WDqWkzAlU/6cJXua0ozELnqD59fy7J6E=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686/go.mod h1:AFGOXZD4tH+KhpmtV0VjWjllXhr8y57MvOsIxTtywc4=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.0.0-dev.0.20230706203022-6b662c0fddaa h1:jhsuQ5Y9dt7RBODw3/WzqjHF1IqYysNq1Nrd/zUZESE=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.0.0-dev.0.20230706203022-6b662c0fddaa/go.mod h1:wMK/qpJjU7hytDAGt3FX5/iGdlUK8TsJLu36pCr+Zvk=
+github.com/vmware-tanzu/tanzu-plugin-runtime v1.0.0-dev.0.20230712185745-27ac1d59d87f h1:gGuh+b3YAOotScat+/g5r28+x3nZNTTWbk/d0PNRFtI=
+github.com/vmware-tanzu/tanzu-plugin-runtime v1.0.0-dev.0.20230712185745-27ac1d59d87f/go.mod h1:wMK/qpJjU7hytDAGt3FX5/iGdlUK8TsJLu36pCr+Zvk=
 github.com/xanzy/go-gitlab v0.83.0 h1:37p0MpTPNbsTMKX/JnmJtY8Ch1sFiJzVF342+RvZEGw=
 github.com/xanzy/go-gitlab v0.83.0/go.mod h1:5ryv+MnpZStBH8I/77HuQBsMbBGANtVpLWC15qOjWAw=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=

--- a/pkg/constants/env_variables.go
+++ b/pkg/constants/env_variables.go
@@ -22,6 +22,7 @@ const (
 	EULAPromptAnswer                                  = "TANZU_CLI_EULA_PROMPT_ANSWER"
 	E2ETestEnvironment                                = "TANZU_CLI_E2E_TEST_ENVIRONMENT"
 	// ControlPlaneEndpointType is the control-plane endpoint type to be used for "self-managed-tmc"(this list may grow in future)
-	ControlPlaneEndpointType = "TANZU_CLI_CONTROL_PLANE_ENDPOINT_TYPE"
-	ShowTelemetryConsoleLogs = "TANZU_CLI_SHOW_TELEMETRY_CONSOLE_LOGS"
+	ControlPlaneEndpointType          = "TANZU_CLI_CONTROL_PLANE_ENDPOINT_TYPE"
+	ShowTelemetryConsoleLogs          = "TANZU_CLI_SHOW_TELEMETRY_CONSOLE_LOGS"
+	TelemetrySuperColliderEnvironment = "TANZU_CLI_SUPERCOLLIDER_ENVIRONMENT"
 )

--- a/pkg/plugincmdtree/plugins_cache_test.go
+++ b/pkg/plugincmdtree/plugins_cache_test.go
@@ -60,7 +60,13 @@ commandTree:
     aliases: {}
 `
 
-func TestCache_ConstructAndAddTree(t *testing.T) {
+func Test_RepeatConstructAndAddTree(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		testConstructAndAddTree(t)
+	}
+}
+
+func testConstructAndAddTree(t *testing.T) {
 	// create the command docs
 	tmpCacheDir, err := os.MkdirTemp("", "cache")
 	assert.NoError(t, err)

--- a/pkg/telemetry/data/sqlite/create_tables.sql
+++ b/pkg/telemetry/data/sqlite/create_tables.sql
@@ -9,8 +9,6 @@ CREATE TABLE IF NOT EXISTS "tanzu_cli_operations"
     "cli_id"            TEXT NOT NULL,
     "command_start_ts"  TEXT NOT NULL,
     "command_end_ts"    TEXT NOT NULL,
-    "csp_org_id"        TEXT,
-    "account_number"    TEXT,
     "target"            TEXT,
     "name_arg"          TEXT,
     "endpoint"          TEXT,

--- a/pkg/telemetry/metric_db.go
+++ b/pkg/telemetry/metric_db.go
@@ -10,4 +10,7 @@ type MetricsDB interface {
 
 	// SaveOperationMetric inserts CLI operation metrics collected into database
 	SaveOperationMetric(*OperationMetricsPayload) error
+
+	// GetRowCount gets metrics table current row count
+	GetRowCount() (int, error)
 }


### PR DESCRIPTION
### What this PR does / why we need it
This PR implements telemetry send operation using telemetry plugin

Summary:
- CLI would use the telemetry plugin to send the metrics to supercollider
- To avoid latency incurred due to send metrics call,affecting users in every command, telemetry data would be sent only if user opt-in for CEIP and the number of rows in DB is hits a threshold
- User should set environment variable 'TANZU_CLI_SUPERCOLLIDER_ENVIRONMENT' to "staging" inorder to send the metrics to staging data lake(default is production
- If user sets `TANZU_CLI_SUPERCOLLIDER_ENVIRONMENT` to "staging" the "is_internal" metrics would set to true
- Removed `csp_org_id` and `account_number` from the local schema as telemetry plugin would be adding these values as metadata

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
Build and installed the telemetry plugin locally and performed the below tests

Ran the `tanzu plugin search` command and `tanzu mc get` command few times until we hit the send threshold(currently set to 10, but may change). Once the threshold is reached the metrics data in DB data is drained and sent to supercollider

```
❯ rm ~/.config/tanzu-cli-telemetry/cli_metrics.db
❯ ./bin/tanzu config get &> /dev/null
❯ ./bin/tanzu config get &> /dev/null
❯ ./bin/tanzu config get &> /dev/null
❯ ./bin/tanzu config get &> /dev/null
❯ ./bin/tanzu config get &> /dev/null
❯ ./bin/tanzu config get &> /dev/null
❯ ./bin/tanzu config get &> /dev/null
❯ ./bin/tanzu config get &> /dev/null
❯ ./bin/tanzu config get &> /dev/null

❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db
select * from tanzu_cli_operations;
cli_version|os_name|os_arch|plugin_name|plugin_version|command|cli_id|command_start_ts|command_end_ts|target|name_arg|endpoint|flags|exit_status|is_internal|error
test/e2e/framework/v1.0.0-dev|darwin|amd64|||config get|7dbe3b36-f07b-4206-bd77-0f7728e75cc2|1689803312624|1689803312641|||||0|1|
test/e2e/framework/v1.0.0-dev|darwin|amd64|||config get|7dbe3b36-f07b-4206-bd77-0f7728e75cc2|1689803314361|1689803314375|||||0|1|
test/e2e/framework/v1.0.0-dev|darwin|amd64|||config get|7dbe3b36-f07b-4206-bd77-0f7728e75cc2|1689803315844|1689803315858|||||0|1|
test/e2e/framework/v1.0.0-dev|darwin|amd64|||config get|7dbe3b36-f07b-4206-bd77-0f7728e75cc2|1689803317369|1689803317380|||||0|1|
test/e2e/framework/v1.0.0-dev|darwin|amd64|||config get|7dbe3b36-f07b-4206-bd77-0f7728e75cc2|1689803318940|1689803318951|||||0|1|
test/e2e/framework/v1.0.0-dev|darwin|amd64|||config get|7dbe3b36-f07b-4206-bd77-0f7728e75cc2|1689803320350|1689803320361|||||0|1|
test/e2e/framework/v1.0.0-dev|darwin|amd64|||config get|7dbe3b36-f07b-4206-bd77-0f7728e75cc2|1689803321882|1689803321893|||||0|1|
test/e2e/framework/v1.0.0-dev|darwin|amd64|||config get|7dbe3b36-f07b-4206-bd77-0f7728e75cc2|1689803323300|1689803323310|||||0|1|
test/e2e/framework/v1.0.0-dev|darwin|amd64|||config get|7dbe3b36-f07b-4206-bd77-0f7728e75cc2|1689803325702|1689803325719|||||0|1|

❯ ./bin/tanzu mc get --show-details &> /dev/null

❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db
select count(*) from tanzu_cli_operations;
count(*)
0


```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Implement telemetry send operation using telemetry plugin
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
