### PR TITLE
Dynamic shell completion for miscellaneous commands

### DIFF
--- a/pkg/command/ceip_participation.go
+++ b/pkg/command/ceip_participation.go
@@ -49,10 +49,11 @@ func newCEIPParticipationCmd() *cobra.Command {
 
 func newCEIPParticipationSetCmd() *cobra.Command {
 	var setCmd = &cobra.Command{
-		Use:   "set OPT_IN_BOOL",
-		Short: "Set the opt-in preference for CEIP (subject to change)",
-		Long:  "Set the opt-in preference for CEIP (subject to change)",
-		Args:  cobra.ExactArgs(1),
+		Use:               "set OPT_IN_BOOL",
+		Short:             "Set the opt-in preference for CEIP (subject to change)",
+		Long:              "Set the opt-in preference for CEIP (subject to change)",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completeCeipSet,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !strings.EqualFold(args[0], "true") && !strings.EqualFold(args[0], "false") {
 				return errors.Errorf("incorrect boolean argument: %q", args[0])
@@ -70,9 +71,10 @@ func newCEIPParticipationSetCmd() *cobra.Command {
 
 func newCEIPParticipationGetCmd() *cobra.Command {
 	var getCmd = &cobra.Command{
-		Use:   "get",
-		Short: "Get the current CEIP opt-in status (subject to change)",
-		Long:  "Get the current CEIP opt-in status (subject to change)",
+		Use:               "get",
+		Short:             "Get the current CEIP opt-in status (subject to change)",
+		Long:              "Get the current CEIP opt-in status (subject to change)",
+		ValidArgsFunction: cobra.NoFileCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			optInVal, err := configlib.GetCEIPOptIn()
 			if err != nil {
@@ -92,4 +94,17 @@ func newCEIPParticipationGetCmd() *cobra.Command {
 	}
 
 	return getCmd
+}
+
+func completeCeipSet(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	// Keep the "true" choice first by using ShellCompDirectiveKeepOrder (may not work for all shells)
+	// This is just to make it "easier" to opt-in :-)
+	return []string{
+			"true\tAccept to participate",
+			"false\tRefuse to participate"},
+		cobra.ShellCompDirectiveKeepOrder | cobra.ShellCompDirectiveNoFileComp
 }

--- a/pkg/command/ceip_participation_test.go
+++ b/pkg/command/ceip_participation_test.go
@@ -6,10 +6,12 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/otiai10/copy"
+	"github.com/stretchr/testify/assert"
 )
 
 var _ = Describe("ceip-participation command tests", func() {
@@ -113,5 +115,56 @@ var _ = Describe("ceip-participation command tests", func() {
 			})
 		})
 	})
-
 })
+
+func TestCompletionCeip(t *testing.T) {
+	tests := []struct {
+		test     string
+		args     []string
+		expected string
+	}{
+		// =====================
+		// tanzu ceip set
+		// =====================
+		{
+			test: "completion of true/false for the ceip set command",
+			args: []string{"__complete", "ceip", "set", ""},
+			// ":36" is the value of the ShellCompDirectiveNoFileComp | ShellCompDirectiveKeepOrder
+			expected: "true\tAccept to participate\n" +
+				"false\tRefuse to participate\n" + ":36\n",
+		},
+		{
+			test: "no completion after the first arg for the ceip set command",
+			args: []string{"__complete", "ceip", "set", "true", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: ":4\n",
+		},
+		// =====================
+		// tanzu ceip get
+		// =====================
+		{
+			test: "no completion for the ceip get command",
+			args: []string{"__complete", "ceip", "get", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: ":4\n",
+		},
+	}
+
+	for _, spec := range tests {
+		t.Run(spec.test, func(t *testing.T) {
+			assert := assert.New(t)
+
+			rootCmd, err := NewRootCmd()
+			assert.Nil(err)
+
+			var out bytes.Buffer
+			rootCmd.SetOut(&out)
+			rootCmd.SetArgs(spec.args)
+
+			err = rootCmd.Execute()
+			assert.Nil(err)
+
+			assert.Equal(spec.expected, out.String())
+		})
+	}
+}

--- a/pkg/command/completion.go
+++ b/pkg/command/completion.go
@@ -79,7 +79,12 @@ var completionCmd = &cobra.Command{
 	Long:                  fmt.Sprintf(completionLongDesc, completionShells),
 	Example:               completionExamples,
 	DisableFlagsInUseLine: true,
-	ValidArgs:             completionShells,
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return completionShells, cobra.ShellCompDirectiveNoFileComp
+		}
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runCompletion(os.Stdout, cmd, args)
 	},

--- a/pkg/command/doc.go
+++ b/pkg/command/doc.go
@@ -28,13 +28,15 @@ var (
 )
 
 func init() {
+	// Shell completion for this flag is file completion which is enabled by default
 	genAllDocsCmd.Flags().StringVarP(&docsDir, "docs-dir", "d", DefaultDocsDir, "destination for docs output")
 }
 
 var genAllDocsCmd = &cobra.Command{
-	Use:    "generate-all-docs",
-	Short:  "Generate Cobra CLI docs for all plugins installed",
-	Hidden: true,
+	Use:               "generate-all-docs",
+	Short:             "Generate Cobra CLI docs for all plugins installed",
+	Hidden:            true,
+	ValidArgsFunction: cobra.NoFileCompletions,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if docsDir == "" {

--- a/pkg/command/doc_test.go
+++ b/pkg/command/doc_test.go
@@ -1,0 +1,49 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package command
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompletionGenerateDocs(t *testing.T) {
+	tests := []struct {
+		test     string
+		args     []string
+		expected string
+	}{
+		{
+			test: "no completion for the generate-all-docs command",
+			args: []string{"__complete", "generate-all-docs", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: ":4\n",
+		},
+		{
+			test: "file completion for the generate-all-docs --docs-dir flag",
+			args: []string{"__complete", "generate-all-docs", "--docs-dir", ""},
+			// ":0" is the value of the ShellCompDirectiveDefault
+			expected: ":0\n",
+		},
+	}
+
+	for _, spec := range tests {
+		t.Run(spec.test, func(t *testing.T) {
+			assert := assert.New(t)
+
+			rootCmd, err := NewRootCmd()
+			assert.Nil(err)
+
+			var out bytes.Buffer
+			rootCmd.SetOut(&out)
+			rootCmd.SetArgs(spec.args)
+
+			err = rootCmd.Execute()
+			assert.Nil(err)
+
+			assert.Equal(spec.expected, out.String())
+		})
+	}
+}

--- a/pkg/command/init.go
+++ b/pkg/command/init.go
@@ -22,7 +22,8 @@ var initCmd = &cobra.Command{
 	Annotations: map[string]string{
 		"group": string(plugin.SystemCmdGroup),
 	},
-	SilenceErrors: true,
+	SilenceErrors:     true,
+	ValidArgsFunction: cobra.NoFileCompletions,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Currently nothing to initialize.
 		// We are keeping this command as it may become useful

--- a/pkg/command/init_test.go
+++ b/pkg/command/init_test.go
@@ -1,0 +1,43 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package command
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompletionInit(t *testing.T) {
+	tests := []struct {
+		test     string
+		args     []string
+		expected string
+	}{
+		{
+			test: "no completion for the init command",
+			args: []string{"__complete", "init", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: ":4\n",
+		},
+	}
+
+	for _, spec := range tests {
+		t.Run(spec.test, func(t *testing.T) {
+			assert := assert.New(t)
+
+			rootCmd, err := NewRootCmd()
+			assert.Nil(err)
+
+			var out bytes.Buffer
+			rootCmd.SetOut(&out)
+			rootCmd.SetArgs(spec.args)
+
+			err = rootCmd.Execute()
+			assert.Nil(err)
+
+			assert.Equal(spec.expected, out.String())
+		})
+	}
+}

--- a/pkg/command/version.go
+++ b/pkg/command/version.go
@@ -21,6 +21,7 @@ func newVersionCmd() *cobra.Command {
 		Annotations: map[string]string{
 			"group": string(plugin.SystemCmdGroup),
 		},
+		ValidArgsFunction: cobra.NoFileCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Printf("version: %s\nbuildDate: %s\nsha: %s\n", buildinfo.Version, buildinfo.Date, buildinfo.SHA)
 			return nil

--- a/pkg/command/version_test.go
+++ b/pkg/command/version_test.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"bytes"
 	"io"
 	"os"
 	"testing"
@@ -57,4 +58,37 @@ func TestVersion(t *testing.T) {
 	got := <-c
 	expected := "version: 1.2.3\nbuildDate: today\nsha: cafecafe\n"
 	assert.Equal(expected, string(got))
+}
+
+func TestCompletionVersion(t *testing.T) {
+	tests := []struct {
+		test     string
+		args     []string
+		expected string
+	}{
+		{
+			test: "no completion for the version command",
+			args: []string{"__complete", "version", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: ":4\n",
+		},
+	}
+
+	for _, spec := range tests {
+		t.Run(spec.test, func(t *testing.T) {
+			assert := assert.New(t)
+
+			rootCmd, err := NewRootCmd()
+			assert.Nil(err)
+
+			var out bytes.Buffer
+			rootCmd.SetOut(&out)
+			rootCmd.SetArgs(spec.args)
+
+			err = rootCmd.Execute()
+			assert.Nil(err)
+
+			assert.Equal(spec.expected, out.String())
+		})
+	}
 }


### PR DESCRIPTION
### What this PR does / why we need it

This commit provides dynamic shell completion for:
- `tanzu ceip-participation set`

The commit turns off file completion for:
- `tanzu init`
- `tanzu version`
- `tanzu ceip-participation get`
- `tanzu generate-all-docs`
- `tanzu completion`

Notice that this commit replaces the use of ValidArgs with ValidArgsFunction for the "tanzu completion" command. Using ValidArgs is not as good because:
  `tanzu completion fish <TAB>`
will perform file completion, which is incorrect.

Unit tests have been added.

**To better understand the visible changes, please refer to the "testing done" section.**

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Part of #500

### Describe testing done for PR

Setup for shell completions:

zsh:
```
source <(tanzu completion zsh)
# if shell completion still does not work, also do (those should be in your .zshrc file)
autoload -Uz compinit
compinit
```

fish:
```
tanzu completion fish | source
```

bash:
```
# You must install the bash-completions@2 package
brew install bash-completion@2
source $(brew --prefix)/etc/profile.d/bash_completion.sh

source <(tanzu completion bash)
```

Tests:

```
#################
# tanzu ceip
#################
# No completion for ceip get
$ tz ceip get <TAB>

$ tz ceip set <TAB>
true   -- Accept to participate
false  -- Refuse to participate

# No completion after the first arg of ceip set
$ tz ceip set true <TAB>

##########################
# tanzu generate-all-docs
##########################
# No completion generate-all-docs
$ tz generate-all-docs

# File completion for the --docs-dir flag
$ tz generate-all-docs --docs-dir <TAB>
CODEOWNERS          LICENSE             ROADMAP.md          bin/                docs/               go.work.sum         plugin-tooling.mk
CODE_OF_CONDUCT.md  Makefile            SECURITY.md         cmd/                go.mod              hack/               rpm/
CONTRIBUTING.md     NOTICE              apis/               coverage.txt        go.sum              packages.bak/       test/
Dockerfile          README.md           artifacts/          discovery/          go.work             pkg/

##########################
# tanzu completion
##########################
$ tz completion <TAB>
bash        fish        powershell  zsh

# No completion after the first arg of tz completion
$ tz completion fish <TAB>

##########################
# tanzu init
##########################
# No completion after the init command
$ tz init <TAB>

##########################
# tanzu version
##########################
# No completion after the version command
$ tz version <TAB>
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add dynamic shell completion for the commands "ceip", "version", "init", "completion", "generate-all-docs"
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
