### PR TITLE
Enable ceip prompt

### DIFF
--- a/docs/quickstart/install.md
+++ b/docs/quickstart/install.md
@@ -147,11 +147,15 @@ available in the default central plugin repository.
 Note: to review the Terms and decide again on the acceptance, this same
 prompt can also be explicitly invoked with `tanzu config eula show`.
 
+****Customer Experience Improvement Program (CEIP) Prompt**** :
+The Tanzu CLI prompts the user to accept participation in CEIP or not.
+
 Systems and users (via automation scripts, for instance) that expect
 non-interactive use of the CLI can avoid being prompted with the
 above by running the following before any other CLI commands:
 
 - `tanzu config eula accept` to accept the EULA.
+- To set the CEIP participation status for automation, the environment variable `TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER` can be set to `No` or `Yes`.
 
 ## Installing and using the Tanzu CLI in internet-restricted environments
 

--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -145,24 +145,27 @@ func newRootCmd() *cobra.Command {
 				}
 			}
 
-			// Prompt user for EULA and CEIP agreement if necessary
+			// Prompt user for EULA agreement if necessary
 			if !shouldSkipPrompts(cmd) {
 				if err := cliconfig.ConfigureEULA(false); err != nil {
 					return err
 				}
-
 				configVal, _ := config.GetEULAStatus()
 				if configVal != config.EULAStatusAccepted {
 					fmt.Fprintf(os.Stderr, "The Tanzu CLI is only usable with reduced functionality until the General Terms are agreed to.\nPlease use `tanzu config eula show` to review the terms, or `tanzu config eula accept` to accept them directly\n")
 					return errors.New("terms not accepted")
 				}
-				// TODO(prkalle): uncomment when the CEIP implementation is done in future release
-				// if err := cliconfig.ConfigureCEIPOptIn(); err != nil {
-				//	return err
-				// }
 			}
+
 			// Install or update essential plugins
 			InstallEssentialPlugins(cmd)
+
+			// Prompt for CEIP agreement
+			if !shouldSkipPrompts(cmd) {
+				if err := cliconfig.ConfigureCEIPOptIn(); err != nil {
+					return err
+				}
+			}
 			return nil
 		},
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -108,6 +108,12 @@ func getCEIPUserOptIn() (bool, error) {
 	if err != nil {
 		return false, err
 	}
+
+	// Put a delimiter after the prompt as it can be followed by
+	// standard CLI output
+	fmt.Println("")
+	fmt.Println("==")
+
 	return strings.EqualFold(ceipOptIn, "Yes"), nil
 }
 


### PR DESCRIPTION
### What this PR does / why we need it
 - Enables the ceip prompt

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

When essentials plugin data is not present in cache

```
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (enable_ceip_prompt)> tanzu plugin list
? You must agree to the VMware General Terms in order to download, install, or
use software from this registry via Tanzu CLI. Acceptance of the VMware General
Terms covers all software installed via the Tanzu CLI during any Session.
“Session” means the period from acceptance until any of the following occurs:
(1) a change to VMware General Terms, (2) a new major release of the Tanzu CLI
is installed, (3) software is accessed in a separate software distribution
registry, or (4) re-acceptance of the General Terms is prompted by VMware.

To view the VMware General Terms, please see https://www.vmware.com/vmware-general-terms.html

If you agree, the essential plugins will be installed that are necessary for the tanzu cli experience

Do you agree to the VMware General Terms?
 Yes

==
? VMware's Customer Experience Improvement Program ("CEIP") provides VMware with
information that enables VMware to improve its products and services and fix
problems. By choosing to participate in CEIP, you agree that VMware may collect
technical information about your use of VMware products and services on a
regular basis. This information does not personally identify you.

For more details about the program, please see https://www.vmware.com/trustvmware/ceip.html

Do you agree to participate in the Customer Experience Improvement Program?
 Yes

==
Standalone Plugins
  NAME  DESCRIPTION  TARGET  VERSION  STATUS
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (enable_ceip_prompt)>


```

When essentials plugin data in present in the cache

```

mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main)> tanzu plugin list
? You must agree to the VMware General Terms in order to download, install, or
use software from this registry via Tanzu CLI. Acceptance of the VMware General
Terms covers all software installed via the Tanzu CLI during any Session.
“Session” means the period from acceptance until any of the following occurs:
(1) a change to VMware General Terms, (2) a new major release of the Tanzu CLI
is installed, (3) software is accessed in a separate software distribution
registry, or (4) re-acceptance of the General Terms is prompted by VMware.

To view the VMware General Terms, please see https://www.vmware.com/vmware-general-terms.html

If you agree, the essential plugins will be installed that are necessary for the tanzu cli experience

Do you agree to the VMware General Terms?
 Yes

==
[i] Looks like you haven't installed essential plugins, installing the essential plugins. this will take a few seconds.

? VMware's Customer Experience Improvement Program ("CEIP") provides VMware with
information that enables VMware to improve its products and services and fix
problems. By choosing to participate in CEIP, you agree that VMware may collect
technical information about your use of VMware products and services on a
regular basis. This information does not personally identify you.

For more details about the program, please see https://www.vmware.com/trustvmware/ceip.html

Do you agree to participate in the Customer Experience Improvement Program?
 Yes

==
Standalone Plugins
  NAME       DESCRIPTION              TARGET  VERSION  STATUS
  telemetry  telemetry functionality  global  v9.9.9   installed
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main)>


```


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
ceip prompt will be shown to the user to accept or reject
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
