### PR TITLE
Sync kube context on tanzu context use

### DIFF
--- a/pkg/auth/utils/kubeconfig/kubeconfig.go
+++ b/pkg/auth/utils/kubeconfig/kubeconfig.go
@@ -46,3 +46,25 @@ func MergeKubeConfigWithoutSwitchContext(kubeConfig []byte, mergeFile string) er
 
 	return clientcmd.WriteToFile(*dest, mergeFile)
 }
+
+// SetCurrentContext updates the current context of a kubeconfig file to one of
+// the contexts in said file.
+func SetCurrentContext(kubeConfigPath, contextName string) error {
+	config, err := clientcmd.LoadFromFile(kubeConfigPath)
+	if err != nil {
+		return errors.Wrap(err, "unable to load kubeconfig")
+	}
+
+	if contextName == "" {
+		return errors.New("context is not provided")
+	}
+
+	for name := range config.Contexts {
+		if name == contextName {
+			config.CurrentContext = contextName
+			return clientcmd.WriteToFile(*config, kubeConfigPath)
+		}
+	}
+
+	return errors.Errorf("context %q does not exist", contextName)
+}

--- a/pkg/constants/env_variables.go
+++ b/pkg/constants/env_variables.go
@@ -36,4 +36,8 @@ const (
 	// Possible values "True" or "False"
 	// by default logs are enabled
 	TanzuCLIShowPluginInstallationLogs = "TANZU_CLI_SHOW_PLUGIN_INSTALLATION_LOGS"
+
+	// Suppress updating the current context of the kubeconfig referenced in
+	// the CLI Context being activated.
+	SkipUpdateKubeconfigOnContextUse = "TANZU_CLI_SKIP_UPDATE_KUBECONFIG_ON_CONTEXT_USE"
 )

--- a/pkg/fakes/config/tanzu_config_ng_yaml.tmpl
+++ b/pkg/fakes/config/tanzu_config_ng_yaml.tmpl
@@ -1,0 +1,45 @@
+contexts:
+  - name: test-mc
+    target: kubernetes
+    clusterOpts:
+      isManagementCluster: true
+      endpoint: test-endpoint
+      path: test-path
+      context: test-mc-context
+  - name: test-tmc-context
+    target: mission-control
+    globalOpts:
+      endpoint: test-endpoint2
+      auth:
+        IDToken: test-id-token
+        accessToken: test-access-token
+        type: api-token
+        userName: test-user-name
+        refresh_token: test-refresh-token
+  - name: test-use-context
+    target: mission-control
+    globalOpts:
+      endpoint: test-endpoint3
+      auth:
+        IDToken: test-id-token2
+        accessToken: test-access-token2
+        type: api-token2
+        userName: test-user-name2
+        refresh_token: test-refresh-token2
+  - name: test-use-context-with-invalid-kubecontext
+    target: kubernetes
+    clusterOpts:
+      isManagementCluster: true
+      endpoint: test-endpoint4
+      path: %s
+      context: MISSING-context-name
+  - name: test-use-context-with-valid-kubecontext
+    target: kubernetes
+    clusterOpts:
+      isManagementCluster: true
+      endpoint: test-endpoint4
+      path: %s
+      context: %s
+currentContext:
+  kubernetes: test-mc
+  mission-control: test-tmc-context

--- a/pkg/fakes/config/tanzu_config_yaml.tmpl
+++ b/pkg/fakes/config/tanzu_config_yaml.tmpl
@@ -1,0 +1,79 @@
+apiVersion: config.tanzu.vmware.com/v1alpha1
+clientOptions:
+  cli:
+    bomRepo: projects.registry.vmware.com/tkg
+    compatibilityFilePath: tkg-compatibility
+    discoverySources:
+      - local:
+          name: default-local
+          path: standalone
+      - local:
+          name: admin-local
+          path: admin
+    edition: tkg
+  features:
+    cluster:
+      custom-nameservers: 'false'
+      dual-stack-ipv4-primary: 'false'
+      dual-stack-ipv6-primary: 'false'
+    global:
+      context-target-v2: 'true'
+      tkr-version-v1alpha3-beta: 'false'
+    management-cluster:
+      aws-instance-types-exclude-arm: 'true'
+      custom-nameservers: 'false'
+      dual-stack-ipv4-primary: 'false'
+      dual-stack-ipv6-primary: 'false'
+      export-from-confirm: 'true'
+      import: 'false'
+      standalone-cluster-mode: 'false'
+    package:
+      kctrl-package-command-tree: 'true'
+kind: ClientConfig
+metadata:
+  creationTimestamp: null
+servers:
+  - name: test-mc
+    type: managementcluster
+    managementClusterOpts:
+      endpoint: test-endpoint
+      path: test-path
+      context: test-mc-context
+    discoverySources:
+      - gcp:
+          name: test
+          bucket: test-bucket
+          manifestPath: test-manifest-path
+  - name: test-tmc-context
+    type: global
+    globalOpts:
+      endpoint: test-endpoint2
+      auth:
+        IDToken: test-id-token
+        accessToken: test-access-token
+        type: api-token
+        userName: test-user-name
+        refresh_token: test-refresh-token
+  - name: test-use-context
+    type: global
+    globalOpts:
+      endpoint: test-endpoint3
+      auth:
+        IDToken: test-id-token2
+        accessToken: test-access-token2
+        type: api-token2
+        userName: test-user-name2
+        refresh_token: test-refresh-token2
+  - name: test-use-context-with-invalid-kubecontext
+    type: managementcluster
+    managementClusterOpts:
+      endpoint: test-endpoint
+      path: %s
+      context: MISSING-context-name
+  - name: test-use-context-with-valid-kubecontext
+    type: managementcluster
+    managementClusterOpts:
+      endpoint: test-endpoint
+      path: %s
+      context: %s
+current: test-mc


### PR DESCRIPTION
Update the `tanzu context use` behavior to update the current kube context of the kubeconfig if the CLI Context being activated references one. This will better facilitate workflows that uses tools (such as kubectl) that respects the kubeconfig state.

This behavior can be suppressed with the environment variable TANZU_CLI_SKIP_UPDATE_KUBECONFIG_ON_CONTEXT_USE=true

```
# given these 3 CLI contexts and kubeconfig state
tmp> kubectl config get-contexts | grep 'kind\|CURRENT'; echo =====; tanzu context list
CURRENT   NAME                                              CLUSTER                AUTHINFO                     NAMESPACE
          kind-foo                                          kind-foo               kind-foo
*         kind-ucp                                          kind-ucp               kind-ucp
=====
Target:  kubernetes
  NAME  ISACTIVE  ENDPOINT  KUBECONFIGPATH                KUBECONTEXT
  kucp  true                /Users/vuichiap/.kube/config  kind-ucp
  foo   false               /Users/vuichiap/.kube/config  kind-foo
Target:  mission-control
  NAME       ISACTIVE  ENDPOINT
  vui-tmc-2  true      unable.tmc-dev.cloud.vmware.com:443

# prior to fix, use of another CLI context does not update the current kube ctx
# with the fix, it does now

tmp> tanzu context use foo
tmp> kubectl config get-contexts | grep 'kind\|CURRENT'; echo =====; tanzu context list
CURRENT   NAME                                              CLUSTER                AUTHINFO                     NAMESPACE
*         kind-foo                                          kind-foo               kind-foo
          kind-ucp                                          kind-ucp               kind-ucp
=====
Target:  kubernetes
  NAME  ISACTIVE  ENDPOINT  KUBECONFIGPATH                KUBECONTEXT
  kucp  false               /Users/vuichiap/.kube/config  kind-ucp
  foo   true                /Users/vuichiap/.kube/config  kind-foo
Target:  mission-control
  NAME       ISACTIVE  ENDPOINT
  vui-tmc-2  true      unable.tmc-dev.cloud.vmware.com:443

# also, with this change, tanzu context use will throw an error if it fails to update the kubeconfig the CLI Context references
tmp> kdown foo
Deleting cluster "foo" ...
tmp> kubectl config get-contexts | grep 'kind\|CURRENT';
CURRENT   NAME                                              CLUSTER                AUTHINFO                     NAMESPACE
          kind-ucp                                          kind-ucp               kind-ucp
tmp> tanzu context use kucp
tmp> tanzu context use foo
[x] : unable to update current kube context: context "kind-foo" does not exist
```

```
# suppressing the sync behavior with environment variable

tmp> kubectl config get-contexts | grep 'kind\|CURRENT'; echo =====; tanzu context list
CURRENT   NAME                                              CLUSTER                AUTHINFO                     NAMESPACE
*         kind-foo                                          kind-foo               kind-foo
          kind-ucp                                          kind-ucp               kind-ucp
=====
Target:  kubernetes
  NAME  ISACTIVE  ENDPOINT  KUBECONFIGPATH                KUBECONTEXT
  kucp  false               /Users/vuichiap/.kube/config  kind-ucp
  foo   true                /Users/vuichiap/.kube/config  kind-foo
Target:  mission-control
  NAME       ISACTIVE  ENDPOINT
  vui-tmc-2  true      unable.tmc-dev.cloud.vmware.com:443
tmp> TANZU_CLI_SKIP_UPDATE_KUBECONFIG_ON_CONTEXT_USE=true tanzu context use kucp
tmp> kubectl config get-contexts | grep 'kind\|CURRENT'; echo =====; tanzu context list
CURRENT   NAME                                              CLUSTER                AUTHINFO                     NAMESPACE
*         kind-foo                                          kind-foo               kind-foo
          kind-ucp                                          kind-ucp               kind-ucp
=====
Target:  kubernetes
  NAME  ISACTIVE  ENDPOINT  KUBECONFIGPATH                KUBECONTEXT
  kucp  true                /Users/vuichiap/.kube/config  kind-ucp
  foo   false               /Users/vuichiap/.kube/config  kind-foo
Target:  mission-control
  NAME       ISACTIVE  ENDPOINT
  vui-tmc-2  true      unable.tmc-dev.cloud.vmware.com:443
```



### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

make test

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
`tanzu context use` of a Context that references a kubeconfig will also update the current context of the kubeconfig referenced
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
