### PR TITLE
Add "tanzu context get-token" command to fetch a valid CSP token for the given context

### DIFF
--- a/pkg/auth/csp/token.go
+++ b/pkg/auth/csp/token.go
@@ -194,7 +194,7 @@ func GetToken(g *configapi.GlobalServerAuth) (*oauth2.Token, error) {
 	}
 
 	// TODO (pbarker): support more issuers.
-	token, err := GetAccessTokenFromAPIToken(g.RefreshToken, ProdIssuer)
+	token, err := GetAccessTokenFromAPIToken(g.RefreshToken, g.Issuer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/auth/ucp/kubeconfig_test.go
+++ b/pkg/auth/ucp/kubeconfig_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Unit tests for ucp auth", func() {
 				Expect(config.Contexts[kubeContext].AuthInfo).To(Equal(kubeconfigUserName(ucpContext.Name)))
 				Expect(gotClusterName).To(Equal(kubeconfigClusterName(ucpContext.Name)))
 				Expect(len(cluster.CertificateAuthorityData)).ToNot(Equal(0))
-				Expect(user.Token).To(Equal(ucpContext.GlobalOpts.Auth.AccessToken))
+				Expect(user.Exec).To(Equal(getExecConfig(ucpContext)))
 			})
 		})
 		Context("When endpointCACertPath is not provided and skipTLSVerify is set to true", func() {
@@ -115,7 +115,7 @@ var _ = Describe("Unit tests for ucp auth", func() {
 				Expect(gotClusterName).To(Equal("tanzu-cli-" + ucpContext.Name + "/current"))
 				Expect(len(cluster.CertificateAuthorityData)).To(Equal(0))
 				Expect(cluster.InsecureSkipTLSVerify).To(Equal(true))
-				Expect(user.Token).To(Equal(ucpContext.GlobalOpts.Auth.AccessToken))
+				Expect(user.Exec).To(Equal(getExecConfig(ucpContext)))
 			})
 		})
 


### PR DESCRIPTION
### What this PR does / why we need it
This PR adds "tanzu context get-token" command to fetch a valid CSP token for the given context

**Changes Summary:**
- Add a hidden command "tanzu context get-token" to fetch a valid CSP token for the given context. This command would be used in the kubeconfig generated for UCP resource to fetch/refresh the access-token dynamically.
- Updated the kubeconfig generation logic to include the exec plugin to fetch the access token dynamically
- Command would return error if the context provided is not an UCP context

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Created the UCP context and ran the tanzu context get-token and it successfully printed the ExecCredentials to stdout.
```
❯ ./bin/tanzu context list
Target:  kubernetes
  NAME           ISACTIVE  ENDPOINT                                                                         KUBECONFIGPATH                           KUBECONTEXT
  test-withcert  false     https://10.206.208.104:6443                                                      /Users/pkalle/.kube-tanzu/config         tanzu-cli-tkg-mgmt-vc@tkg-mgmt-vc
  tkg-mgmt-vc    false                                                                                      /Users/pkalle/temp/tkgCluster_admin.kfg  tkg-mgmt-vc-admin@tkg-mgmt-vc
  myucp          true      https://api-dev.tanzu.cloud.vmware.com/org/bc27608b-4809-4cac-9e04-778803963da2  /Users/pkalle/.kube/config               tanzu-cli-myucp
Target:  mission-control
  NAME            ISACTIVE  ENDPOINT
  tt-test-selfmg  false     tmc-sm-main.local-dev.7infra.com:443
  mytmc           false     unstable.tmc-dev.cloud.vmware.com:443
  mytmc2          true      unstable.tmc-dev.cloud.vmware.com:443


❯ ./bin/tanzu context get-token myucp
{"kind":"ExecCredential","apiVersion":"client.authentication.k8s.io/v1","spec":{"interactive":false},"status":{"expirationTimestamp":"2023-09-27T22:08:24Z","token":"<REDACTED>"}}
```

Tested with context that is not of UCP type

```
❯ ./bin/tanzu context get-token tkg-mgmt-vc
[x] : context "tkg-mgmt-vc" is not of type UCP
```

Created a UCP context and verified the kubeconfig has user information with ExecConfig with reference to `tanzu context get-token`
```
❯ ./bin/tanzu context create myucp --endpoint https://api-dev.tanzu.cloud.vmware.com --type application-engine  --staging
[i] API token env var is set

[ok] successfully created a Application Engine(UCP) context



//kubeconfig generated

apiVersion: v1
clusters:
- cluster:
    server: https://api-dev.tanzu.cloud.vmware.com/org/bc27608b-4809-4cac-9e04-778803963da2
  name: tanzu-cli-myucp/current
contexts:
- context:
    cluster: tanzu-cli-myucp/current
    user: tanzu-cli-myucp-user
  name: tanzu-cli-myucp
current-context: ""
kind: Config
preferences: {}
users:
- name: tanzu-cli-myucp-user
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1
      args:
      - context
      - get-token
      - myucp
      command: tanzu
      env: []
      provideClusterInfo: false
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add "tanzu context get-token" command to fetch a valid CSP token for the given context
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
