### PR TITLE
Merge plugin manifest automatically when building individual plugins with the `builder` plugin

### DIFF
--- a/cmd/plugin/builder/command/cli_compile.go
+++ b/cmd/plugin/builder/command/cli_compile.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -549,8 +550,9 @@ func savePluginManifest(manifest cli.Manifest, artifactsDir string, groupByOSArc
 	log.Info("saving plugin manifest...")
 
 	if groupByOSArch {
+		pluginBundleOverwrite, _ := strconv.ParseBool(os.Getenv("PLUGIN_BUNDLE_OVERWRITE"))
 		existingManifest, err := helpers.ReadPluginManifest(filepath.Join(artifactsDir, cli.PluginManifestFileName))
-		if err == nil {
+		if err == nil && !pluginBundleOverwrite {
 			// Since a manifest already exists, merge it with the newly generated manifest.
 			// Note that we are appending the existing manifest to the generated one
 			// which gives the generated one priority if there is already an existing plugin with

--- a/cmd/plugin/builder/command/cli_compile.go
+++ b/cmd/plugin/builder/command/cli_compile.go
@@ -546,12 +546,22 @@ func getPluginTarget(pd *rtplugin.PluginDescriptor, pluginPath, id string) (stri
 }
 
 func savePluginManifest(manifest cli.Manifest, artifactsDir string, groupByOSArch bool) error {
-	b, err := yaml.Marshal(manifest)
-	if err != nil {
-		return err
-	}
+	log.Info("saving plugin manifest...")
 
 	if groupByOSArch {
+		existingManifest, err := helpers.ReadPluginManifest(filepath.Join(artifactsDir, cli.PluginManifestFileName))
+		if err == nil {
+			// Since a manifest already exists, merge it with the newly generated manifest.
+			// Note that we are appending the existing manifest to the generated one
+			// which gives the generated one priority if there is already an existing plugin with
+			// a different version.
+			manifest = mergePluginManifest(manifest, *existingManifest)
+		}
+		b, err := yaml.Marshal(manifest)
+		if err != nil {
+			return err
+		}
+
 		arrTargetArch := getBuildArch(targetArch)
 		arrTargetArch = append(arrTargetArch, "")
 		for _, osarch := range arrTargetArch {
@@ -562,10 +572,37 @@ func savePluginManifest(manifest cli.Manifest, artifactsDir string, groupByOSArc
 			}
 		}
 	} else {
+		b, err := yaml.Marshal(manifest)
+		if err != nil {
+			return err
+		}
 		manifestPath := filepath.Join(artifactsDir, cli.ManifestFileName)
 		err = os.WriteFile(manifestPath, b, 0644)
 		if err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// mergePluginManifest merges 'incomingManifest' into 'baseManifest' giving 'baseManifest'
+// higher precedence in case of overlaps.
+func mergePluginManifest(baseManifest, incomingManifest cli.Manifest) cli.Manifest {
+	mergedManifest := baseManifest
+	for _, p := range incomingManifest.Plugins {
+		// if plugin not found in base manifest append
+		if findpluginInManifest(baseManifest, p) == nil {
+			mergedManifest.Plugins = append(mergedManifest.Plugins, p)
+		}
+	}
+	return mergedManifest
+}
+
+// findpluginInManifest checks if the plugin already specified in the manifest or not
+func findpluginInManifest(manifest cli.Manifest, plugin cli.Plugin) *cli.Plugin {
+	for _, p := range manifest.Plugins {
+		if p.Name == plugin.Name && p.Target == plugin.Target {
+			return &p
 		}
 	}
 	return nil

--- a/cmd/plugin/builder/command/cli_compile_test.go
+++ b/cmd/plugin/builder/command/cli_compile_test.go
@@ -1,0 +1,96 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package command
+
+import (
+	"testing"
+
+	"github.com/tj/assert"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
+)
+
+func TestMergePluginManifest(t *testing.T) {
+	assert := assert.New(t)
+
+	baseManifest := cli.Manifest{
+		Plugins: []cli.Plugin{
+			cli.Plugin{
+				Name:        "plugin1",
+				Target:      "target-foo",
+				Description: "desc-1-foo",
+				Versions:    []string{"v1.1.1"},
+			},
+			cli.Plugin{
+				Name:        "plugin2",
+				Target:      "target-foo",
+				Description: "desc-2-foo",
+				Versions:    []string{"v4.0.0"},
+			},
+			cli.Plugin{
+				Name:        "plugin3",
+				Target:      "target-baz",
+				Description: "desc-3",
+				Versions:    []string{"v3.0.0"},
+			},
+		},
+	}
+
+	incomingManifest := cli.Manifest{
+		Plugins: []cli.Plugin{
+			cli.Plugin{
+				Name:        "plugin1",
+				Target:      "target-foo",
+				Description: "desc-1-foo",
+				Versions:    []string{"v1.0.0"},
+			},
+			cli.Plugin{
+				Name:        "plugin2",
+				Target:      "target-bar",
+				Description: "desc-2",
+				Versions:    []string{"v2.0.0"},
+			},
+		},
+	}
+
+	expectedMergedManifest := cli.Manifest{
+		Plugins: []cli.Plugin{
+			cli.Plugin{
+				Name:        "plugin1",
+				Target:      "target-foo",
+				Description: "desc-1-foo",
+				Versions:    []string{"v1.1.1"},
+			},
+			cli.Plugin{
+				Name:        "plugin3",
+				Target:      "target-baz",
+				Description: "desc-3",
+				Versions:    []string{"v3.0.0"},
+			},
+			cli.Plugin{
+				Name:        "plugin2",
+				Target:      "target-foo",
+				Description: "desc-2-foo",
+				Versions:    []string{"v4.0.0"},
+			},
+			cli.Plugin{
+				Name:        "plugin2",
+				Target:      "target-bar",
+				Description: "desc-2",
+				Versions:    []string{"v2.0.0"},
+			},
+		},
+	}
+
+	mergedManifest := mergePluginManifest(baseManifest, incomingManifest)
+
+	for _, plugin := range expectedMergedManifest.Plugins {
+		foundPlugin := findpluginInManifest(mergedManifest, plugin)
+		assert.NotNil(foundPlugin, "expected plugin:%v, target:%v not found", plugin.Name, plugin.Target)
+		assert.Equal(foundPlugin.Name, plugin.Name)
+		assert.Equal(foundPlugin.Target, plugin.Target)
+		assert.Equal(foundPlugin.Description, plugin.Description)
+		assert.Equal(foundPlugin.Versions, plugin.Versions)
+	}
+}

--- a/docs/plugindev/README.md
+++ b/docs/plugindev/README.md
@@ -210,7 +210,7 @@ make plugin-build PLUGIN_NAME="baz" PLUGIN_BUILD_VERSION=v3.0.0
 ```
 
 **Note:** Because the builder plugin will automatically create merged plugin bundle if the `plugin_manifest.yaml` already exists,
-To remove all the already built plugins and start from fresh, please remove the artifacts directly by running `rm -rf ./artifacts`.
+For each new plugin build to replace any previous available bundle and start fresh, please configure the environment variable `PLUGIN_BUNDLE_OVERWRITE=true`
 
 The next steps are to write the plugin code to implement what the plugin is meant to do.
 

--- a/docs/plugindev/README.md
+++ b/docs/plugindev/README.md
@@ -147,7 +147,7 @@ the plugins. These capabilities are most easily accessed through Makefile
 targets already set up for the same purposes. All plugin-related tooling has been
 added using the `plugin-tooling.mk` file.
 
-#### Build the plugin binary
+#### Build the plugin binary for local install
 
 ```sh
 # Building all plugins within the repository
@@ -180,6 +180,37 @@ Your plugin is now available for you through the Tanzu CLI. You can confirm
 this by running `tanzu plugin list` which will now show your plugin.
 
 Plugins are installed into `$XDG_DATA_HOME`, (read more about the XDG Base Directory Specification [here.](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+
+#### Build the plugin binary for publishing
+
+```sh
+# Building all plugins within the repository for all required os-arch combination
+make plugin-build
+
+# Building only a single plugin for all required os-arch combination
+make plugin-build PLUGIN_NAME="<plugin-name>"
+
+# Building multiple plugins at a time for all required os-arch combination
+make plugin-build PLUGIN_NAME="{plugin-name-1,plugin-name-2}"
+```
+
+The `builder` plugin v1.0.0 or greater, supports generating the correct `plugin_manifest.yaml` and
+`plugin_bundle.tar.gz` when the user runs `make plugin-build PLUGIN_NAME="<plugin-name>"` individually
+multiple times to build different plugins possibly with different plugin versions. For example:
+
+```sh
+# Build `foo`. This will generate `plugin_bundle.tar.gz` containing just `foo:v1.0.0` plugin
+make plugin-build PLUGIN_NAME="foo" PLUGIN_BUILD_VERSION=v1.0.0
+
+# Build `bar`. This will generate `plugin_bundle.tar.gz` containing `foo:v1.0.0` and `bar:v2.0.0`
+make plugin-build PLUGIN_NAME="bar" PLUGIN_BUILD_VERSION=v2.0.0
+
+# Build `baz`. This will generate `plugin_bundle.tar.gz` containing `foo:v1.0.0`, `bar:v2.0.0`, `baz:v3.0.0`
+make plugin-build PLUGIN_NAME="baz" PLUGIN_BUILD_VERSION=v3.0.0
+```
+
+**Note:** Because the builder plugin will automatically create merged plugin bundle if the `plugin_manifest.yaml` already exists,
+To remove all the already built plugins and start from fresh, please remove the artifacts directly by running `rm -rf ./artifacts`.
 
 The next steps are to write the plugin code to implement what the plugin is meant to do.
 


### PR DESCRIPTION
### What this PR does / why we need it
* Merge `plugin_manifest.yaml` automatically when building individual plugins with the `builder` plugin

* The `builder` plugin v1.0.0 or greater, supports generating the correct `plugin_manifest.yaml` and
`plugin_bundle.tar.gz` when the user runs `make plugin-build PLUGIN_NAME="<plugin-name>"` individually
multiple times to build different plugins possibly with different plugin versions. For example:

```sh
# Build `foo`. This will generate `plugin_bundle.tar.gz` containing just `foo:v1.0.0` plugin
make plugin-build PLUGIN_NAME="foo" PLUGIN_BUILD_VERSION=v1.0.0

# Build `bar`. This will generate `plugin_bundle.tar.gz` containing `foo:v1.0.0` and `bar:v2.0.0`
make plugin-build PLUGIN_NAME="bar" PLUGIN_BUILD_VERSION=v2.0.0

# Build `baz`. This will generate `plugin_bundle.tar.gz` containing `foo:v1.0.0`, `bar:v2.0.0`, `baz:v3.0.0`
make plugin-build PLUGIN_NAME="baz" PLUGIN_BUILD_VERSION=v3.0.0
```

**Note:** Because the builder plugin will automatically create merged plugin bundle if the `plugin_manifest.yaml` already exists,
To remove all the already built plugins and start from fresh, please configure environment variable `PLUGIN_BUNDLE_OVERWRITE=true`.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
```
$ make prepare-builder
cd cmd/plugin/builder && go build -o /Users/anujc/Documents/code/tanzu-cli/bin/builder .
$ rm -rf artifacts/
$ $ git describe --tags 
v1.0.0-dev-37-g569df492
```

* Build just the `builder` plugin and notice the plugin manifest file contains only the `builder` plugin with the correct version
```
$ make plugin-build PLUGIN_NAME=builder
.
.
$ cat artifacts/plugins/plugin_manifest.yaml
created: 2023-08-01T23:39:14.758537-07:00
plugins:
    - name: builder
      target: global
      description: Build Tanzu components
      versions:
        - v1.0.0-dev
```

* Now, build just `test` plugin and notice that `test` plugin gets added to the plugin_manifest file along with `builder`
```
$ make plugin-build PLUGIN_NAME=test
.
.
$ cat artifacts/plugins/plugin_manifest.yaml
created: 2023-08-01T23:41:02.373134-07:00
plugins:
    - name: test
      target: global
      description: Test the CLI
      versions:
        - v1.0.0-dev
    - name: builder
      target: global
      description: Build Tanzu components
      versions:
        - v1.0.0-dev
```

* Now, force CLI to build plugins with version `v2.0.0` and build only `builder` plugin and notice that `builder` plugin version in plugin_manifest gets updated
```
$ export PLUGIN_BUILD_VERSION=v2.0.0
$ make plugin-build PLUGIN_NAME=builder
.
.
$ cat artifacts/plugins/plugin_manifest.yaml
created: 2023-08-01T23:42:39.901108-07:00
plugins:
    - name: builder
      target: global
      description: Build Tanzu components
      versions:
        - v2.0.0
    - name: test
      target: global
      description: Test the CLI
      versions:
        - v1.0.0-dev
```

* While keeping the `PLUGIN_BUILD_VERSION=v2.0.0` run make a target to build all plugins and notice both the plugin entry is updated in plugin_manifest with version v2.0.0
```
$ make plugin-build
.
.
$ cat artifacts/plugins/plugin_manifest.yaml
created: 2023-08-01T23:43:49.704985-07:00
plugins:
    - name: builder
      target: global
      description: Build Tanzu components
      versions:
        - v2.0.0
    - name: test
      target: global
      description: Test the CLI
      versions:
        - v2.0.0
```

* Run the `make plugin-build` again after upsetting the `PLUGIN_BUILD_VERSION` and verify plugin_manifest gets updated again with the right plugin versions.

```
# Unset PLUGIN_BUILD_VERSION so CLI uses the default git tag
$ make plugin-build
.
.
$ cat artifacts/plugins/plugin_manifest.yaml
created: 2023-08-01T23:45:08.591372-07:00
plugins:
    - name: builder
      target: global
      description: Build Tanzu components
      versions:
        - v1.0.0-dev
    - name: test
      target: global
      description: Test the CLI
      versions:
        - v1.0.0-dev
```

* Use `PLUGIN_BUNDLE_OVERWRITE` to overwrite the plugin bundle and manifest file.
```
$ make plugin-build PLUGIN_NAME=builder PLUGIN_BUNDLE_OVERWRITE=true
.
.
$ cat artifacts/plugins/plugin_manifest.yaml
created: 2023-08-02T11:35:49.47775-07:00
plugins:
    - name: builder
      target: global
      description: Build Tanzu components
      versions:
        - v1.0.0-dev
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Merge `plugin_manifest.yaml` automatically when building individual plugins with the `builder` plugin
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
