### PR TITLE
Remove unsupported code "discovery_source.go" and increase test coverage

### DIFF
--- a/pkg/command/discovery_source_test.go
+++ b/pkg/command/discovery_source_test.go
@@ -7,134 +7,388 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/config"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
+	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
+	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
 
 func Test_createDiscoverySource(t *testing.T) {
 	assert := assert.New(t)
 
-	common.DefaultLocalPluginDistroDir = "../pluginmanager/test/local/"
-
 	// When discovery source name is empty
-	_, err := createDiscoverySource("LOCAL", "", "fake/path")
+	_, err := createDiscoverySource("", "fake/path")
 	assert.NotNil(err)
 	assert.Equal(err.Error(), "discovery source name cannot be empty")
 
-	// When discovery source type is empty
-	_, err = createDiscoverySource("", "fake-discovery-name", "fake/path")
-	assert.NotNil(err)
-	assert.Contains(err.Error(), "discovery source type cannot be empty")
-
-	// When discovery source is `local` and data is provided correctly
-	// but path is invalid
-	pd, err := createDiscoverySource("local", "fake-discovery-name", "fake/path")
-	assert.NotNil(err)
-	assert.Contains(err.Error(), "error while reading local plugin manifest directory")
-	assert.NotNil(pd.Local)
-	assert.Equal(pd.Local.Name, "fake-discovery-name")
-	assert.Equal(pd.Local.Path, "fake/path")
-
-	// When discovery source is `local` with a valid path
-	pd, err = createDiscoverySource("local", "fake-discovery-name", "standalone")
-	assert.Nil(err)
-	assert.NotNil(pd.Local)
-	assert.Equal(pd.Local.Name, "fake-discovery-name")
-	assert.Equal(pd.Local.Path, "standalone")
-
-	// When discovery source is `LOCAL` with a valid path
-	pd, err = createDiscoverySource("LOCAL", "fake-discovery-name", "standalone")
-	assert.Nil(err)
-	assert.NotNil(pd.Local)
-	assert.Equal(pd.Local.Name, "fake-discovery-name")
-	assert.Equal(pd.Local.Path, "standalone")
-
-	// When discovery source is `oci` with an invalid image
-	pd, err = createDiscoverySource("oci", "fake-oci-discovery-name", "test.registry.com/test-image:v1.0.0")
+	// With an invalid image
+	pd, err := createDiscoverySource("fake-oci-discovery-name", "test.registry.com/test-image:v1.0.0")
 	assert.NotNil(err)
 	assert.Contains(err.Error(), "unable to fetch the inventory of discovery 'fake-oci-discovery-name' for plugins")
 	assert.NotNil(pd.OCI)
 	assert.Equal(pd.OCI.Name, "fake-oci-discovery-name")
 	assert.Equal(pd.OCI.Image, "test.registry.com/test-image:v1.0.0")
-
-	// When discovery source is gcp
-	_, err = createDiscoverySource("gcp", "fake-discovery-name", "fake/path")
-	assert.NotNil(err)
-	assert.Contains(err.Error(), "not yet supported")
-
-	// When discovery source is kubernetes
-	_, err = createDiscoverySource("kubernetes", "fake-discovery-name", "fake/path")
-	assert.NotNil(err)
-	assert.Contains(err.Error(), "not yet supported")
-
-	// When discovery source is rest with invalid endpoint
-	pd, err = createDiscoverySource("rest", "fake-discovery-name", "fake/path")
-	assert.NotNil(err)
-	assert.Contains(err.Error(), "unsupported protocol scheme")
-	assert.NotNil(pd.REST)
-	assert.Equal(pd.REST.Name, "fake-discovery-name")
-	assert.Equal(pd.REST.Endpoint, "fake/path")
-
-	// When discovery source is an unknown value
-	_, err = createDiscoverySource("unexpectedValue", "fake-discovery-name", "fake/path")
-	assert.NotNil(err)
-	assert.Contains(err.Error(), "unknown discovery source type 'unexpectedValue'")
 }
 
 // Test_createAndListDiscoverySources test 'tanzu plugin source list' when TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY has set test only discovery sources
 func Test_createAndListDiscoverySources(t *testing.T) {
-	oldVal := os.Getenv(constants.ConfigVariableAdditionalDiscoveryForTesting)
+	assert := assert.New(t)
+
+	// Set temporary configuration
+	configFile, _ := os.CreateTemp("", "config")
+	os.Setenv(configlib.EnvConfigKey, configFile.Name())
+	defer os.RemoveAll(configFile.Name())
+
+	configFileNG, _ := os.CreateTemp("", "config_ng")
+	os.Setenv(configlib.EnvConfigNextGenKey, configFileNG.Name())
+	defer os.RemoveAll(configFileNG.Name())
+
 	os.Setenv(constants.CEIPOptInUserPromptAnswer, "No")
 	os.Setenv(constants.EULAPromptAnswer, "Yes")
 
-	// Initialize the plugin source
+	// Initialize the plugin source to the default one
+	err := configlib.SetCLIDiscoverySource(configtypes.PluginDiscovery{
+		OCI: &configtypes.OCIDiscovery{
+			Name:  config.DefaultStandaloneDiscoveryName,
+			Image: constants.TanzuCLIDefaultCentralPluginDiscoveryImage,
+		}})
+	assert.Nil(err)
+
+	// List with one extra plugin source
+	testSource1 := "harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest"
+	os.Setenv(constants.ConfigVariableAdditionalDiscoveryForTesting, testSource1)
+
 	rootCmd, err := NewRootCmd()
-	assert.Nil(t, err)
-	rootCmd.SetArgs([]string{"plugin", "source", "init"})
-	err = rootCmd.Execute()
-	assert.Nil(t, err)
-
-	// List plugin source - one
-	os.Setenv(constants.ConfigVariableAdditionalDiscoveryForTesting, "harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest")
-
+	assert.Nil(err)
 	rootCmd.SetArgs([]string{"plugin", "source", "list"})
 	b := bytes.NewBufferString("")
 	rootCmd.SetOut(b)
 	err = rootCmd.Execute()
-	assert.Nil(t, err)
+	assert.Nil(err)
 
 	got, err := io.ReadAll(b)
-	assert.Nil(t, err)
+	assert.Nil(err)
 
-	str := string(got)
-	assert.Contains(t, str, "disc_0 (test only)")
+	// whitespace-agnostic match
+	assert.Contains(strings.Join(strings.Fields(string(got)), " "),
+		config.DefaultStandaloneDiscoveryName+" "+constants.TanzuCLIDefaultCentralPluginDiscoveryImage)
+	assert.Contains(strings.Join(strings.Fields(string(got)), " "),
+		"disc_0 (test only) "+testSource1)
 
-	// List plugin source - two
-	os.Setenv(constants.ConfigVariableAdditionalDiscoveryForTesting, "harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest,localhost:9876/tanzu-cli/plugins/sandbox1:small")
+	// List with two extra plugin sources
+	testSource2 := "localhost:9876/tanzu-cli/plugins/sandbox1:small"
+	os.Setenv(constants.ConfigVariableAdditionalDiscoveryForTesting, testSource1+","+testSource2)
 
 	rootCmd.SetArgs([]string{"plugin", "source", "list"})
 	b = bytes.NewBufferString("")
 	rootCmd.SetOut(b)
 	err = rootCmd.Execute()
-	assert.Nil(t, err)
+	assert.Nil(err)
 
 	got, err = io.ReadAll(b)
-	assert.Nil(t, err)
+	assert.Nil(err)
 
-	str = string(got)
-	assert.Contains(t, str, "disc_0 (test only)")
-	assert.Contains(t, str, "disc_1 (test only)")
-	os.Setenv(constants.ConfigVariableAdditionalDiscoveryForTesting, oldVal)
+	// whitespace-agnostic match
+	assert.Contains(strings.Join(strings.Fields(string(got)), " "),
+		config.DefaultStandaloneDiscoveryName+" "+constants.TanzuCLIDefaultCentralPluginDiscoveryImage)
+	assert.Contains(strings.Join(strings.Fields(string(got)), " "),
+		"disc_0 (test only) "+testSource1)
+	assert.Contains(strings.Join(strings.Fields(string(got)), " "),
+		"disc_1 (test only) "+testSource2)
+
+	// Reset variables
+	os.Unsetenv(configlib.EnvConfigKey)
+	os.Unsetenv(configlib.EnvConfigNextGenKey)
+	os.Unsetenv(constants.CEIPOptInUserPromptAnswer)
+	os.Unsetenv(constants.EULAPromptAnswer)
 }
-func Test_addDiscoverySource(t *testing.T) {
+
+func Test_initDiscoverySources(t *testing.T) {
+	tests := []struct {
+		test            string
+		args            []string
+		expected        string
+		expectedFailure bool
+	}{
+		{
+			test:            "init with extra arg error",
+			args:            []string{"plugin", "source", "init", "extra"},
+			expectedFailure: true,
+			expected:        "accepts at most 0 arg(s), received 1",
+		},
+		{
+			test:            "init success",
+			args:            []string{"plugin", "source", "init"},
+			expectedFailure: false,
+			expected:        "successfully initialized discovery source",
+		},
+	}
+
+	configFile, _ := os.CreateTemp("", "config")
+	os.Setenv(configlib.EnvConfigKey, configFile.Name())
+	defer os.RemoveAll(configFile.Name())
+
+	configFileNG, _ := os.CreateTemp("", "config_ng")
+	os.Setenv(configlib.EnvConfigNextGenKey, configFileNG.Name())
+	defer os.RemoveAll(configFileNG.Name())
+
+	os.Setenv(constants.CEIPOptInUserPromptAnswer, "No")
+	os.Setenv(constants.EULAPromptAnswer, "Yes")
+
+	for _, spec := range tests {
+		t.Run(spec.test, func(t *testing.T) {
+			assert := assert.New(t)
+
+			// Start with a different plugin source than the default one
+			// so we can test the "plugin source init" command
+			err := configlib.SetCLIDiscoverySource(configtypes.PluginDiscovery{
+				OCI: &configtypes.OCIDiscovery{
+					Name:  config.DefaultStandaloneDiscoveryName,
+					Image: "test/uri",
+				}})
+			assert.Nil(err)
+
+			rootCmd, err := NewRootCmd()
+			assert.Nil(err)
+			rootCmd.SetArgs(spec.args)
+			b := bytes.NewBufferString("")
+			rootCmd.SetOut(b)
+			rootCmd.SetErr(b)
+			log.SetStdout(b)
+			log.SetStderr(b)
+
+			err = rootCmd.Execute()
+			assert.Equal(err != nil, spec.expectedFailure)
+
+			if spec.expected != "" {
+				if spec.expectedFailure {
+					// Check we got the correct error
+					assert.Contains(err.Error(), spec.expected)
+				} else {
+					got, err := io.ReadAll(b)
+					assert.Nil(err)
+					assert.Contains(string(got), spec.expected)
+
+					// Check that there is only one plugin source and that it
+					// is the default one
+					discoverySources, err := configlib.GetCLIDiscoverySources()
+					assert.Nil(err)
+					assert.Equal(1, len(discoverySources))
+
+					for _, ds := range discoverySources {
+						assert.NotNil(ds.OCI)
+						assert.Equal(config.DefaultStandaloneDiscoveryName, ds.OCI.Name)
+						assert.Equal(constants.TanzuCLIDefaultCentralPluginDiscoveryImage, ds.OCI.Image)
+					}
+				}
+			}
+		})
+	}
+	os.Unsetenv(configlib.EnvConfigKey)
+	os.Unsetenv(configlib.EnvConfigNextGenKey)
+	os.Unsetenv(constants.CEIPOptInUserPromptAnswer)
+	os.Unsetenv(constants.EULAPromptAnswer)
 }
 
 func Test_updateDiscoverySources(t *testing.T) {
+	tests := []struct {
+		test            string
+		args            []string
+		expected        string
+		expectedFailure bool
+	}{
+		{
+			test:            "update missing arg error",
+			args:            []string{"plugin", "source", "update"},
+			expectedFailure: true,
+			expected:        "accepts 1 arg(s), received 0",
+		},
+		{
+			test:            "update extra arg error",
+			args:            []string{"plugin", "source", "update", "default", "extra"},
+			expectedFailure: true,
+			expected:        "accepts 1 arg(s), received 2",
+		},
+		{
+			test:            "update invalid source",
+			args:            []string{"plugin", "source", "update", "invalid", "-u", constants.TanzuCLIDefaultCentralPluginDiscoveryImage},
+			expectedFailure: true,
+			expected:        `discovery "invalid" does not exist`,
+		},
+		{
+			test:            "update invalid uri error",
+			args:            []string{"plugin", "source", "update", "default", "-u", "example.com"},
+			expectedFailure: true,
+			expected:        "unable to fetch the inventory of discovery",
+		},
+		{
+			test:            "update success",
+			args:            []string{"plugin", "source", "update", "default", "-u", constants.TanzuCLIDefaultCentralPluginDiscoveryImage},
+			expectedFailure: false,
+			expected:        "updated discovery source",
+		},
+	}
+
+	configFile, _ := os.CreateTemp("", "config")
+	os.Setenv(configlib.EnvConfigKey, configFile.Name())
+	defer os.RemoveAll(configFile.Name())
+
+	configFileNG, _ := os.CreateTemp("", "config_ng")
+	os.Setenv(configlib.EnvConfigNextGenKey, configFileNG.Name())
+	defer os.RemoveAll(configFileNG.Name())
+
+	os.Setenv(constants.CEIPOptInUserPromptAnswer, "No")
+	os.Setenv(constants.EULAPromptAnswer, "Yes")
+
+	for _, spec := range tests {
+		t.Run(spec.test, func(t *testing.T) {
+			assert := assert.New(t)
+
+			// Set the discovery source to a fake one before each test
+			// to see being updated
+			err := configlib.SetCLIDiscoverySource(configtypes.PluginDiscovery{
+				OCI: &configtypes.OCIDiscovery{
+					Name:  config.DefaultStandaloneDiscoveryName,
+					Image: "test/uri",
+				}})
+			assert.Nil(err)
+
+			rootCmd, err := NewRootCmd()
+			assert.Nil(err)
+			rootCmd.SetArgs(spec.args)
+			b := bytes.NewBufferString("")
+			rootCmd.SetOut(b)
+			rootCmd.SetErr(b)
+			log.SetStdout(b)
+			log.SetStderr(b)
+
+			err = rootCmd.Execute()
+			assert.Equal(err != nil, spec.expectedFailure)
+
+			if spec.expected != "" {
+				if spec.expectedFailure {
+					// Check we got the correct error
+					assert.Contains(err.Error(), spec.expected)
+				} else {
+					got, err := io.ReadAll(b)
+					assert.Nil(err)
+					assert.Contains(string(got), spec.expected)
+
+					// Check that there is only one plugin source and that it
+					// is the default one
+					discoverySources, err := configlib.GetCLIDiscoverySources()
+					assert.Nil(err)
+					assert.Equal(1, len(discoverySources))
+
+					for _, ds := range discoverySources {
+						assert.NotNil(ds.OCI)
+						assert.Equal(config.DefaultStandaloneDiscoveryName, ds.OCI.Name)
+						assert.Equal(constants.TanzuCLIDefaultCentralPluginDiscoveryImage, ds.OCI.Image)
+					}
+				}
+			}
+		})
+	}
+	os.Unsetenv(configlib.EnvConfigKey)
+	os.Unsetenv(configlib.EnvConfigNextGenKey)
+	os.Unsetenv(constants.CEIPOptInUserPromptAnswer)
+	os.Unsetenv(constants.EULAPromptAnswer)
 }
 
 func Test_deleteDiscoverySource(t *testing.T) {
+	tests := []struct {
+		test            string
+		args            []string
+		expected        string
+		expectedFailure bool
+	}{
+		{
+			test:            "delete missing arg error",
+			args:            []string{"plugin", "source", "delete"},
+			expectedFailure: true,
+			expected:        "accepts 1 arg(s), received 0",
+		},
+		{
+			test:            "delete extra arg error",
+			args:            []string{"plugin", "source", "delete", "default", "extra"},
+			expectedFailure: true,
+			expected:        "accepts 1 arg(s), received 2",
+		},
+		{
+			test:            "delete invalid source",
+			args:            []string{"plugin", "source", "delete", "invalid"},
+			expectedFailure: true,
+			expected:        `discovery "invalid" does not exist`,
+		},
+		{
+			test:            "delete success",
+			args:            []string{"plugin", "source", "delete", "default"},
+			expectedFailure: false,
+			expected:        "deleted discovery source",
+		},
+	}
+
+	configFile, _ := os.CreateTemp("", "config")
+	os.Setenv(configlib.EnvConfigKey, configFile.Name())
+	defer os.RemoveAll(configFile.Name())
+
+	configFileNG, _ := os.CreateTemp("", "config_ng")
+	os.Setenv(configlib.EnvConfigNextGenKey, configFileNG.Name())
+	defer os.RemoveAll(configFileNG.Name())
+
+	os.Setenv(constants.CEIPOptInUserPromptAnswer, "No")
+	os.Setenv(constants.EULAPromptAnswer, "Yes")
+
+	for _, spec := range tests {
+		t.Run(spec.test, func(t *testing.T) {
+			assert := assert.New(t)
+
+			// Reset the discovery source to the default one
+			// before each test
+			err := configlib.SetCLIDiscoverySource(configtypes.PluginDiscovery{
+				OCI: &configtypes.OCIDiscovery{
+					Name:  config.DefaultStandaloneDiscoveryName,
+					Image: constants.TanzuCLIDefaultCentralPluginDiscoveryImage,
+				}})
+			assert.Nil(err)
+
+			rootCmd, err := NewRootCmd()
+			assert.Nil(err)
+			rootCmd.SetArgs(spec.args)
+			b := bytes.NewBufferString("")
+			rootCmd.SetOut(b)
+			rootCmd.SetErr(b)
+			log.SetStdout(b)
+			log.SetStderr(b)
+
+			err = rootCmd.Execute()
+			assert.Equal(err != nil, spec.expectedFailure)
+
+			if spec.expected != "" {
+				if spec.expectedFailure {
+					// Check we got the correct error
+					assert.Contains(err.Error(), spec.expected)
+				} else {
+					got, err := io.ReadAll(b)
+					assert.Nil(err)
+					assert.Contains(string(got), spec.expected)
+
+					// Check that there are no more plugin sources
+					discoverySources, err := configlib.GetCLIDiscoverySources()
+					assert.Nil(err)
+					assert.Equal(0, len(discoverySources))
+				}
+			}
+		})
+	}
+	os.Unsetenv(configlib.EnvConfigKey)
+	os.Unsetenv(configlib.EnvConfigNextGenKey)
+	os.Unsetenv(constants.CEIPOptInUserPromptAnswer)
+	os.Unsetenv(constants.EULAPromptAnswer)
 }


### PR DESCRIPTION
### What this PR does / why we need it

The CLI does not support turning off the Central Repository feature.  Therefore, the current feature flag `constants.FeatureDisableCentralRepositoryForTesting` cannot be used, and its unused code paths should be removed.

This PR starts by fixing only the `discovery_source.go` file and its tests, in an attempt to simplify the review by keeping the changes logically contained.

The changes are:
1. Remove code paths from the `discovery_source.go` file that only run when the central repo feature is disabled through the use of the feature flag `constants.FeatureDisableCentralRepositoryForTesting`
2. mark the `--uri` flag as required for `plugin source update`; this was forgotten when we implemented the central repo feature (it used to be marked as required); also update the usage text to include the use of the `--uri` flag since it is now required
3. Update and add more unit tests to increase coverage from 55.5% to 93.7%
4. Fix test for "plugin source list" to use a temporary configuration instead of the user's real CLI config

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Part of #477

### Describe testing done for PR

```
$ tz version
version: v1.0.0-dev
buildDate: 2023-09-12
sha: 0a6eb1d26

# Check that all the sub-commands are present (except 'delete' which is hidden)
$ tz plugin source -h
Manage plugin discovery sources. Discovery source provides metadata about the list of available plugins, their supported versions and how to download them.

Usage:
  tanzu plugin source [command]

Available Commands:
  init        Initialize the discovery source to its default value
  list        List available discovery sources
  update      Update a discovery source configuration

Flags:
  -h, --help   help for source

Use "tanzu plugin source [command] --help" for more information about a command.

# Check that the 'delete' command is still there
$ tz plugin source delete -h
Delete a discovery source

Usage:
tanzu plugin source delete SOURCE_NAME

Examples:

    # Delete a discovery source
    tanzu plugin discovery delete default

Flags:
  -h, --help   help for delete

# Check the updated help output for "plugin source update"
$ tz plugin source update -h
Update a discovery source configuration

Usage:
tanzu plugin source update SOURCE_NAME --uri <URI>

Examples:

    # Update the discovery source for an air-gapped scenario. The URI must be an OCI image.
    tanzu plugin source update default --uri registry.example.com/tanzu/plugin-inventory:latest

Flags:
  -h, --help         help for update
  -u, --uri string   URI for discovery source. The URI must be of an OCI image

# Check the fact that '--uri' is now marked as required
$ tz plugin source update default
[x] : required flag(s) "uri" not set

# Make sure the command works
$ tz plugin source update default -u projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest", this will take a few seconds.
[ok] updated discovery source default
$ tz plugin source list
  NAME                IMAGE
  default             projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest
  disc_0 (test only)  localhost:9876/tanzu-cli/plugins/airgapped:large
$ tz plugin source init
[ok] successfully initialized discovery source
$ tz plugin source list
  NAME                IMAGE
  default             projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest
  disc_0 (test only)  localhost:9876/tanzu-cli/plugins/airgapped:large
$ tz plugin source list -o json
[
  {
    "image": "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest",
    "name": "default"
  },
  {
    "image": "localhost:9876/tanzu-cli/plugins/airgapped:large",
    "name": "disc_0 (test only)"
  }
]
```

I also ran the unit tests and checked the test coverage for `discovery_source.go`: except from minor error case, the file is fully covered.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Mark the `--uri` flag as required for `tanzu plugin source update`.  Cleanup and increase test coverage for the `tanzu plugin source` sub-commands.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
