### PR TITLE
Allow linux plugins to be built with different CGO_ENABLED configuration using the builder plugins

### DIFF
--- a/cmd/plugin/builder/command/cli_compile.go
+++ b/cmd/plugin/builder/command/cli_compile.go
@@ -334,7 +334,7 @@ var archMap = map[cli.Arch]targetBuilder{
 	cli.Linux386: func(pluginName, outPath string) target {
 		return target{
 			env: []string{
-				"CGO_ENABLED=0",
+				CGOEnabled(),
 				"GOARCH=386",
 				"GOOS=linux",
 			},
@@ -346,7 +346,7 @@ var archMap = map[cli.Arch]targetBuilder{
 	cli.LinuxAMD64: func(pluginName, outPath string) target {
 		return target{
 			env: []string{
-				"CGO_ENABLED=0",
+				CGOEnabled(),
 				"GOARCH=amd64",
 				"GOOS=linux",
 			},
@@ -358,7 +358,7 @@ var archMap = map[cli.Arch]targetBuilder{
 	cli.LinuxARM64: func(pluginName, outPath string) target {
 		return target{
 			env: []string{
-				"CGO_ENABLED=0",
+				CGOEnabled(),
 				"GOARCH=arm64",
 				"GOOS=linux",
 			},
@@ -625,4 +625,12 @@ func savePluginGroupManifest(plugins []cli.Plugin, artifactsDir, pluginScopeAsso
 	}
 
 	return nil
+}
+
+func CGOEnabled() string {
+	cgoEnabled := os.Getenv("CGO_ENABLED")
+	if cgoEnabled != "" {
+		return fmt.Sprintf("CGO_ENABLED=%s", cgoEnabled)
+	}
+	return "CGO_ENABLED=0"
 }


### PR DESCRIPTION
### What this PR does / why we need it
* It seems like the builder plugin is hard-coding to use `CGO_ENABLED=0` while building a plugin for Linux.
* This change removes the hard-coded configuration which allows plugin developers to pass this as an environment variable as needed.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #418

### Describe testing done for PR

* Build plugins with `CGO_ENABLED=1` and without configuring `CGO_ENABLED`.


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Allow Linux plugins to be built with different `CGO_ENABLED` configurations while building plugins
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
