### PR TITLE
Fix the last tag generation in release yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,16 +49,18 @@ jobs:
         if [ "$revision" -gt 0 ];then
           revision=$(($revision-1))
           RELEASE_BRANCH="release-${major}.${minor}"
+          LAST_TAG="v${major}.${minor}.${revision}"
         elif [ "$minor" -gt 0 ]; then
           minor=$(($minor-1))
+          LAST_TAG=$(git tag | grep -E "^v${major}\.${minor}\.[0-9]+$" | tail -1)
         elif [ "$major" -gt 0 ]; then
           major=$(($major-1))
+          LAST_TAG=$(git tag | grep -E "^v${major}\.[0-9]+\.[0-9]+$" | tail -1)
         else
           echo "Please validate that the tag release version(${RELEASE_VERSION}) conforms to semver."
           exit 1
         fi
         git log -3 --format=oneline
-        LAST_TAG="v${major}.${minor}.${revision}"
         echo "Last release tag - $LAST_TAG"
         START_SHA=$(git rev-list -n 1 $LAST_TAG)
         echo "Release note generator start SHA - $START_SHA"


### PR DESCRIPTION
### What this PR does / why we need it

When tagging a major release, the release notes workflow did not work properly.
Example:
tag 1.0.0 would cause a comparison with a release tag of 0.0.0 which did not exist
tag 2.0.0 would cause a comparison with 1.0.0 which would ignore any 1.x.y releases.

This change looks for the last tag of the previous release.
So 1.0.0 would find 0.90.1 since it is our last release.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
