### PR TITLE
Get plugin digest in parallel when adding plugin entry to the inventory database as part of builder plugin

### DIFF
--- a/cmd/plugin/builder/inventory/inventory_plugin.go
+++ b/cmd/plugin/builder/inventory/inventory_plugin.go
@@ -114,6 +114,8 @@ func (ipuo *InventoryPluginUpdateOptions) preparePluginInventoryEntriesFromManif
 	return pluginInventoryEntries, nil
 }
 
+// Take the image download logic to get the digest out of the updatePluginInventoryEntry and run it in parallel
+// Pass the digest map to this function to update the plugin inventory entry in sync operation
 func (ipuo *InventoryPluginUpdateOptions) updatePluginInventoryEntry(pluginInventoryEntry *plugininventory.PluginInventoryEntry, plugin cli.Plugin, osArch cli.Arch, version string) (*plugininventory.PluginInventoryEntry, error) {
 	var err error
 	var digest string

--- a/cmd/plugin/builder/inventory/inventory_plugin.go
+++ b/cmd/plugin/builder/inventory/inventory_plugin.go
@@ -8,8 +8,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
@@ -96,12 +98,20 @@ func (ipuo *InventoryPluginUpdateOptions) preparePluginInventoryEntriesFromManif
 
 	var pluginInventoryEntries []*plugininventory.PluginInventoryEntry
 
+	pluginBinaryDigestMap := map[string]string{}
+	if !ipuo.ValidateOnly {
+		pluginBinaryDigestMap, err = ipuo.fetchPluginBinaryDigest(pluginManifest)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	for i := range pluginManifest.Plugins {
 		var pluginInventoryEntry *plugininventory.PluginInventoryEntry
 
 		for _, osArch := range cli.MinOSArch {
 			for _, version := range pluginManifest.Plugins[i].Versions {
-				pluginInventoryEntry, err = ipuo.updatePluginInventoryEntry(pluginInventoryEntry, pluginManifest.Plugins[i], osArch, version)
+				pluginInventoryEntry, err = ipuo.updatePluginInventoryEntry(pluginInventoryEntry, pluginManifest.Plugins[i], osArch, version, pluginBinaryDigestMap)
 				if err != nil {
 					return nil, err
 				}
@@ -114,22 +124,75 @@ func (ipuo *InventoryPluginUpdateOptions) preparePluginInventoryEntriesFromManif
 	return pluginInventoryEntries, nil
 }
 
+func (ipuo *InventoryPluginUpdateOptions) fetchPluginBinaryDigest(pluginManifest *cli.Manifest) (map[string]string, error) {
+	pluginBinaryDigestMap := map[string]string{}
+
+	// Limit the number of concurrent operations we perform so we don't overwhelm the system.
+	maxConcurrent := helpers.GetMaxParallelism()
+	guard := make(chan struct{}, maxConcurrent)
+	var wg sync.WaitGroup
+	fatalErrors := make(chan helpers.ErrInfo, helpers.GetNumberOfIndividualPluginBinariesFromManifest(pluginManifest))
+	var mutex = &sync.RWMutex{}
+
+	fetchPluginBinaryDigestFromImage := func(threadID string, pluginImage string, filename string) {
+		defer func() {
+			<-guard
+			wg.Done()
+		}()
+
+		log.Infof("%s getting plugin digest from image: '%s'", threadID, pluginImage)
+
+		digest, err := ipuo.ImageOperationsImpl.GetFileDigestFromImage(pluginImage, filename)
+		if err != nil {
+			fatalErrors <- helpers.ErrInfo{Err: errors.Wrapf(err, "error while getting plugin binary digest from the image %q", pluginImage), ID: threadID, Path: pluginImage}
+		}
+		mutex.Lock()
+		pluginBinaryDigestMap[pluginImage] = digest
+		mutex.Unlock()
+	}
+
+	if !ipuo.ValidateOnly {
+		id := 0
+		for i := range pluginManifest.Plugins {
+			for _, osArch := range cli.MinOSArch {
+				for _, version := range pluginManifest.Plugins[i].Versions {
+					wg.Add(1)
+					guard <- struct{}{}
+					pluginImageBasePath := fmt.Sprintf("%s/%s/%s/%s/%s/%s:%s", ipuo.Vendor, ipuo.Publisher, osArch.OS(), osArch.Arch(), pluginManifest.Plugins[i].Target, pluginManifest.Plugins[i].Name, version)
+					pluginImage := fmt.Sprintf("%s/%s", ipuo.Repository, pluginImageBasePath)
+					go fetchPluginBinaryDigestFromImage(helpers.GetID(id), pluginImage, cli.MakeArtifactName(pluginManifest.Plugins[i].Name, osArch))
+					id++
+				}
+			}
+		}
+		wg.Wait()
+		close(fatalErrors)
+
+		errList := []error{}
+		for err := range fatalErrors {
+			log.Errorf("%s - error while getting plugin binary digest - %v", err.ID, err.Err)
+			errList = append(errList, err.Err)
+		}
+		if len(errList) > 0 {
+			return pluginBinaryDigestMap, kerrors.NewAggregate(errList)
+		}
+	}
+	return pluginBinaryDigestMap, nil
+}
+
 // Take the image download logic to get the digest out of the updatePluginInventoryEntry and run it in parallel
 // Pass the digest map to this function to update the plugin inventory entry in sync operation
-func (ipuo *InventoryPluginUpdateOptions) updatePluginInventoryEntry(pluginInventoryEntry *plugininventory.PluginInventoryEntry, plugin cli.Plugin, osArch cli.Arch, version string) (*plugininventory.PluginInventoryEntry, error) {
-	var err error
+func (ipuo *InventoryPluginUpdateOptions) updatePluginInventoryEntry(pluginInventoryEntry *plugininventory.PluginInventoryEntry, plugin cli.Plugin, osArch cli.Arch, version string, pluginBinaryDigestMap map[string]string) (*plugininventory.PluginInventoryEntry, error) {
 	var digest string
-
-	log.Infof("validating plugin '%s_%s_%s_%s'", plugin.Name, plugin.Target, osArch.String(), version)
 
 	pluginImageBasePath := fmt.Sprintf("%s/%s/%s/%s/%s/%s:%s", ipuo.Vendor, ipuo.Publisher, osArch.OS(), osArch.Arch(), plugin.Target, plugin.Name, version)
 	if !ipuo.ValidateOnly {
 		// If we are only validating the plugin's existence, we don't need to waste
 		// resources downloading the image to get the digest which won't actually be used.
 		pluginImage := fmt.Sprintf("%s/%s", ipuo.Repository, pluginImageBasePath)
-		digest, err = ipuo.ImageOperationsImpl.GetFileDigestFromImage(pluginImage, cli.MakeArtifactName(plugin.Name, osArch))
-		if err != nil {
-			return nil, errors.Wrapf(err, "error while getting plugin binary digest from the image %q", pluginImage)
+		digest = pluginBinaryDigestMap[pluginImage]
+		if digest == "" {
+			return nil, errors.Errorf("plugin binary digest cannot be empty for image %q", pluginImage)
 		}
 	}
 

--- a/cmd/plugin/builder/inventory/inventory_plugin_test.go
+++ b/cmd/plugin/builder/inventory/inventory_plugin_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Unit tests for inventory plugin add", func() {
 			Expect(err.Error()).To(ContainSubstring("error while getting plugin binary digest"))
 		})
 
-		var _ = It("when plugin inventory database can be pulled, plugin binary digest can be calculated by publishing image fails", func() {
+		var _ = It("when plugin inventory database can be pulled, plugin binary digest can be calculated but publishing image fails", func() {
 			fakeImgpkgWrapper.ResolveImageReturns(nil)
 			fakeImgpkgWrapper.PushImageReturns(errors.New("image not found"))
 			fakeImgpkgWrapper.DownloadImageAndSaveFilesToDirCalls(pullDBImageStub)


### PR DESCRIPTION
### What this PR does / why we need it
- Get plugin digest in parallel when adding plugin entry to the inventory database as part of the builder plugin
- When adding a plugin entry to the database a plugin binary digest(sha256) gets calculated and added to the database which gets verified as part of the post-plugin installation step to verify that the correct plugin binary was downloaded on the user's machine.
- As part of the publishing step, this plugin binary digest(sha256) gets calculated by downloading the plugin image from the remote registry. This PR improves the performance by running this step in parallel.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
```
# Build plugins
$ make plugin-build
```

```
# Build and publish plugin images to the local registry
$ make plugin-publish-packages
/Users/anujc/Documents/code/tanzu-cli/bin/builder plugin build-package \
                --binary-artifacts /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins \
                --package-artifacts /Users/anujc/Documents/code/tanzu-cli/artifacts/packages
2023-07-24T13:38:56-07:00 [i] starting local registry server on port 51855, logs available at /var/folders/xc/12mmbpb50qxfb3ch8vv9nvwm0000gq/T/241448794
2023-07-24T13:38:56-07:00 [i] Using plugin binary artifacts from "/Users/anujc/Documents/code/tanzu-cli/artifacts/plugins"
2023-07-24T13:38:56-07:00 [i] 🐯 Validating Plugin Binary file: /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins/windows/amd64/global/test/v1.0.0-dev/tanzu-test-windows_amd64.exe
2023-07-24T13:38:56-07:00 [i] 🐵 Validating Plugin Binary file: /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins/linux/amd64/global/builder/v1.0.0-dev/tanzu-builder-linux_amd64
2023-07-24T13:38:56-07:00 [i] 🐯 Generating plugin package for 'plugin:test' 'target:global' 'os:windows' 'arch:amd64' 'version:v1.0.0-dev'
2023-07-24T13:38:56-07:00 [i] 🐵 Generating plugin package for 'plugin:builder' 'target:global' 'os:linux' 'arch:amd64' 'version:v1.0.0-dev'
.
.
.
docker stop temp-package-registry && docker rm -v temp-package-registry || true
temp-package-registry
temp-package-registry
docker run -d -p 5001:5000 --name temp-package-registry mirror.gcr.io/library/registry:2.7.1
5bd99b00c28f3856d6ad83c1dc4453eba9151663b3ca55a182e5994d7f93aff8
/Users/anujc/Documents/code/tanzu-cli/bin/builder plugin publish-package \
                --package-artifacts /Users/anujc/Documents/code/tanzu-cli/artifacts/packages \
                --publisher tanzucli \
                --vendor vmware \
                --repository localhost:5001/test/v1/tanzu-cli/plugins
2023-07-24T13:39:06-07:00 [i] using plugin package artifacts from "/Users/anujc/Documents/code/tanzu-cli/artifacts/packages"
2023-07-24T13:39:06-07:00 [i] 🐵 publishing plugin 'name:builder' 'target:global' 'os:linux' 'arch:amd64' 'version:v1.0.0-dev'
2023-07-24T13:39:06-07:00 [i] 🐱 publishing plugin 'name:test' 'target:global' 'os:linux' 'arch:amd64' 'version:v1.0.0-dev'
.
.
.
2023-07-24T13:39:11-07:00 [i] 🦁 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/amd64/global/test:v1.0.0-dev'
```

```
# Initialize the inventory database on the localhost repository
$ make inventory-init
...
2023-07-24T13:39:47-07:00 [i] successfully published plugin inventory database
```

```
# Add plugin inventory entry in the database. Notice that digest will be fetched in parallel 
$ make inventory-plugin-add
/Users/anujc/Documents/code/tanzu-cli/bin/builder inventory plugin add \
                --repository localhost:5001/test/v1/tanzu-cli/plugins \
                --plugin-inventory-image-tag latest \
                --publisher tanzucli \
                --vendor vmware \
                --manifest /Users/anujc/Documents/code/tanzu-cli/artifacts/packages/plugin_manifest.yaml \
                --plugin-inventory-db-file ""
2023-07-24T13:40:19-07:00 [i] pulling plugin inventory database from: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
2023-07-24T13:40:19-07:00 [i] 🐵 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/amd64/global/builder:v1.0.0-dev'
2023-07-24T13:40:19-07:00 [i] 🐶 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/amd64/global/builder:v1.0.0-dev'
2023-07-24T13:40:19-07:00 [i] 🐱 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/amd64/global/test:v1.0.0-dev'
2023-07-24T13:40:19-07:00 [i] 🐼 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/amd64/global/builder:v1.0.0-dev'
2023-07-24T13:40:19-07:00 [i] 🦊 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/amd64/global/test:v1.0.0-dev'
2023-07-24T13:40:19-07:00 [i] 🐰 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/amd64/global/test:v1.0.0-dev'
2023-07-24T13:40:22-07:00 [i] publishing plugin inventory database
2023-07-24T13:40:22-07:00 [i] successfully published plugin inventory database at: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
```

* Verify that we can install plugins from the newly created plugin inventory database
```
$ export TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST=localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest
$ tz plugin source update default --uri localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest

$ tz plugin search
  NAME     DESCRIPTION             TARGET  LATEST      
  builder  Build Tanzu components  global  v1.0.0-dev  
  test     Test the CLI            global  v1.0.0-dev  

$ tz plugin install builder
[i] Installing plugin 'builder:v1.0.0-dev' with target 'global'
[ok] successfully installed 'builder' plugin

$ tz plugin install test
[i] Installing plugin 'test:v1.0.0-dev' with target 'global'
[ok] successfully installed 'test' plugin
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
None
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
