### PR TITLE
Improve error message for the 'all' keyword for `plugin install`

### DIFF
--- a/pkg/command/plugin.go
+++ b/pkg/command/plugin.go
@@ -229,6 +229,7 @@ func newDescribePluginCmd() *cobra.Command {
 	return describeCmd
 }
 
+// nolint: gocyclo
 func newInstallPluginCmd() *cobra.Command {
 	var installCmd = &cobra.Command{
 		Use:   "install [" + pluginNameCaps + "]",
@@ -241,7 +242,6 @@ func newInstallPluginCmd() *cobra.Command {
 			if !configtypes.IsValidTarget(targetStr, true, true) {
 				return errors.New(invalidTargetMsg)
 			}
-
 			if config.IsFeatureActivated(constants.FeatureDisableCentralRepositoryForTesting) {
 				return legacyPluginInstall(cmd, args)
 			}
@@ -269,13 +269,13 @@ func newInstallPluginCmd() *cobra.Command {
 				return nil
 			}
 
-			if len(args) == 0 {
-				return fmt.Errorf("missing plugin name or '%s' as an argument, or the use of '--group'", cli.AllPlugins)
-			}
-			pluginName = args[0]
-
 			// Invoke install plugin from local source if local files are provided
 			if local != "" {
+				if len(args) == 0 {
+					return fmt.Errorf("missing plugin name or '%s' as an argument", cli.AllPlugins)
+				}
+				pluginName = args[0]
+
 				// get absolute local path
 				local, err = filepath.Abs(local)
 				if err != nil {
@@ -293,9 +293,13 @@ func newInstallPluginCmd() *cobra.Command {
 				return nil
 			}
 
+			if len(args) == 0 {
+				return errors.New("missing plugin name as an argument or the use of '--group'")
+			}
+			pluginName = args[0]
+
 			if pluginName == cli.AllPlugins {
-				return fmt.Errorf("the '%s' argument can only be used with the --group or --local flags",
-					cli.AllPlugins)
+				return fmt.Errorf("the '%s' argument can only be used with the '--group' flag", cli.AllPlugins)
 			}
 
 			pluginVersion := version

--- a/pkg/command/plugin_test.go
+++ b/pkg/command/plugin_test.go
@@ -324,18 +324,18 @@ func TestInstallPlugin(t *testing.T) {
 			expectedErrorMsg:    "missing plugin name or 'all' as an argument",
 		},
 		{
-			test:                "need plugin name or 'all' if no group",
+			test:                "need plugin name if no group",
 			centralRepoDisabled: "false",
 			args:                []string{"plugin", "install"},
 			expectedFailure:     true,
-			expectedErrorMsg:    "missing plugin name or 'all' as an argument",
+			expectedErrorMsg:    "missing plugin name as an argument",
 		},
 		{
 			test:                "no 'all' option",
 			centralRepoDisabled: "false",
 			args:                []string{"plugin", "install", "all"},
 			expectedFailure:     true,
-			expectedErrorMsg:    "the 'all' argument can only be used with the --group or --local flags",
+			expectedErrorMsg:    "the 'all' argument can only be used with the '--group' flag",
 		},
 		{
 			test:                "invalid target",


### PR DESCRIPTION
### What this PR does / why we need it

1. the --local flag should not be mentioned unless it is being used since this flag is hidden (also it has been deprecated in favour of `--local-source`
2. the previous error message gave the impression that 'all' could be used without '--group' which is not the case

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #439 

### Describe testing done for PR

```
# 'all' is not mentioned anymore
$ tz plugin install
[x] : missing plugin name as an argument or the use of '--group'

$ tz plugin install all
[x] : the 'all' argument can only be used with the '--group' flag

# With --local-source, the user can use the 'all' keyword
$ tz plugin install --local-source artifacts/plugins/darwin/amd64
[x] : missing plugin name or 'all' as an argument
```

Regression tests:
```
$ tz plugin install telemetry
[x] : unable to uniquely identify plugin 'telemetry'. Please specify the target (kubernetes[k8s]/mission-control[tmc]/global) of the plugin using the `--target` flag
$ tz plugin install telemetry --target global
[i] Installing plugin 'telemetry:v9.9.9' with target 'global'
[i] Plugin binary for 'telemetry:v9.9.9' found in cache
[ok] successfully installed 'telemetry' plugin

# As before, no arg needed when using a group
$ tz plugin install --group vmware-tkg/default
[i] Installing plugin 'cluster:v9.9.9' with target 'kubernetes'
[i] Plugin binary for 'cluster:v9.9.9' found in cache
[i] Installing plugin 'feature:v9.9.9' with target 'kubernetes'
[i] Installing plugin 'kubernetes-release:v9.9.9' with target 'kubernetes'
[i] Installing plugin 'management-cluster:v9.9.9' with target 'kubernetes'
[i] Installing plugin 'package:v9.9.9' with target 'kubernetes'
[i] Installing plugin 'secret:v9.9.9' with target 'kubernetes'
[ok] successfully installed all plugins from group 'vmware-tkg/default:v9.9.9'

# As before 'all' is accepted when using a group
$ tz plugin install --group vmware-tkg/default all
[i] Installing plugin 'cluster:v9.9.9' with target 'kubernetes'
[i] Plugin binary for 'cluster:v9.9.9' found in cache
[i] Installing plugin 'feature:v9.9.9' with target 'kubernetes'
[i] Plugin binary for 'feature:v9.9.9' found in cache
[i] Installing plugin 'kubernetes-release:v9.9.9' with target 'kubernetes'
[i] Plugin binary for 'kubernetes-release:v9.9.9' found in cache
[i] Installing plugin 'management-cluster:v9.9.9' with target 'kubernetes'
[i] Plugin binary for 'management-cluster:v9.9.9' found in cache
[i] Installing plugin 'package:v9.9.9' with target 'kubernetes'
[i] Plugin binary for 'package:v9.9.9' found in cache
[i] Installing plugin 'secret:v9.9.9' with target 'kubernetes'
[i] Plugin binary for 'secret:v9.9.9' found in cache
[ok] successfully installed all plugins from group 'vmware-tkg/default:v9.9.9'

# As before, a single plugin can be specified with --group
$ tz plugin install --group vmware-tkg/default secret
[i] Installing plugin 'secret:v9.9.9' with target 'kubernetes'
[i] Plugin binary for 'secret:v9.9.9' found in cache
[ok] successfully installed 'secret' from group 'vmware-tkg/default:v9.9.9'

# As before, only one plugin can be specified
$ tz plugin install --group vmware-tkg/default secret package
[x] : accepts at most 1 arg(s), received 2

# Only one plugin installed
$ tz plugin install --local-source artifacts/plugins/darwin/amd64 builder
[i] Installing plugin 'builder:v1.0.0-dev' with target 'global'
[ok] successfully installed 'builder' plugin

# All plugins installed
$ tz plugin install --local-source artifacts/plugins/darwin/amd64 all
[i] Installing plugin 'builder:v1.0.0-dev' with target 'global'
[i] Installing plugin 'test:v1.0.0-dev' with target 'global'
[ok] successfully installed all plugins

```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Improve error message for `tanzu plugin install`
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
