### PR TITLE
Update the telemetry send metrics timeout

### DIFF
--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -372,7 +372,7 @@ func Execute() error {
 		telemetry.LogError(updateErr, "")
 	} else if saveErr := telemetry.Client().SaveMetrics(); saveErr != nil {
 		telemetry.LogError(saveErr, "")
-	} else if sendErr := telemetry.Client().SendMetrics(context.Background(), 1); sendErr != nil {
+	} else if sendErr := telemetry.Client().SendMetrics(context.Background(), 2); sendErr != nil {
 		telemetry.LogError(sendErr, "")
 	}
 	return executionErr

--- a/pkg/telemetry/client.go
+++ b/pkg/telemetry/client.go
@@ -159,9 +159,9 @@ func (tc *telemetryClient) SendMetrics(ctx context.Context, timeoutInSecs int) e
 		args = append(args, "--timeout", strconv.Itoa(timeoutInSecs))
 	}
 	runner := cli.NewRunner(plugin.Name, plugin.InstallationPath, args)
-	_, _, err = runner.RunOutput(ctx)
+	_, stdErr, err := runner.RunOutput(ctx)
 	if err != nil {
-		return err
+		return errors.Wrap(err, stdErr)
 	}
 	return nil
 }


### PR DESCRIPTION
### What this PR does / why we need it
This PR updates the telemetry send metrics operation timeout from 1 sec to 2 sec
While testing the telemetry on VPN from different country it was observed 1sec timeout is not sufficient to send the metrics to supercollider
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

CI check and unit tests passed
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
