### PR TITLE
List plugins deactivated for context unset and context delete

### DIFF
--- a/test/e2e/context/k8s/context_k8s_lifecycle_test.go
+++ b/test/e2e/context/k8s/context_k8s_lifecycle_test.go
@@ -174,7 +174,7 @@ func k8sContextLifeCycleTests() bool {
 		It("delete context command", func() {
 			By("delete all contexts created in previous tests")
 			for _, ctx := range contextNames {
-				err := tf.ContextCmd.DeleteContext(ctx)
+				_, _, err := tf.ContextCmd.DeleteContext(ctx)
 				Expect(framework.IsContextExists(tf, ctx)).To(BeFalse(), fmt.Sprintf(framework.ContextShouldNotExists, ctx))
 				Expect(err).To(BeNil(), "delete context should delete context without any error")
 			}
@@ -182,7 +182,7 @@ func k8sContextLifeCycleTests() bool {
 		// Test case: (negative test) test 'tanzu context delete' command for context name which is not exists
 		It("delete context command", func() {
 			By("delete context command with random string")
-			err := tf.ContextCmd.DeleteContext(framework.RandomString(4))
+			_, _, err := tf.ContextCmd.DeleteContext(framework.RandomString(4))
 			Expect(err).ToNot(BeNil())
 		})
 	})
@@ -206,7 +206,7 @@ func k8sContextStressTests() bool {
 			list, err := tf.ContextCmd.ListContext()
 			Expect(err).To(BeNil(), "list context should not return any error")
 			for _, ctx := range list {
-				err := tf.ContextCmd.DeleteContext(ctx.Name)
+				_, _, err := tf.ContextCmd.DeleteContext(ctx.Name)
 				Expect(err).To(BeNil(), "delete context should delete context without any error")
 				Expect(framework.IsContextExists(tf, ctx.Name)).To(BeFalse(), fmt.Sprintf(framework.ContextShouldNotExists, ctx.Name))
 			}
@@ -249,7 +249,7 @@ func k8sContextStressTests() bool {
 		It("delete context command", func() {
 			By("delete all contexts created in previous tests")
 			for _, ctx := range contextNamesStress {
-				err := tf.ContextCmd.DeleteContext(ctx)
+				_, _, err := tf.ContextCmd.DeleteContext(ctx)
 				log.Infof("context: %s deleted", ctx)
 				Expect(framework.IsContextExists(tf, ctx)).To(BeFalse(), fmt.Sprintf(framework.ContextShouldNotExists, ctx))
 				Expect(err).To(BeNil(), "delete context should delete context without any error")

--- a/test/e2e/context/tmc/context_tmc_lifecycle_test.go
+++ b/test/e2e/context/tmc/context_tmc_lifecycle_test.go
@@ -80,7 +80,7 @@ func tmcStressTestCases() bool {
 		It("delete context command", func() {
 			By("delete all contexts created in previous tests")
 			for _, ctx := range contextNamesStress {
-				err := tf.ContextCmd.DeleteContext(ctx)
+				_, _, err := tf.ContextCmd.DeleteContext(ctx)
 				log.Infof("context: %s deleted", ctx)
 				Expect(framework.IsContextExists(tf, ctx)).To(BeFalse(), fmt.Sprintf(framework.ContextShouldNotExists, ctx))
 				Expect(err).To(BeNil(), "delete context should delete context without any error")
@@ -139,10 +139,10 @@ func tmcAndK8sContextTests() bool {
 
 			// Test case: d. delete both k8s and tmc contexts
 			It("delete context command", func() {
-				err := tf.ContextCmd.DeleteContext(k8sCtx)
+				_, _, err := tf.ContextCmd.DeleteContext(k8sCtx)
 				Expect(err).To(BeNil(), "delete context should delete context without any error")
 				Expect(framework.IsContextExists(tf, k8sCtx)).To(BeFalse(), fmt.Sprintf(ContextShouldNotExists+" as been deleted", k8sCtx))
-				err = tf.ContextCmd.DeleteContext(tmcCtx)
+				_, _, err = tf.ContextCmd.DeleteContext(tmcCtx)
 				Expect(err).To(BeNil(), "delete context should delete context without any error")
 				Expect(framework.IsContextExists(tf, tmcCtx)).To(BeFalse(), fmt.Sprintf(ContextShouldNotExists+" as been deleted", tmcCtx))
 			})
@@ -220,11 +220,11 @@ func tmcAndK8sContextTests() bool {
 			// Test case: e. delete all contexts
 			It("delete all contexts", func() {
 				for _, ctx := range k8sCtxs {
-					err := tf.ContextCmd.DeleteContext(ctx)
+					_, _, err := tf.ContextCmd.DeleteContext(ctx)
 					Expect(err).To(BeNil(), "delete context should delete context without any error")
 				}
 				for _, ctx := range tmcCtxs {
-					err := tf.ContextCmd.DeleteContext(ctx)
+					_, _, err := tf.ContextCmd.DeleteContext(ctx)
 					Expect(err).To(BeNil(), "delete context should delete context without any error")
 				}
 			})
@@ -387,7 +387,7 @@ func tmcLifeCycleTests() bool {
 		// Test case: n. test 'tanzu context delete' command, make sure to delete all context's created in previous test cases
 		It("delete context command", func() {
 			for _, ctx := range contextNames {
-				err := tf.ContextCmd.DeleteContext(ctx)
+				_, _, err := tf.ContextCmd.DeleteContext(ctx)
 				Expect(framework.IsContextExists(tf, ctx)).To(BeFalse(), fmt.Sprintf(ContextShouldNotExists+" as been deleted", ctx))
 				Expect(err).To(BeNil(), "delete context should delete context without any error")
 			}

--- a/test/e2e/framework/context_lifecycle_operations.go
+++ b/test/e2e/framework/context_lifecycle_operations.go
@@ -23,7 +23,7 @@ type ContextCmdOps interface {
 	// ListContext helps to run `context list` command
 	ListContext(opts ...E2EOption) ([]*ContextListInfo, error)
 	// DeleteContext helps to run `context delete` command
-	DeleteContext(contextName string, opts ...E2EOption) error
+	DeleteContext(contextName string, opts ...E2EOption) (stdOutStr, stdErrStr string, err error)
 	// GetActiveContext returns current active context
 	GetActiveContext(targetType string, opts ...E2EOption) (string, error)
 	// GetActiveContexts returns all active contexts
@@ -111,13 +111,13 @@ func (cc *contextCmdOps) GetActiveContexts(opts ...E2EOption) ([]*ContextListInf
 	return contexts, nil
 }
 
-func (cc *contextCmdOps) DeleteContext(contextName string, opts ...E2EOption) error {
+func (cc *contextCmdOps) DeleteContext(contextName string, opts ...E2EOption) (string, string, error) {
 	deleteContextCmd := fmt.Sprintf(DeleteContext, "%s", contextName)
 	stdOut, stdErr, err := cc.cmdExe.TanzuCmdExec(deleteContextCmd, opts...)
 	if err != nil {
 		log.Infof("failed to delete context:%s", contextName)
-		return errors.Wrapf(err, FailedToDeleteContext+", stderr:%s stdout:%s , ", stdErr.String(), stdOut.String())
+		return stdOut.String(), stdErr.String(), errors.Wrapf(err, FailedToDeleteContext+", stderr:%s stdout:%s , ", stdErr.String(), stdOut.String())
 	}
 	log.Infof(ContextDeleted, contextName)
-	return err
+	return stdOut.String(), stdErr.String(), err
 }

--- a/test/e2e/framework/framework_constants.go
+++ b/test/e2e/framework/framework_constants.go
@@ -104,6 +104,7 @@ const (
 	NoActiveContextExistsForTarget = "There is no active context for the given target %v"
 	ContextNotActiveOrNotExists    = "The provided context %v is not active or does not exist"
 	ContextForTargetSetInactive    = "The context %v for the target %v has been set as inactive"
+	DeactivatingPlugin             = "Deactivating plugin '%v:%v' for context '%v'"
 
 	KindClusterCreate = "kind create cluster --name %s"
 	KindClusterStatus = "kubectl cluster-info --context %s"

--- a/test/e2e/framework/output_handling.go
+++ b/test/e2e/framework/output_handling.go
@@ -22,6 +22,7 @@ type PluginSearch struct {
 }
 
 type PluginGroup struct {
+	Name        string   `json:"name"`
 	Group       string   `json:"group"`
 	Description string   `json:"description"`
 	Latest      string   `json:"latest"`


### PR DESCRIPTION
### What this PR does / why we need it

This pull request enhances the user experience for the `tanzu context delete` and `tanzu context unset` commands by listing all installed plugins as deactivated.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
```

1. E2E tests are updated to test the `tanzu context unset `and `tanzu context delete` use cases.

2. Manual testing has done, below are the details for `tanzu context unset `and `tanzu context delete` use cases
❯ t context create --endpoint unstable.tmc-dev.cloud.vmware.com --staging  --name tmc2   
Flag --name has been deprecated, it has been replaced by using an argument to the command
[i] API token env var is set

[ok] successfully created a TMC context
[i] Checking for required plugins...
[i] Installing plugin 'account:v0.1.3' with target 'mission-control'
[i] Plugin binary for 'account:v0.1.3' found in cache
[i] Installing plugin 'iam:v0.1.3' with target 'mission-control'
[i] Plugin binary for 'iam:v0.1.3' found in cache
[i] Installing plugin 'cluster:v0.1.6' with target 'mission-control'
[i] Plugin binary for 'cluster:v0.1.6' found in cache
[i] Successfully installed all required plugins
❯ 
❯ t context unset tmc2
The context tmc2 for the target mission-control has been set as inactive
Deactivating plugin 'continuousdelivery:v0.1.3' for context 'tmc2'
Deactivating plugin 'data-protection:v0.1.3' for context 'tmc2'
Deactivating plugin 'secret:v0.1.3' for context 'tmc2'
Deactivating plugin 'workspace:v0.1.5' for context 'tmc2'
Deactivating plugin 'audit:v0.1.3' for context 'tmc2'
Deactivating plugin 'helm:v0.1.3' for context 'tmc2'
Deactivating plugin 'policy:v0.1.3' for context 'tmc2'
Deactivating plugin 'tanzupackage:v0.2.2' for context 'tmc2'
Deactivating plugin 'clustergroup:v0.1.3' for context 'tmc2'
Deactivating plugin 'provider-aks-cluster:v0.1.3' for context 'tmc2'
Deactivating plugin 'events:v0.1.3' for context 'tmc2'
Deactivating plugin 'inspection:v0.1.3' for context 'tmc2'
Deactivating plugin 'apply:v0.3.0' for context 'tmc2'
Deactivating plugin 'agentartifacts:v0.1.3' for context 'tmc2'
Deactivating plugin 'integration:v0.1.3' for context 'tmc2'
Deactivating plugin 'management-cluster:v0.1.3' for context 'tmc2'
Deactivating plugin 'ekscluster:v0.1.3' for context 'tmc2'
Deactivating plugin 'provider-eks-cluster:v0.1.3' for context 'tmc2'
Deactivating plugin 'setting:v0.2.1' for context 'tmc2'
Deactivating plugin 'aks-cluster:v0.1.6' for context 'tmc2'
❯
❯ t context delete tmc2
Deleting the context entry from the config will remove it from the list of tracked contexts. You will need to use `tanzu context create` to re-create this context. Are you sure you want to continue? [y/N]: y
[i] Deleting entry for cluster tmc2
❯ 
❯ t context create --endpoint unstable.tmc-dev.cloud.vmware.com --staging  --name tmc2
Flag --name has been deprecated, it has been replaced by using an argument to the command
[i] API token env var is set

[ok] successfully created a TMC context
[i] Checking for required plugins...
[i] Installing plugin 'cluster:v0.1.6' with target 'mission-control'
[i] Plugin binary for 'cluster:v0.1.6' found in cache
[i] Installing plugin 'iam:v0.1.3' with target 'mission-control'
[i] Plugin binary for 'iam:v0.1.3' found in cache
[i] Installing plugin 'account:v0.1.3' with target 'mission-control'
[i] Plugin binary for 'account:v0.1.3' found in cache
[i] Successfully installed all required plugins
❯ t context delete tmc2
Deleting the context entry from the config will remove it from the list of tracked contexts. You will need to use `tanzu context create` to re-create this context. Are you sure you want to continue? [y/N]: y
[i] Deleting entry for cluster tmc2
Deactivating plugin 'audit:v0.1.3' for context 'tmc2'
Deactivating plugin 'helm:v0.1.3' for context 'tmc2'
Deactivating plugin 'policy:v0.1.3' for context 'tmc2'
Deactivating plugin 'continuousdelivery:v0.1.3' for context 'tmc2'
Deactivating plugin 'data-protection:v0.1.3' for context 'tmc2'
Deactivating plugin 'secret:v0.1.3' for context 'tmc2'
Deactivating plugin 'workspace:v0.1.5' for context 'tmc2'
Deactivating plugin 'inspection:v0.1.3' for context 'tmc2'
Deactivating plugin 'apply:v0.3.0' for context 'tmc2'
Deactivating plugin 'tanzupackage:v0.2.2' for context 'tmc2'
Deactivating plugin 'clustergroup:v0.1.3' for context 'tmc2'
Deactivating plugin 'provider-aks-cluster:v0.1.3' for context 'tmc2'
Deactivating plugin 'events:v0.1.3' for context 'tmc2'
Deactivating plugin 'agentartifacts:v0.1.3' for context 'tmc2'
Deactivating plugin 'integration:v0.1.3' for context 'tmc2'
Deactivating plugin 'management-cluster:v0.1.3' for context 'tmc2'
Deactivating plugin 'provider-eks-cluster:v0.1.3' for context 'tmc2'
Deactivating plugin 'setting:v0.2.1' for context 'tmc2'
Deactivating plugin 'aks-cluster:v0.1.6' for context 'tmc2'
Deactivating plugin 'ekscluster:v0.1.3' for context 'tmc2'
❯ 
```
### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The UX has been updated for the `tanzu context delete` and `tanzu context unset` commands to list plugins that are being deactivated.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
