### PR TITLE
[Release-1.0] Merge plugin manifest automatically when building individual plugins with the `builder` plugin

### DIFF
--- a/cmd/plugin/builder/command/cli_compile_test.go
+++ b/cmd/plugin/builder/command/cli_compile_test.go
@@ -1,0 +1,96 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package command
+
+import (
+	"testing"
+
+	"github.com/tj/assert"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
+)
+
+func TestMergePluginManifest(t *testing.T) {
+	assert := assert.New(t)
+
+	baseManifest := cli.Manifest{
+		Plugins: []cli.Plugin{
+			cli.Plugin{
+				Name:        "plugin1",
+				Target:      "target-foo",
+				Description: "desc-1-foo",
+				Versions:    []string{"v1.1.1"},
+			},
+			cli.Plugin{
+				Name:        "plugin2",
+				Target:      "target-foo",
+				Description: "desc-2-foo",
+				Versions:    []string{"v4.0.0"},
+			},
+			cli.Plugin{
+				Name:        "plugin3",
+				Target:      "target-baz",
+				Description: "desc-3",
+				Versions:    []string{"v3.0.0"},
+			},
+		},
+	}
+
+	incomingManifest := cli.Manifest{
+		Plugins: []cli.Plugin{
+			cli.Plugin{
+				Name:        "plugin1",
+				Target:      "target-foo",
+				Description: "desc-1-foo",
+				Versions:    []string{"v1.0.0"},
+			},
+			cli.Plugin{
+				Name:        "plugin2",
+				Target:      "target-bar",
+				Description: "desc-2",
+				Versions:    []string{"v2.0.0"},
+			},
+		},
+	}
+
+	expectedMergedManifest := cli.Manifest{
+		Plugins: []cli.Plugin{
+			cli.Plugin{
+				Name:        "plugin1",
+				Target:      "target-foo",
+				Description: "desc-1-foo",
+				Versions:    []string{"v1.1.1"},
+			},
+			cli.Plugin{
+				Name:        "plugin3",
+				Target:      "target-baz",
+				Description: "desc-3",
+				Versions:    []string{"v3.0.0"},
+			},
+			cli.Plugin{
+				Name:        "plugin2",
+				Target:      "target-foo",
+				Description: "desc-2-foo",
+				Versions:    []string{"v4.0.0"},
+			},
+			cli.Plugin{
+				Name:        "plugin2",
+				Target:      "target-bar",
+				Description: "desc-2",
+				Versions:    []string{"v2.0.0"},
+			},
+		},
+	}
+
+	mergedManifest := mergePluginManifest(baseManifest, incomingManifest)
+
+	for _, plugin := range expectedMergedManifest.Plugins {
+		foundPlugin := findpluginInManifest(mergedManifest, plugin)
+		assert.NotNil(foundPlugin, "expected plugin:%v, target:%v not found", plugin.Name, plugin.Target)
+		assert.Equal(foundPlugin.Name, plugin.Name)
+		assert.Equal(foundPlugin.Target, plugin.Target)
+		assert.Equal(foundPlugin.Description, plugin.Description)
+		assert.Equal(foundPlugin.Versions, plugin.Versions)
+	}
+}

--- a/docs/plugindev/README.md
+++ b/docs/plugindev/README.md
@@ -147,7 +147,7 @@ the plugins. These capabilities are most easily accessed through Makefile
 targets already set up for the same purposes. All plugin-related tooling has been
 added using the `plugin-tooling.mk` file.
 
-#### Build the plugin binary
+#### Build the plugin binary for local install
 
 ```sh
 # Building all plugins within the repository
@@ -180,6 +180,37 @@ Your plugin is now available for you through the Tanzu CLI. You can confirm
 this by running `tanzu plugin list` which will now show your plugin.
 
 Plugins are installed into `$XDG_DATA_HOME`, (read more about the XDG Base Directory Specification [here.](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+
+#### Build the plugin binary for publishing
+
+```sh
+# Building all plugins within the repository for all required os-arch combination
+make plugin-build
+
+# Building only a single plugin for all required os-arch combination
+make plugin-build PLUGIN_NAME="<plugin-name>"
+
+# Building multiple plugins at a time for all required os-arch combination
+make plugin-build PLUGIN_NAME="{plugin-name-1,plugin-name-2}"
+```
+
+The `builder` plugin v1.0.0 or greater, supports generating the correct `plugin_manifest.yaml` and
+`plugin_bundle.tar.gz` when the user runs `make plugin-build PLUGIN_NAME="<plugin-name>"` individually
+multiple times to build different plugins possibly with different plugin versions. For example:
+
+```sh
+# Build `foo`. This will generate `plugin_bundle.tar.gz` containing just `foo:v1.0.0` plugin
+make plugin-build PLUGIN_NAME="foo" PLUGIN_BUILD_VERSION=v1.0.0
+
+# Build `bar`. This will generate `plugin_bundle.tar.gz` containing `foo:v1.0.0` and `bar:v2.0.0`
+make plugin-build PLUGIN_NAME="bar" PLUGIN_BUILD_VERSION=v2.0.0
+
+# Build `baz`. This will generate `plugin_bundle.tar.gz` containing `foo:v1.0.0`, `bar:v2.0.0`, `baz:v3.0.0`
+make plugin-build PLUGIN_NAME="baz" PLUGIN_BUILD_VERSION=v3.0.0
+```
+
+**Note:** Because the builder plugin will automatically create merged plugin bundle if the `plugin_manifest.yaml` already exists,
+For each new plugin build to replace any previous available bundle and start fresh, please configure the environment variable `PLUGIN_BUNDLE_OVERWRITE=true`
 
 The next steps are to write the plugin code to implement what the plugin is meant to do.
 


### PR DESCRIPTION
### What this PR does / why we need it

Cherrypick: https://github.com/vmware-tanzu/tanzu-cli/pull/454


* Merge plugin manifest automatically when building individual plugins

* Expose PLUGIN_BUNDLE_OVERWRITE to forcefully overwrite the plugin_manifest in PluginBundle

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Merge `plugin_manifest.yaml` automatically when building individual plugins with the `builder` plugin
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
