### PR TITLE
Skip downloading essentials plugin group if it's not available

### DIFF
--- a/pkg/airgapped/plugin_bundle_download.go
+++ b/pkg/airgapped/plugin_bundle_download.go
@@ -152,14 +152,18 @@ func (o *DownloadPluginBundleOptions) getSelectedPluginInfo() ([]*plugininventor
 
 		// Add essential plugins
 		name, version := essentials.GetEssentialsPluginGroupDetails()
-		pluginGroupName := name
+		essentialPluginGroup := name
 		if version != "" {
-			pluginGroupName = fmt.Sprintf("%v:%v", pluginGroupName, version)
+			essentialPluginGroup = fmt.Sprintf("%v:%v", essentialPluginGroup, version)
 		}
-		o.Groups = append(o.Groups, pluginGroupName)
+		o.Groups = append(o.Groups, essentialPluginGroup)
 		for _, groupID := range o.Groups {
 			pluginGroups, pluginEntries, err := o.getAllPluginGroupsAndPluginEntriesFromPluginGroupVersion(groupID, pi)
 			if err != nil {
+				// Continue to download rest of the plugin groups if essentials is not available
+				if groupID == essentialPluginGroup {
+					continue
+				}
 				return nil, nil, err
 			}
 			selectedPluginGroups = append(selectedPluginGroups, pluginGroups...)


### PR DESCRIPTION
### What this PR does / why we need it

- `tanzu plugin download-bundle` should continue to download the plugin plugin groups even if essentials plugin group is not available.
- Skip downloading the essentials plugin group if its not found.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

skip downloading essentials pg if not available
```
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (skip_download_essentials_if_not_available)> tanzu plugin download-bundle --to-tar plugin_bundle.tar --group vmware-tkg/default
[i] Getting selected plugin information...
[i] will be downloading the 9 plugins from group: vmware-tkg/default:v2.3.0
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory@sha256:282eefdda68bc06c4608e7ae7362898e21f14a29ba11fd9bc5047273fb89f3cd
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory@sha256:74f3aad6d868a529f7f93430193ee4c34253d3fd21a7675a4cb1e6390f7b74ab
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (152.083µs)
[i] copy | done: file 'sha256-5796aefbe64d75ad76951035c600dc201e543de61c09e91aa2a0707d3303e9b5.tar.gz' (4.384417ms)
[i] copy | done: file 'sha256-fde4ff618bc897b6c2dae528cd05333a64236b2f43f92f413b026e040f954a44.tar.gz' (100.879833ms)
[i] copy | done: file 'sha256-e25347f6f6aa6ede5fe03736092b63e6472430a7bbad85853cfae0eb0686751b.tar.gz' (337.125µs)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tkg/darwin/amd64/kubernetes/cluster:v0.30.0"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tkg/darwin/amd64/kubernetes/cluster@sha256:5ab27ed80d96458979c2853276c7d5dd0168d23eaf6e7f4f9c4cf921b3cf4016
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tkg/darwin/amd64/kubernetes/cluster@sha256:9a8240b4a5703ad612726a7639bac2180c21f80c40ef2a9117ed0678f91a074a
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (24.917µs)
[i] copy | done: file 'sha256-ad0802b7c177149d20d6fa2941d73867fcbe4f770e4471a0cc0da2c8a0f75269.tar.gz' (237.917µs)


```

download essentials pg if available

```
mpanchajanya@mpanchajanF09MK ~ [1]> tanzu plugin download-bundle --image localhost:9876/tanzu-cli/plugins/central:small --to-tar plugin_bundle.tar --group vmware-tkg/default
[!] Skipping the plugins discovery image signature verification for "localhost:9876/tanzu-cli/plugins/central:small"

[i] Getting selected plugin information...
[i] will be downloading the 6 plugins from group: vmware-tkg/default:v9.9.9
[i] will be downloading the one plugin from group: vmware-tanzucli/essentials:v9.9.9
[i] downloading image "localhost:9876/tanzu-cli/plugins/central:small"
[i] copy | exporting 1 images...
[i] copy | will export localhost:9876/tanzu-cli/plugins/central@sha256:15328cdd59a2d05d874de7e5cb110c2c2142a7bef2210ec126cf3156014e6576
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (52.75µs)
[i] copy | done: file 'sha256-98427d24d7808a852c9f7c7a816504310eb7d60a366266f2272156b33bbccda7.tar.gz' (335.083µs)
[i] ---------------------------

```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
