### PR TITLE
Refactor and improve kubeconfig/context unit tests

### DIFF
--- a/pkg/cluster/client_test.go
+++ b/pkg/cluster/client_test.go
@@ -24,7 +24,7 @@ var (
 	dynamicClientFactoryFake   *fakes.DynamicClientFactory
 	options                    cluster.Options
 	optionsTest                cluster.Options
-	kubeconfiFile              string
+	kubeconfigFile             string
 	clusterClient              cluster.Client
 )
 
@@ -39,7 +39,7 @@ var _ = Describe("New Cluster Client Tests", func() {
 		discoveryClientFactoryFake = &fakes.DiscoveryClientFactory{}
 		dynamicClientFactoryFake = &fakes.DynamicClientFactory{}
 		options = cluster.NewOptions(crtClientFake, discoveryClientFactoryFake, dynamicClientFactoryFake)
-		kubeconfiFile = "../fakes/config/kubeconfig1.yaml"
+		kubeconfigFile = "../fakes/config/kubeconfig1.yaml"
 	})
 	When("kubeconfig and context is valid ", func() {
 		BeforeEach(func() {
@@ -47,7 +47,7 @@ var _ = Describe("New Cluster Client Tests", func() {
 			discoveryClientFactoryFake.ServerVersionReturns(nil, nil)
 		})
 		It("return cluster client", func() {
-			client, err := cluster.NewClient(kubeconfiFile, "federal-context", options)
+			client, err := cluster.NewClient(kubeconfigFile, "foo-context", options)
 			Expect(client).NotTo(BeNil())
 			Expect(err).To(BeNil())
 		})
@@ -61,7 +61,7 @@ var _ = Describe("New Cluster Client Tests", func() {
 			BeforeEach(func() {
 				discoveryClientFactoryFake.NewDiscoveryClientForConfigReturns(&discovery.DiscoveryClient{}, nil)
 				discoveryClientFactoryFake.ServerVersionReturns(nil, nil)
-				clusterClient, _ = cluster.NewClient(kubeconfiFile, "federal-context", options)
+				clusterClient, _ = cluster.NewClient(kubeconfigFile, "foo-context", options)
 				crtClientFake.ListObjectsReturns(nil)
 			})
 			It("return empty plugins and no error", func() {
@@ -74,7 +74,7 @@ var _ = Describe("New Cluster Client Tests", func() {
 			BeforeEach(func() {
 				discoveryClientFactoryFake.NewDiscoveryClientForConfigReturns(&discovery.DiscoveryClient{}, nil)
 				discoveryClientFactoryFake.ServerVersionReturns(nil, nil)
-				clusterClient, _ = cluster.NewClient(kubeconfiFile, "federal-context", options)
+				clusterClient, _ = cluster.NewClient(kubeconfigFile, "foo-context", options)
 				crtClientFake.ListObjectsReturns(nil)
 			})
 			It("return clusterQuery object and no errors", func() {
@@ -87,7 +87,7 @@ var _ = Describe("New Cluster Client Tests", func() {
 			BeforeEach(func() {
 				discoveryClientFactoryFake.NewDiscoveryClientForConfigReturns(&discovery.DiscoveryClient{}, nil)
 				discoveryClientFactoryFake.ServerVersionReturns(nil, nil)
-				clusterClient, _ = cluster.NewClient(kubeconfiFile, "federal-context", options)
+				clusterClient, _ = cluster.NewClient(kubeconfigFile, "foo-context", options)
 				crtClientFake.ListObjectsReturns(nil)
 			})
 			It("return empty map and no error", func() {
@@ -102,10 +102,10 @@ var _ = Describe("New Cluster Client Tests", func() {
 		BeforeEach(func() {
 			discoveryClientFactoryFake.NewDiscoveryClientForConfigReturns(&discovery.DiscoveryClient{}, nil)
 			discoveryClientFactoryFake.ServerVersionReturns(nil, nil)
-			kubeconfiFile = "invalidkubeconfigfile.yaml"
+			kubeconfigFile = "invalidkubeconfigfile.yaml"
 		})
 		It("should return error for NewClient()", func() {
-			client, err := cluster.NewClient(kubeconfiFile, "federal-context", options)
+			client, err := cluster.NewClient(kubeconfigFile, "foo-context", options)
 			Expect(client).To(BeNil())
 			Expect(err.Error()).To(ContainSubstring("Failed to load Kubeconfig file from \"invalidkubeconfigfile.yaml\""))
 		})

--- a/pkg/command/context_test.go
+++ b/pkg/command/context_test.go
@@ -46,29 +46,32 @@ var _ = Describe("Test tanzu context command", func() {
 		err             error
 		buf             bytes.Buffer
 	)
+	BeforeEach(func() {
+		tkgConfigFile, err = os.CreateTemp("", "config")
+		Expect(err).To(BeNil())
+		err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config.yaml"), tkgConfigFile.Name())
+		Expect(err).To(BeNil(), "Error while copying tanzu config file for testing")
+		os.Setenv("TANZU_CONFIG", tkgConfigFile.Name())
+
+		tkgConfigFileNG, err = os.CreateTemp("", "config_ng")
+		Expect(err).To(BeNil())
+		os.Setenv("TANZU_CONFIG_NEXT_GEN", tkgConfigFileNG.Name())
+		err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config_ng.yaml"), tkgConfigFileNG.Name())
+		Expect(err).To(BeNil(), "Error while copying tanzu-ng config file for testing")
+	})
+	AfterEach(func() {
+		os.Unsetenv("TANZU_CONFIG")
+		os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
+		os.RemoveAll(tkgConfigFile.Name())
+		os.RemoveAll(tkgConfigFileNG.Name())
+	})
 
 	Describe("tanzu context list", func() {
 		cmd := &cobra.Command{}
 		BeforeEach(func() {
-			tkgConfigFile, err = os.CreateTemp("", "config")
-			Expect(err).To(BeNil())
-			err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config.yaml"), tkgConfigFile.Name())
-			Expect(err).To(BeNil(), "Error while copying tanzu config file for testing")
-			os.Setenv("TANZU_CONFIG", tkgConfigFile.Name())
-
-			tkgConfigFileNG, err = os.CreateTemp("", "config_ng")
-			Expect(err).To(BeNil())
-			os.Setenv("TANZU_CONFIG_NEXT_GEN", tkgConfigFileNG.Name())
-			err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config_ng.yaml"), tkgConfigFileNG.Name())
-			Expect(err).To(BeNil(), "Error while copying tanzu config_ng file for testing")
-
 			cmd.SetOut(&buf)
 		})
 		AfterEach(func() {
-			os.Unsetenv("TANZU_CONFIG")
-			os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
-			os.RemoveAll(tkgConfigFile.Name())
-			os.RemoveAll(tkgConfigFileNG.Name())
 			resetContextCommandFlags()
 			buf.Reset()
 		})
@@ -116,25 +119,9 @@ var _ = Describe("Test tanzu context command", func() {
 	Describe("tanzu context get", func() {
 		cmd := &cobra.Command{}
 		BeforeEach(func() {
-			tkgConfigFile, err = os.CreateTemp("", "config")
-			Expect(err).To(BeNil())
-			err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config.yaml"), tkgConfigFile.Name())
-			Expect(err).To(BeNil(), "Error while copying tanzu config file for testing")
-			os.Setenv("TANZU_CONFIG", tkgConfigFile.Name())
-
-			tkgConfigFileNG, err = os.CreateTemp("", "config_ng")
-			Expect(err).To(BeNil())
-			os.Setenv("TANZU_CONFIG_NEXT_GEN", tkgConfigFileNG.Name())
-			err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config_ng.yaml"), tkgConfigFileNG.Name())
-			Expect(err).To(BeNil(), "Error while copying tanzu config_ng file for testing")
-
 			cmd.SetOut(&buf)
 		})
 		AfterEach(func() {
-			os.Unsetenv("TANZU_CONFIG")
-			os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
-			os.RemoveAll(tkgConfigFile.Name())
-			os.RemoveAll(tkgConfigFileNG.Name())
 			resetContextCommandFlags()
 			buf.Reset()
 		})
@@ -163,25 +150,9 @@ clusterOpts:
 	Describe("tanzu context delete", func() {
 		cmd := &cobra.Command{}
 		BeforeEach(func() {
-			tkgConfigFile, err = os.CreateTemp("", "config")
-			Expect(err).To(BeNil())
-			err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config.yaml"), tkgConfigFile.Name())
-			Expect(err).To(BeNil(), "Error while copying tanzu config file for testing")
-			os.Setenv("TANZU_CONFIG", tkgConfigFile.Name())
-
-			tkgConfigFileNG, err = os.CreateTemp("", "config_ng")
-			Expect(err).To(BeNil())
-			os.Setenv("TANZU_CONFIG_NEXT_GEN", tkgConfigFileNG.Name())
-			err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config_ng.yaml"), tkgConfigFileNG.Name())
-			Expect(err).To(BeNil(), "Error while copying tanzu-ng config file for testing")
-
 			cmd.SetOut(&buf)
 		})
 		AfterEach(func() {
-			os.Unsetenv("TANZU_CONFIG")
-			os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
-			os.RemoveAll(tkgConfigFile.Name())
-			os.RemoveAll(tkgConfigFileNG.Name())
 			resetContextCommandFlags()
 			buf.Reset()
 		})
@@ -206,25 +177,9 @@ clusterOpts:
 	Describe("tanzu context use", func() {
 		cmd := &cobra.Command{}
 		BeforeEach(func() {
-			tkgConfigFile, err = os.CreateTemp("", "config")
-			Expect(err).To(BeNil())
-			err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config.yaml"), tkgConfigFile.Name())
-			Expect(err).To(BeNil(), "Error while copying tanzu config file for testing")
-			os.Setenv("TANZU_CONFIG", tkgConfigFile.Name())
-
-			tkgConfigFileNG, err = os.CreateTemp("", "config_ng")
-			Expect(err).To(BeNil())
-			os.Setenv("TANZU_CONFIG_NEXT_GEN", tkgConfigFileNG.Name())
-			err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config_ng.yaml"), tkgConfigFileNG.Name())
-			Expect(err).To(BeNil(), "Error while copying tanzu config_ng file for testing")
-
 			cmd.SetOut(&buf)
 		})
 		AfterEach(func() {
-			os.Unsetenv("TANZU_CONFIG")
-			os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
-			os.RemoveAll(tkgConfigFile.Name())
-			os.RemoveAll(tkgConfigFileNG.Name())
 			resetContextCommandFlags()
 			buf.Reset()
 		})
@@ -249,25 +204,10 @@ clusterOpts:
 	Describe("tanzu context unset", func() {
 		cmd := &cobra.Command{}
 		BeforeEach(func() {
-			tkgConfigFile, err = os.CreateTemp("", "config")
-			Expect(err).To(BeNil())
-			err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config.yaml"), tkgConfigFile.Name())
-			Expect(err).To(BeNil(), "Error while copying tanzu config file for testing")
-			os.Setenv("TANZU_CONFIG", tkgConfigFile.Name())
-
-			tkgConfigFileNG, err = os.CreateTemp("", "config_ng")
-			Expect(err).To(BeNil())
-			os.Setenv("TANZU_CONFIG_NEXT_GEN", tkgConfigFileNG.Name())
-			err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config_ng.yaml"), tkgConfigFileNG.Name())
-			Expect(err).To(BeNil(), "Error while copying tanzu config_ng file for testing")
 			targetStr = ""
 			cmd.SetOut(&buf)
 		})
 		AfterEach(func() {
-			os.Unsetenv("TANZU_CONFIG")
-			os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
-			os.RemoveAll(tkgConfigFile.Name())
-			os.RemoveAll(tkgConfigFileNG.Name())
 			resetContextCommandFlags()
 			buf.Reset()
 		})
@@ -379,32 +319,35 @@ var _ = Describe("create new context", func() {
 		fakeTMCEndpoint    = "https://cloud.vmware.com/auth"
 		fakeUCPEndpoint    = "https://fake.api.tanzu.cloud.vmware.com"
 	)
+	var (
+		tkgConfigFile   *os.File
+		tkgConfigFileNG *os.File
+		err             error
+		ctx             *configtypes.Context
+	)
+
+	BeforeEach(func() {
+		tkgConfigFile, err = os.CreateTemp("", "config")
+		Expect(err).To(BeNil())
+		err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config.yaml"), tkgConfigFile.Name())
+		Expect(err).To(BeNil(), "Error while copying tanzu config file for testing")
+		os.Setenv("TANZU_CONFIG", tkgConfigFile.Name())
+
+		tkgConfigFileNG, err = os.CreateTemp("", "config_ng")
+		Expect(err).To(BeNil())
+		os.Setenv("TANZU_CONFIG_NEXT_GEN", tkgConfigFileNG.Name())
+		err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config_ng.yaml"), tkgConfigFileNG.Name())
+		Expect(err).To(BeNil(), "Error while copying tanzu config_ng file for testing")
+	})
+	AfterEach(func() {
+		os.Unsetenv("TANZU_CONFIG")
+		os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
+		os.RemoveAll(tkgConfigFile.Name())
+		os.RemoveAll(tkgConfigFileNG.Name())
+	})
 
 	Describe("create context with kubeconfig", func() {
-		var (
-			tkgConfigFile   *os.File
-			tkgConfigFileNG *os.File
-			err             error
-			ctx             *configtypes.Context
-		)
-		BeforeEach(func() {
-			tkgConfigFile, err = os.CreateTemp("", "config")
-			Expect(err).To(BeNil())
-			err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config.yaml"), tkgConfigFile.Name())
-			Expect(err).To(BeNil(), "Error while copying tanzu config file for testing")
-			os.Setenv("TANZU_CONFIG", tkgConfigFile.Name())
-
-			tkgConfigFileNG, err = os.CreateTemp("", "config_ng")
-			Expect(err).To(BeNil())
-			os.Setenv("TANZU_CONFIG_NEXT_GEN", tkgConfigFileNG.Name())
-			err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config_ng.yaml"), tkgConfigFileNG.Name())
-			Expect(err).To(BeNil(), "Error while copying tanzu config_ng file for testing")
-		})
 		AfterEach(func() {
-			os.Unsetenv("TANZU_CONFIG")
-			os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
-			os.RemoveAll(tkgConfigFile.Name())
-			os.RemoveAll(tkgConfigFileNG.Name())
 			resetContextCommandFlags()
 		})
 		Context("with only kubecontext provided", func() {
@@ -444,31 +387,7 @@ var _ = Describe("create new context", func() {
 		})
 	})
 	Describe("create context with tmc endpoint", func() {
-		var (
-			tkgConfigFile   *os.File
-			tkgConfigFileNG *os.File
-			err             error
-			ctx             *configtypes.Context
-		)
-
-		BeforeEach(func() {
-			tkgConfigFile, err = os.CreateTemp("", "config")
-			Expect(err).To(BeNil())
-			err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config.yaml"), tkgConfigFile.Name())
-			Expect(err).To(BeNil(), "Error while copying tanzu config file for testing")
-			os.Setenv("TANZU_CONFIG", tkgConfigFile.Name())
-
-			tkgConfigFileNG, err = os.CreateTemp("", "config_ng")
-			Expect(err).To(BeNil())
-			os.Setenv("TANZU_CONFIG_NEXT_GEN", tkgConfigFileNG.Name())
-			err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config_ng.yaml"), tkgConfigFileNG.Name())
-			Expect(err).To(BeNil(), "Error while copying tanzu config_ng file for testing")
-		})
 		AfterEach(func() {
-			os.Unsetenv("TANZU_CONFIG")
-			os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
-			os.RemoveAll(tkgConfigFile.Name())
-			os.RemoveAll(tkgConfigFileNG.Name())
 			resetContextCommandFlags()
 		})
 		Context("with only endpoint and context name provided", func() {

--- a/pkg/fakes/config/kubeconfig1.yaml
+++ b/pkg/fakes/config/kubeconfig1.yaml
@@ -1,32 +1,28 @@
-current-context: federal-context
 apiVersion: v1
-clusters:
-  - cluster:
-      api-version: v1
-      server: http://cow.org:8080
-    name: cow-cluster
-  - cluster:
-      insecure-skip-tls-verify: true
-      server: https://horse.org:4443
-    name: horse-cluster
-  - cluster:
-      insecure-skip-tls-verify: true
-      server: https://pig.org:443
-    name: pig-cluster
-contexts:
-  - context:
-      cluster: horse-cluster
-      namespace: chisel-ns
-      user: green-user
-    name: federal-context
-  - context:
-      cluster: pig-cluster
-      namespace: saw-ns
-      user: black-user
-    name: queen-anne-context
 kind: Config
+current-context: foo-context
 preferences:
   colors: true
+clusters:
+  - cluster:
+      insecure-skip-tls-verify: true
+      server: https://bar.org:4443
+    name: bar-cluster
+  - cluster:
+      insecure-skip-tls-verify: true
+      server: https://foo.org:443
+    name: foo-cluster
+contexts:
+  - context:
+      cluster: bar-cluster
+      namespace: chisel-ns
+      user: green-user
+    name: bar-context
+  - context:
+      cluster: foo-cluster
+      namespace: saw-ns
+      user: blue-user
+    name: foo-context
 users:
   - name: blue-user
     user:

--- a/pkg/fakes/config/kubeconfig2.yaml
+++ b/pkg/fakes/config/kubeconfig2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+current-context: baz-context
+clusters:
+  - cluster:
+      insecure-skip-tls-verify: true
+      server: https://baz.org:4443
+    name: baz-cluster
+contexts:
+  - context:
+      cluster: baz-cluster
+      namespace: default
+      user: baz-user
+    name: baz-context
+users:
+  - name: baz-user
+    user:
+      token: baz-user-token


### PR DESCRIPTION
- Adds a missing test file kubeconfig2.yaml
- Fix copyFile to actually check for errors, which would have caught the above
- Fixup test file data to be more sensible
- Refactor a bunch of identical setup/teardown of configX.yaml pairs
- Actually do some checking of merged results in kubeconfig tests for merge

Fixes #N/A

### Describe testing done for PR

make test

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
