### PR TITLE
Cleanup pluginmanager of unused feature flag code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,6 @@ require (
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686
 	github.com/vmware-tanzu/tanzu-plugin-runtime v1.0.0
 	go.pinniped.dev v0.20.0
-	go.uber.org/multierr v1.11.0
 	golang.org/x/mod v0.10.0
 	golang.org/x/oauth2 v0.8.0
 	golang.org/x/sync v0.2.0
@@ -212,6 +211,7 @@ require (
 	go.opentelemetry.io/otel v1.15.0 // indirect
 	go.opentelemetry.io/otel/trace v1.15.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.9.0 // indirect
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29 // indirect

--- a/pkg/constants/featureflags.go
+++ b/pkg/constants/featureflags.go
@@ -7,8 +7,6 @@ package constants
 const (
 	// FeatureContextCommand determines whether to surface the context command. This is disabled by default.
 	FeatureContextCommand = "features.global.context-target-v2"
-	// FeatureDisableCentralRepositoryForTesting determines if the CLI uses the Central Repository of plugins.
-	FeatureDisableCentralRepositoryForTesting = "features.global.no-central-repo-test-only"
 )
 
 // DefaultCliFeatureFlags is used to populate an initially empty config file with default values for feature flags.

--- a/pkg/discovery/oci.go
+++ b/pkg/discovery/oci.go
@@ -4,8 +4,10 @@
 package discovery
 
 import (
+	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/plugininventory"
@@ -22,6 +24,10 @@ func NewOCIDiscovery(name, image string, options ...DiscoveryOptions) Discovery 
 	discovery := newDBBackedOCIDiscovery(name, image)
 	discovery.pluginCriteria = opts.PluginDiscoveryCriteria
 	discovery.useLocalCacheOnly = opts.UseLocalCacheOnly
+	// NOTE: the use of TEST_TANZU_CLI_USE_DB_CACHE_ONLY is for testing only
+	if useCacheOnlyForTesting, _ := strconv.ParseBool(os.Getenv("TEST_TANZU_CLI_USE_DB_CACHE_ONLY")); useCacheOnlyForTesting {
+		discovery.useLocalCacheOnly = true
+	}
 	return discovery
 }
 
@@ -36,6 +42,10 @@ func NewOCIGroupDiscovery(name, image string, options ...DiscoveryOptions) Group
 	discovery := newDBBackedOCIDiscovery(name, image)
 	discovery.groupCriteria = opts.GroupDiscoveryCriteria
 	discovery.useLocalCacheOnly = opts.UseLocalCacheOnly
+	// NOTE: the use of TEST_TANZU_CLI_USE_DB_CACHE_ONLY is for testing only
+	if useCacheOnlyForTesting, _ := strconv.ParseBool(os.Getenv("TEST_TANZU_CLI_USE_DB_CACHE_ONLY")); useCacheOnlyForTesting {
+		discovery.useLocalCacheOnly = true
+	}
 
 	return discovery
 }

--- a/pkg/pluginmanager/manager_test.go
+++ b/pkg/pluginmanager/manager_test.go
@@ -8,13 +8,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
-	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
@@ -25,7 +23,6 @@ import (
 	"github.com/vmware-tanzu/tanzu-cli/pkg/distribution"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/plugininventory"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/pluginsupplier"
-	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
 
 var expectedDiscoveredContextPlugins = []discovery.Discovered{
@@ -53,181 +50,152 @@ var expectedDiscoveredContextPlugins = []discovery.Discovered{
 }
 var expectedDiscoveredStandalonePlugins = []discovery.Discovered{
 	{
-		Name:               "login",
-		RecommendedVersion: "v0.2.0",
+		Name:               "management-cluster",
+		Description:        "Plugin management-cluster description",
+		RecommendedVersion: "v1.6.0",
+		SupportedVersions:  []string{"v1.6.0"},
 		Scope:              common.PluginScopeStandalone,
 		ContextName:        "",
-		Target:             configtypes.TargetUnknown,
+		Target:             configtypes.TargetK8s,
+	},
+	{
+		Name:               "cluster",
+		Description:        "Plugin cluster description",
+		RecommendedVersion: "v1.6.0",
+		SupportedVersions:  []string{"v1.6.0"},
+		Scope:              common.PluginScopeStandalone,
+		ContextName:        "",
+		Target:             configtypes.TargetK8s,
+	},
+	{
+		Name:               "myplugin",
+		Description:        "Plugin myplugin description",
+		RecommendedVersion: "v1.6.0",
+		SupportedVersions:  []string{"v1.6.0"},
+		Scope:              common.PluginScopeStandalone,
+		ContextName:        "",
+		Target:             configtypes.TargetK8s,
 	},
 	{
 		Name:               "feature",
+		Description:        "Plugin feature description",
 		RecommendedVersion: "v0.2.0",
+		SupportedVersions:  []string{"v0.2.0"},
 		Scope:              common.PluginScopeStandalone,
 		ContextName:        "",
 		Target:             configtypes.TargetK8s,
+	},
+	{
+		Name:               "isolated-cluster",
+		Description:        "Plugin isolated-cluster description",
+		RecommendedVersion: "v1.3.0",
+		SupportedVersions:  []string{"v1.2.3", "v1.3.0"},
+		Scope:              common.PluginScopeStandalone,
+		ContextName:        "",
+		Target:             configtypes.TargetGlobal,
+	},
+	{
+		Name:               "login",
+		Description:        "Plugin login description",
+		RecommendedVersion: "v0.2.0",
+		SupportedVersions:  []string{"v0.2.0"},
+		Scope:              common.PluginScopeStandalone,
+		ContextName:        "",
+		Target:             configtypes.TargetGlobal,
 	},
 	{
 		Name:               "management-cluster",
-		RecommendedVersion: "v1.6.0",
-		Scope:              common.PluginScopeStandalone,
-		ContextName:        "",
-		Target:             configtypes.TargetK8s,
-	},
-	{
-		Name:               "myplugin",
-		RecommendedVersion: "v1.6.0",
-		Scope:              common.PluginScopeStandalone,
-		ContextName:        "",
-		Target:             configtypes.TargetK8s,
-	},
-	{
-		Name:               "myplugin",
+		Description:        "Plugin management-cluster description",
 		RecommendedVersion: "v0.2.0",
+		SupportedVersions:  []string{"v0.0.1", "v0.0.2", "v0.0.3", "v0.2.0"},
+		Scope:              common.PluginScopeStandalone,
+		ContextName:        "",
+		Target:             configtypes.TargetTMC,
+	},
+	{
+		Name:               "cluster",
+		Description:        "Plugin cluster description",
+		RecommendedVersion: "v0.2.0",
+		SupportedVersions:  []string{"v0.2.0"},
+		Scope:              common.PluginScopeStandalone,
+		ContextName:        "",
+		Target:             configtypes.TargetTMC,
+	},
+	{
+		Name:               "myplugin",
+		Description:        "Plugin myplugin description",
+		RecommendedVersion: "v0.2.0",
+		SupportedVersions:  []string{"v0.2.0"},
 		Scope:              common.PluginScopeStandalone,
 		ContextName:        "",
 		Target:             configtypes.TargetTMC,
 	},
 }
 
-func Test_DiscoverPlugins(t *testing.T) {
+var expectedDiscoveredGroups = []string{"vmware-test/default:v1.6.0", "vmware-test/default:v2.1.0"}
+
+const (
+	testGroupName    = "vmware-test/default"
+	testGroupVersion = "v1.6.0"
+)
+
+func Test_DiscoverStandalonePlugins(t *testing.T) {
 	assertions := assert.New(t)
 
-	defer setupLocalDistroForTesting()()
+	defer setupPluginSourceForTesting()()
 
-	serverPlugins, standalonePlugins := DiscoverPlugins()
-	assertions.Equal(len(expectedDiscoveredContextPlugins), len(serverPlugins))
+	standalonePlugins, err := DiscoverStandalonePlugins()
+	assertions.Nil(err)
 	assertions.Equal(len(expectedDiscoveredStandalonePlugins), len(standalonePlugins))
 
-	discoveredPlugins := append(serverPlugins, standalonePlugins...)
-	expectedDiscoveredPlugins := append(expectedDiscoveredContextPlugins, expectedDiscoveredStandalonePlugins...)
-
-	for i := 0; i < len(expectedDiscoveredPlugins); i++ {
-		p := findDiscoveredPlugin(discoveredPlugins, expectedDiscoveredPlugins[i].Name, expectedDiscoveredPlugins[i].Target)
+	for i := range expectedDiscoveredStandalonePlugins {
+		p := findDiscoveredPlugin(standalonePlugins, expectedDiscoveredStandalonePlugins[i].Name, expectedDiscoveredStandalonePlugins[i].Target)
 		assertions.NotNil(p)
-		assertions.Equal(expectedDiscoveredPlugins[i].Name, p.Name)
-		assertions.Equal(expectedDiscoveredPlugins[i].RecommendedVersion, p.RecommendedVersion)
-		assertions.Equal(expectedDiscoveredPlugins[i].Target, p.Target)
-	}
-
-	err := configlib.SetFeature("global", "context-target-v2", "false")
-	assertions.Nil(err)
-
-	serverPlugins, standalonePlugins = DiscoverPlugins()
-	assertions.Equal(1, len(serverPlugins))
-	assertions.Equal(len(expectedDiscoveredStandalonePlugins), len(standalonePlugins))
-}
-
-func Test_InstallPlugin_InstalledPlugins_No_Central_Repo(t *testing.T) {
-	assertions := assert.New(t)
-
-	defer setupLocalDistroForTesting()()
-	execCommand = fakeInfoExecCommand
-	defer func() { execCommand = exec.Command }()
-
-	// Turn off central repo feature
-	featureArray := strings.Split(constants.FeatureDisableCentralRepositoryForTesting, ".")
-	err := configlib.SetFeature(featureArray[1], featureArray[2], "true")
-	assertions.Nil(err)
-
-	// Try installing nonexistent plugin
-	err = InstallStandalonePlugin("not-exists", "v0.2.0", configtypes.TargetUnknown)
-	assertions.NotNil(err)
-	assertions.Contains(err.Error(), "unable to find plugin 'not-exists'")
-
-	// Install login (standalone) plugin
-	err = InstallStandalonePlugin("login", "v0.2.0", configtypes.TargetUnknown)
-	assertions.Nil(err)
-	// Verify installed plugin
-	installedPlugins, err := pluginsupplier.GetInstalledPlugins()
-	assertions.Nil(err)
-	assertions.Equal(1, len(installedPlugins))
-	assertions.Equal("login", installedPlugins[0].Name)
-
-	// Try installing cluster plugin with no context-type
-	err = InstallStandalonePlugin("cluster", "v0.2.0", configtypes.TargetUnknown)
-	assertions.NotNil(err)
-	assertions.Contains(err.Error(), fmt.Sprintf(missingTargetStr, "cluster"))
-
-	// Try installing cluster plugin with context-type=tmc
-	err = InstallStandalonePlugin("cluster", "v0.2.0", configtypes.TargetTMC)
-	assertions.Nil(err)
-
-	// Try installing cluster plugin through context-type=k8s with incorrect version
-	err = InstallStandalonePlugin("cluster", "v1.0.0", configtypes.TargetK8s)
-	assertions.NotNil(err)
-	assertions.Contains(err.Error(), "plugin pre-download verification failed")
-
-	// Try installing cluster plugin through context-type=k8s
-	err = InstallStandalonePlugin("cluster", "v1.6.0", configtypes.TargetK8s)
-	assertions.Nil(err)
-
-	// Try installing management-cluster plugin from standalone discovery without context-type
-	err = InstallStandalonePlugin("management-cluster", "v1.6.0", configtypes.TargetUnknown)
-	assertions.NotNil(err)
-	assertions.Contains(err.Error(), fmt.Sprintf(missingTargetStr, "management-cluster"))
-
-	// Try installing management-cluster plugin from standalone discovery
-	err = InstallStandalonePlugin("management-cluster", "v1.6.0", configtypes.TargetK8s)
-	assertions.Nil(err)
-
-	// Try installing the feature plugin which is targeted for k8s but requesting the TMC target
-	err = InstallStandalonePlugin("feature", "v0.2.0", configtypes.TargetTMC)
-	assertions.NotNil(err)
-	assertions.Contains(err.Error(), "unable to find plugin 'feature' with version 'v0.2.0' for target 'mission-control'")
-
-	// Verify installed plugins
-	installedStandalonePlugins, err := pluginsupplier.GetInstalledStandalonePlugins()
-	assertions.Nil(err)
-	assertions.Equal(2, len(installedStandalonePlugins))
-	installedServerPlugins, err := pluginsupplier.GetInstalledServerPlugins()
-	assertions.Nil(err)
-	assertions.Equal(2, len(installedServerPlugins))
-
-	expectedInstalledServerPlugins := []cli.PluginInfo{
-		{
-			Name:    "cluster",
-			Version: "v1.6.0",
-			Scope:   common.PluginScopeContext,
-			Target:  configtypes.TargetK8s,
-		},
-		{
-			Name:    "cluster",
-			Version: "v0.2.0",
-			Scope:   common.PluginScopeContext,
-			Target:  configtypes.TargetTMC,
-		},
-	}
-	expectedInstalledStandalonePlugins := []cli.PluginInfo{
-		{
-			Name:    "login",
-			Version: "v0.2.0",
-			Scope:   common.PluginScopeStandalone,
-			Target:  configtypes.TargetUnknown,
-		},
-		{
-			Name:    "management-cluster",
-			Version: "v1.6.0",
-			Scope:   common.PluginScopeStandalone,
-			Target:  configtypes.TargetK8s,
-		},
-	}
-
-	for i := 0; i < len(expectedInstalledServerPlugins); i++ {
-		pd := findPluginInfo(installedServerPlugins, expectedInstalledServerPlugins[i].Name, expectedInstalledServerPlugins[i].Target)
-		assertions.NotNil(pd)
-		assertions.Equal(expectedInstalledServerPlugins[i].Version, pd.Version)
-	}
-	for i := 0; i < len(expectedInstalledStandalonePlugins); i++ {
-		pd := findPluginInfo(installedStandalonePlugins, expectedInstalledStandalonePlugins[i].Name, expectedInstalledStandalonePlugins[i].Target)
-		assertions.NotNil(pd)
-		assertions.Equal(expectedInstalledStandalonePlugins[i].Version, pd.Version)
+		assertions.Equal(expectedDiscoveredStandalonePlugins[i].Description, p.Description)
+		assertions.Equal(expectedDiscoveredStandalonePlugins[i].RecommendedVersion, p.RecommendedVersion)
+		assertions.Equal(expectedDiscoveredStandalonePlugins[i].SupportedVersions, p.SupportedVersions)
+		assertions.Equal(expectedDiscoveredStandalonePlugins[i].Scope, p.Scope)
+		assertions.Equal(expectedDiscoveredStandalonePlugins[i].ContextName, p.ContextName)
 	}
 }
 
-func Test_InstallPlugin_InstalledPlugins_Central_Repo(t *testing.T) {
+func Test_DiscoverServerPlugins(t *testing.T) {
 	assertions := assert.New(t)
 
-	defer setupLocalDistroForTesting()()
+	defer setupPluginSourceForTesting()()
+
+	serverPlugins, err := DiscoverServerPlugins()
+	assertions.NotNil(err)
+	assertions.Contains(err.Error(), "unable to list plugins from discovery source 'default-mgmt': Failed to load Kubeconfig file")
+	assertions.Equal(len(expectedDiscoveredContextPlugins), len(serverPlugins))
+
+	for i := range expectedDiscoveredContextPlugins {
+		p := findDiscoveredPlugin(serverPlugins, expectedDiscoveredContextPlugins[i].Name, expectedDiscoveredContextPlugins[i].Target)
+		assertions.NotNil(p)
+		assertions.Equal(expectedDiscoveredContextPlugins[i].RecommendedVersion, p.RecommendedVersion)
+		assertions.Equal(expectedDiscoveredContextPlugins[i].Scope, p.Scope)
+		assertions.Equal(expectedDiscoveredContextPlugins[i].ContextName, p.ContextName)
+	}
+}
+
+func Test_DiscoverPluginGroups(t *testing.T) {
+	assertions := assert.New(t)
+
+	defer setupPluginSourceForTesting()()
+
+	groups, err := DiscoverPluginGroups()
+	assertions.Nil(err)
+
+	for _, id := range expectedDiscoveredGroups {
+		found := findGroupVersion(groups, id)
+		assertions.True(found, fmt.Sprintf("unable to find group %s", id))
+	}
+}
+
+func Test_InstallStandalonePlugin(t *testing.T) {
+	assertions := assert.New(t)
+
+	defer setupPluginSourceForTesting()()
 	execCommand = fakeInfoExecCommand
 	defer func() { execCommand = exec.Command }()
 
@@ -245,25 +213,25 @@ func Test_InstallPlugin_InstalledPlugins_Central_Repo(t *testing.T) {
 	assertions.Equal(1, len(installedPlugins))
 	assertions.Equal("login", installedPlugins[0].Name)
 
-	// Try installing myplugin plugin with no context-type
-	err = InstallStandalonePlugin("myplugin", "v0.2.0", configtypes.TargetUnknown)
+	// Try installing myplugin plugin with no context-type and no specific version
+	err = InstallStandalonePlugin("myplugin", cli.VersionLatest, configtypes.TargetUnknown)
 	assertions.NotNil(err)
 	assertions.Contains(err.Error(), fmt.Sprintf(missingTargetStr, "myplugin"))
 
-	// Try installing myplugin plugin with context-type=tmc
-	err = InstallStandalonePlugin("myplugin", "v0.2.0", configtypes.TargetTMC)
+	// Try installing myplugin plugin with context-type=tmc with no specific version
+	err = InstallStandalonePlugin("myplugin", cli.VersionLatest, configtypes.TargetTMC)
 	assertions.Nil(err)
 
 	// Try installing myplugin plugin through context-type=k8s with incorrect version
 	err = InstallStandalonePlugin("myplugin", "v1.0.0", configtypes.TargetK8s)
 	assertions.NotNil(err)
-	assertions.Contains(err.Error(), "plugin pre-download verification failed")
+	assertions.Contains(err.Error(), "unable to find plugin 'myplugin' with version 'v1.0.0'")
 
-	// Try installing myplugin plugin through context-type=k8s
+	// Try installing myplugin plugin through context-type=k8s with the correct version
 	err = InstallStandalonePlugin("myplugin", "v1.6.0", configtypes.TargetK8s)
 	assertions.Nil(err)
 
-	// Try installing management-cluster plugin from standalone discovery
+	// Try installing management-cluster plugin
 	err = InstallStandalonePlugin("management-cluster", "v1.6.0", configtypes.TargetK8s)
 	assertions.Nil(err)
 
@@ -285,7 +253,7 @@ func Test_InstallPlugin_InstalledPlugins_Central_Repo(t *testing.T) {
 			Name:    "login",
 			Version: "v0.2.0",
 			Scope:   common.PluginScopeStandalone,
-			Target:  configtypes.TargetUnknown,
+			Target:  configtypes.TargetGlobal,
 		},
 		{
 			Name:    "management-cluster",
@@ -314,23 +282,76 @@ func Test_InstallPlugin_InstalledPlugins_Central_Repo(t *testing.T) {
 	}
 }
 
-func Test_InstallPluginFromGroup(t *testing.T) {
+func Test_InstallPluginsFromGroup(t *testing.T) {
 	assertions := assert.New(t)
 
-	defer setupLocalDistroForTesting()()
+	defer setupPluginSourceForTesting()()
 	execCommand = fakeInfoExecCommand
 	defer func() { execCommand = exec.Command }()
 
-	// A local discovery currently does not support groups, but we can
-	// at least do negative testing
-	groupID := "vmware-tkg/default:v2.1.0"
-	_, err := InstallPluginsFromGroup("cluster", groupID)
-	assertions.NotNil(err)
-	assertions.Contains(err.Error(), "unable to create group discovery: unknown group discovery source")
+	// Install the management-cluster plugin from a group:version
+	groupID := testGroupName + ":" + testGroupVersion
+	fullGroupID, err := InstallPluginsFromGroup("management-cluster", groupID)
+	assertions.Nil(err)
+	assertions.Equal(groupID, fullGroupID)
+
+	installedStandalonePlugins, err := pluginsupplier.GetInstalledStandalonePlugins()
+	assertions.Nil(err)
+	assertions.Equal(1, len(installedStandalonePlugins))
+	pd := findPluginInfo(installedStandalonePlugins, "management-cluster", configtypes.TargetK8s)
+	assertions.NotNil(pd)
+	assertions.Equal("v1.6.0", pd.Version)
+
+	// Install the isolated-cluster from the latest group
+	groupID = testGroupName
+	fullGroupID, err = InstallPluginsFromGroup("isolated-cluster", groupID)
+	assertions.Nil(err)
+	assertions.Equal(groupID+":v2.1.0", fullGroupID)
+
+	installedStandalonePlugins, err = pluginsupplier.GetInstalledStandalonePlugins()
+	assertions.Nil(err)
+	assertions.Equal(2, len(installedStandalonePlugins))
+	pd = findPluginInfo(installedStandalonePlugins, "management-cluster", configtypes.TargetK8s)
+	assertions.NotNil(pd)
+	assertions.Equal("v1.6.0", pd.Version)
+	pd = findPluginInfo(installedStandalonePlugins, "isolated-cluster", configtypes.TargetGlobal)
+	assertions.NotNil(pd)
+	assertions.Equal("v1.3.0", pd.Version)
+
+	// Install all plugins from a group:version
+	// Note that this should replace isolated-cluster:v1.3.0 with its v1.2.3 version
+	groupID = testGroupName + ":" + testGroupVersion
+	fullGroupID, err = InstallPluginsFromGroup(cli.AllPlugins, groupID)
+	assertions.Nil(err)
+	assertions.Equal(groupID, fullGroupID)
+
+	installedStandalonePlugins, err = pluginsupplier.GetInstalledStandalonePlugins()
+	assertions.Nil(err)
+	assertions.Equal(4, len(installedStandalonePlugins))
+	pd = findPluginInfo(installedStandalonePlugins, "management-cluster", configtypes.TargetK8s)
+	assertions.NotNil(pd)
+	assertions.Equal("v1.6.0", pd.Version)
+	pd = findPluginInfo(installedStandalonePlugins, "isolated-cluster", configtypes.TargetGlobal)
+	assertions.NotNil(pd)
+	assertions.Equal("v1.2.3", pd.Version)
+	pd = findPluginInfo(installedStandalonePlugins, "myplugin", configtypes.TargetK8s)
+	assertions.NotNil(pd)
+	assertions.Equal("v1.6.0", pd.Version)
+	pd = findPluginInfo(installedStandalonePlugins, "feature", configtypes.TargetK8s)
+	assertions.NotNil(pd)
+	assertions.Equal("v0.2.0", pd.Version)
+}
+
+func Test_InstallPluginsFromGroupErrors(t *testing.T) {
+	assertions := assert.New(t)
+
+	defer setupPluginSourceForTesting()()
+	execCommand = fakeInfoExecCommand
+	defer func() { execCommand = exec.Command }()
 
 	// make sure a poorly formatted group is properly handled
-	groupID = "invalid"
-	_, err = InstallPluginsFromGroup("cluster", groupID)
+	groupID := "invalid"
+	_, err := InstallPluginsFromGroup("cluster", groupID)
 	assertions.NotNil(err)
 	assertions.Contains(err.Error(), "could not find group")
 
@@ -353,295 +374,18 @@ func Test_InstallPluginFromGroup(t *testing.T) {
 	_, err = InstallPluginsFromGroup("cluster", groupID)
 	assertions.NotNil(err)
 	assertions.Contains(err.Error(), "could not find group")
-}
 
-func Test_DiscoverPluginGroups(t *testing.T) {
-	assertions := assert.New(t)
-
-	defer setupLocalDistroForTesting()()
-	execCommand = fakeInfoExecCommand
-	defer func() { execCommand = exec.Command }()
-
-	// A local discovery currently does not support groups, but we can
-	// at least do negative testing
-	_, err := DiscoverPluginGroups(nil)
+	groupID = testGroupName
+	fullGroupID, err := InstallPluginsFromGroup("cluster", groupID)
 	assertions.NotNil(err)
-	assertions.Contains(err.Error(), "unable to create group discovery: unknown group discovery source")
-}
+	assertions.Equal(groupID+":v2.1.0", fullGroupID)
+	assertions.Contains(err.Error(), fmt.Sprintf("plugin 'cluster' is not part of the group '%s'", fullGroupID))
 
-func Test_AvailablePlugins(t *testing.T) {
-	assertions := assert.New(t)
-
-	defer setupLocalDistroForTesting()()
-
-	expectedDiscoveredPlugins := append(expectedDiscoveredContextPlugins, expectedDiscoveredStandalonePlugins...)
-	discoveredPlugins, err := AvailablePlugins()
-	assertions.Nil(err)
-	assertions.Equal(len(expectedDiscoveredPlugins), len(discoveredPlugins))
-
-	for i := 0; i < len(expectedDiscoveredPlugins); i++ {
-		pd := findDiscoveredPlugin(discoveredPlugins, expectedDiscoveredPlugins[i].Name, expectedDiscoveredPlugins[i].Target)
-		assertions.NotNil(pd)
-		assertions.Equal(expectedDiscoveredPlugins[i].Name, pd.Name)
-		assertions.Equal(expectedDiscoveredPlugins[i].RecommendedVersion, pd.RecommendedVersion)
-		assertions.Equal(expectedDiscoveredPlugins[i].Target, pd.Target)
-		assertions.Equal(expectedDiscoveredPlugins[i].Scope, pd.Scope)
-		assertions.Equal(common.PluginStatusNotInstalled, pd.Status)
-	}
-
-	// Install login, myplugin plugins
-	mockInstallPlugin(assertions, "login", "v0.2.0", configtypes.TargetUnknown)
-	mockInstallPlugin(assertions, "myplugin", "v0.2.0", configtypes.TargetTMC)
-
-	expectedInstallationStatusOfPlugins := []discovery.Discovered{
-		{
-			Name:             "myplugin",
-			Target:           configtypes.TargetTMC,
-			InstalledVersion: "v0.2.0",
-			Status:           common.PluginStatusInstalled,
-		},
-		{
-			Name:             "myplugin",
-			Target:           configtypes.TargetK8s,
-			InstalledVersion: "",
-			Status:           common.PluginStatusNotInstalled,
-		},
-		{
-			Name:             "login",
-			Target:           configtypes.TargetUnknown,
-			InstalledVersion: "v0.2.0",
-			Status:           common.PluginStatusInstalled,
-		},
-	}
-
-	// Get available plugin after install and verify installation status
-	discoveredPlugins, err = AvailablePlugins()
-	assertions.Nil(err)
-	assertions.Equal(len(expectedDiscoveredPlugins), len(discoveredPlugins))
-
-	for _, eisp := range expectedInstallationStatusOfPlugins {
-		p := findDiscoveredPlugin(discoveredPlugins, eisp.Name, eisp.Target)
-		assertions.NotNil(p)
-		assertions.Equal(eisp.Status, p.Status)
-		assertions.Equal(eisp.InstalledVersion, p.InstalledVersion)
-	}
-
-	// Install management-cluster, feature plugins
-	mockInstallPlugin(assertions, "management-cluster", "v1.6.0", configtypes.TargetK8s)
-	mockInstallPlugin(assertions, "feature", "v0.2.0", configtypes.TargetK8s)
-
-	expectedInstallationStatusOfPlugins = []discovery.Discovered{
-		{
-			Name:             "management-cluster",
-			Target:           configtypes.TargetK8s,
-			InstalledVersion: "v1.6.0",
-			Status:           common.PluginStatusInstalled,
-		},
-		{
-			Name:             "feature",
-			Target:           configtypes.TargetK8s,
-			InstalledVersion: "v0.2.0",
-			Status:           common.PluginStatusInstalled,
-		},
-		{
-			Name:             "management-cluster",
-			Target:           configtypes.TargetTMC,
-			InstalledVersion: "",
-			Status:           common.PluginStatusNotInstalled,
-		},
-		{
-			Name:             "login",
-			Target:           configtypes.TargetUnknown,
-			InstalledVersion: "v0.2.0",
-			Status:           common.PluginStatusInstalled,
-		},
-	}
-
-	// Get available plugin after install and verify installation status
-	discoveredPlugins, err = AvailablePlugins()
-	assertions.Nil(err)
-	assertions.Equal(len(expectedDiscoveredPlugins), len(discoveredPlugins))
-
-	for _, eisp := range expectedInstallationStatusOfPlugins {
-		p := findDiscoveredPlugin(discoveredPlugins, eisp.Name, eisp.Target)
-		assertions.NotNil(p)
-		assertions.Equal(eisp.Status, p.Status, eisp.Name)
-		assertions.Equal(eisp.InstalledVersion, p.InstalledVersion, eisp.Name)
-	}
-}
-
-func Test_AvailablePlugins_With_K8s_None_Target_Plugin_Name_Conflict_With_One_Installed_Getting_Discovered(t *testing.T) {
-	assertions := assert.New(t)
-
-	defer setupLocalDistroForTesting()()
-
-	expectedDiscoveredPlugins := append(expectedDiscoveredContextPlugins, expectedDiscoveredStandalonePlugins...)
-	discoveredPlugins, err := AvailablePlugins()
-	assertions.Nil(err)
-	assertions.Equal(len(expectedDiscoveredPlugins), len(discoveredPlugins))
-
-	// Install login, cluster plugins
-	mockInstallPlugin(assertions, "login", "v0.2.0", configtypes.TargetUnknown)
-
-	// Considering `login` plugin with `<none>` target is already installed and
-	// getting discovered through some discoveries source
-	//
-	// if the same `login` plugin is now getting discovered with `k8s` target
-	// verify the result of AvailablePlugins
-
-	discoverySource := configtypes.PluginDiscovery{
-		Local: &configtypes.LocalDiscovery{
-			Name: "fake-with-k8s-target",
-			Path: "standalone-k8s-target",
-		},
-	}
-	err = configlib.SetCLIDiscoverySource(discoverySource)
-	assertions.Nil(err)
-
-	discoveredPlugins, err = AvailablePlugins()
-	assertions.Nil(err)
-	assertions.Equal(len(expectedDiscoveredPlugins), len(discoveredPlugins))
-
-	expectedInstallationStatusOfPlugins := []discovery.Discovered{
-		{
-			Name:             "login",
-			Target:           configtypes.TargetK8s,
-			InstalledVersion: "v0.2.0",
-			Status:           common.PluginStatusInstalled,
-		},
-	}
-
-	for i := range discoveredPlugins {
-		log.Infof("Discovered: %v, %v, %v, %v", discoveredPlugins[i].Name, discoveredPlugins[i].Target, discoveredPlugins[i].Status, discoveredPlugins[i].InstalledVersion)
-	}
-
-	for _, eisp := range expectedInstallationStatusOfPlugins {
-		p := findDiscoveredPlugin(discoveredPlugins, eisp.Name, eisp.Target)
-		assertions.NotNil(p)
-		assertions.Equal(eisp.Status, p.Status, eisp.Name)
-		assertions.Equal(eisp.InstalledVersion, p.InstalledVersion, eisp.Name)
-	}
-}
-
-func Test_AvailablePlugins_With_K8s_None_Target_Plugin_Name_Conflict_With_Plugin_Installed_But_Not_Getting_Discovered(t *testing.T) {
-	assertions := assert.New(t)
-
-	defer setupLocalDistroForTesting()()
-
-	expectedDiscoveredPlugins := append(expectedDiscoveredContextPlugins, expectedDiscoveredStandalonePlugins...)
-	discoveredPlugins, err := AvailablePlugins()
-	assertions.Nil(err)
-	assertions.Equal(len(expectedDiscoveredPlugins), len(discoveredPlugins))
-
-	// Install login, cluster plugins
-	mockInstallPlugin(assertions, "login", "v0.2.0", configtypes.TargetUnknown)
-
-	// Considering `login` plugin with `<none>` target is already installed and
-	// getting discovered through some discoveries source
-	//
-	// if the same `login` plugin is now getting discovered with `k8s` target
-	// verify the result of AvailablePlugins
-
-	// Replace old discovery source to point to new standalone discovery where the same plugin is getting
-	// discovered through k8s target
-	discoverySource := configtypes.PluginDiscovery{
-		Local: &configtypes.LocalDiscovery{
-			Name: "fake",
-			Path: "standalone-k8s-target",
-		},
-	}
-	err = configlib.SetCLIDiscoverySource(discoverySource)
-	assertions.Nil(err)
-
-	discoveredPlugins, err = AvailablePlugins()
-	assertions.Nil(err)
-	assertions.Equal(len(expectedDiscoveredPlugins), len(discoveredPlugins))
-
-	expectedInstallationStatusOfPlugins := []discovery.Discovered{
-		{
-			Name:             "login",
-			Target:           configtypes.TargetK8s,
-			InstalledVersion: "v0.2.0",
-			Status:           common.PluginStatusInstalled,
-		},
-	}
-
-	for _, eisp := range expectedInstallationStatusOfPlugins {
-		p := findDiscoveredPlugin(discoveredPlugins, eisp.Name, eisp.Target)
-		assertions.NotNil(p)
-		assertions.Equal(eisp.Status, p.Status, eisp.Name)
-		assertions.Equal(eisp.InstalledVersion, p.InstalledVersion, eisp.Name)
-	}
-}
-
-func Test_AvailablePlugins_From_LocalSource(t *testing.T) {
-	assertions := assert.New(t)
-
-	defer setupLocalDistroForTesting()()
-
-	currentDirAbsPath, _ := filepath.Abs(".")
-	discoveredPlugins, err := AvailablePluginsFromLocalSource(filepath.Join(currentDirAbsPath, "test", "local"))
-	assertions.Nil(err)
-
-	expectedInstallationStatusOfPlugins := []discovery.Discovered{
-		{
-			Name:   "cluster",
-			Scope:  common.PluginScopeStandalone,
-			Target: configtypes.TargetK8s,
-			Status: common.PluginStatusNotInstalled,
-		},
-		{
-			Name:   "management-cluster",
-			Scope:  common.PluginScopeStandalone,
-			Target: configtypes.TargetK8s,
-			Status: common.PluginStatusNotInstalled,
-		},
-		{
-			Name:   "management-cluster",
-			Scope:  common.PluginScopeStandalone,
-			Target: configtypes.TargetTMC,
-			Status: common.PluginStatusNotInstalled,
-		},
-		{
-			Name:   "login",
-			Scope:  common.PluginScopeStandalone,
-			Target: configtypes.TargetK8s,
-			Status: common.PluginStatusNotInstalled,
-		},
-		{
-			Name:   "feature",
-			Scope:  common.PluginScopeStandalone,
-			Target: configtypes.TargetK8s,
-			Status: common.PluginStatusNotInstalled,
-		},
-		{
-			Name:   "cluster",
-			Scope:  common.PluginScopeStandalone,
-			Target: configtypes.TargetTMC,
-			Status: common.PluginStatusNotInstalled,
-		},
-		{
-			Name:   "myplugin",
-			Scope:  common.PluginScopeStandalone,
-			Target: configtypes.TargetK8s,
-			Status: common.PluginStatusNotInstalled,
-		},
-		{
-			Name:   "myplugin",
-			Scope:  common.PluginScopeStandalone,
-			Target: configtypes.TargetTMC,
-			Status: common.PluginStatusNotInstalled,
-		},
-	}
-
-	assertions.Equal(len(expectedInstallationStatusOfPlugins), len(discoveredPlugins))
-
-	for _, eisp := range expectedInstallationStatusOfPlugins {
-		p := findDiscoveredPlugin(discoveredPlugins, eisp.Name, eisp.Target)
-		assertions.NotNil(p, "plugin %q with target %q not found", eisp.Name, eisp.Target)
-		assertions.Equal(eisp.Status, p.Status, "status mismatch for plugin %q with target %q", eisp.Name, eisp.Target)
-		assertions.Equal(eisp.Scope, p.Scope, "scope mismatch for plugin %q with target %q", eisp.Name, eisp.Target)
-	}
+	groupID = testGroupName + ":" + testGroupVersion
+	fullGroupID, err = InstallPluginsFromGroup("cluster", groupID)
+	assertions.NotNil(err)
+	assertions.Equal(groupID, fullGroupID)
+	assertions.Contains(err.Error(), fmt.Sprintf("plugin 'cluster' from group '%s' is not mandatory to install", fullGroupID))
 }
 
 func Test_InstallPlugin_InstalledPlugins_From_LocalSource(t *testing.T) {
@@ -771,102 +515,42 @@ func Test_DeletePlugin(t *testing.T) {
 	assertions.Contains(err.Error(), fmt.Sprintf(missingTargetStr, "myplugin"))
 }
 
-func Test_ValidatePlugin(t *testing.T) {
+func Test_SyncPlugins(t *testing.T) {
 	assertions := assert.New(t)
 
-	pd := cli.PluginInfo{}
-	err := ValidatePlugin(&pd)
-	assertions.Contains(err.Error(), "plugin name cannot be empty")
-
-	pd.Name = "fake-plugin"
-	err = ValidatePlugin(&pd)
-	assertions.NotContains(err.Error(), "plugin name cannot be empty")
-	assertions.Contains(err.Error(), "plugin \"fake-plugin\" version cannot be empty")
-	assertions.Contains(err.Error(), "plugin \"fake-plugin\" group cannot be empty")
-}
-
-func Test_SyncPlugins_All_Plugins_No_Central_Repo(t *testing.T) {
-	assertions := assert.New(t)
-
-	defer setupLocalDistroForTesting()()
+	defer setupPluginSourceForTesting()()
 	execCommand = fakeInfoExecCommand
 	defer func() { execCommand = exec.Command }()
 
-	// Turn off central repo feature
-	featureArray := strings.Split(constants.FeatureDisableCentralRepositoryForTesting, ".")
-	err := configlib.SetFeature(featureArray[1], featureArray[2], "true")
-	assertions.Nil(err)
+	// Get the server plugins (they are not installed yet)
+	serverPlugins, err := DiscoverServerPlugins()
+	assertions.NotNil(err)
+	// There is an error for the kubernetes discovery since we don't have a cluster
+	// but other server plugins will be found, so we use those
+	assertions.Contains(err.Error(), `Failed to load Kubeconfig file from "config"`)
+	assertions.Equal(len(expectedDiscoveredContextPlugins), len(serverPlugins))
 
-	expectedDiscoveredPlugins := append(expectedDiscoveredContextPlugins, expectedDiscoveredStandalonePlugins...)
-
-	// Get all available plugins(standalone+context-aware) and verify the status is `not installed`
-	discovered, err := AvailablePlugins()
-	assertions.Nil(err)
-	assertions.Equal(len(expectedDiscoveredPlugins), len(discovered))
-
-	for _, edp := range expectedDiscoveredPlugins {
-		p := findDiscoveredPlugin(discovered, edp.Name, edp.Target)
+	for _, edp := range expectedDiscoveredContextPlugins {
+		p := findDiscoveredPlugin(serverPlugins, edp.Name, edp.Target)
 		assertions.NotNil(p)
 		assertions.Equal(common.PluginStatusNotInstalled, p.Status)
 	}
 
 	// Sync all available plugins
 	err = SyncPlugins()
-	assertions.Nil(err)
+	assertions.NotNil(err)
+	// There is an error for the kubernetes discovery since we don't have a cluster
+	// but other server plugins will be found, so we use those
+	assertions.Contains(err.Error(), `Failed to load Kubeconfig file from "config"`)
 
-	// Get all available plugins(standalone+context-aware) and verify the status is updated to `installed`
-	discovered, err = AvailablePlugins()
+	installedServerPlugins, err := pluginsupplier.GetInstalledServerPlugins()
 	assertions.Nil(err)
-	assertions.Equal(len(expectedDiscoveredPlugins), len(discovered))
+	assertions.Equal(len(installedServerPlugins), len(serverPlugins))
 
-	for _, edp := range expectedDiscoveredPlugins {
-		p := findDiscoveredPlugin(discovered, edp.Name, edp.Target)
+	for _, isp := range installedServerPlugins {
+		p := findDiscoveredPlugin(serverPlugins, isp.Name, isp.Target)
 		assertions.NotNil(p)
-		assertions.Equal(common.PluginStatusInstalled, p.Status)
-		assertions.Equal(edp.RecommendedVersion, p.InstalledVersion)
 	}
-}
-
-func Test_getInstalledButNotDiscoveredStandalonePlugins(t *testing.T) {
-	assertions := assert.New(t)
-
-	availablePlugins := []discovery.Discovered{{Name: "fake1", DiscoveryType: "oci", RecommendedVersion: "v1.0.0", Status: common.PluginStatusInstalled}}
-	installedPlugin := []cli.PluginInfo{{Name: "fake2", Version: "v2.0.0", Discovery: "local"}}
-
-	// If installed plugin is not part of available(discovered) plugins
-	plugins := getInstalledButNotDiscoveredStandalonePlugins(availablePlugins, installedPlugin)
-	assertions.Equal(len(plugins), 1)
-	assertions.Equal("fake2", plugins[0].Name)
-	assertions.Equal("v2.0.0", plugins[0].RecommendedVersion)
-	assertions.Equal(common.PluginStatusInstalled, plugins[0].Status)
-
-	// If installed plugin is part of available(discovered) plugins and provided available plugin is already marked as `installed`
-	installedPlugin = append(installedPlugin, cli.PluginInfo{Name: "fake1", Version: "v1.0.0", Discovery: "local"})
-	plugins = getInstalledButNotDiscoveredStandalonePlugins(availablePlugins, installedPlugin)
-	assertions.Equal(len(plugins), 1)
-	assertions.Equal("fake2", plugins[0].Name)
-	assertions.Equal("v2.0.0", plugins[0].RecommendedVersion)
-	assertions.Equal(common.PluginStatusInstalled, plugins[0].Status)
-
-	// If installed plugin is part of available(discovered) plugins and provided available plugin is already marked as `not installed`
-	// then test the availablePlugin status gets updated to `installed`
-	availablePlugins[0].Status = common.PluginStatusNotInstalled
-	plugins = getInstalledButNotDiscoveredStandalonePlugins(availablePlugins, installedPlugin)
-	assertions.Equal(len(plugins), 1)
-	assertions.Equal("fake2", plugins[0].Name)
-	assertions.Equal("v2.0.0", plugins[0].RecommendedVersion)
-	assertions.Equal(common.PluginStatusInstalled, plugins[0].Status)
-	assertions.Equal(common.PluginStatusInstalled, availablePlugins[0].Status)
-
-	// If installed plugin is part of available(discovered) plugins and versions installed is different than discovered version
-	availablePlugins[0].Status = common.PluginStatusNotInstalled
-	availablePlugins[0].RecommendedVersion = "v4.0.0"
-	plugins = getInstalledButNotDiscoveredStandalonePlugins(availablePlugins, installedPlugin)
-	assertions.Equal(len(plugins), 1)
-	assertions.Equal("fake2", plugins[0].Name)
-	assertions.Equal("v2.0.0", plugins[0].RecommendedVersion)
-	assertions.Equal(common.PluginStatusInstalled, plugins[0].Status)
-	assertions.Equal(common.PluginStatusInstalled, availablePlugins[0].Status)
 }
 
 func Test_setAvailablePluginsStatus(t *testing.T) {
@@ -1153,141 +837,6 @@ func TestVerifyPluginPostDownload(t *testing.T) {
 	}
 }
 
-func Test_removeDuplicates(t *testing.T) {
-	assertions := assert.New(t)
-
-	tcs := []struct {
-		name           string
-		inputPlugins   []discovery.Discovered
-		expectedResult []discovery.Discovered
-	}{
-		{
-			name: "when plugin name-target conflict happens with '' and 'k8s' targeted plugins ",
-			inputPlugins: []discovery.Discovered{
-				{
-					Name:   "foo",
-					Target: configtypes.TargetUnknown,
-					Scope:  common.PluginScopeStandalone,
-				},
-				{
-					Name:   "foo",
-					Target: configtypes.TargetK8s,
-					Scope:  common.PluginScopeStandalone,
-				},
-				{
-					Name:   "bar",
-					Target: configtypes.TargetK8s,
-					Scope:  common.PluginScopeStandalone,
-				},
-			},
-			expectedResult: []discovery.Discovered{
-				{
-					Name:   "foo",
-					Target: configtypes.TargetK8s,
-					Scope:  common.PluginScopeStandalone,
-				},
-				{
-					Name:   "bar",
-					Target: configtypes.TargetK8s,
-					Scope:  common.PluginScopeStandalone,
-				},
-			},
-		},
-		{
-			name: "when same plugin exists for '', 'k8s' and 'tmc' target as standalone plugin",
-			inputPlugins: []discovery.Discovered{
-				{
-					Name:   "foo",
-					Target: configtypes.TargetUnknown,
-					Scope:  common.PluginScopeStandalone,
-				},
-				{
-					Name:   "foo",
-					Target: configtypes.TargetK8s,
-					Scope:  common.PluginScopeStandalone,
-				},
-				{
-					Name:   "foo",
-					Target: configtypes.TargetTMC,
-					Scope:  common.PluginScopeStandalone,
-				},
-			},
-			expectedResult: []discovery.Discovered{
-				{
-					Name:   "foo",
-					Target: configtypes.TargetK8s,
-					Scope:  common.PluginScopeStandalone,
-				},
-				{
-					Name:   "foo",
-					Target: configtypes.TargetTMC,
-					Scope:  common.PluginScopeStandalone,
-				},
-			},
-		},
-		{
-			name: "when foo standalone plugin is available with `k8s` and `` target and also available as context-scoped plugin with `k8s` target",
-			inputPlugins: []discovery.Discovered{
-				{
-					Name:   "foo",
-					Target: configtypes.TargetUnknown,
-					Scope:  common.PluginScopeStandalone,
-				},
-				{
-					Name:   "foo",
-					Target: configtypes.TargetK8s,
-					Scope:  common.PluginScopeStandalone,
-				},
-				{
-					Name:   "foo",
-					Target: configtypes.TargetK8s,
-					Scope:  common.PluginScopeContext,
-				},
-			},
-			expectedResult: []discovery.Discovered{
-				{
-					Name:   "foo",
-					Target: configtypes.TargetK8s,
-					Scope:  common.PluginScopeContext,
-				},
-			},
-		},
-		{
-			name: "when tmc targeted plugin exists as standalone as well as context-scope",
-			inputPlugins: []discovery.Discovered{
-				{
-					Name:   "foo",
-					Target: configtypes.TargetTMC,
-					Scope:  common.PluginScopeStandalone,
-				},
-				{
-					Name:   "foo",
-					Target: configtypes.TargetTMC,
-					Scope:  common.PluginScopeContext,
-				},
-			},
-			expectedResult: []discovery.Discovered{
-				{
-					Name:   "foo",
-					Target: configtypes.TargetTMC,
-					Scope:  common.PluginScopeContext,
-				},
-			},
-		},
-	}
-
-	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			result := combineDuplicatePlugins(tc.inputPlugins)
-			assertions.Equal(len(result), len(tc.expectedResult))
-			for i := range tc.expectedResult {
-				p := findDiscoveredPlugin(result, tc.expectedResult[i].Name, tc.expectedResult[i].Target)
-				assertions.Equal(p.Scope, tc.expectedResult[i].Scope)
-			}
-		})
-	}
-}
-
 func TestHelperProcess(t *testing.T) {
 	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
 		return
@@ -1408,17 +957,6 @@ func TestGetPluginDiscoveries(t *testing.T) {
 	assertions.Equal(expectedTestDiscoveries[1], discoveries[3].OCI.Image)
 	assertions.Equal(expectedTestDiscoveries[2], discoveries[4].OCI.Image)
 	assertions.Equal(expectedTestDiscoveries[3], discoveries[5].OCI.Image)
-
-	// Test with the Central Repo feature disabled
-	featureArray := strings.Split(constants.FeatureDisableCentralRepositoryForTesting, ".")
-	err = configlib.SetFeature(featureArray[1], featureArray[2], "true")
-	assertions.Nil(err)
-
-	discoveries, err = getPluginDiscoveries()
-	assertions.Nil(err)
-	assertions.Equal(2, len(discoveries))
-	assertions.Equal("default-local", discoveries[0].Local.Name)
-	assertions.Equal("fake", discoveries[1].Local.Name)
 
 	os.Unsetenv(constants.ConfigVariableAdditionalDiscoveryForTesting)
 }

--- a/pkg/pluginmanager/test/config-ng2.yaml
+++ b/pkg/pluginmanager/test/config-ng2.yaml
@@ -1,11 +1,8 @@
 cli:
   discoverySources:
-    - local:
-        name: default-local
-        path: default
-    - local:
-        name: fake
-        path: standalone
+    - oci:
+        name: default
+        image: example.com/plugin-inventory:latest
   eulaStatus: accepted
   ceipOptIn: "false"
 currentContext:

--- a/pkg/pluginmanager/test/config.yaml
+++ b/pkg/pluginmanager/test/config.yaml
@@ -1,36 +1,26 @@
-apiVersion: config.tanzu.vmware.com/v1alpha1
-current: mgmt
-currentContext:
-  kubernetes: mgmt
-  mission-control: tmc-fake
-kind: ClientConfig
-metadata:
-  creationTimestamp: null
+clientOptions:
+  features:
+    global:
+      context-target-v2: "true"
+    cli:
+      edition: tkg
+      bomRepo: projects.registry.vmware.com/tkg
+      compatibilityFilePath: tkg-compatibility
 servers:
   - managementClusterOpts:
       context: mgmt-admin@mgmt
       path: config
     name: mgmt
+    type: managementcluster
+    discoverySources:
+      - local:
+          name: fake-mgmt
+          path: context-mgmt
+  - name: tmc-fake
     type: global
-    discoverySources:
-      - local:
-          name: fake-mgmt
-          path: context-mgmt
-contexts:
-  - clusterOpts:
-      context: mgmt-admin@mgmt
-      path: config
-      isManagementCluster: true
-    name: mgmt
-    target: kubernetes
-    discoverySources:
-      - local:
-          name: fake-mgmt
-          path: context-mgmt
-  - globalOpts:
-    name: tmc-fake
-    target: mission-control
+    globalOpts:
     discoverySources:
       - local:
           name: fake-tmc
           path: context-tmc
+current: mgmt


### PR DESCRIPTION
### What this PR does / why we need it

This commit removes all the unused code around feature flags from the `manager.go` file.  

**Code cleanup details:**
1. Remove `ValidatePlugin()` which was never used.  There is a separate copy of this function in the tanzu-plugin-runtime repository.
2. Remove `discoverPlugins()` and directly use `discoverSpecificPlugins()`
3. Remove `discoverServerPluginsBasedOnCurrentServer` which is no longer used.
4. Include the logic of `discoverServerPluginsBasedOnAllCurrentContexts()` directly into `DiscoverServerPlugins()` which had become a one-liner.
5. Remove the following functions that were no longer used:
          - `AvailablePlugins()`
          - `AvailablePluginsFromLocalSource()`
          - `availablePlugins()`
          - `combineDuplicatePlugins()`
          - `getInstalledButNotDiscoveredStandalonePlugins()`
          - `DiscoveredFromPlugininfo()`
          - `availablePluginsFromStandaloneAndServerPlugins()`
          - `pluginIndexForName()`
          - `legacyPluginInstall()`
          - `GetRecommendedVersionOfPlugin()`

Completely remove the feature flag constant: `FeatureDisableCentralRepositoryForTesting`

**Update the unit tests for the plugin manager.**

This commit also improves our ability to test the pluginmanager.
It does this using two techniques:
1. Creating a test plugin inventory DB in the cache and requesting the inventory code to always use the cache (without checking the digest). To force the use of the cache the commit Introduces a test variable `TANZU_CLI_USE_DB_CACHE_ONLY`.  This approach allows to discover plugins and groups without needing a real OCI registry.

2. Creating "fake" plugin binaries in the plugin binary cache.  This allows installation of plugins to find the binaries in the cache and therefore never have to go to an OCI registry to download them.

With these two techniques, the unit tests can discovery and install plugins, and can also do so using groups.  The plugin sync can also be tested with this.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Part of #477

### Describe testing done for PR

```
# Remove the existing plugin DB
$ \rm -rf ~/.cache/tanzu/plugin_inventory
# Confirm the DB gets downloaded
$ tz plugin search --name apps
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
  NAME  DESCRIPTION                 TARGET      LATEST
  apps  Applications on Kubernetes  kubernetes  v0.12.1
# Confirm the DB does not get downloaded again
$ tz plugin search --name isolated-cluster
  NAME              DESCRIPTION                                                       TARGET  LATEST
  isolated-cluster  Prepopulating images/bundle for internet-restricted environments  global  v0.30.1
$ tz plugin group search --name vmware-tkg/default
  GROUP               DESCRIPTION      LATEST
  vmware-tkg/default  Plugins for TKG  v2.3.0

# Remove the DB again
$ \rm -rf ~/.cache/tanzu/plugin_inventory

# Confirm the DB gets downloaded for groups
$ tz plugin group search --name vmware-tkg/default
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
  GROUP               DESCRIPTION      LATEST
  vmware-tkg/default  Plugins for TKG  v2.3.0
# Confirm the DB does not get downloaded again
$ tz plugin group search --name vmware-tkg/default
  GROUP               DESCRIPTION      LATEST
  vmware-tkg/default  Plugins for TKG  v2.3.0

# Start with no plugins installed
$ rm ~/.cache/tanzu/catalog.yaml

# Install one plugin and also see the essential plugins get installed
$ tz plugin install secret
[i] The tanzu cli essential plugins have not been installed and are being installed now. The install may take a few seconds.

[x] : unable to uniquely identify plugin 'secret'. Please specify the target (kubernetes[k8s]/mission-control[tmc]/global) of the plugin using the `--target` flag
$ tz plugin install secret --target k8s
[i] Installing plugin 'secret:v0.30.1' with target 'kubernetes'
[i] Plugin binary for 'secret:v0.30.1' found in cache
[ok] successfully installed 'secret' plugin
$ tz plugin list
Standalone Plugins
  NAME       DESCRIPTION                                                 TARGET      VERSION  STATUS
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  global      v1.1.0   installed
  secret     Tanzu secret management                                     kubernetes  v0.30.1  installed

# Install a specific plugin version
$ tz plugin install apps --version v0.11.1
[i] Installing plugin 'apps:v0.11.1' with target 'kubernetes'
[i] Plugin binary for 'apps:v0.11.1' found in cache
[ok] successfully installed 'apps' plugin

# Install plugins from a group
$ tz plugin install --group vmware-tkg/default
[i] Installing plugin 'isolated-cluster:v0.30.1' with target 'global'
[i] Plugin binary for 'isolated-cluster:v0.30.1' found in cache
[i] Installing plugin 'management-cluster:v0.30.1' with target 'kubernetes'
[i] Plugin binary for 'management-cluster:v0.30.1' found in cache
[i] Installing plugin 'package:v0.30.1' with target 'kubernetes'
[i] Plugin binary for 'package:v0.30.1' found in cache
[i] Installing plugin 'pinniped-auth:v0.30.1' with target 'global'
[i] Plugin binary for 'pinniped-auth:v0.30.1' found in cache
[i] Installing plugin 'secret:v0.30.1' with target 'kubernetes'
[i] Plugin binary for 'secret:v0.30.1' found in cache
[i] Installing plugin 'telemetry:v0.30.1' with target 'kubernetes'
[i] Plugin binary for 'telemetry:v0.30.1' found in cache
[ok] successfully installed all plugins from group 'vmware-tkg/default:v2.3.0'

# Look for plugin group versions
$ tz plugin group search --name vmware-tkg/default --show-details
name: vmware-tkg/default
description: Plugins for TKG
latest: v2.3.0
versions:
    - v1.6.0
    - v1.6.1
    - v2.1.0
    - v2.1.1
    - v2.2.0
    - v2.3.0

# Install plugins from a specific group version
$ tz plugin install --group vmware-tkg/default:v2.2.0
[i] Installing plugin 'isolated-cluster:v0.29.0' with target 'global'
[i] Installing plugin 'management-cluster:v0.29.0' with target 'kubernetes'
[i] Installing plugin 'package:v0.29.0' with target 'kubernetes'
[i] Installing plugin 'pinniped-auth:v0.29.0' with target 'global'
[i] Installing plugin 'secret:v0.29.0' with target 'kubernetes'
[i] Installing plugin 'telemetry:v0.29.0' with target 'kubernetes'
[ok] successfully installed all plugins from group 'vmware-tkg/default:v2.2.0'

# Do some installation through contexts
$ tz context list
Target:  kubernetes
  NAME  ISACTIVE  ENDPOINT  KUBECONFIGPATH                          KUBECONTEXT
  tkg1  false               /Users/kmarc/.k3d/kubeconfig-tkg1.yaml  k3d-tkg1
Target:  mission-control
  NAME  ISACTIVE  ENDPOINT
  tmc   false     unstable.tmc-dev.cloud.vmware.com:443
$ tz context use tkg1
[i] Checking for required plugins...
[i] Installing plugin 'cluster:v0.30.1' with target 'kubernetes'
[i] Plugin binary for 'cluster:v0.30.1' found in cache
[i] Installing plugin 'kubernetes-release:v0.30.1' with target 'kubernetes'
[i] Plugin binary for 'kubernetes-release:v0.30.1' found in cache
[i] Installing plugin 'feature:v0.30.1' with target 'kubernetes'
[i] Plugin binary for 'feature:v0.30.1' found in cache
[i] Successfully installed all required plugins

$ tz plugin list
Standalone Plugins
  NAME                DESCRIPTION                                                        TARGET      VERSION  STATUS
  isolated-cluster    Prepopulating images/bundle for internet-restricted environments   global      v0.29.0  installed
  pinniped-auth       Pinniped authentication operations (usually not directly invoked)  global      v0.29.0  installed
  telemetry           configure cluster-wide settings for vmware tanzu telemetry         global      v1.1.0   installed
  apps                Applications on Kubernetes                                         kubernetes  v0.11.1  installed
  management-cluster  Kubernetes management cluster operations                           kubernetes  v0.29.0  installed
  package             Tanzu package management                                           kubernetes  v0.29.0  installed
  secret              Tanzu secret management                                            kubernetes  v0.29.0  installed
  telemetry           configure cluster-wide settings for vmware tanzu telemetry         kubernetes  v0.29.0  installed

Plugins from Context:  tkg1
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v0.30.1  installed
  feature             Operate on features and featuregates  kubernetes  v0.30.1  installed
  kubernetes-release  Kubernetes release operations         kubernetes  v0.30.1  installed

# Check that the installation happens (but then I interrupted because it is very long)
$ tz context use tmc
[i] Checking for required plugins...
[i] Installing plugin 'management-cluster:v0.1.2' with target 'mission-control'
^C
$ tz plugin list
Standalone Plugins
  NAME                DESCRIPTION                                                        TARGET      VERSION  STATUS
  isolated-cluster    Prepopulating images/bundle for internet-restricted environments   global      v0.29.0  installed
  pinniped-auth       Pinniped authentication operations (usually not directly invoked)  global      v0.29.0  installed
  telemetry           configure cluster-wide settings for vmware tanzu telemetry         global      v1.1.0   installed
  apps                Applications on Kubernetes                                         kubernetes  v0.11.1  installed
  management-cluster  Kubernetes management cluster operations                           kubernetes  v0.29.0  installed
  package             Tanzu package management                                           kubernetes  v0.29.0  installed
  secret              Tanzu secret management                                            kubernetes  v0.29.0  installed
  telemetry           configure cluster-wide settings for vmware tanzu telemetry         kubernetes  v0.29.0  installed

Plugins from Context:  tkg1
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v0.30.1  installed
  feature             Operate on features and featuregates  kubernetes  v0.30.1  installed
  kubernetes-release  Kubernetes release operations         kubernetes  v0.30.1  installed

Plugins from Context:  tmc
  NAME                  DESCRIPTION                                                     TARGET           VERSION  STATUS
  account               Account for tmc resources                                       mission-control  v0.1.4   not installed
  agentartifacts        helm for tmc resources                                          mission-control  v0.1.4   not installed
  aks-cluster           Manage and unmanage tmc aks clusters                            mission-control  v0.1.7   not installed
  apply                 Create/Update a resource with a resource file                   mission-control  v0.3.1   not installed
  audit                 Run an audit request on an org                                  mission-control  v0.1.4   not installed
  cluster                                                                               mission-control  v0.1.6   not installed
  clustergroup          A group of Kubernetes clusters                                  mission-control  v0.1.4   not installed
  continuousdelivery    Continuousdelivery for tmc resources                            mission-control  v0.1.4   not installed
  data-protection       Data protection for tmc resources                               mission-control  v0.1.4   not installed
  ekscluster                                                                            mission-control  v0.1.4   not installed
  events                Events for any meaningful user activity or system state change  mission-control  v0.1.4   not installed
  helm                  helm for tmc resources                                          mission-control  v0.1.4   not installed
  iam                   IAM Policies for tmc resources                                  mission-control  v0.1.4   not installed
  inspection            Inspection for tmc resources                                    mission-control  v0.1.4   not installed
  integration           Get available integrations and their information from registry  mission-control  v0.1.4   not installed
  management-cluster    A TMC registered Management cluster                             mission-control  v0.1.2   not installed
  policy                Policy for tmc resources                                        mission-control  v0.1.4   not installed
  provider-aks-cluster  Manage and unmanage tmc provider aks clusters                   mission-control  v0.1.4   not installed
  provider-eks-cluster                                                                  mission-control  v0.1.4   not installed
  secret                secret for tmc resources                                        mission-control  v0.1.4   not installed
  setting               Setting plugin for tmc resources                                mission-control  v0.2.2   not installed
  tanzupackage          Tanzupackage for tmc resources                                  mission-control  v0.2.3   not installed
  workspace             A group of Kubernetes namespaces                                mission-control  v0.1.6   not installed

[!] As shown above, some recommended plugins have not been installed or are outdated. To install them please run 'tanzu plugin sync'.

# Try the other plugin operations
$ tz plugin delete cluster
Deleting Plugin 'cluster' for target 'kubernetes'. Are you sure? [y/N]: y
[ok] successfully deleted plugin 'cluster'
$ tz plugin list
Standalone Plugins
  NAME                DESCRIPTION                                                        TARGET      VERSION  STATUS
  isolated-cluster    Prepopulating images/bundle for internet-restricted environments   global      v0.29.0  installed
  pinniped-auth       Pinniped authentication operations (usually not directly invoked)  global      v0.29.0  installed
  telemetry           configure cluster-wide settings for vmware tanzu telemetry         global      v1.1.0   installed
  apps                Applications on Kubernetes                                         kubernetes  v0.11.1  installed
  management-cluster  Kubernetes management cluster operations                           kubernetes  v0.29.0  installed
  package             Tanzu package management                                           kubernetes  v0.29.0  installed
  secret              Tanzu secret management                                            kubernetes  v0.29.0  installed
  telemetry           configure cluster-wide settings for vmware tanzu telemetry         kubernetes  v0.29.0  installed

Plugins from Context:  tkg1
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v0.30.1  not installed
  feature             Operate on features and featuregates  kubernetes  v0.30.1  installed
  kubernetes-release  Kubernetes release operations         kubernetes  v0.30.1  installed

Plugins from Context:  tmc
  NAME                  DESCRIPTION                                                     TARGET           VERSION  STATUS
  account               Account for tmc resources                                       mission-control  v0.1.4   not installed
  agentartifacts        helm for tmc resources                                          mission-control  v0.1.4   not installed
  aks-cluster           Manage and unmanage tmc aks clusters                            mission-control  v0.1.7   not installed
  apply                 Create/Update a resource with a resource file                   mission-control  v0.3.1   not installed
  audit                 Run an audit request on an org                                  mission-control  v0.1.4   not installed
  cluster                                                                               mission-control  v0.1.6   not installed
  clustergroup          A group of Kubernetes clusters                                  mission-control  v0.1.4   not installed
  continuousdelivery    Continuousdelivery for tmc resources                            mission-control  v0.1.4   not installed
  data-protection       Data protection for tmc resources                               mission-control  v0.1.4   not installed
  ekscluster                                                                            mission-control  v0.1.4   not installed
  events                Events for any meaningful user activity or system state change  mission-control  v0.1.4   not installed
  helm                  helm for tmc resources                                          mission-control  v0.1.4   not installed
  iam                   IAM Policies for tmc resources                                  mission-control  v0.1.4   not installed
  inspection            Inspection for tmc resources                                    mission-control  v0.1.4   not installed
  integration           Get available integrations and their information from registry  mission-control  v0.1.4   not installed
  management-cluster    A TMC registered Management cluster                             mission-control  v0.1.2   not installed
  policy                Policy for tmc resources                                        mission-control  v0.1.4   not installed
  provider-aks-cluster  Manage and unmanage tmc provider aks clusters                   mission-control  v0.1.4   not installed
  provider-eks-cluster                                                                  mission-control  v0.1.4   not installed
  secret                secret for tmc resources                                        mission-control  v0.1.4   not installed
  setting               Setting plugin for tmc resources                                mission-control  v0.2.2   not installed
  tanzupackage          Tanzupackage for tmc resources                                  mission-control  v0.2.3   not installed
  workspace             A group of Kubernetes namespaces                                mission-control  v0.1.6   not installed

[!] As shown above, some recommended plugins have not been installed or are outdated. To install them please run 'tanzu plugin sync'.
$ tz plugin describe cluster
[x] : unable to find plugin 'cluster'
$ tz plugin describe isolated-cluster
  NAME              VERSION  STATUS     TARGET  DESCRIPTION                                                       INSTALLATIONPATH
  isolated-cluster  v0.29.0  installed  global  Prepopulating images/bundle for internet-restricted environments  /Users/kmarc/Library/Application
                                                                                                                  Support/tanzu-cli/isolated-cluster/v0.29.0_a5daf2abfcad79a73eebd952bf0623b0a93e1eb6c76f417fb0c8d31726f1b483_global
$ tz plugin upgrade package
[i] Installing plugin 'package:v0.30.1' with target 'kubernetes'
[i] Plugin binary for 'package:v0.30.1' found in cache
[ok] successfully upgraded plugin 'package'
$ tz plugin list
Standalone Plugins
  NAME                DESCRIPTION                                                        TARGET      VERSION  STATUS
  isolated-cluster    Prepopulating images/bundle for internet-restricted environments   global      v0.29.0  installed
  pinniped-auth       Pinniped authentication operations (usually not directly invoked)  global      v0.29.0  installed
  telemetry           configure cluster-wide settings for vmware tanzu telemetry         global      v1.1.0   installed
  apps                Applications on Kubernetes                                         kubernetes  v0.11.1  installed
  management-cluster  Kubernetes management cluster operations                           kubernetes  v0.29.0  installed
  package             Tanzu package management                                           kubernetes  v0.30.1  installed
  secret              Tanzu secret management                                            kubernetes  v0.29.0  installed
  telemetry           configure cluster-wide settings for vmware tanzu telemetry         kubernetes  v0.29.0  installed

Plugins from Context:  tkg1
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v0.30.1  not installed
  feature             Operate on features and featuregates  kubernetes  v0.30.1  installed
  kubernetes-release  Kubernetes release operations         kubernetes  v0.30.1  installed

Plugins from Context:  tmc
  NAME                  DESCRIPTION                                                     TARGET           VERSION  STATUS
  account               Account for tmc resources                                       mission-control  v0.1.4   not installed
  agentartifacts        helm for tmc resources                                          mission-control  v0.1.4   not installed
  aks-cluster           Manage and unmanage tmc aks clusters                            mission-control  v0.1.7   not installed
  apply                 Create/Update a resource with a resource file                   mission-control  v0.3.1   not installed
  audit                 Run an audit request on an org                                  mission-control  v0.1.4   not installed
  cluster                                                                               mission-control  v0.1.6   not installed
  clustergroup          A group of Kubernetes clusters                                  mission-control  v0.1.4   not installed
  continuousdelivery    Continuousdelivery for tmc resources                            mission-control  v0.1.4   not installed
  data-protection       Data protection for tmc resources                               mission-control  v0.1.4   not installed
  ekscluster                                                                            mission-control  v0.1.4   not installed
  events                Events for any meaningful user activity or system state change  mission-control  v0.1.4   not installed
  helm                  helm for tmc resources                                          mission-control  v0.1.4   not installed
  iam                   IAM Policies for tmc resources                                  mission-control  v0.1.4   not installed
  inspection            Inspection for tmc resources                                    mission-control  v0.1.4   not installed
  integration           Get available integrations and their information from registry  mission-control  v0.1.4   not installed
  management-cluster    A TMC registered Management cluster                             mission-control  v0.1.2   not installed
  policy                Policy for tmc resources                                        mission-control  v0.1.4   not installed
  provider-aks-cluster  Manage and unmanage tmc provider aks clusters                   mission-control  v0.1.4   not installed
  provider-eks-cluster                                                                  mission-control  v0.1.4   not installed
  secret                secret for tmc resources                                        mission-control  v0.1.4   not installed
  setting               Setting plugin for tmc resources                                mission-control  v0.2.2   not installed
  tanzupackage          Tanzupackage for tmc resources                                  mission-control  v0.2.3   not installed
  workspace             A group of Kubernetes namespaces                                mission-control  v0.1.6   not installed

[!] As shown above, some recommended plugins have not been installed or are outdated. To install them please run 'tanzu plugin sync'.
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Improve unit testing for plugin lifecycle and remove unused code around the previous use of feature flags.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

A new test variable is introduced: `TEST_TANZU_CLI_USE_DB_CACHE_ONLY`.  When set to `1` (or any other enabled boolean value) it forces the `DBBackedOCIDiscovery` to only use the cache.  Using this variable, tests now setup an sqlite
DB file in the cache, and the tests will use it without having to access a registry.  Note that we have a `DiscoveryOptions` `WithUseLocalCacheOnly()` which could have been used for some tests, specifically the tests discovering plugins.  However, in other tests such as the ones installing plugins, using only the cache is not normally supported so this variable is a way to short-circuit that.

The test coverage from the `manager.go` has gone from 73.6% to 76.5%.  This may not seem like a big deal, but after the cleanup the test coverage had actually dropped to 68.6%, so getting back to over 75% required some effort.

More unit tests would benefit from moving to the new approach of testing instead of relying on local plugin installation.  However such an improvement will need to be done in a future effort.

