### PR TITLE
Dynamic shell completion for the context cmds

### DIFF
--- a/pkg/command/completion_helper.go
+++ b/pkg/command/completion_helper.go
@@ -1,0 +1,25 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package command
+
+import (
+	"github.com/spf13/cobra"
+)
+
+const (
+	// Completion strings for the values of the --target flag
+	compK8sTarget = "k8s\tFor interactions with a Kubernetes cluster"
+	compTAETarget = "tae\tFor interactions with a Application Engine endpoint"
+	compTMCTarget = "tmc\tFor interactions with a Mission-Control endpoint"
+
+	// Completion strings for the values of the --output flag
+	compTableOutput = "table\tOutput results in human-readable format"
+	compJSONOutput  = "json\tOutput results in JSON format"
+	compYAMLOutput  = "yaml\tOutput results in YAML format"
+)
+
+// TODO(khouzam): move this to tanzu-plugin-runtime to be usable by plugins
+func completionGetOutputFormats(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return []string{compTableOutput, compJSONOutput, compYAMLOutput}, cobra.ShellCompDirectiveNoFileComp
+}

--- a/pkg/command/completion_helper_test.go
+++ b/pkg/command/completion_helper_test.go
@@ -1,0 +1,9 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package command
+
+const (
+	// Completion output for testing the --output flag
+	expectedOutForOutputFlag = compTableOutput + "\n" + compJSONOutput + "\n" + compYAMLOutput + "\n"
+)

--- a/pkg/command/plugin.go
+++ b/pkg/command/plugin.go
@@ -24,6 +24,7 @@ import (
 	"github.com/vmware-tanzu/tanzu-cli/pkg/discovery"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/pluginmanager"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/pluginsupplier"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/utils"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
 
@@ -72,20 +73,13 @@ func newPluginCmd() *cobra.Command {
 	// --local is renamed to --local-source
 	installPluginCmd.Flags().StringVarP(&local, "local", "", "", "path to local plugin source")
 	msg := "this was done in the v1.0.0 release, it will be removed following the deprecation policy (6 months). Use the --local-source flag instead.\n"
-	if err := installPluginCmd.Flags().MarkDeprecated("local", msg); err != nil {
-		// Will only fail if the flag does not exist, which would indicate a coding error,
-		// so let's panic so we notice immediately.
-		panic(err)
-	}
+	utils.PanicOnErr(installPluginCmd.Flags().MarkDeprecated("local", msg))
 
 	// The --local-source flag for installing plugins is only used in development testing
 	// and should not be used in production.  We mark it as hidden to help convey this reality.
 	installPluginCmd.Flags().StringVarP(&local, "local-source", "l", "", "path to local plugin source")
-	if err := installPluginCmd.Flags().MarkHidden("local-source"); err != nil {
-		// Will only fail if the flag does not exist, which would indicate a coding error,
-		// so let's panic so we notice immediately.
-		panic(err)
-	}
+	utils.PanicOnErr(installPluginCmd.Flags().MarkHidden("local-source"))
+
 	installPluginCmd.Flags().StringVarP(&version, "version", "v", cli.VersionLatest, "version of the plugin")
 	deletePluginCmd.Flags().BoolVarP(&forceDelete, "yes", "y", false, "delete the plugin without asking for confirmation")
 

--- a/pkg/command/plugin_search.go
+++ b/pkg/command/plugin_search.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/discovery"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/pluginmanager"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/utils"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/component"
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
@@ -84,19 +85,13 @@ func newSearchPluginCmd() *cobra.Command {
 
 	f.StringVarP(&local, "local", "", "", "path to local plugin source")
 	msg := fmt.Sprintf("this was done in the %q release, it will be removed following the deprecation policy (6 months). Use the %q flag instead.\n", "v1.0.0", "--local-source")
-	if err := f.MarkDeprecated("local", msg); err != nil {
-		// Will only fail if the flag does not exist, which would indicate a coding error,
-		// so let's panic so we notice immediately.
-		panic(err)
-	}
+	utils.PanicOnErr(f.MarkDeprecated("local", msg))
+
 	f.StringVarP(&local, "local-source", "l", "", "path to local plugin source")
 	// We hide the "local-source" flag because installing from a local-source is not supported in production.
 	// See the "local-source" flag of the "plugin install" command.
-	if err := f.MarkHidden("local-source"); err != nil {
-		// Will only fail if the flag does not exist, which would indicate a coding error,
-		// so let's panic so we notice immediately.
-		panic(err)
-	}
+	utils.PanicOnErr(f.MarkHidden("local-source"))
+
 	f.StringVarP(&targetStr, "target", "t", "", fmt.Sprintf("limit the search to plugins of the specified target (%s)", common.TargetList))
 
 	searchCmd.MarkFlagsMutuallyExclusive("local", "name")

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -48,3 +48,12 @@ func EnsureMutualExclusiveCurrentContexts() error {
 	}
 	return nil
 }
+
+// PanicOnErr calls 'panic' if 'err' is non-nil.
+func PanicOnErr(err error) {
+	if err == nil {
+		return
+	}
+
+	panic(err)
+}


### PR DESCRIPTION
### What this PR does / why we need it

This commit provides dynamic shell completion for:
- `tanzu context delete`
- `tanzu context use`
- `tanzu context unset`
- `tanzu context get`
- `tanzu context create`
- `tanzu context get-token`
- `tanzu context update tae-active-resource`
 
The commit also turns off file completion for:
- `tanzu context list`

The commit also provides shell completion for all (non-boolean) flags of the `tanzu context` sub-commands.

Units tests are included for each added completion.

To better understand the visible changes, please refer to the "testing done" section.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Part of #500

### Describe testing done for PR

Setup for shell completions:

zsh:
```
source <(tanzu completion zsh)
# if shell completion still does not work, also do (those should be in your .zshrc file)
autoload -Uz compinit
compinit
```

fish:
```
tanzu completion fish | source
```

bash:
```
# You must install the bash-completions@2 package
brew install bash-completion@2
source $(brew --prefix)/etc/profile.d/bash_completion.sh

source <(tanzu completion bash)
```

Tests:
```
##############################################
# Completions for the "tanzu context" commands
##############################################

# We have two contexts per target
$ tz context list
Target:  kubernetes
  NAME  ISACTIVE  ENDPOINT  KUBECONFIGPATH                          KUBECONTEXT
  tkg1  false               /Users/kmarc/.k3d/kubeconfig-tkg1.yaml  k3d-tkg1
  tkg2  true                /Users/kmarc/.k3d/kubeconfig-tkg1.yaml  k3d-tkg1
Target:  mission-control
  NAME  ISACTIVE  ENDPOINT
  tmc   false     unstable.tmc-dev.cloud.vmware.com:443
  tmc2  true      unstable.tmc-dev.cloud.vmware.com:443

# All contexts must be suggested
$ tz context delete t<TAB>
tkg2  tkg1  -- /Users/kmarc/.k3d/kubeconfig-tkg1.yaml:k3d-tkg1
tmc2  tmc   -- unstable.tmc-dev.cloud.vmware.com:443

# After the first arg, no more completions
$ tz context delete tmc <TAB>

# All contexts must be suggested
$ tz context get t<TAB>
tkg2  tkg1  -- /Users/kmarc/.k3d/kubeconfig-tkg1.yaml:k3d-tkg1
tmc2  tmc   -- unstable.tmc-dev.cloud.vmware.com:443

# After the first arg, no more completions
$ tz context get tmc <TAB>

# No completions since no args accepted by "list"
$ tz context list <TAB>

# All contexts must be suggested
$ tz context use t<TAB>
tkg2  tkg1  -- /Users/kmarc/.k3d/kubeconfig-tkg1.yaml:k3d-tkg1
tmc2  tmc   -- unstable.tmc-dev.cloud.vmware.com:443

# After the first arg, no more completions
$ tz context use tmc <TAB>

# Notice that for "unset" only the active contexts are suggested
$ tz context unset t<TAB>
tkg2  -- /Users/kmarc/.k3d/kubeconfig-tkg1.yaml:k3d-tkg1
tmc2  -- unstable.tmc-dev.cloud.vmware.com:443

# After the first arg, no more completions
$ tz context unset tmc2 <TAB>

# See that the --target flag limits the completion to the correct target
# It is the only "context" command where a flag makes a difference
$ tz context unset -t k8s <TAB>
$ tz context unset -t k8s tkg2

# ActiveHelp to ask the user to choose a name for the context
# Only visible on zsh and bash
$ tz context create <TAB>
Please specify a name for the context

# After the first arg we complete flags until we have enough information
$ tz context create tkg1 <TAB>
$ tz context create tkg1 --

$ tz context create tkg1 --<TAB>
--kubecontext k3d-tkg1 --kubeconfig /Users/kmarc/.k3d/kubeconfig-tkg1.yaml
--endpoint                  -- endpoint to create a context for
--endpoint-ca-certificate   -- path to the endpoint public certificate
--help                      -- help for create
--insecure-skip-tls-verify  -- skip endpoint's TLS certificate verification
--kubeconfig                -- path to the kubeconfig file; valid only if user doesn't choose 'endpoint' option.(See [*])
--kubecontext               -- the context in the kubeconfig to use; valid only if user doesn't choose 'endpoint' option.(See [*])

# No more completions once we have enough info
$ tz context create tkg1 --endpoint a <TAB>
$ tz context create tkg1 --kubecontext a <TAB>

# Continue to complete flags until we have enough info
$ tz context create tkg1 --kubeconfig a <TAB>
$ tz context create tkg1 --kubeconfig a --

# No more completions once we have enough info
$ tz context create tkg1 --kubeconfig a --kubecontext a <TAB>

# Continue to complete flags until we have enough info
$ tz context create tkg1 --insecure-skip-tls-verify <TAB>
$ tz context create tkg1 --insecure-skip-tls-verify --

###################################################
# Completions for the "tanzu context" command flags
##################################################
$ tz context list -t <TAB>
k8s  -- For interactions with a Kubernetes cluster
tae  -- For interactions with a Application Engine endpoint
tmc  -- For interactions with a Mission-Control endpoint

$ tz context list -o <TAB>
json   -- Output results in JSON format
table  -- Output results in human-readable format
yaml   -- Output results in YAML format

$ tz context get -o <TAB>
json   -- Output results in JSON format
table  -- Output results in human-readable format
yaml   -- Output results in YAML format

$ tz context unset --target <TAB>
k8s  -- For interactions with a Kubernetes cluster
tae  -- For interactions with a Application Engine endpoint
tmc  -- For interactions with a Mission-Control endpoint

# No completion possible
$ tz context create --endpoint <TAB>

# File completion
$ tz context create --endpoint-ca-certificate <TAB>
CODEOWNERS          LICENSE             ROADMAP.md          bin/                docs/               go.work.sum         plugin-tooling.mk
CODE_OF_CONDUCT.md  Makefile            SECURITY.md         cmd/                go.mod              hack/               rpm/
CONTRIBUTING.md     NOTICE              apis/               coverage.txt        go.sum              packages.bak/       test/
Dockerfile          README.md           artifacts/          discovery/          go.work             pkg/

# No completion
$ tz context create --api-token <TAB>

# File completion
$ tz context create --kubeconfig <TAB>
CODEOWNERS          LICENSE             ROADMAP.md          bin/                docs/               go.work.sum         plugin-tooling.mk
CODE_OF_CONDUCT.md  Makefile            SECURITY.md         cmd/                go.mod              hack/               rpm/
CONTRIBUTING.md     NOTICE              apis/               coverage.txt        go.sum              packages.bak/       test/
Dockerfile          README.md           artifacts/          discovery/          go.work             pkg/

# All contexts in my ~/.kube/config file are suggested
$ tz context create --kubeconfig ~/.kube/config --kubecontext <TAB>
docker-desktop           -- docker-desktop@docker-desktop
kind-c1                  -- kind-c1@kind-c1
kind-c2                  -- kind-c2@kind-c2
kind-c3                  -- kind-c3@kind-c3
kind-unmanaged-one       -- kind-unmanaged-one@kind-unmanaged-one
tanzu-community-edition  -- tanzu-community-edition@tanzu-community-edition

# Without --kubeconfig, the one context in my $KUBECONFIG (~/.kube/config.lever) file is completed
export KUBECONFIG=/Users/kmarc/.kube/config.lever
$ tz context create --kubecontext <TAB>
$ tz context create --kubecontext tanzu-cli-basic@prod-tap

$ tz context create --type <TAB>
application-engine    -- Context for a Tanzu Application Engine endpoint
k8s-cluster-endpoint  -- Context for a Kubernetes Cluster endpoint
k8s-local-kubeconfig  -- Context using a Kubernetes local kubeconfig file
mission-control       -- Context for a Tanzu Mission Control endpoint

########################
# TAE commands
########################
$ tz context update tae-active-resource <TAB>
myucp  tae  -- https://ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com/org/ee04bfae-a665-4f20-a5b9-d8b043180252

$ tz context get-token <TAB>
myucp  tae  -- https://ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com/org/ee04bfae-a665-4f20-a5b9-d8b043180252
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add dynamic shell completion for the commands and flags under the `tanzu context` command tree
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
