### PR TITLE
Fallback to installing AMD64 plugins on Darwin

### DIFF
--- a/pkg/cli/arch.go
+++ b/pkg/cli/arch.go
@@ -15,6 +15,9 @@ var (
 
 	// AllOSArch defines all OS/ARCH combination for which plugin can be built
 	AllOSArch = []Arch{LinuxAMD64, DarwinAMD64, WinAMD64, DarwinARM64, LinuxARM64}
+
+	GOOS   = runtime.GOOS
+	GOARCH = runtime.GOARCH
 )
 
 // Arch represents a system architecture.
@@ -22,7 +25,12 @@ type Arch string
 
 // BuildArch returns compile time build arch or locates it.
 func BuildArch() Arch {
-	return Arch(fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH))
+	return Arch(fmt.Sprintf("%s_%s", GOOS, GOARCH))
+}
+
+func SetArch(a Arch) {
+	GOOS = a.OS()
+	GOARCH = a.Arch()
 }
 
 // IsWindows tells if an arch is windows.

--- a/pkg/pluginmanager/manager.go
+++ b/pkg/pluginmanager/manager.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -486,13 +485,28 @@ func installPlugin(pluginName, version string, target configtypes.Target, contex
 		Name:    pluginName,
 		Target:  target,
 		Version: version,
-		OS:      runtime.GOOS,
-		Arch:    runtime.GOARCH,
+		OS:      cli.GOOS,
+		Arch:    cli.GOARCH,
 	}
 	errorList := make([]error, 0)
 	availablePlugins, err := discoverSpecificPlugins(discoveries, discovery.WithPluginDiscoveryCriteria(criteria))
 	if err != nil {
 		errorList = append(errorList, err)
+	}
+
+	// If we cannot find the plugin for DarwinARM64, let's fallback to DarwinAMD64.
+	// This leverages Apples Rosetta emulator and helps until plugins are all available
+	// for ARM64.  Note that this cannot be used on Linux since there is no such emulator.
+	if len(availablePlugins) == 0 && cli.BuildArch() == cli.DarwinARM64 {
+		// Pretend we are on a AMD64 machine
+		cli.SetArch(cli.DarwinAMD64)
+		defer cli.SetArch(cli.DarwinARM64) // Go back to ARM64 once the plugin is installed
+
+		criteria.Arch = cli.DarwinAMD64.Arch()
+		availablePlugins, err = discoverSpecificPlugins(discoveries, discovery.WithPluginDiscoveryCriteria(criteria))
+		if err != nil {
+			errorList = append(errorList, err)
+		}
 	}
 
 	if len(availablePlugins) == 0 {
@@ -689,7 +703,7 @@ func installOrUpgradePlugin(p *discovery.Discovered, version string, installTest
 }
 
 func getPluginFromCache(p *discovery.Discovered, version string) *cli.PluginInfo {
-	pluginArtifact, err := p.Distribution.DescribeArtifact(version, runtime.GOOS, runtime.GOARCH)
+	pluginArtifact, err := p.Distribution.DescribeArtifact(version, cli.GOOS, cli.GOARCH)
 	if err != nil {
 		return nil
 	}
@@ -721,13 +735,13 @@ func fetchAndVerifyPlugin(p *discovery.Discovered, version string) ([]byte, erro
 		return nil, errors.Wrapf(err, "%q plugin pre-download verification failed", p.Name)
 	}
 
-	b, err := p.Distribution.Fetch(version, runtime.GOOS, runtime.GOARCH)
+	b, err := p.Distribution.Fetch(version, cli.GOOS, cli.GOARCH)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to fetch the plugin metadata for plugin %q", p.Name)
 	}
 
 	// verify plugin after download but before installation
-	d, err := p.Distribution.GetDigest(version, runtime.GOOS, runtime.GOARCH)
+	d, err := p.Distribution.GetDigest(version, cli.GOOS, cli.GOARCH)
 	if err != nil {
 		return nil, err
 	}
@@ -782,7 +796,7 @@ func describePlugin(p *discovery.Discovered, pluginPath string) (*cli.PluginInfo
 
 func doInstallTestPlugin(p *discovery.Discovered, pluginPath, version string) error {
 	log.Infof("Installing test plugin for '%v:%v'", p.Name, version)
-	binary, err := p.Distribution.FetchTest(version, runtime.GOOS, runtime.GOARCH)
+	binary, err := p.Distribution.FetchTest(version, cli.GOOS, cli.GOARCH)
 	if err != nil {
 		if os.Getenv("TZ_ENFORCE_TEST_PLUGIN") == "1" {
 			return errors.Wrapf(err, "unable to install test plugin for '%v:%v'", p.Name, version)
@@ -1149,8 +1163,8 @@ func getCLIPluginResourceWithLocalDistroFromPluginInfo(plugin *cli.PluginInfo, p
 					{
 						URI:  pluginBinaryPath,
 						Type: common.DistributionTypeLocal,
-						OS:   runtime.GOOS,
-						Arch: runtime.GOARCH,
+						OS:   cli.GOOS,
+						Arch: cli.GOARCH,
 					},
 				},
 			},
@@ -1213,7 +1227,7 @@ func discoverPluginsFromLocalSourceBasedOnManifestFile(localPath string) ([]disc
 		// Sample path: cli/[target]/<plugin-name>/<plugin-version>/tanzu-<plugin-name>-<os>_<arch>
 		// 				cli/[target]/v0.14.0/tanzu-login-darwin_amd64
 		// As mentioned above, we expect the binary for user's OS-ARCH is present and hence creating path accordingly
-		pluginBinaryPath := filepath.Join(absLocalPath, string(pluginInfo.Target), p.Name, pluginInfo.Version, fmt.Sprintf("tanzu-%s-%s_%s", p.Name, runtime.GOOS, runtime.GOARCH))
+		pluginBinaryPath := filepath.Join(absLocalPath, string(pluginInfo.Target), p.Name, pluginInfo.Version, fmt.Sprintf("tanzu-%s-%s_%s", p.Name, cli.GOOS, cli.GOARCH))
 		if cli.BuildArch().IsWindows() {
 			pluginBinaryPath += exe
 		}
@@ -1272,7 +1286,7 @@ func getPluginInfoResource(pluginFilePath string) (*cli.PluginInfo, error) {
 // verifyPluginPreDownload verifies that the plugin distribution repo is trusted
 // and returns error if the verification fails.
 func verifyPluginPreDownload(p *discovery.Discovered, version string) error {
-	artifactInfo, err := p.Distribution.DescribeArtifact(version, runtime.GOOS, runtime.GOARCH)
+	artifactInfo, err := p.Distribution.DescribeArtifact(version, cli.GOOS, cli.GOARCH)
 	if err != nil {
 		return err
 	}
@@ -1282,7 +1296,7 @@ func verifyPluginPreDownload(p *discovery.Discovered, version string) error {
 	if artifactInfo.URI != "" {
 		return verifyArtifactLocation(artifactInfo.URI)
 	}
-	return errors.Errorf("no download information available for artifact \"%s:%s:%s:%s\"", p.Name, p.RecommendedVersion, runtime.GOOS, runtime.GOARCH)
+	return errors.Errorf("no download information available for artifact \"%s:%s:%s:%s\"", p.Name, p.RecommendedVersion, cli.GOOS, cli.GOARCH)
 }
 
 // verifyRegistry verifies the authenticity of the registry from where cli is

--- a/pkg/pluginmanager/manager_helper_test.go
+++ b/pkg/pluginmanager/manager_helper_test.go
@@ -32,6 +32,7 @@ var testPlugins = []plugininventory.PluginIdentifier{
 	{Name: "cluster", Target: configtypes.TargetK8s, Version: "v1.6.0"},
 	{Name: "myplugin", Target: configtypes.TargetK8s, Version: "v1.6.0"},
 	{Name: "feature", Target: configtypes.TargetK8s, Version: "v0.2.0"},
+	{Name: "pluginwitharm", Target: configtypes.TargetK8s, Version: "v2.0.0"},
 
 	{Name: "isolated-cluster", Target: configtypes.TargetGlobal, Version: "v1.2.3"},
 	{Name: "isolated-cluster", Target: configtypes.TargetGlobal, Version: "v1.3.0"},
@@ -45,6 +46,10 @@ var testPlugins = []plugininventory.PluginIdentifier{
 	{Name: "management-cluster", Target: configtypes.TargetTMC, Version: "v0.2.0"},
 	{Name: "cluster", Target: configtypes.TargetTMC, Version: "v0.2.0"},
 	{Name: "myplugin", Target: configtypes.TargetTMC, Version: "v0.2.0"},
+}
+
+var testPluginsNoARM64 = []plugininventory.PluginIdentifier{
+	{Name: "pluginnoarm", Target: configtypes.TargetK8s, Version: "v1.0.0"},
 }
 
 const createGroupsStmt = `
@@ -115,6 +120,10 @@ INSERT INTO PluginGroups VALUES(
 	'true',
 	'false');
 `
+const (
+	digestForAMD64 = "0000000000"
+	digestForARM64 = "1111111111"
+)
 
 func findDiscoveredPlugin(discovered []discovery.Discovered, pluginName string, target configtypes.Target) *discovery.Discovered {
 	for i := range discovered {
@@ -185,20 +194,39 @@ func setupPluginBinaryInCache(name, version string, target configtypes.Target, d
 	}
 }
 
+func createPluginEntry(db *sql.DB, plugin plugininventory.PluginIdentifier, arch cli.Arch, digest string) {
+	uri := fmt.Sprintf("vmware/test/%s/%s/%s/%s:%s", arch.OS(), arch.Arch(), plugin.Target, plugin.Name, plugin.Version)
+	desc := fmt.Sprintf("Plugin %s description", plugin.Name)
+
+	_, err := db.Exec("INSERT INTO PluginBinaries (PluginName,Target,RecommendedVersion,Version,Hidden,Description,Publisher,Vendor,OS,Architecture,Digest,URI) VALUES(?,?,'',?,'false',?,'test','vmware',?,?,?,?);", plugin.Name, plugin.Target, plugin.Version, desc, arch.OS(), arch.Arch(), digest, uri)
+
+	if err != nil {
+		log.Fatal(err, fmt.Sprintf("failed to create %s:%s for target %s for testing", plugin.Name, plugin.Version, plugin.Target))
+	}
+}
+
 func setupPluginEntriesAndBinaries(db *sql.DB) {
-	digest := "0000000000"
+	// Setup DB entries and plugin binaries for all os/architecture combinations
 	for _, plugin := range testPlugins {
-		desc := fmt.Sprintf("Plugin %s description", plugin.Name)
 		for _, osArch := range cli.AllOSArch {
-			uri := fmt.Sprintf("vmware/test/%s/%s/%s/%s:%s", osArch.OS(), osArch.Arch(), plugin.Target, plugin.Name, plugin.Version)
+			digest := digestForAMD64
+			if osArch.Arch() == cli.DarwinARM64.Arch() {
+				digest = digestForARM64
+			}
+			createPluginEntry(db, plugin, osArch, digest)
+			setupPluginBinaryInCache(plugin.Name, plugin.Version, plugin.Target, digest)
+		}
+	}
 
-			_, err := db.Exec("INSERT INTO PluginBinaries (PluginName,Target,RecommendedVersion,Version,Hidden,Description,Publisher,Vendor,OS,Architecture,Digest,URI) VALUES(?,?,'',?,'false',?,'test','vmware',?,?,?,?);", plugin.Name, plugin.Target, plugin.Version, desc, osArch.OS(), osArch.Arch(), digest, uri)
-
-			if err != nil {
-				log.Fatal(err, fmt.Sprintf("failed to create %s:%s for target %s for testing", plugin.Name, plugin.Version, plugin.Target))
+	// Setup DB entries and plugin binaries but skip ARM64
+	digest := digestForAMD64
+	for _, plugin := range testPluginsNoARM64 {
+		for _, osArch := range cli.AllOSArch {
+			if osArch.Arch() != cli.DarwinARM64.Arch() {
+				createPluginEntry(db, plugin, osArch, digest)
+				setupPluginBinaryInCache(plugin.Name, plugin.Version, plugin.Target, digest)
 			}
 		}
-		setupPluginBinaryInCache(plugin.Name, plugin.Version, plugin.Target, digest)
 	}
 }
 

--- a/pkg/registry/helpers.go
+++ b/pkg/registry/helpers.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"runtime"
 	"strconv"
 	"time"
 
@@ -19,6 +18,7 @@ import (
 	gocontainerregistry "github.com/google/go-containerregistry/pkg/registry"
 	"github.com/pkg/errors"
 
+	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/configpaths"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
@@ -38,7 +38,7 @@ func GetRegistryCertOptions(registryHost string) (*CertOptions, error) {
 		Insecure:       false,
 	}
 
-	if runtime.GOOS == "windows" {
+	if cli.GOOS == "windows" {
 		err := AddRegistryTrustedRootCertsFileForWindows(registryCertOpts)
 		if err != nil {
 			return nil, err

--- a/pkg/telemetry/sqlite_metrics_db.go
+++ b/pkg/telemetry/sqlite_metrics_db.go
@@ -7,7 +7,6 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 
 	// Import the sqlite3 driver
@@ -15,6 +14,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
 )
 
@@ -110,8 +110,8 @@ func (b *sqliteMetricsDB) SaveOperationMetric(entry *OperationMetricsPayload) er
 
 	row := cliOperationsRow{
 		cliVersion:         entry.CliVersion,
-		osName:             runtime.GOOS,
-		osArch:             runtime.GOARCH,
+		osName:             cli.GOOS,
+		osArch:             cli.GOARCH,
 		pluginName:         entry.PluginName,
 		pluginVersion:      entry.PluginVersion,
 		command:            entry.CommandName,

--- a/pkg/telemetry/sqlite_metrics_db_test.go
+++ b/pkg/telemetry/sqlite_metrics_db_test.go
@@ -7,13 +7,14 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/pkg/errors"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 )
 
 var _ = Describe("Inserting CLI metrics to database and verifying it by fetching the metrics from database", func() {
@@ -65,8 +66,8 @@ var _ = Describe("Inserting CLI metrics to database and verifying it by fetching
 			Expect(len(metricsRows)).To(Equal(1))
 			Expect(metricsRows[0].cliID).To(Equal("fake-cli-cliID"))
 			Expect(metricsRows[0].cliVersion).To(Equal("v1.0.0"))
-			Expect(metricsRows[0].osName).To(Equal(runtime.GOOS))
-			Expect(metricsRows[0].osArch).To(Equal(runtime.GOARCH))
+			Expect(metricsRows[0].osName).To(Equal(cli.GOOS))
+			Expect(metricsRows[0].osArch).To(Equal(cli.GOARCH))
 			Expect(metricsRows[0].nameArg).To(Equal("fake-name-arg"))
 			Expect(metricsRows[0].command).To(Equal("fake-cmd-name"))
 			Expect(metricsRows[0].commandStartTSMsec).ToNot(BeEmpty())


### PR DESCRIPTION
### What this PR does / why we need it

**With this PR it is now possible to fully use a locally built CLI on Mac ARM64 machines**

Although the CLI is available for Darwin ARM64, the vast majority of plugins are not, and therefore an ARM64 CLI will not be able to install most plugins.

Thanks to Apple's Rosetta emulator available on Darwin ARM64 machines, it is possible to run AMD64 binaries.  This is currently how the CLI and its plugins are being run.

This commit teaches a Darwin ARM64 CLI that if a plugin is not available for Darwin ARM64, it should instead install the Darwin AMD64 version. With this approach, it now become possible to use a Darwin ARM64 CLI to its full potential.

Note that this approach cannot be used for Linux as there is no standard emulator for AMD64 binaries.  For Linux, plugins will need to be published for ARM64.

Unit tests have been added for this new feature.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Part of #357

### Describe testing done for PR

```
# Reset the CLI
$ rm ~/.cache/tanzu/catalog.yaml
$ rm ~/.config/tanzu/config*
$ rm ~/.cache/tanzu/plugin_inventory

# Build an ARM64 CLI on Darwin
$ make build
build darwin-arm64 CLI with version: v1.1.0-dev
mkdir -p bin
cp /Users/kmarc/git/tanzu-cli/artifacts/darwin/arm64/cli/core/v1.1.0-dev/tanzu-cli-darwin_arm64 ./bin/tanzu

$ tz ceip set false
$ tz config eula accept
[ok] Marking agreement as accepted.

# Install a plugin that is not available in ARM64
$ tz plugin install telemetry --target global
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Installing plugin 'telemetry:v1.1.0' with target 'global'
[i] Plugin binary for 'telemetry:v1.1.0' found in cache
[ok] successfully installed 'telemetry' plugin

# Confirm that the installed plugin binary is AMD64
$ tz plugin describe telemetry
  NAME       VERSION  STATUS     TARGET  DESCRIPTION                                                 INSTALLATIONPATH
  telemetry  v1.1.0   installed  global  configure cluster-wide settings for vmware tanzu telemetry  /Users/kmarc/Library/Application
                                                                                                     Support/tanzu-cli/telemetry/v1.1.0_a93519154dc71368d738aec09f9bc964a0c3bcd02a856106ccaddaaf31426636_global
$ file ~/Library/Application\ Support/tanzu-cli/telemetry/v1.1.0_a93519154dc71368d738aec09f9bc964a0c3bcd02a856106ccaddaaf31426636_global
/Users/kmarc/Library/Application Support/tanzu-cli/telemetry/v1.1.0_a93519154dc71368d738aec09f9bc964a0c3bcd02a856106ccaddaaf31426636_global: Mach-O 64-bit executable x86_64

# Now install a plugin that is available in ARM64
$ tz plugin install builder
[i] Installing plugin 'builder:v1.0.0' with target 'global'
[i] Plugin binary for 'builder:v1.0.0' found in cache
[ok] successfully installed 'builder' plugin

# Confirm that the installed plugin binary is ARM64
$ tz plugin describe builder
  NAME     VERSION  STATUS     TARGET  DESCRIPTION             INSTALLATIONPATH
  builder  v1.0.0   installed  global  Build Tanzu components  /Users/kmarc/Library/Application
                                                               Support/tanzu-cli/builder/v1.0.0_9e15f81e9a1dc5655aca06562922a48525231072b30033a187aef78ff56d3f74_global
$ file ~/Library/Application\ Support/tanzu-cli/builder/v1.0.0_9e15f81e9a1dc5655aca06562922a48525231072b30033a187aef78ff56d3f74_global
/Users/kmarc/Library/Application Support/tanzu-cli/builder/v1.0.0_9e15f81e9a1dc5655aca06562922a48525231072b30033a187aef78ff56d3f74_global: Mach-O 64-bit executable arm64

# Create a context for TMC.  None of the plugins are available in ARM64
# but with this PR, the installation of those plugins will now work
$ tz context create tmc2 --endpoint unstable.tmc-dev.cloud.vmware.com --staging

[i] If you don't have an API token, visit the VMware Cloud Services console, select your organization, and create an API token with the TMC service roles:
  https://console.cloud.vmware.com/csp/gateway/portal/#/user/tokens

? API Token ****************************************************************

[ok] successfully created a TMC context
[i] Checking for required plugins...
[i] Installing plugin 'secret:v0.1.4' with target 'mission-control'
[i] Installing plugin 'clustergroup:v0.1.4' with target 'mission-control'
[i] Installing plugin 'account:v0.1.4' with target 'mission-control'
[i] Installing plugin 'integration:v0.1.4' with target 'mission-control'
[i] Installing plugin 'aks-cluster:v0.1.7' with target 'mission-control'
[i] Installing plugin 'provider-eks-cluster:v0.1.4' with target 'mission-control'
[i] Installing plugin 'apply:v0.3.1' with target 'mission-control'
[i] Installing plugin 'setting:v0.2.2' with target 'mission-control'
[i] Installing plugin 'tanzupackage:v0.2.3' with target 'mission-control'
[i] Installing plugin 'continuousdelivery:v0.1.4' with target 'mission-control'
[i] Installing plugin 'ekscluster:v0.1.4' with target 'mission-control'
[i] Installing plugin 'helm:v0.1.4' with target 'mission-control'
[i] Installing plugin 'inspection:v0.1.4' with target 'mission-control'
[i] Installing plugin 'provider-aks-cluster:v0.1.4' with target 'mission-control'
[i] Installing plugin 'iam:v0.1.4' with target 'mission-control'
[i] Installing plugin 'audit:v0.1.4' with target 'mission-control'
[i] Installing plugin 'events:v0.1.4' with target 'mission-control'
[i] Installing plugin 'workspace:v0.1.6' with target 'mission-control'
[i] Installing plugin 'data-protection:v0.1.4' with target 'mission-control'
[i] Installing plugin 'policy:v0.1.4' with target 'mission-control'
[i] Installing plugin 'management-cluster:v0.2.4' with target 'mission-control'
[i] Installing plugin 'cluster:v0.1.6' with target 'mission-control'
[i] Plugin binary for 'cluster:v0.1.6' found in cache
[i] Installing plugin 'agentartifacts:v0.1.4' with target 'mission-control'
[i] Successfully installed all required plugins

# Check that these plugin binaries are AMD64
$ file ~/Library/Application\ Support/tanzu-cli/agentartifacts/v0.1.4_8f6cbbbd670ad0c32bc39adc37835e6d4dac28b66230af4517aa6c3ff83b3c3c_mission-control
/Users/kmarc/Library/Application Support/tanzu-cli/agentartifacts/v0.1.4_8f6cbbbd670ad0c32bc39adc37835e6d4dac28b66230af4517aa6c3ff83b3c3c_mission-control: Mach-O 64-bit executable x86_64
$ file ~/Library/Application\ Support/tanzu-cli/events/v0.1.4_e93c2eb67ee0cc21a0997cd116b66d81cc40064c121483daff530d31dd45cd9f_mission-control
/Users/kmarc/Library/Application Support/tanzu-cli/events/v0.1.4_e93c2eb67ee0cc21a0997cd116b66d81cc40064c121483daff530d31dd45cd9f_mission-control: Mach-O 64-bit executable x86_64
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Allow fully using an ARM64 CLI on Mac (Darwin) by having the CLI install plugins for AMD64 when an ARM64 version of the plugin is not available. 
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

**Implementation approach**
The implementation approach chosen is to replace the use of `runtime.GOOS/GOARCH` with our own version `cli.GOOS/GOARCH` everywhere in the code.  The new variable are set to the same value as the `runtime` ones.  However, it now becomes possible to programatically make the CLI believe it is running on a different OS/ARCH (for this PR, we change the ARCH to `AMD64` to install plugins not available for ARM64 on Darwin).

An alternative approach would have been to add arguments to many different function to specify what ARCH should be used.  This second approach would have required a bit more changes.  

However, the real reason I opted for the first approach is that it also allows to write unit tests for this feature, even if those tests are run on Linux, or AMD64, by using the `cli.GOOS/GOARCH` to make the CLI believe it is running on Darwin ARM64 for the test in question.

**No E2E tests**

To be able to use this feature, one must run on a Darwin ARM64 machine.  Therefore to be able to exercise the feature in E2E tests, those tests would need to run on darwin_arm64, which is not something offered out-of-the-box for Github actions.   Here are the options I can see:
1. implement an e2e test which will only test the feature when run manually by someone on their darwin_arm64 machine
    - inconsistent testing since requires to run it manually
1. deploy a self-hosted runner on a darwin_arm64 machine and have github run our e2e tests on it
    - does not seem possible to run a MacOS VM on Azure.  Not sure of other options.
1. don't implement an e2e test for this feature and rely on the existing unit test
    - should be a sufficient indication that the feature is functional

I prefer option 3 but am open to other opinions or suggestions.

**Other aspect**

A aspect that I did NOT implement is the following: when running a Darwin AMD64 CLI on a Darwin ARM64 machine, we could install ARM64 plugins when available; now, and with this PR, an Darwin AMD64 will _only_ install AMD64 plugins.

I opted against this because with this PR, there should be no reason to run an AMD64 CLI on a Darwin ARM64 machine.  Therefore we should direct users to use the ARM64 CLI.  Same goes for plugin devs.  Note that 'brew install' will install the ARM64 CLI starting with the v1.1 version when on ARM64 Macs.

Besides, even if we did implement this extra "feature", a plugin dev would need to install the v1.1 CLI to benefit from it, which takes us back to: might as well install the ARM64 version of the CLI 1.1.