### PR TITLE
Run E2E test for `tanzu plugin upload-bundle` against authenticated registry

### DIFF
--- a/hack/central-repo/.gitignore
+++ b/hack/central-repo/.gitignore
@@ -2,3 +2,4 @@ registry-content
 create_tables.sql
 local-central-repo-testcontent.bz2
 certs
+auth

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -44,6 +44,20 @@ ifndef TANZU_CLI_E2E_AIRGAPPED_REPO
 TANZU_CLI_E2E_AIRGAPPED_REPO = localhost:6001/tanzu-cli/plugins/
 endif
 
+ifndef TANZU_CLI_E2E_AIRGAPPED_REPO_WITH_AUTH
+TANZU_CLI_E2E_AIRGAPPED_REPO_WITH_AUTH = localhost:6002/tanzu-cli/plugins/
+endif
+
+ifndef TANZU_CLI_E2E_AIRGAPPED_REPO_WITH_AUTH_USERNAME
+TANZU_CLI_E2E_AIRGAPPED_REPO_WITH_AUTH_USERNAME = testuser
+endif
+
+ifndef TANZU_CLI_E2E_AIRGAPPED_REPO_WITH_AUTH_PASSWORD
+TANZU_CLI_E2E_AIRGAPPED_REPO_WITH_AUTH_PASSWORD = testpassword
+endif
+
+
+
 # Set the plugin group name for the plugins used to execute E2E test cases.
 E2E_TEST_USE_PLGINS_FROM_PLUGIN_GROUP_FOR_TMC ?= vmware-tmc/tmc-user:v9.9.9
 E2E_TEST_USE_PLGINS_FROM_PLUGIN_GROUP_FOR_K8S ?= vmware-tkg/default:v9.9.9
@@ -143,6 +157,9 @@ e2e-airgapped-tests:
 	export TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_CA_CERT_PATH=${TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_CA_CERT_PATH} ; \
 	export TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST=$(TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_IMAGE_FOR_AIRGAPPED) ; \
 	export TANZU_CLI_E2E_AIRGAPPED_REPO=$(TANZU_CLI_E2E_AIRGAPPED_REPO) ; \
+	export TANZU_CLI_E2E_AIRGAPPED_REPO_WITH_AUTH=$(TANZU_CLI_E2E_AIRGAPPED_REPO_WITH_AUTH) ; \
+	export TANZU_CLI_E2E_AIRGAPPED_REPO_WITH_AUTH_USERNAME=$(TANZU_CLI_E2E_AIRGAPPED_REPO_WITH_AUTH_USERNAME) ; \
+	export TANZU_CLI_E2E_AIRGAPPED_REPO_WITH_AUTH_PASSWORD=$(TANZU_CLI_E2E_AIRGAPPED_REPO_WITH_AUTH_PASSWORD) ; \
 	export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="Yes" ; \
 	export TANZU_CLI_EULA_PROMPT_ANSWER="Yes" ; \
 	${GINKGO} --keep-going --output-dir ${ROOT_DIR}/test/e2e/testresults --json-report=results.json --keep-separate-reports --race --nodes=1 ${GOTEST_VERBOSE} -r ${ROOT_DIR}/test/e2e/airgapped  --trace > /tmp/out && { cat /tmp/out | grep -Ev 'STEP:|seconds|.go:'; rm /tmp/out; } || { exit_code=$$?; cat /tmp/out | grep -Ev 'STEP:|seconds|.go:'; rm /tmp/out; exit $$exit_code; } \

--- a/test/e2e/airgapped/airgapped_suite_test.go
+++ b/test/e2e/airgapped/airgapped_suite_test.go
@@ -25,14 +25,17 @@ func TestAirgapped(t *testing.T) {
 }
 
 var (
-	tf                           *framework.Framework
-	e2eTestLocalCentralRepoImage string
-	e2eAirgappedCentralRepo      string
-	e2eAirgappedCentralRepoImage string
-	pluginsSearchList            []*framework.PluginInfo
-	pluginGroups                 []*framework.PluginGroup
-	tempDir                      string
-	err                          error
+	tf                                      *framework.Framework
+	e2eTestLocalCentralRepoImage            string
+	e2eAirgappedCentralRepo                 string
+	e2eAirgappedCentralRepoImage            string
+	e2eAirgappedCentralRepoWithAuth         string
+	e2eAirgappedCentralRepoWithAuthUsername string
+	e2eAirgappedCentralRepoWithAuthPassword string
+	pluginsSearchList                       []*framework.PluginInfo
+	pluginGroups                            []*framework.PluginGroup
+	tempDir                                 string
+	err                                     error
 )
 
 // BeforeSuite initializes and set up the environment to execute the airgapped tests
@@ -45,8 +48,15 @@ var _ = BeforeSuite(func() {
 	// check E2E airgapped central repo (TANZU_CLI_E2E_AIRGAPPED_REPO)
 	e2eAirgappedCentralRepo = os.Getenv(framework.TanzuCliE2ETestAirgappedRepo)
 	Expect(e2eAirgappedCentralRepo).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with airgapped central repository URL", framework.TanzuCliE2ETestAirgappedRepo))
-
 	e2eAirgappedCentralRepoImage = fmt.Sprintf("%s%s", e2eAirgappedCentralRepo, filepath.Base(e2eTestLocalCentralRepoImage))
+
+	// check E2E configuration for airgapped central repository with authentication
+	e2eAirgappedCentralRepoWithAuth = os.Getenv(framework.TanzuCliE2ETestAirgappedRepoWithAuth)
+	Expect(e2eAirgappedCentralRepoWithAuth).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with airgapped central repository URL", framework.TanzuCliE2ETestAirgappedRepoWithAuth))
+	e2eAirgappedCentralRepoWithAuthUsername = os.Getenv(framework.TanzuCliE2ETestAirgappedRepoWithAuthUsername)
+	Expect(e2eAirgappedCentralRepoWithAuthUsername).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with airgapped central repository URL", framework.TanzuCliE2ETestAirgappedRepoWithAuthUsername))
+	e2eAirgappedCentralRepoWithAuthPassword = os.Getenv(framework.TanzuCliE2ETestAirgappedRepoWithAuthPassword)
+	Expect(e2eAirgappedCentralRepoWithAuthPassword).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with airgapped central repository URL", framework.TanzuCliE2ETestAirgappedRepoWithAuthPassword))
 
 	os.Setenv(framework.TanzuCliPluginDiscoverySignatureVerificationSkipList, fmt.Sprintf("%v,%v", e2eAirgappedCentralRepoImage, e2eTestLocalCentralRepoImage))
 
@@ -56,7 +66,7 @@ var _ = BeforeSuite(func() {
 	e2eTestLocalCentralRepoCACertPath := os.Getenv(framework.TanzuCliE2ETestLocalCentralRepositoryCACertPath)
 	Expect(e2eTestLocalCentralRepoCACertPath).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with local central repository CA cert path", framework.TanzuCliE2ETestLocalCentralRepositoryCACertPath))
 
-	// set up the CA cert fort local central repository
+	// set up the CA cert for local central repository
 	_ = tf.Config.ConfigCertDelete(e2eTestLocalCentralRepoPluginHost)
 	_, err = tf.Config.ConfigCertAdd(&framework.CertAddOptions{Host: e2eTestLocalCentralRepoPluginHost, CACertificatePath: e2eTestLocalCentralRepoCACertPath, SkipCertVerify: "false", Insecure: "false"})
 	Expect(err).To(BeNil())
@@ -67,7 +77,7 @@ var _ = BeforeSuite(func() {
 	os.Setenv(framework.TanzuCliPluginDiscoveryImageSignaturePublicKeyPath, e2eTestLocalCentralRepoPluginDiscoveryImageSignaturePublicKeyPath)
 
 	// setup the test central repo
-	err := framework.UpdatePluginDiscoverySource(tf, e2eTestLocalCentralRepoImage)
+	err = framework.UpdatePluginDiscoverySource(tf, e2eTestLocalCentralRepoImage)
 	Expect(err).To(BeNil(), "should not get any error for plugin source update")
 
 	// search plugin groups and make sure there plugin groups available

--- a/test/e2e/airgapped/airgapped_test.go
+++ b/test/e2e/airgapped/airgapped_test.go
@@ -33,6 +33,9 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Airgapped-Plugin-Download
 			defer func() {
 				os.Setenv("HOME", curHomeDir)
 			}()
+			// We are resetting the HOME environment variable for this specific tests as when we do docker login we need to have actually HOME variable set correctly
+			// otherwise the docker login fails with different errors on different systems (on macos we see keychain specific error)
+			// We are also using above defer function to revert the HOME environment variable after this test is ran
 			os.Setenv("HOME", framework.OriginalHomeDir)
 
 			// Try uploading plugin bundle without docker login, it should fail

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -19,6 +19,9 @@ var (
 	// FullPathForTempDir is the absolute path for the temp directory under $TestDir
 	FullPathForTempDir string
 
+	// OriginalHomeDir is the actual HOME directory of the machine before E2E test overwrites it
+	OriginalHomeDir string
+
 	// ConfigFilePath represents config.yaml file path which under $HOME/.tanzu-cli-e2e/.config/tanzu
 	ConfigFilePath string
 	// ConfigFilePath represents config-ng.yaml file path which under $HOME/.tanzu-cli-e2e/.config/tanzu
@@ -92,8 +95,8 @@ func NewFramework() *Framework {
 }
 
 func init() {
-	homeDir := GetHomeDir()
-	TestDirPath = filepath.Join(homeDir, TestDir)
+	OriginalHomeDir = GetHomeDir()
+	TestDirPath = filepath.Join(OriginalHomeDir)
 	FullPathForTempDir = filepath.Join(TestDirPath, TempDirInTestDirPath)
 	// Update $HOME as $HOME/.tanzu-cli-e2e
 	os.Setenv("HOME", TestDirPath)

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -96,7 +96,7 @@ func NewFramework() *Framework {
 
 func init() {
 	OriginalHomeDir = GetHomeDir()
-	TestDirPath = filepath.Join(OriginalHomeDir)
+	TestDirPath = filepath.Join(OriginalHomeDir, TestDir)
 	FullPathForTempDir = filepath.Join(TestDirPath, TempDirInTestDirPath)
 	// Update $HOME as $HOME/.tanzu-cli-e2e
 	os.Setenv("HOME", TestDirPath)

--- a/test/e2e/framework/framework_constants.go
+++ b/test/e2e/framework/framework_constants.go
@@ -64,6 +64,9 @@ const (
 	TanzuCliE2ETestLocalCentralRepositoryHost                                       = "TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_HOST"
 	TanzuCliE2ETestLocalCentralRepositoryCACertPath                                 = "TANZU_CLI_E2E_TEST_LOCAL_CENTRAL_REPO_CA_CERT_PATH"
 	TanzuCliE2ETestAirgappedRepo                                                    = "TANZU_CLI_E2E_AIRGAPPED_REPO"
+	TanzuCliE2ETestAirgappedRepoWithAuth                                            = "TANZU_CLI_E2E_AIRGAPPED_REPO_WITH_AUTH"
+	TanzuCliE2ETestAirgappedRepoWithAuthUsername                                    = "TANZU_CLI_E2E_AIRGAPPED_REPO_WITH_AUTH_USERNAME"
+	TanzuCliE2ETestAirgappedRepoWithAuthPassword                                    = "TANZU_CLI_E2E_AIRGAPPED_REPO_WITH_AUTH_PASSWORD"
 	TanzuCliPluginDiscoverySignatureVerificationSkipList                            = "TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST"
 
 	// CLI Coexistence


### PR DESCRIPTION
### What this PR does / why we need it

* Run E2E test for `tanzu plugin upload-bundle` against authenticated registry

NOTE:
* Today Tanzu CLI only supports authenticated registries for the `tanzu plugin upload-bundle` command (push operations).
* But any image pull from the registry requires images to be publically available without requiring authentication
* As part of this test, I am using docker basic authentication to spin up an authenticated registry but only testing the `tanzu plugin upload-bundle` command to verify it works.

Reference: https://github.com/distribution/distribution/blob/main/docs/deploying.md#native-basic-auth

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

* Run existing E2E tests

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
None
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
