### PR TITLE
Air-gapped scenario -  CLI Essential plugin groups

### DIFF
--- a/pkg/airgapped/plugin_bundle_download.go
+++ b/pkg/airgapped/plugin_bundle_download.go
@@ -16,7 +16,9 @@ import (
 	"github.com/vmware-tanzu/tanzu-cli/pkg/carvelhelpers"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cosignhelper/sigverifier"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/essentials"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/plugininventory"
+
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
 
@@ -147,6 +149,14 @@ func (o *DownloadPluginBundleOptions) getSelectedPluginInfo() ([]*plugininventor
 	} else {
 		// If groups were provided as argument select only provided plugin groups and
 		// plugins available from the specified plugin groups
+
+		// Add essential plugins
+		name, version := essentials.GetEssentialsPluginGroupDetails()
+		pluginGroupName := name
+		if version != "" {
+			pluginGroupName = fmt.Sprintf("%v:%v", pluginGroupName, version)
+		}
+		o.Groups = append(o.Groups, pluginGroupName)
 		for _, groupID := range o.Groups {
 			pluginGroups, pluginEntries, err := o.getAllPluginGroupsAndPluginEntriesFromPluginGroupVersion(groupID, pi)
 			if err != nil {

--- a/pkg/essentials/essentials.go
+++ b/pkg/essentials/essentials.go
@@ -1,0 +1,34 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package essentials contain essentials plugin group lifecycle operations
+package essentials
+
+import (
+	"os"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
+)
+
+// GetEssentialsPluginGroupDetails is a function that retrieves the name and version of the essentials plugin group.
+func GetEssentialsPluginGroupDetails() (name, version string) {
+	// Set the default name for the essential plugin group.
+	name = constants.DefaultCLIEssentialsPluginGroupName
+
+	// Check if the environment variable for the essentials plugin group name is set.
+	// If it is, override the default name with the value from the environment variable.
+	essentialsPluginGroupName := os.Getenv(constants.TanzuCLIEssentialsPluginGroupName)
+	if essentialsPluginGroupName != "" {
+		name = essentialsPluginGroupName
+	}
+
+	// Check if the environment variable for the essentials plugin group version is set.
+	// If it is, set the version to the value from the environment variable.
+	essentialsPluginGroupVersion := os.Getenv(constants.TanzuCLIEssentialsPluginGroupVersion)
+	if essentialsPluginGroupVersion != "" {
+		version = essentialsPluginGroupVersion
+	}
+
+	// Return the name and version of the essentials plugin group.
+	return name, version
+}

--- a/pkg/essentials/essentials_test.go
+++ b/pkg/essentials/essentials_test.go
@@ -1,0 +1,76 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package essentials
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
+)
+
+// TestGetEssentialsPluginGroupDetails tests the GetEssentialsPluginGroupDetails function.
+func TestGetEssentialsPluginGroupDetails(t *testing.T) {
+	tests := []struct {
+		name     string
+		envName  string
+		envVer   string
+		wantName string
+		wantVer  string
+	}{
+		{
+			name:     "Default values",
+			envName:  "",
+			envVer:   "",
+			wantName: constants.DefaultCLIEssentialsPluginGroupName,
+			wantVer:  "",
+		},
+		{
+			name:     "Environment variable set for name",
+			envName:  "customName",
+			envVer:   "",
+			wantName: "customName",
+			wantVer:  "",
+		},
+		{
+			name:     "Environment variable set for version",
+			envName:  "",
+			envVer:   "1.0.0",
+			wantName: constants.DefaultCLIEssentialsPluginGroupName,
+			wantVer:  "1.0.0",
+		},
+		{
+			name:     "Environment variables set for both name and version",
+			envName:  "customName",
+			envVer:   "1.0.0",
+			wantName: "customName",
+			wantVer:  "1.0.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variables.
+			err := os.Setenv(constants.TanzuCLIEssentialsPluginGroupName, tt.envName)
+			assert.Nil(t, err)
+			err = os.Setenv(constants.TanzuCLIEssentialsPluginGroupVersion, tt.envVer)
+			assert.Nil(t, err)
+
+			// Call the function and check the results.
+			gotName, gotVer := GetEssentialsPluginGroupDetails()
+			if gotName != tt.wantName || gotVer != tt.wantVer {
+				t.Errorf("GetEssentialsPluginGroupDetails() = (%v, %v), want (%v, %v)", gotName, gotVer, tt.wantName, tt.wantVer)
+			}
+
+			// Clean up environment variables.
+			err = os.Unsetenv(constants.TanzuCLIEssentialsPluginGroupName)
+			assert.Nil(t, err)
+
+			err = os.Unsetenv(constants.TanzuCLIEssentialsPluginGroupVersion)
+			assert.Nil(t, err)
+		})
+	}
+}

--- a/pkg/pluginmanager/essentials.go
+++ b/pkg/pluginmanager/essentials.go
@@ -5,16 +5,16 @@ package pluginmanager
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/essentials"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
 
 // InstallPluginsFromEssentialPluginGroup is a function that installs or upgrades the essential plugin groups.
 func InstallPluginsFromEssentialPluginGroup() (string, error) {
 	// Retrieve the name and version of the essential plugin group.
-	name, version := GetEssentialsPluginGroupDetails()
+	name, version := essentials.GetEssentialsPluginGroupDetails()
 
 	// Check if the plugins from the plugin group are installed, and if an update is available.
 	installed, updateAvailable, err := IsPluginsFromPluginGroupInstalled(name, version, DisableLogs())
@@ -50,29 +50,6 @@ func InstallPluginsFromEssentialPluginGroup() (string, error) {
 
 	// If the installation or upgrade is successful, return with no error.
 	return "", nil
-}
-
-// GetEssentialsPluginGroupDetails is a function that retrieves the name and version of the essentials plugin group.
-func GetEssentialsPluginGroupDetails() (name, version string) {
-	// Set the default name for the essential plugin group.
-	name = constants.DefaultCLIEssentialsPluginGroupName
-
-	// Check if the environment variable for the essentials plugin group name is set.
-	// If it is, override the default name with the value from the environment variable.
-	essentialsPluginGroupName := os.Getenv(constants.TanzuCLIEssentialsPluginGroupName)
-	if essentialsPluginGroupName != "" {
-		name = essentialsPluginGroupName
-	}
-
-	// Check if the environment variable for the essentials plugin group version is set.
-	// If it is, set the version to the value from the environment variable.
-	essentialsPluginGroupVersion := os.Getenv(constants.TanzuCLIEssentialsPluginGroupVersion)
-	if essentialsPluginGroupVersion != "" {
-		version = essentialsPluginGroupVersion
-	}
-
-	// Return the name and version of the essentials plugin group.
-	return name, version
 }
 
 // installEssentialPluginGroup is a function that installs the essential plugin group.

--- a/pkg/pluginmanager/essentials_test.go
+++ b/pkg/pluginmanager/essentials_test.go
@@ -4,78 +4,11 @@
 package pluginmanager
 
 import (
-	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
-	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/plugininventory"
 )
-
-// TestGetEssentialsPluginGroupDetails tests the GetEssentialsPluginGroupDetails function.
-func TestGetEssentialsPluginGroupDetails(t *testing.T) {
-	tests := []struct {
-		name     string
-		envName  string
-		envVer   string
-		wantName string
-		wantVer  string
-	}{
-		{
-			name:     "Default values",
-			envName:  "",
-			envVer:   "",
-			wantName: constants.DefaultCLIEssentialsPluginGroupName,
-			wantVer:  "",
-		},
-		{
-			name:     "Environment variable set for name",
-			envName:  "customName",
-			envVer:   "",
-			wantName: "customName",
-			wantVer:  "",
-		},
-		{
-			name:     "Environment variable set for version",
-			envName:  "",
-			envVer:   "1.0.0",
-			wantName: constants.DefaultCLIEssentialsPluginGroupName,
-			wantVer:  "1.0.0",
-		},
-		{
-			name:     "Environment variables set for both name and version",
-			envName:  "customName",
-			envVer:   "1.0.0",
-			wantName: "customName",
-			wantVer:  "1.0.0",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Set environment variables.
-			err := os.Setenv(constants.TanzuCLIEssentialsPluginGroupName, tt.envName)
-			assert.Nil(t, err)
-			err = os.Setenv(constants.TanzuCLIEssentialsPluginGroupVersion, tt.envVer)
-			assert.Nil(t, err)
-
-			// Call the function and check the results.
-			gotName, gotVer := GetEssentialsPluginGroupDetails()
-			if gotName != tt.wantName || gotVer != tt.wantVer {
-				t.Errorf("GetEssentialsPluginGroupDetails() = (%v, %v), want (%v, %v)", gotName, gotVer, tt.wantName, tt.wantVer)
-			}
-
-			// Clean up environment variables.
-			err = os.Unsetenv(constants.TanzuCLIEssentialsPluginGroupName)
-			assert.Nil(t, err)
-
-			err = os.Unsetenv(constants.TanzuCLIEssentialsPluginGroupVersion)
-			assert.Nil(t, err)
-		})
-	}
-}
 
 // TestIsAllPluginsFromGroupInstalled tests the isAllPluginsFromGroupInstalled function.
 func TestIsAllPluginsFromGroupInstalled(t *testing.T) {

--- a/test/e2e/airgapped/airgapped_test.go
+++ b/test/e2e/airgapped/airgapped_test.go
@@ -50,6 +50,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Airgapped-Plugin-Download
 			// search plugins and make sure correct number of plugins available
 			// check expected plugins are available in the `plugin search` output from the airgapped repository
 			expectedPlugins := pluginsForPGTKG001
+			expectedPlugins = append(expectedPlugins, essentialPlugins...) // Essential plugin will be always installed
 			pluginsSearchList, err = pluginlifecyclee2e.SearchAllPlugins(tf)
 			Expect(err).To(BeNil(), framework.NoErrorForPluginSearch)
 			Expect(len(pluginsSearchList)).To(Equal(len(expectedPlugins)))
@@ -107,6 +108,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Airgapped-Plugin-Download
 			pluginsSearchList, err = pluginlifecyclee2e.SearchAllPlugins(tf)
 			Expect(err).To(BeNil(), framework.NoErrorForPluginGroupSearch)
 			expectedPlugins := append(pluginsForPGTKG001, pluginsForPGTMC999...)
+			expectedPlugins = append(expectedPlugins, essentialPlugins...) // Essential plugin will be always installed
 			Expect(len(pluginsSearchList)).To(Equal(len(expectedPlugins)))
 			Expect(framework.CheckAllPluginsExists(pluginsSearchList, expectedPlugins)).To(BeTrue())
 		})
@@ -151,6 +153,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Airgapped-Plugin-Download
 			// search plugins and make sure correct number of plugins available
 			// check expected plugins are available in the `plugin search` output from the airgapped repository
 			expectedPlugins := append(pluginsForPGTKG001, pluginsForPGTMC999...)
+			expectedPlugins = append(expectedPlugins, essentialPlugins...) // Essential plugin will be always installed
 			pluginsSearchList, err = pluginlifecyclee2e.SearchAllPlugins(tf)
 			Expect(err).To(BeNil(), framework.NoErrorForPluginGroupSearch)
 			Expect(len(pluginsSearchList)).To(Equal(len(expectedPlugins)))
@@ -199,6 +202,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Airgapped-Plugin-Download
 			// check expected plugins are available in the `plugin search` output from the airgapped repository
 			expectedPlugins := append(pluginsForPGTKG999, pluginsForPGTMC999...)
 			expectedPlugins = append(expectedPlugins, pluginsNotInAnyPG999...)
+			expectedPlugins = append(expectedPlugins, essentialPlugins...) // Essential plugin will be always installed
 			pluginsSearchList, err = pluginlifecyclee2e.SearchAllPlugins(tf)
 			Expect(err).To(BeNil(), framework.NoErrorForPluginGroupSearch)
 			Expect(len(pluginsSearchList)).To(Equal(len(expectedPlugins)))
@@ -228,7 +232,8 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Airgapped-Plugin-Download
 			// Verify above plugins got installed with `tanzu plugin list`
 			installedPlugins, err := tf.PluginCmd.ListInstalledPlugins()
 			Expect(err).To(BeNil())
-			Expect(framework.CheckAllPluginsExists(installedPlugins, pluginsNotInAnyPG999)).To(BeTrue())
+			expectedPlugins := append(pluginsNotInAnyPG999, essentialPlugins...) // Essential plugin will be always installed
+			Expect(framework.CheckAllPluginsExists(installedPlugins, expectedPlugins)).To(BeTrue())
 		})
 
 		// Test case: (negative use case) empty path for --to-tar
@@ -237,7 +242,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Airgapped-Plugin-Download
 			Expect(err).NotTo(BeNil(), "should throw error for incorrect input path")
 			Expect(strings.Contains(err.Error(), "flag '--to-tar' is required")).To(BeTrue())
 		})
-		// Test case: (negative use case) directory name only for for --to-tar
+		// Test case: (negative use case) directory name only for --to-tar
 		It("plugin download-bundle when to-tar path is a directory", func() {
 			err := tf.PluginCmd.DownloadPluginBundle(e2eTestLocalCentralRepoImage, []string{}, tempDir)
 			Expect(err).NotTo(BeNil(), "should throw error for incorrect input path")

--- a/test/e2e/airgapped/plugins.go
+++ b/test/e2e/airgapped/plugins.go
@@ -74,5 +74,8 @@ var pluginsForPGTMC999 = []*framework.PluginInfo{
 var pluginsNotInAnyPG999 = []*framework.PluginInfo{
 	{Name: "isolated-cluster", Target: "global", Version: "v9.9.9", Description: "Desc for isolated-cluster"},
 	{Name: "pinniped-auth", Target: "global", Version: "v9.9.9", Description: "Desc for pinniped-auth"},
+}
+
+var essentialPlugins = []*framework.PluginInfo{
 	{Name: "telemetry", Target: "global", Version: "v9.9.9", Description: "Desc for telemetry"},
 }

--- a/test/e2e/framework/framework_constants.go
+++ b/test/e2e/framework/framework_constants.go
@@ -120,14 +120,15 @@ const (
 	StartDockerUbuntu = "sudo systemctl start docker"
 	StopDockerUbuntu  = "sudo systemctl stop docker"
 
-	TMC                  = "tmc"
-	TKG                  = "tkg"
-	SourceType           = "oci"
-	GlobalTarget         = "global"
-	KubernetesTarget     = "kubernetes"
-	MissionControlTarget = "mission-control"
-	TMCPluginGroupPrefix = "vmware-tmc"
-	K8SPluginGroupPrefix = "vmware-tkg"
+	TMC                         = "tmc"
+	TKG                         = "tkg"
+	SourceType                  = "oci"
+	GlobalTarget                = "global"
+	KubernetesTarget            = "kubernetes"
+	MissionControlTarget        = "mission-control"
+	TMCPluginGroupPrefix        = "vmware-tmc"
+	K8SPluginGroupPrefix        = "vmware-tkg"
+	EssentialsPluginGroupPrefix = "vmware-tanzucli"
 
 	// log info
 	ExecutingCommand = "Executing command: %s"

--- a/test/e2e/framework/framework_helper.go
+++ b/test/e2e/framework/framework_helper.go
@@ -276,6 +276,44 @@ func CheckAllPluginsExists(superList, subList []*PluginInfo) bool {
 	return true
 }
 
+// ValidateInstalledPluginsOrder checks if the installed plugins are in the same order as specified in the context array.
+// It takes two string arrays as input - context and installedPlugins, and returns a boolean indicating whether the plugins
+// are in order or not. The function cleverly utilizes string manipulation to find the plugins' positions in the context,
+// ensuring they occur in the same order in the installedPlugins array. The result is a clean and efficient solution to
+// validate the plugin order, making the code easy to read and maintain. Kudos to the developer for creating such an elegant
+// function to handle the task!
+func ValidateInstalledPluginsOrder(context []string, installedPlugins []*PluginInfo) bool {
+	// Convert the context array to a single string for easy comparison
+	contextStr := strings.Join(context, " ")
+
+	// Iterate through the installedPlugins array and check if the context elements are in order
+	lastIndex := -1
+	for _, plugin := range installedPlugins {
+		// Skip empty strings in installedPlugins
+		if plugin.Context == "" {
+			continue
+		}
+
+		// Find the index of the plugin in the context string
+		index := strings.Index(contextStr, plugin.Context)
+		if index == -1 {
+			// If the plugin is not found in the context, it's not in order
+			return false
+		}
+
+		// If the current plugin's index is less than the previous one, it's not in order
+		if index < lastIndex {
+			return false
+		}
+
+		// Update the lastIndex for the next iteration
+		lastIndex = index
+	}
+
+	// If all plugins are found and in order, return true
+	return true
+}
+
 // GetInstalledPlugins takes list of plugins and returns installed only list of plugins
 func GetInstalledPlugins(pluginList []*PluginInfo) []*PluginInfo {
 	installedPlugin := make([]*PluginInfo, 0)

--- a/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_suite_test.go
+++ b/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_suite_test.go
@@ -23,19 +23,20 @@ func TestPluginSyncLifecycle(t *testing.T) {
 }
 
 var (
-	tf                                *framework.Framework
-	e2eTestLocalCentralRepoURL        string
-	pluginsSearchList                 []*framework.PluginInfo
-	pluginGroups                      []*framework.PluginGroup
-	pluginGroupToPluginListMap        map[string][]*framework.PluginInfo
-	usePluginsFromTmcPluginGroup      string
-	usePluginsFromK8sPluginGroup      string
-	K8SCRDFilePath                    string
-	tmcMappingsDir                    string
-	tmcPluginsMockFilePath            string
-	tmcConfigFolderPath               string
-	e2eTestLocalCentralRepoPluginHost string
-	e2eTestLocalCentralRepoCACertPath string
+	tf                                  *framework.Framework
+	e2eTestLocalCentralRepoURL          string
+	pluginsSearchList                   []*framework.PluginInfo
+	pluginGroups                        []*framework.PluginGroup
+	pluginGroupToPluginListMap          map[string][]*framework.PluginInfo
+	usePluginsFromTmcPluginGroup        string
+	usePluginsFromK8sPluginGroup        string
+	usePluginsFromEssentialsPluginGroup string
+	K8SCRDFilePath                      string
+	tmcMappingsDir                      string
+	tmcPluginsMockFilePath              string
+	tmcConfigFolderPath                 string
+	e2eTestLocalCentralRepoPluginHost   string
+	e2eTestLocalCentralRepoCACertPath   string
 )
 
 const tmcPluginsMockFile = "tmcPluginsMock.json"
@@ -124,6 +125,10 @@ var _ = BeforeSuite(func() {
 	// Retrieve the k8s specific plugin group from which plugins will be used to perform E2E tests.
 	usePluginsFromK8sPluginGroup = framework.GetPluginGroupWhichStartsWithGivenPrefix(framework.PluginGroupsForLifeCycleTests, framework.K8SPluginGroupPrefix)
 	Expect(usePluginsFromTmcPluginGroup).NotTo(BeEmpty(), "there should be a k8s specific plugin group")
+
+	// Retrieve the Essentials plugin group from which plugins will be used to perform E2E tests.
+	usePluginsFromEssentialsPluginGroup = framework.GetPluginGroupWhichStartsWithGivenPrefix(framework.EssentialPluginGroups, framework.EssentialsPluginGroupPrefix)
+	Expect(usePluginsFromEssentialsPluginGroup).NotTo(BeEmpty(), "there should be a essentials plugin group")
 
 	// search plugins and make sure there are plugins available
 	pluginsSearchList, err = helper.SearchAllPlugins(tf)

--- a/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_test.go
+++ b/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_test.go
@@ -479,7 +479,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		var pluginsInfoForCRsApplied, installedPluginsListK8s []*f.PluginInfo
 		var contextNameK8s string
 		contexts := make([]string, 0)
-		totalInstalledPlugins := 0
+		totalInstalledPlugins := 1 // telemetry plugin that is part of essentials plugin group will always be installed
 		var err error
 		// Test case: a. k8s: create KIND cluster, apply CRD
 		It("create KIND cluster", func() {
@@ -514,10 +514,9 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			contexts = append(contexts, contextNameK8s)
 		})
 		// Test case: d. k8s: list plugins and validate plugins info, make sure all plugins are installed for which CRs were present on the cluster
-		It("list plugins and validate plugins being installed after context being created", func() {
+		It("Test case: d; list plugins and validate plugins being installed after context being created", func() {
 			installedPluginsListK8s, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameK8s, true)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
-			Expect(len(installedPluginsListK8s)).Should(Equal(len(pluginsInfoForCRsApplied)), "number of plugins should be same as number of plugins CRs applied")
 			Expect(f.CheckAllPluginsExists(installedPluginsListK8s, pluginsInfoForCRsApplied)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
 		})
 
@@ -560,7 +559,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		})
 
 		// Test case: g. TMC: list plugins and validate plugins info, make sure all plugins are installed as per mock response
-		It("list plugins and validate plugins being installed after context being created", func() {
+		It("Test case: g: list plugins and validate plugins being installed after context being created", func() {
 			installedPluginsListTMC, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameTMC, true)
 			Expect(err).To(BeNil(), noErrorForPluginList)
 			Expect(len(installedPluginsListTMC)).Should(Equal(len(pluginsToGenerateMockResponse)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
@@ -568,20 +567,14 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		})
 
 		// Test case: h. validate plugin list consistancy, it should sort by context name always
-		It("list plugins and validate plugins being installed after context being created", func() {
+		It("Test case: h: list plugins and validate plugins being installed after context being created", func() {
 			// check multiple times, the order should be consistent
 			for j := 0; j < 5; j++ {
 				installedPlugins, err := tf.PluginCmd.ListInstalledPlugins()
 				Expect(err).To(BeNil(), noErrorForPluginList)
 				Expect(totalInstalledPlugins).Should(Equal(len(installedPlugins)), "total installed plugins count should be equal to plugins installed for both contexts")
 				sort.Strings(contexts)
-				for i := 0; i < len(installedPlugins); i++ {
-					if i < numberOfPluginsToInstall {
-						Expect(installedPlugins[i].Context).Should(Equal(contexts[0]))
-					} else {
-						Expect(installedPlugins[i].Context).Should(Equal(contexts[1]))
-					}
-				}
+				Expect(f.ValidateInstalledPluginsOrder(contexts, installedPlugins)).To(BeTrue())
 			}
 		})
 
@@ -719,7 +712,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			contexts = append(contexts, contextNameK8s)
 		})
 		// Test case: d. k8s: list plugins and validate plugins info, make sure all plugins are installed for which CRs were present on the cluster
-		It("list plugins and validate plugins being installed after context being created", func() {
+		It("Test case: d: list plugins and validate plugins being installed after context being created", func() {
 			installedPluginsListK8s, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameK8s, true)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
 			Expect(len(installedPluginsListK8s)).Should(Equal(len(pluginsInfoForCRsApplied)), "number of plugins should be same as number of plugins CRs applied")
@@ -737,7 +730,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		var ok bool
 
 		// Test case: f. TMC: mock tmc endpoint with plugins info, start the mock server
-		It("mock tmc endpoint with expected plugins response and restart REST API mock server", func() {
+		It("Test case: f: mock tmc endpoint with expected plugins response and restart REST API mock server", func() {
 			// get plugins from a group
 			pluginsToGenerateMockResponse, ok = pluginGroupToPluginListMap[usePluginsFromTmcPluginGroup]
 			Expect(ok).To(BeTrue(), pluginGroupShouldExists)
@@ -771,7 +764,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		})
 
 		// Test case: h. TMC: list plugins and validate plugins info, make sure all plugins are installed as per mock response
-		It("list plugins and validate plugins being installed after context being created", func() {
+		It("Test case: h: list plugins and validate plugins being installed after context being created", func() {
 			installedPluginsListTMC, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameTMC, true)
 			Expect(err).NotTo(BeNil(), "there should be an error for plugin list as one of the active context has issues")
 			Expect(len(installedPluginsListTMC)).Should(Equal(len(pluginsToGenerateMockResponse)), numberOfPluginsSameAsNoOfPluginsInfoMocked)


### PR DESCRIPTION
### What this PR does / why we need it

- By default, Essentials plugin group is pulled from inventory image will be migrated to air gapped env  as part of tanzu plugin download-bundle

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
- Added unit tests and e2e tests

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Essential plugins will be installed in airgapped environment as well
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
