### PR TITLE
Update tanzu context list to include UCP data

### DIFF
--- a/pkg/fakes/config/tanzu_config_ng.yaml
+++ b/pkg/fakes/config/tanzu_config_ng.yaml
@@ -31,6 +31,24 @@ contexts:
         type: api-token2
         userName: test-user-name2
         refresh_token: test-refresh-token2
+  - name: test-ucp-context
+    target: ucp
+    globalOpts:
+      endpoint: ucp-endpoint
+      auth:
+        IDToken: test-id-token
+        accessToken: test-access-token
+        type: api-token
+        userName: test-user-name
+        refresh_token: test-refresh-token
+    clusterOpts:
+      isManagementCluster: false
+      endpoint: kube-endpoint
+      path: dummy/path
+      context: dummy-context
+    additionalMetadata:
+      ucpProjectName: dummyP
+      ucpOrgID: dummyO
 currentContext:
   kubernetes: test-mc
   mission-control: test-tmc-context


### PR DESCRIPTION
### What this PR does / why we need it

Shows additional information relevant to the UCP context variant.
Not that the tabular output conditionally hides the UCP-specific columns if no such contexts are available.
An upcoming rename exercise will fix up the terminology to use TAE, till then only `context list --target ucp`
works as a means to filter TAE contexts.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #N/A

### Describe testing done for PR

```
tanzu-cli (context-list)> tz context list
Target:  kubernetes
  NAME    ISACTIVE  TYPE     ENDPOINT                                                                                           KUBECONFIGPATH                KUBECONTEXT       PROJECT  SPACE
  kucp    true      cluster                                                                                                     /Users/vuichiap/.kube/config  kind-ucp
  foo     false     cluster                                                                                                     /Users/vuichiap/.kube/config  kind-foo
  stucp   false     TAE      https://api-dev.tanzu.cloud.vmware.com/org/7753c388-914c-4085-1111-111111111111                    /Users/vuichiap/.kube/config  tanzu-cli-stucp   projA
  sprucp  true      TAE      https://ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com/org/ee04bfae-a665-4f20-2222-222222222222  /Users/vuichiap/.kube/config  tanzu-cli-sprucp
Target:  mission-control
  NAME       ISACTIVE  ENDPOINT
  vui-tmc-2  true      unable.tmc-dev.cloud.vmware.com:443

tanzu-cli (context-list)> tz context list --target ucp
Target:  kubernetes
  NAME    ISACTIVE  TYPE  ENDPOINT                                                                                           KUBECONFIGPATH                KUBECONTEXT       PROJECT  SPACE
  stucp   false     TAE   https://api-dev.tanzu.cloud.vmware.com/org/7753c388-914c-4085-1111-111111111111                    /Users/vuichiap/.kube/config  tanzu-cli-stucp   projA
  sprucp  true      TAE   https://ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com/org/ee04bfae-a665-4f20-2222-222222222222  /Users/vuichiap/.kube/config  tanzu-cli-sprucp

tanzu-cli (context-list)> tz context list --target k8s
Target:  kubernetes
  NAME  ISACTIVE  TYPE     ENDPOINT  KUBECONFIGPATH                KUBECONTEXT
  kucp  true      cluster            /Users/vuichiap/.kube/config  kind-ucp
  foo   false     cluster            /Users/vuichiap/.kube/config  kind-foo

tanzu-cli (context-list)> tz context list --target tmc
Target:  mission-control
  NAME       ISACTIVE  ENDPOINT
  vui-tmc-2  true      unable.tmc-dev.cloud.vmware.com:443

tanzu-cli (context-list)> # removes two ucp-based contexts...
tanzu-cli (context-list)> tz context list
Target:  kubernetes
  NAME  ISACTIVE  TYPE     ENDPOINT  KUBECONFIGPATH                KUBECONTEXT
  kucp  true      cluster            /Users/vuichiap/.kube/config  kind-ucp
  foo   false     cluster            /Users/vuichiap/.kube/config  kind-foo
Target:  mission-control
  NAME       ISACTIVE  ENDPOINT
  vui-tmc-2  true      unable.tmc-dev.cloud.vmware.com:443
```

```
tanzu-cli (context-list)> tz context list --target ucp -o json
[
  {
    "additionalmetadata": {
      "ucpOrgID": "7753c388-914c-4085-1111-111111111111",
      "ucpProjectName": "projA"
    },
    "endpoint": "https://api-dev.tanzu.cloud.vmware.com/org/7753c388-914c-4085-1111-111111111111",
    "iscurrent": false,
    "ismanagementcluster": false,
    "kubeconfigpath": "/Users/vuichiap/.kube/config",
    "kubecontext": "tanzu-cli-stucp",
    "name": "stucp",
    "type": "ucp"
  },
  {
    "additionalmetadata": {
      "ucpOrgID": "ee04bfae-a665-4f20-2222-222222222222"
    },
    "endpoint": "https://ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com/org/ee04bfae-a665-4f20-2222-222222222222,
    "iscurrent": true,
    "ismanagementcluster": false,
    "kubeconfigpath": "/Users/vuichiap/.kube/config",
    "kubecontext": "tanzu-cli-sprucp",
    "name": "sprucp",
    "type": "ucp"
  }
]

tanzu-cli (context-list)> tz context list --target ucp -o yaml
- additionalmetadata:
    ucpOrgID: 7753c388-914c-4085-1111-111111111111
    ucpProjectName: projA
  endpoint: https://api-dev.tanzu.cloud.vmware.com/org/7753c388-914c-4085-1111-111111111111
  iscurrent: false
  ismanagementcluster: false
  kubeconfigpath: /Users/vuichiap/.kube/config
  kubecontext: tanzu-cli-stucp
  name: stucp
  type: ucp
- additionalmetadata:
    ucpOrgID: ee04bfae-a665-4f20-2222-222222222222
  endpoint: https://ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com/org/ee04bfae-a665-4f20-2222-222222222222
  iscurrent: true
  ismanagementcluster: false
  kubeconfigpath: /Users/vuichiap/.kube/config
  kubecontext: tanzu-cli-sprucp
  name: sprucp
  type: ucp
```


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
tanzu context list shows additional data for application-engine contexts
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
