### PR TITLE
Add more logs to k8s discovery logic

### DIFF
--- a/pkg/discovery/kubernetes.go
+++ b/pkg/discovery/kubernetes.go
@@ -46,6 +46,8 @@ func (k *KubernetesDiscovery) Name() string {
 
 // Manifest returns the manifest for a kubernetes repository.
 func (k *KubernetesDiscovery) Manifest() ([]Discovered, error) {
+	log.V(6).Infof("creating kubernetes client with kubeconfig %q, kubecontext %q", k.kubeconfigPath, k.kubecontext)
+
 	// Create cluster client
 	clusterClient, err := cluster.NewClient(k.kubeconfigPath, k.kubecontext, cluster.Options{RequestTimeout: defaultTimeout})
 	if err != nil {
@@ -72,8 +74,11 @@ func (k *KubernetesDiscovery) GetDiscoveredPlugins(clusterClient cluster.Client)
 	// get all cliplugins resources available on the cluster
 	cliplugins, err := clusterClient.ListCLIPluginResources()
 	if err != nil {
+		log.V(4).Infof("error while fetching the list of CLIPlugin resources. %v", err.Error())
 		return nil, err
 	}
+
+	log.V(4).Infof("found %v CLIPlugin resources.", len(cliplugins))
 
 	imageRepositoryOverride, err := clusterClient.GetCLIPluginImageRepositoryOverride()
 	if err != nil {
@@ -86,6 +91,7 @@ func (k *KubernetesDiscovery) GetDiscoveredPlugins(clusterClient cluster.Client)
 		if err != nil {
 			return nil, err
 		}
+		log.V(5).Infof("processing CLIPlugin %q", cliplugins[i].Name)
 		dp.Source = k.name
 		dp.DiscoveryType = k.Type()
 		plugins = append(plugins, dp)


### PR DESCRIPTION
### What this PR does / why we need it

* Add more logs to k8s discovery logic

Once https://github.com/vmware-tanzu/tanzu-plugin-runtime/pull/83 is merged user will be able to configure the logs at the runtime using the `TANZU_CLI_LOG_LEVEL` environment variable and will able to see additional debug logs added as part of this PR.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
* Tested along with  https://github.com/vmware-tanzu/tanzu-plugin-runtime/pull/83

```
~ $ kind create cluster --name test-cluster

~ $ tanzu context create kind --kubeconfig /Users/anujc/.kube/config --kubecontext kind-test-cluster
```

```
~ $ export TANZU_CLI_LOG_LEVEL=8

~ $ tz plugin list
[i] creating kubernetes client with kubeconfig "/Users/anujc/.kube/config", kubecontext "kind-test-cluster"
[i] Skipping context-aware plugin discovery because CLIPlugin CRD not present on the logged in cluster.
Standalone Plugins
  NAME           DESCRIPTION                                                        TARGET  VERSION  STATUS
  pinniped-auth  Pinniped authentication operations (usually not directly invoked)  global  v0.28.0  installed
  telemetry      configure cluster-wide settings for vmware tanzu telemetry         global  v2.0.0   installed
```
```  
~ $ kubectl apply -f /Users/anujc/Documents/code/tanzu-cli/apis/config/crd/bases/cli.tanzu.vmware.com_cliplugins.yaml
customresourcedefinition.apiextensions.k8s.io/cliplugins.cli.tanzu.vmware.com created

~ $ tz plugin list
[i] creating kubernetes client with kubeconfig "/Users/anujc/.kube/config", kubecontext "kind-test-cluster"
[i] found 0 CLIPlugin resources.
Standalone Plugins
  NAME           DESCRIPTION                                                        TARGET  VERSION  STATUS
  pinniped-auth  Pinniped authentication operations (usually not directly invoked)  global  v0.28.0  installed
  telemetry      configure cluster-wide settings for vmware tanzu telemetry         global  v2.0.0   installed
```

```
~ $ kubectl apply -f 0.25-plugin-cr.yaml
cliplugin.cli.tanzu.vmware.com/cluster created
cliplugin.cli.tanzu.vmware.com/feature created

~ $ tz plugin list
[i] creating kubernetes client with kubeconfig "/Users/anujc/.kube/config", kubecontext "kind-test-cluster"
[i] found 2 CLIPlugin resources.
[i] processing CLIPlugin "cluster"
[i] processing CLIPlugin "feature"
Standalone Plugins
  NAME           DESCRIPTION                                                        TARGET  VERSION  STATUS
  pinniped-auth  Pinniped authentication operations (usually not directly invoked)  global  v0.28.0  installed
  telemetry      configure cluster-wide settings for vmware tanzu telemetry         global  v2.0.0   installed

Plugins from Context:  kind
  NAME     DESCRIPTION                    TARGET      VERSION  STATUS
  cluster  Cluster Plugin For Kubernetes  kubernetes  v0.25    not installed
  feature  Feature Plugin For Kubernetes  kubernetes  v0.25    not installed

[!] As shown above, some recommended plugins have not been installed or are outdated. To install them please run 'tanzu plugin sync'.
```

```
~ $ export TANZU_CLI_LOG_LEVEL=
~ $ tz plugin list
Standalone Plugins
  NAME           DESCRIPTION                                                        TARGET  VERSION  STATUS
  pinniped-auth  Pinniped authentication operations (usually not directly invoked)  global  v0.28.0  installed
  telemetry      configure cluster-wide settings for vmware tanzu telemetry         global  v2.0.0   installed
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
None
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
