### PR TITLE
Remove --local from "plugin list"

### DIFF
--- a/pkg/command/plugin_test.go
+++ b/pkg/command/plugin_test.go
@@ -82,7 +82,7 @@ func TestPluginList(t *testing.T) {
 			centralRepoFeature: true,
 			args:               []string{"plugin", "list", "--local", "someDirectory"},
 			expectedFailure:    true,
-			expected:           "the '--local' flag does not apply to this command. Please use 'tanzu plugin search --local-source'",
+			expected:           "unknown flag: --local",
 		},
 		{
 			test:               "With empty config file(no discovery sources added) and no plugins installed",


### PR DESCRIPTION
### What this PR does / why we need it

This cleanup was agreed upon here: https://github.com/vmware-tanzu/tanzu-cli/pull/380#issuecomment-1643026987

The `--local` flag was kept in the `v0.90` versions for `tanzu plugin list` to help the user transition to use `tanzu plugin search`, but now that we are preparing for `v1.0`, we don't need to have such special handling as the user should be familiar with the fact that `tanzu plugin search --local` is to way to list a local discovery.

So this commit completely remove the `--local` flag from `tanzu plugin list`.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Reminder that before the PR we had:
```
$ /opt/homebrew/bin/tanzu plugin list --local hello
[x] : the '--local' flag does not apply to this command. Please use 'tanzu plugin search --local'

With this PR:
```
$ tz plugin list --local hello
[x] : unknown flag: --local

# Some regression testing for code that got moved
$ tz plugin install --group vmware-tkg/default
[i] Installing plugin 'isolated-cluster:v0.29.0' with target 'global'
[...]
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The `--local` flag for `tanzu plugin list` is removed. This flag was previously disabled with a warning to users.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
