### PR TITLE
Fix tests to properly enable/disable central repo

### DIFF
--- a/pkg/command/plugin_search_test.go
+++ b/pkg/command/plugin_search_test.go
@@ -34,25 +34,25 @@ func TestPluginSearch(t *testing.T) {
 			test:            "invalid target",
 			args:            []string{"plugin", "search", "--target", "invalid"},
 			expectedFailure: true,
-			expected:        "unknown flag: --target",
+			expected:        invalidTargetMsg,
 		},
 		{
 			test:            "no --local and --name together",
 			args:            []string{"plugin", "search", "--local", "./", "--name", "myplugin"},
 			expectedFailure: true,
-			expected:        "unknown flag: --local",
+			expected:        "if any flags in the group [local name] are set none of the others can be",
 		},
 		{
 			test:            "no --local and --target together",
 			args:            []string{"plugin", "search", "--local", "./", "--target", "tmc"},
 			expectedFailure: true,
-			expected:        "unknown flag: --local",
+			expected:        "if any flags in the group [local target] are set none of the others can be",
 		},
 		{
 			test:            "no --local and --show-details together",
 			args:            []string{"plugin", "search", "--local", "./", "--show-details"},
 			expectedFailure: true,
-			expected:        "unknown flag: --local",
+			expected:        "if any flags in the group [local show-details] are set none of the others can be",
 		},
 	}
 
@@ -84,11 +84,13 @@ func TestPluginSearch(t *testing.T) {
 	for _, spec := range tests {
 		t.Run(spec.test, func(t *testing.T) {
 			// Disable the Central Repository feature if needed
-			if strings.EqualFold(spec.centralRepoDisabled, "true") {
-				featureArray := strings.Split(constants.FeatureDisableCentralRepositoryForTesting, ".")
-				err := config.SetFeature(featureArray[1], featureArray[2], spec.centralRepoDisabled)
-				assert.Nil(err)
+			enabled := "true"
+			if !strings.EqualFold(spec.centralRepoDisabled, "true") {
+				enabled = "false"
 			}
+			featureArray := strings.Split(constants.FeatureDisableCentralRepositoryForTesting, ".")
+			err := config.SetFeature(featureArray[1], featureArray[2], enabled)
+			assert.Nil(err)
 
 			rootCmd, err := NewRootCmd()
 			assert.Nil(err)


### PR DESCRIPTION
### What this PR does / why we need it

Some unit tests were not properly enabling the central repo and therefore were not testing what they were meant to test.

The problem was that all tests within `TestPluginSearch` would re-use a test configuration file and therefore it is important to enable/disable the central repo for each test, instead of re-using the last configuration value.
Before this PR, since the first test would turn off the central repo, all following tests would run with the central repo disabled.

This commit properly enables/disables the central repo for those tests.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Make test

**Note that the tests currently fail locally.  This is a know and pre-existing problem**

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix unit tests for plugin search
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
