### PR TITLE
Use in-memory container registry to build plugin packages using `builder` plugin

### DIFF
--- a/cmd/plugin/builder/README.md
+++ b/cmd/plugin/builder/README.md
@@ -164,7 +164,7 @@ Below are the flags available with `tanzu builder plugin build-package` command:
 ```txt
       --binary-artifacts string    plugin binary artifact directory (default "./artifacts/plugins")
   -h, --help                       help for build-package
-      --oci-registry string        local oci-registry to use for generating packages
+      --oci-registry string        local oci-registry to use for generating packages (optional)
       --package-artifacts string   plugin package artifacts directory (default "./artifacts/packages")
 ```
 
@@ -172,7 +172,7 @@ Below are the examples:
 
 ```shell
   # Build all plugin packages available under the './artifacts/plugins' directory
-  tanzu builder plugin build-package --oci-registry localhost:5001 --binary-artifacts ./artifacts/plugins
+  tanzu builder plugin build-package --binary-artifacts ./artifacts/plugins
 ```
 
 Once user generate the plugin packages, user can use `tanzu builder plugin publish-package` command to actually publish the generate packages to the remote repository as OCI image.

--- a/cmd/plugin/builder/template/plugintemplates/plugin-tooling.mk.tmpl
+++ b/cmd/plugin/builder/template/plugintemplates/plugin-tooling.mk.tmpl
@@ -102,14 +102,13 @@ plugin-build-%:
 		--plugin-scope-association-file $(PLUGIN_SCOPE_ASSOCIATION_FILE)
 
 .PHONY: plugin-build-packages
-plugin-build-packages: plugin-local-registry ## Build plugin packages
+plugin-build-packages: ## Build plugin packages
 	$(BUILDER_PLUGIN) plugin build-package \
 		--binary-artifacts $(PLUGIN_BINARY_ARTIFACTS_DIR) \
-		--package-artifacts $(PLUGIN_PACKAGE_ARTIFACTS_DIR) \
-		--oci-registry $(REGISTRY_ENDPOINT)
+		--package-artifacts $(PLUGIN_PACKAGE_ARTIFACTS_DIR)
 
 .PHONY: plugin-publish-packages
-plugin-publish-packages: plugin-build-packages ## Publish plugin packages
+plugin-publish-packages: plugin-build-packages plugin-local-registry ## Publish plugin packages
 	$(BUILDER_PLUGIN) plugin publish-package \
 		--package-artifacts $(PLUGIN_PACKAGE_ARTIFACTS_DIR) \
 		--publisher $(PUBLISHER) \

--- a/plugin-tooling.mk
+++ b/plugin-tooling.mk
@@ -106,14 +106,13 @@ plugin-build-%:
 		--plugin-scope-association-file $(PLUGIN_SCOPE_ASSOCIATION_FILE)
 
 .PHONY: plugin-build-packages
-plugin-build-packages: plugin-local-registry ## Build plugin packages
+plugin-build-packages:  ## Build plugin packages
 	$(BUILDER_PLUGIN) plugin build-package \
 		--binary-artifacts $(PLUGIN_BINARY_ARTIFACTS_DIR) \
-		--package-artifacts $(PLUGIN_PACKAGE_ARTIFACTS_DIR) \
-		--oci-registry $(REGISTRY_ENDPOINT)
+		--package-artifacts $(PLUGIN_PACKAGE_ARTIFACTS_DIR)
 
 .PHONY: plugin-publish-packages
-plugin-publish-packages: plugin-build-packages ## Publish plugin packages
+plugin-publish-packages: plugin-build-packages plugin-local-registry ## Publish plugin packages
 	$(BUILDER_PLUGIN) plugin publish-package \
 		--package-artifacts $(PLUGIN_PACKAGE_ARTIFACTS_DIR) \
 		--publisher $(PUBLISHER) \


### PR DESCRIPTION
### What this PR does / why we need it

This change removes the requirement of passing an external container registry to build plugin packages by using an implementation of a local registry server within the code and uses that to build plugin packages.

As part of https://github.com/vmware-tanzu/tanzu-cli/pull/370 where we removed the dependency of the builder plugin on docker and imgpkg CLI, we had to add an additional required parameter `--oci-registry` to build plugin packages.

With this change, we are still keeping that parameter but making it optional. This means if the user does not provide any external container registry, the builder plugin will spin up a local in-memory registry and will use that registry to build plugin packages.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Related to #372

### Describe testing done for PR

```
$ make prepare-builder
cd cmd/plugin/builder && go build -o /Users/anujc/Documents/code/tanzu-cli/bin/builder .
```

Use updated builder plugin to build local builder and test plugin packages and publish them to localhost:5001
```
$ make plugin-publish-packages
/Users/anujc/Documents/code/tanzu-cli/bin/builder plugin build-package \
                --binary-artifacts /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins \
                --package-artifacts /Users/anujc/Documents/code/tanzu-cli/artifacts/packages
2023-07-20T14:54:41-07:00 [i] starting local registry server on port 58595, logs available at /var/folders/xc/12mmbpb50qxfb3ch8vv9nvwm0000gq/T/994070398
2023-07-20T14:54:41-07:00 [i] Using plugin binary artifacts from "/Users/anujc/Documents/code/tanzu-cli/artifacts/plugins"
2023-07-20T14:54:41-07:00 [i] 🐯 Validating Plugin Binary file: /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins/windows/amd64/global/test/v1.0.0-dev/tanzu-test-windows_amd64.exe
2023-07-20T14:54:41-07:00 [i] 🐵 Validating Plugin Binary file: /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins/linux/amd64/global/builder/v1.0.0-dev/tanzu-builder-linux_amd64
2023-07-20T14:54:41-07:00 [i] 🐼 Validating Plugin Binary file: /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins/darwin/amd64/global/builder/v1.0.0-dev/tanzu-builder-darwin_amd64
2023-07-20T14:54:41-07:00 [i] 🐶 Validating Plugin Binary file: /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins/windows/amd64/global/builder/v1.0.0-dev/tanzu-builder-windows_amd64.exe
2023-07-20T14:54:41-07:00 [i] 🐱 Validating Plugin Binary file: /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins/linux/amd64/global/test/v1.0.0-dev/tanzu-test-linux_amd64
2023-07-20T14:54:41-07:00 [i] 🦁 Validating Plugin Binary file: /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins/darwin/amd64/global/test/v1.0.0-dev/tanzu-test-darwin_amd64
2023-07-20T14:54:41-07:00 [i] 🐯 Generating plugin package for 'plugin:test' 'target:global' 'os:windows' 'arch:amd64' 'version:v1.0.0-dev'
2023-07-20T14:54:41-07:00 [i] 🦁 Generating plugin package for 'plugin:test' 'target:global' 'os:darwin' 'arch:amd64' 'version:v1.0.0-dev'
2023-07-20T14:54:41-07:00 [i] 🐱 Generating plugin package for 'plugin:test' 'target:global' 'os:linux' 'arch:amd64' 'version:v1.0.0-dev'
2023-07-20T14:54:41-07:00 [i] 🐵 Generating plugin package for 'plugin:builder' 'target:global' 'os:linux' 'arch:amd64' 'version:v1.0.0-dev'
2023-07-20T14:54:41-07:00 [i] 🐼 Generating plugin package for 'plugin:builder' 'target:global' 'os:darwin' 'arch:amd64' 'version:v1.0.0-dev'
2023-07-20T14:54:41-07:00 [i] 🐶 Generating plugin package for 'plugin:builder' 'target:global' 'os:windows' 'arch:amd64' 'version:v1.0.0-dev'
2023-07-20T14:54:43-07:00 [i] 🐶 Generated plugin package at "/Users/anujc/Documents/code/tanzu-cli/artifacts/packages/windows/amd64/global/builder/v1.0.0-dev/builder-windows_amd64.tar"
2023-07-20T14:54:45-07:00 [i] 🐵 Generated plugin package at "/Users/anujc/Documents/code/tanzu-cli/artifacts/packages/linux/amd64/global/builder/v1.0.0-dev/builder-linux_amd64.tar"
2023-07-20T14:54:48-07:00 [i] 🐼 Generated plugin package at "/Users/anujc/Documents/code/tanzu-cli/artifacts/packages/darwin/amd64/global/builder/v1.0.0-dev/builder-darwin_amd64.tar"
2023-07-20T14:54:48-07:00 [i] 🐱 Generated plugin package at "/Users/anujc/Documents/code/tanzu-cli/artifacts/packages/linux/amd64/global/test/v1.0.0-dev/test-linux_amd64.tar"
2023-07-20T14:54:48-07:00 [i] 🐯 Generated plugin package at "/Users/anujc/Documents/code/tanzu-cli/artifacts/packages/windows/amd64/global/test/v1.0.0-dev/test-windows_amd64.tar"
2023-07-20T14:54:48-07:00 [i] 🦁 Generated plugin package at "/Users/anujc/Documents/code/tanzu-cli/artifacts/packages/darwin/amd64/global/test/v1.0.0-dev/test-darwin_amd64.tar"
2023-07-20T14:54:48-07:00 [i] Saved plugin manifest at "/Users/anujc/Documents/code/tanzu-cli/artifacts/packages/plugin_manifest.yaml"
2023-07-20T14:54:48-07:00 [i] shutting down local registry server...

====================

docker stop temp-package-registry && docker rm -v temp-package-registry || true
temp-package-registry
temp-package-registry
docker run -d -p 5001:5000 --name temp-package-registry mirror.gcr.io/library/registry:2.7.1
5a8d5d5fe1af81060721ca34d4d3003e896220a5b2c00af42dfdbc04281fc7b7

====================

/Users/anujc/Documents/code/tanzu-cli/bin/builder plugin publish-package \
                --package-artifacts /Users/anujc/Documents/code/tanzu-cli/artifacts/packages \
                --publisher tzcli \
                --vendor vmware \
                --repository localhost:5001/test/v1/tanzu-cli/plugins
2023-07-20T14:54:50-07:00 [i] using plugin package artifacts from "/Users/anujc/Documents/code/tanzu-cli/artifacts/packages"
2023-07-20T14:54:50-07:00 [i] 🐼 publishing plugin 'name:builder' 'target:global' 'os:darwin' 'arch:amd64' 'version:v1.0.0-dev'
2023-07-20T14:54:50-07:00 [i] 🐯 publishing plugin 'name:test' 'target:global' 'os:windows' 'arch:amd64' 'version:v1.0.0-dev'
2023-07-20T14:54:50-07:00 [i] 🐱 publishing plugin 'name:test' 'target:global' 'os:linux' 'arch:amd64' 'version:v1.0.0-dev'
2023-07-20T14:54:50-07:00 [i] 🦁 publishing plugin 'name:test' 'target:global' 'os:darwin' 'arch:amd64' 'version:v1.0.0-dev'
2023-07-20T14:54:50-07:00 [i] 🐶 publishing plugin 'name:builder' 'target:global' 'os:windows' 'arch:amd64' 'version:v1.0.0-dev'
2023-07-20T14:54:50-07:00 [i] 🐵 publishing plugin 'name:builder' 'target:global' 'os:linux' 'arch:amd64' 'version:v1.0.0-dev'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tzcli/darwin/amd64/global/builder@sha256:4e368a18657b554d3862b71d3b9afe670771d04717909f3baa519c043a52ee42
2023-07-20T14:54:53-07:00 [i] 🐼 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tzcli/darwin/amd64/global/builder:v1.0.0-dev'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tzcli/windows/amd64/global/builder@sha256:3ff0d4085490bf6ea5c9405c675a9ef1509f6f25ca6da7c65d937ba461736042
2023-07-20T14:54:54-07:00 [i] 🐶 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tzcli/windows/amd64/global/builder:v1.0.0-dev'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tzcli/linux/amd64/global/builder@sha256:7c8044c0c519f8c6241dcc00df860d892bfb23589b02ecc8b6742cac93cc4b3f
2023-07-20T14:54:54-07:00 [i] 🐵 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tzcli/linux/amd64/global/builder:v1.0.0-dev'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tzcli/linux/amd64/global/test@sha256:94ba60d9d897f77f1455d45564343e2ae8bf3c8ec1a8239e9246875e01a0d554
2023-07-20T14:54:54-07:00 [i] 🐱 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tzcli/linux/amd64/global/test:v1.0.0-dev'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tzcli/windows/amd64/global/test@sha256:0aac66b51b033e65339b0038850c0e8961386e224352ee5dde65452ccdce8847
2023-07-20T14:54:55-07:00 [i] 🐯 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tzcli/windows/amd64/global/test:v1.0.0-dev'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tzcli/darwin/amd64/global/test@sha256:96ed195d0c3914d050dfdd56003f986808e497ba6bd7d7b625aa96a6a9c22071
2023-07-20T14:54:55-07:00 [i] 🦁 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tzcli/darwin/amd64/global/test:v1.0.0-dev'
~/D/c/tanzu-cli (use-crane-registry-serve|✔) $ 
```


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
None
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
