### PR TITLE
Show log message on plugin installation based on various plugin installation states

### DIFF
--- a/pkg/pluginmanager/manager.go
+++ b/pkg/pluginmanager/manager.go
@@ -665,14 +665,14 @@ func InstallPluginsFromGroup(pluginName, groupIDAndVersion string, options ...Pl
 func logPluginInstallationMessage(p *discovery.Discovered, version string, isPluginInCache, isPluginAlreadyInstalled bool) {
 	withTarget := ""
 	if p.Target != configtypes.TargetUnknown {
-		withTarget = fmt.Sprintf("with target '%v'", p.Target)
+		withTarget = fmt.Sprintf("with target '%v' ", p.Target)
 	}
 
 	if isPluginInCache {
 		if !isPluginAlreadyInstalled {
-			log.Infof("Installing plugin '%v:%v' %v (from cache)", p.Name, version, withTarget)
+			log.Infof("Installing plugin '%v:%v' %v(from cache)", p.Name, version, withTarget)
 		} else {
-			log.Infof("Plugin '%v:%v' %v is already installed. Reinitializing...", p.Name, version, withTarget)
+			log.Infof("Plugin '%v:%v' %vis already installed. Reinitializing...", p.Name, version, withTarget)
 		}
 	} else {
 		log.Infof("Installing plugin '%v:%v' %v", p.Name, version, withTarget)

--- a/pkg/pluginsupplier/plugin_supplier.go
+++ b/pkg/pluginsupplier/plugin_supplier.go
@@ -12,6 +12,7 @@ import (
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
+	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
 
 // GetInstalledPlugins return the installed plugins( both standalone and server plugins )
@@ -45,6 +46,22 @@ func GetInstalledServerPlugins() ([]cli.PluginInfo, error) {
 		return nil, err
 	}
 	return serverPlugins, nil
+}
+
+// IsStandalonePluginInstalled returns true if standalone plugin is already installed
+func IsStandalonePluginInstalled(name string, target configtypes.Target, version string) bool {
+	// Check if the standalone plugin is already installed, if installed skip the installation of the plugin
+	installedStandalonePlugins, err := GetInstalledStandalonePlugins()
+	if err == nil {
+		for i := range installedStandalonePlugins {
+			if installedStandalonePlugins[i].Name == name &&
+				installedStandalonePlugins[i].Target == target &&
+				installedStandalonePlugins[i].Version == version {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func getInstalledStandaloneAndServerPlugins() (standalonePlugins, serverPlugins []cli.PluginInfo, err error) {

--- a/pkg/pluginsupplier/plugin_supplier_test.go
+++ b/pkg/pluginsupplier/plugin_supplier_test.go
@@ -226,6 +226,13 @@ var _ = Describe("GetInstalledPlugins (both standalone and context plugins)", fu
 			Expect(len(installedPlugins)).To(Equal(1))
 			Expect(installedPlugins).Should(ContainElement(*pd1))
 		})
+
+		It("should return correct result for IsStandalonePluginInstalled", func() {
+			isInstalled := IsStandalonePluginInstalled("fake-server-plugin1", types.TargetK8s, "v1.0.0")
+			Expect(isInstalled).To(BeTrue())
+			isInstalled = IsStandalonePluginInstalled("random-plugin", types.TargetK8s, "v1.0.0")
+			Expect(isInstalled).To(BeFalse())
+		})
 	})
 	Context("when a standalone and server plugin for k8s target installed", func() {
 		BeforeEach(func() {


### PR DESCRIPTION
### What this PR does / why we need it

* Updated the PR to show proper log messages based on different plugin installation states

Here is how the log messages are shown:

**Scenario 1: If the plugin binary is NOT available in the cache OR the plugin is NOT installed (as per catalog cache)**
    * `Installing plugin 'pluginName:version'`

**Scenario 2: If the plugin binary is available in the cache AND the plugin is NOT installed (as per catalog cache)**
    * `Installing plugin 'pluginName:version' (from cache)`

**Scenario 3: If the plugin binary is available in the cache AND the plugin is installed (as per catalog cache)**
    * `Plugin 'pluginName:version' is already installed. Reinitializing...`

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
```
$ tz plugin list
Standalone Plugins
  NAME       DESCRIPTION                                                 TARGET  VERSION  STATUS     
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  global  v1.1.0   installed 

## Install `package` plugin for the first time
$ tz plugin install package
[i] Installing plugin 'package:v0.31.0' with target 'kubernetes'
[ok] successfully installed 'package' plugin

## Reinstall `package` plugin when it is already installed
$ tz plugin install package
[i] Plugin 'package:v0.31.0' with target 'kubernetes' is already installed. Reinitializing...
[ok] successfully installed 'package' plugin


## Delete the package plugin
$ tz plugin delete package
Deleting Plugin 'package' for target 'kubernetes'. Are you sure? [y/N]: y
[ok] successfully deleted plugin 'package'

## Reinstall the `package` plugin after deletion (should fetch the plugin from cache)
$ tz plugin install package
[i] Installing plugin 'package:v0.31.0' with target 'kubernetes' (from cache)
[ok] successfully installed 'package' plugin

## Remove the plugin binary directly from file system without updating catalog cache
$ rm /Users/anujc/Library/ApplicationSupport/tanzu-cli/package/v0.31.0_7439a6a7dcb8d584b13c7780abb5b181c234d0d6d642e516e8e402c4ac416052_kubernetes

## Reinstall the `package` plugin after deleting binary
$ tz plugin install package
[i] Installing plugin 'package:v0.31.0' with target 'kubernetes'
[ok] successfully installed 'package' plugin
```

For context-scoped plugins the behavior remain as it is.
```
## Activate a context (after cleaning all installed plugins)
$ tz context use kind
[i] Checking for required plugins...
[i] Installing plugin 'kubernetes-release:v0.31.0' with target 'kubernetes'

$ tz plugin sync
[i] Checking for required plugins...
[i] All required plugins are already installed and up-to-date
[ok] Done

## Delete the kubernetes-release plugin
$ tz plugin delete kubernetes-release
Deleting Plugin 'kubernetes-release' for target 'kubernetes'. Are you sure? [y/N]: y
[ok] successfully deleted plugin 'kubernetes-release'

## Run sync after plugin deletion should install plugins from cache
$ tz plugin sync
[i] Checking for required plugins...
[i] Installing plugin 'kubernetes-release:v0.31.0' with target 'kubernetes' (from cache)
[i] Successfully installed all required plugins
[ok] Done
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Show log message on plugin installation based on various plugin installation states
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

* Thanks for the feedback on the draft PR. I have updated the PR to show logs based on different plugin installation condition based on the feedback from @vuil and @marckhouzam 

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
