### PR TITLE
Add ARM64 to the CLI builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ CHOCO_IMAGE=$(CHOCO_BUILDER_IMAGE)
 endif
 
 # Add supported OS-ARCHITECTURE combinations here
-ENVS ?= linux-amd64 windows-amd64 darwin-amd64
+ENVS ?= linux-amd64 windows-amd64 darwin-amd64 linux-arm64 darwin-arm64
 
 CLI_TARGETS := $(addprefix build-cli-,${ENVS})
 


### PR DESCRIPTION
### What this PR does / why we need it

This PR adds ARM64 as a target for Linux and Darwin for the actual CLI binary.
Related to #367.

An ARM64 CLI currently can only install ARM64 plugins, of which none are published.  For this reason, amongst others,
the ARM64 build of the CLI would remain experimental for the moment.  It is however valuable to have it available to allow testing ARM64 plugins locally as will be needed with #367.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Part of #357

### Describe testing done for PR

```
$ make cross-build
build linux-amd64 CLI with version: v1.0.0-dev
build windows-amd64 CLI with version: v1.0.0-dev
build darwin-amd64 CLI with version: v1.0.0-dev
build linux-arm64 CLI with version: v1.0.0-dev
build darwin-arm64 CLI with version: v1.0.0-dev
cd cmd/plugin/builder && go build -o /Users/kmarc/git/tanzu-cli/bin/builder .
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.0.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-02' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=b6a743c60' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev'" \
		--goflags "" \
		--os-arch linux_amd64 \
		--match "builder" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-08-01T22:35:34-04:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.0.0-dev, [linux_amd64]
2023-08-01T22:35:34-04:00 [i] 🐯 - building plugin at path "cmd/plugin/builder"
2023-08-01T22:35:37-04:00 [i] 🐯 - $ /Users/kmarc/.asdf/shims/go build -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/linux/amd64/global/builder/v1.0.0-dev/tanzu-builder-linux_amd64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-02' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=b6a743c60' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -tags  ./cmd/plugin/builder
2023-08-01T22:35:39-04:00 [i] ========
2023-08-01T22:35:39-04:00 [i] saving plugin group manifest...
2023-08-01T22:35:39-04:00 [ok] successfully built local repository
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.0.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-02' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=b6a743c60' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev'" \
		--goflags "" \
		--os-arch windows_amd64 \
		--match "builder" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-08-01T22:35:39-04:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.0.0-dev, [windows_amd64]
2023-08-01T22:35:39-04:00 [i] 🐯 - building plugin at path "cmd/plugin/builder"
2023-08-01T22:35:41-04:00 [i] 🐯 - $ /Users/kmarc/.asdf/shims/go build -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/windows/amd64/global/builder/v1.0.0-dev/tanzu-builder-windows_amd64.exe -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-02' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=b6a743c60' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -tags  ./cmd/plugin/builder
2023-08-01T22:35:44-04:00 [i] ========
2023-08-01T22:35:44-04:00 [i] saving plugin group manifest...
2023-08-01T22:35:44-04:00 [ok] successfully built local repository
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.0.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-02' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=b6a743c60' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev'" \
		--goflags "" \
		--os-arch darwin_amd64 \
		--match "builder" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-08-01T22:35:44-04:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.0.0-dev, [darwin_amd64]
2023-08-01T22:35:44-04:00 [i] 🐶 - building plugin at path "cmd/plugin/builder"
2023-08-01T22:35:46-04:00 [i] 🐶 - $ /Users/kmarc/.asdf/shims/go build -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/amd64/global/builder/v1.0.0-dev/tanzu-builder-darwin_amd64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-08-02' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=b6a743c60' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.0.0-dev' -tags  ./cmd/plugin/builder
2023-08-01T22:35:49-04:00 [i] ========
2023-08-01T22:35:49-04:00 [i] saving plugin group manifest...
2023-08-01T22:35:49-04:00 [ok] successfully built local repository
cd /Users/kmarc/git/tanzu-cli/artifacts/plugins && tar -czvf ../plugin_bundle.tar.gz .
a .
a ./plugin_group_manifest.yaml
a ./plugin_manifest.yaml
a ./linux
a ./darwin
a ./windows
a ./windows/amd64
a ./windows/amd64/plugin_manifest.yaml
a ./windows/amd64/global
a ./windows/amd64/global/builder
a ./windows/amd64/global/builder/v1.0.0-dev
a ./windows/amd64/global/builder/v1.0.0-dev/tanzu-builder-windows_amd64.exe
a ./darwin/amd64
a ./darwin/amd64/plugin_manifest.yaml
a ./darwin/amd64/global
a ./darwin/amd64/global/builder
a ./darwin/amd64/global/builder/v1.0.0-dev
a ./darwin/amd64/global/builder/v1.0.0-dev/tanzu-builder-darwin_amd64
a ./linux/amd64
a ./linux/amd64/plugin_manifest.yaml
a ./linux/amd64/global
a ./linux/amd64/global/builder
a ./linux/amd64/global/builder/v1.0.0-dev
a ./linux/amd64/global/builder/v1.0.0-dev/tanzu-builder-linux_amd64

$ file artifacts/darwin/arm64/cli/core/v1.0.0-dev/tanzu-cli-darwin_arm64
artifacts/darwin/arm64/cli/core/v1.0.0-dev/tanzu-cli-darwin_arm64: Mach-O 64-bit executable arm64

$ file artifacts/darwin/arm64/cli/core/v1.0.0-dev/tanzu-cli-darwin_arm64
artifacts/darwin/arm64/cli/core/v1.0.0-dev/tanzu-cli-darwin_arm64: Mach-O 64-bit executable arm64

# Note there is no more warning about building for darwin arm64
$ make build
build darwin-arm64 CLI with version: v1.0.0-dev
mkdir -p bin
cp /Users/kmarc/git/tanzu-cli/artifacts/darwin/arm64/cli/core/v1.0.0-dev/tanzu-cli-darwin_arm64 ./bin/tanzu
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Build the Tanzu CLI for linux-arm64 and darwin-arm64.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
