### PR TITLE
Use --local-source to locally installing a plugin

### DIFF
--- a/cmd/plugin/builder/template/plugintemplates/plugin-tooling.mk.tmpl
+++ b/cmd/plugin/builder/template/plugintemplates/plugin-tooling.mk.tmpl
@@ -82,7 +82,8 @@ plugin-build-install-local: plugin-build-local plugin-install-local
 
 .PHONY: plugin-install-local ## Install all plugins from local plugin artifacts directory
 plugin-install-local:
-	tanzu plugin install all --local $(PLUGIN_BINARY_ARTIFACTS_DIR)/$(GOHOSTOS)/$(GOHOSTARCH)
+	@# The `tanzu` CLI >= v1.0.0 is required to use `--local-source` which is replacing the old `--local` flag 
+	tanzu plugin install all --local-source $(PLUGIN_BINARY_ARTIFACTS_DIR)/$(GOHOSTOS)/$(GOHOSTARCH)
 
 .PHONY: plugin-build
 plugin-build: $(PLUGIN_BUILD_TARGETS) generate-plugin-bundle ## Build all plugin binaries for all supported os-arch

--- a/plugin-tooling.mk
+++ b/plugin-tooling.mk
@@ -87,7 +87,7 @@ plugin-build-install-local: plugin-build-local plugin-install-local
 
 .PHONY: plugin-install-local ## Install all plugins from local plugin artifacts directory
 plugin-install-local:
-	tanzu plugin install all --local $(PLUGIN_BINARY_ARTIFACTS_DIR)/$(GOHOSTOS)/$(GOHOSTARCH)
+	tanzu plugin install all --local-source $(PLUGIN_BINARY_ARTIFACTS_DIR)/$(GOHOSTOS)/$(GOHOSTARCH)
 
 .PHONY: plugin-build
 plugin-build: $(PLUGIN_BUILD_TARGETS) generate-plugin-bundle ## Build all plugin binaries for all supported os-arch


### PR DESCRIPTION
### What this PR does / why we need it

The previously used --local flag has been deprecated.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Before this PR:
```
$ cd tanzu-cli
$ export PLUGIN_NAME=builder
$ make plugin-build-install-local
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.0.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-07-28' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=26c97e72f' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev'" \
		--goflags "" \
		--os-arch darwin_amd64 \
		--match "builder" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-07-28T10:30:57-04:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.0.0-dev, [darwin_amd64]
2023-07-28T10:30:57-04:00 [i] 🐼 - building plugin at path "cmd/plugin/builder"
2023-07-28T10:31:02-04:00 [i] 🐼 - $ /usr/local/go/bin/go build -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/amd64/global/builder/v1.0.0-dev/tanzu-builder-darwin_amd64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-07-28' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=26c97e72f' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -tags  ./cmd/plugin/builder
2023-07-28T10:31:04-04:00 [i] ========
2023-07-28T10:31:04-04:00 [i] saving plugin group manifest...
2023-07-28T10:31:04-04:00 [ok] successfully built local repository
tanzu plugin install all --local /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/amd64
Flag --local has been deprecated, this was done in the v1.0.0 release, it will be removed following the deprecation policy (6 months). Use the --local-source flag instead.

[i] Installing plugin 'builder:v1.0.0-dev' with target 'global'
[ok] successfully installed all plugins
```
Notice the "Flag --local has been deprecated" message.

With this PR:
```
$ make plugin-build-install-local
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.0.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-07-28' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=509e46c67' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev'" \
		--goflags "" \
		--os-arch darwin_amd64 \
		--match "builder" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-07-28T10:32:57-04:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.0.0-dev, [darwin_amd64]
2023-07-28T10:32:57-04:00 [i] 🐨 - building plugin at path "cmd/plugin/builder"
2023-07-28T10:33:02-04:00 [i] 🐨 - $ /usr/local/go/bin/go build -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/amd64/global/builder/v1.0.0-dev/tanzu-builder-darwin_amd64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-07-28' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=509e46c67' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -tags  ./cmd/plugin/builder
2023-07-28T10:33:03-04:00 [i] ========
2023-07-28T10:33:03-04:00 [i] saving plugin group manifest...
2023-07-28T10:33:03-04:00 [ok] successfully built local repository
tanzu plugin install all --local-source /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/amd64
[i] Installing plugin 'builder:v1.0.0-dev' with target 'global'
[ok] successfully installed all plugins
```
I have also tested when creating a brand new plugin project.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
