### PR TITLE
Dynamic shell completion for the tanzu config command tree

### DIFF
--- a/pkg/command/cert_test.go
+++ b/pkg/command/cert_test.go
@@ -7,13 +7,16 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
 
 	"gopkg.in/yaml.v3"
 
 	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
+	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
 
 var _ = Describe("config cert command tests", func() {
@@ -238,6 +241,182 @@ func getConfigCertData(host string) string {
 	caData, err := base64.StdEncoding.DecodeString(cert.CACertData)
 	Expect(err).To(BeNil())
 	return string(caData)
+}
+
+func TestCompletionCert(t *testing.T) {
+	// Setup a temporary configuration
+	configFile, err := os.CreateTemp("", "config")
+	assert.Nil(t, err)
+	os.Setenv("TANZU_CONFIG", configFile.Name())
+	configFileNG, err := os.CreateTemp("", "config_ng")
+	assert.Nil(t, err)
+	os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
+
+	// Create some test certs
+	cert1 := configtypes.Cert{
+		Host:           "example.com",
+		CACertData:     "abcde",
+		Insecure:       "false",
+		SkipCertVerify: "false",
+	}
+
+	cert2 := configtypes.Cert{
+		Host:           "localhost:9876",
+		CACertData:     "edcba",
+		Insecure:       "true",
+		SkipCertVerify: "true",
+	}
+
+	err = configlib.SetCert(&cert1)
+	assert.Nil(t, err)
+	err = configlib.SetCert(&cert2)
+	assert.Nil(t, err)
+
+	tests := []struct {
+		test     string
+		args     []string
+		expected string
+	}{
+		// ======================
+		// tanzu config cert list
+		// ======================
+		{
+			test: "no completion for the cert list command",
+			args: []string{"__complete", "config", "cert", "list", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: ":4\n",
+		},
+		{
+			test: "completion for the --output flag value of the cert list command",
+			args: []string{"__complete", "config", "cert", "list", "--output", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: expectedOutForOutputFlag + ":4\n",
+		},
+		// =====================
+		// tanzu config cert add
+		// =====================
+		{
+			test: "completion of required flags for the cert add command",
+			args: []string{"__complete", "config", "cert", "add", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: "--host\thost or host:port\n:4\n",
+		},
+		{
+			test: "no completion for the cert add command once the --host flag is present",
+			args: []string{"__complete", "config", "cert", "add", "--host", "example.com", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: ":4\n",
+		},
+		{
+			test: "completion for the --host flag value of the cert add command",
+			args: []string{"__complete", "config", "cert", "add", "--host", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: "_activeHelp_ Please provide 'host' or 'host:port'\n:4\n",
+		},
+		{
+			test: "completion for the --ca-certificate flag value of the cert add command",
+			args: []string{"__complete", "config", "cert", "add", "--ca-certificate", ""},
+			// ":0" is the value of the ShellCompDirectiveDefault
+			expected: ":0\n",
+		},
+		{
+			test: "completion for the --skip-cert-verify flag value of the cert add command",
+			args: []string{"__complete", "config", "cert", "add", "--skip-cert-verify", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: "true\tSkip TLS certificate verification (insecure)\n" +
+				"false\tPerform TLS certificate verification\n" +
+				":4\n",
+		},
+		{
+			test: "completion for the --insecure flag value of the cert add command",
+			args: []string{"__complete", "config", "cert", "add", "--insecure", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: "true\tAllow the use of http when interacting with the host (insecure)\n" +
+				"false\tPrevent the use of http when interacting with the host\n" +
+				":4\n",
+		},
+		// ========================
+		// tanzu config cert update
+		// ========================
+		{
+			test: "completion of existing certificate hosts for the cert update command",
+			args: []string{"__complete", "config", "cert", "update", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: "example.com\tInsecure: false, Skip cert verification: false\n" +
+				"localhost:9876\tInsecure: true, Skip cert verification: true\n" +
+				":4\n",
+		},
+		{
+			test: "no completion after the first arg for the cert update command",
+			args: []string{"__complete", "config", "cert", "update", "localhost:9876", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: ":4\n",
+		},
+		{
+			test: "completion for the --ca-certificate flag value of the cert update command",
+			args: []string{"__complete", "config", "cert", "update", "--ca-certificate", ""},
+			// ":0" is the value of the ShellCompDirectiveDefault
+			expected: ":0\n",
+		},
+		{
+			test: "completion for the --skip-cert-verify flag value of the cert update command",
+			args: []string{"__complete", "config", "cert", "update", "--skip-cert-verify", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: "true\tSkip TLS certificate verification (insecure)\n" +
+				"false\tPerform TLS certificate verification\n" +
+				":4\n",
+		},
+		{
+			test: "completion for the --insecure flag value of the cert update command",
+			args: []string{"__complete", "config", "cert", "update", "--insecure", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: "true\tAllow the use of http when interacting with the host (insecure)\n" +
+				"false\tPrevent the use of http when interacting with the host\n" +
+				":4\n",
+		},
+		// ========================
+		// tanzu config cert delete
+		// ========================
+		{
+			test: "completion of existing certificate hosts for the cert delete command",
+			args: []string{"__complete", "config", "cert", "delete", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: "example.com\tInsecure: false, Skip cert verification: false\n" +
+				"localhost:9876\tInsecure: true, Skip cert verification: true\n" +
+				":4\n",
+		},
+		{
+			test: "no completion after the first arg for the cert delete command",
+			args: []string{"__complete", "config", "cert", "delete", "localhost:9876", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: ":4\n",
+		},
+	}
+
+	for _, spec := range tests {
+		t.Run(spec.test, func(t *testing.T) {
+			assert := assert.New(t)
+
+			rootCmd, err := NewRootCmd()
+			assert.Nil(err)
+
+			var out bytes.Buffer
+			rootCmd.SetOut(&out)
+			rootCmd.SetArgs(spec.args)
+
+			err = rootCmd.Execute()
+			assert.Nil(err)
+
+			assert.Equal(spec.expected, out.String())
+
+			resetCertCommandFlags()
+		})
+	}
+
+	os.RemoveAll(configFile.Name())
+	os.RemoveAll(configFileNG.Name())
+	os.Unsetenv("TANZU_CONFIG")
+	os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
 }
 
 func resetCertCommandFlags() {

--- a/pkg/command/eula.go
+++ b/pkg/command/eula.go
@@ -34,10 +34,10 @@ func newEULACmd() *cobra.Command {
 
 func newShowEULACmd() *cobra.Command {
 	var showEULACmd = &cobra.Command{
-		Use:   "show",
-		Short: "Present EULA",
-		Long:  "Present EULA for review",
-
+		Use:               "show",
+		Short:             "Present EULA",
+		Long:              "Present EULA for review",
+		ValidArgsFunction: cobra.NoFileCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return config.ConfigureEULA(true)
 		},
@@ -47,9 +47,10 @@ func newShowEULACmd() *cobra.Command {
 
 func newAcceptEULACmd() *cobra.Command {
 	var acceptEULACmd = &cobra.Command{
-		Use:   "accept",
-		Short: "Accept the EULA",
-		Long:  "Accept the EULA for Tanzu CLI non-interactively.",
+		Use:               "accept",
+		Short:             "Accept the EULA",
+		Long:              "Accept the EULA for Tanzu CLI non-interactively.",
+		ValidArgsFunction: cobra.NoFileCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := configlib.SetEULAStatus(configlib.EULAStatusAccepted)
 			if err != nil {

--- a/pkg/command/eula_test.go
+++ b/pkg/command/eula_test.go
@@ -3,12 +3,15 @@
 package command
 
 import (
+	"bytes"
 	"os"
 	"strings"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
@@ -111,3 +114,48 @@ var _ = Describe("EULA command tests", func() {
 		})
 	})
 })
+
+func TestCompletionEULA(t *testing.T) {
+	tests := []struct {
+		test     string
+		args     []string
+		expected string
+	}{
+		// =====================
+		// tanzu config eula accept
+		// =====================
+		{
+			test: "no completion for the eula accept command",
+			args: []string{"__complete", "config", "eula", "accept", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: ":4\n",
+		},
+		// =====================
+		// tanzu config eula show
+		// =====================
+		{
+			test: "no completion for the eula show command",
+			args: []string{"__complete", "config", "eula", "show", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: ":4\n",
+		},
+	}
+
+	for _, spec := range tests {
+		t.Run(spec.test, func(t *testing.T) {
+			assert := assert.New(t)
+
+			rootCmd, err := NewRootCmd()
+			assert.Nil(err)
+
+			var out bytes.Buffer
+			rootCmd.SetOut(&out)
+			rootCmd.SetArgs(spec.args)
+
+			err = rootCmd.Execute()
+			assert.Nil(err)
+
+			assert.Equal(spec.expected, out.String())
+		})
+	}
+}


### PR DESCRIPTION
### What this PR does / why we need it

This commit provides dynamic shell completion for:
- `tanzu config set`
- `tanzu config unset`
- `tanzu config cert update`
- `tanzu config cert delete`

The commit also turns off file completion for:
- `tanzu config get`
- `tanzu config init`
- `tanzu config eula accept`
- `tanzu config eula show`
- `tanzu config cert list`
- `tanzu config cert add`

The commit also provides shell completion for all (non-boolean) flags of the above commands.

Unit tests have been added.

**To better understand the visible changes, please refer to the "testing done" section.**

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #500

### Describe testing done for PR

Setup for shell completions:

zsh:
```
source <(tanzu completion zsh)
# if shell completion still does not work, also do (those should be in your .zshrc file)
autoload -Uz compinit
compinit
```

fish:
```
tanzu completion fish | source
```

bash:
```
# You must install the bash-completions@2 package
brew install bash-completion@2
source $(brew --prefix)/etc/profile.d/bash_completion.sh

source <(tanzu completion bash)
```

Tests:

```
###################
# tanzu config eula
###################
# No completions since no args accepted
$ tz config eula accept <TAB>
$ tz config eula show <TAB>

########################
# tanzu config cert list
########################
# No completions since no args accepted
$ tz config cert list <TAB>

$ tz config cert list -o <TAB>
json   -- Output results in JSON format
table  -- Output results in human-readable format
yaml   -- Output results in YAML format

########################
# tanzu config cert add
########################
# No completions (once --host is provided) since no args accepted
$ tz config cert add --host localhost <TAB>

# Active Help for the --host flag value
$ tz config cert add --host <TAB>
Please provide 'host' or 'host:port'

# File completion for --ca-certificate
$ tz config cert add --ca-certificate <TAB>
CODEOWNERS          LICENSE             ROADMAP.md          bin/                docs/               go.work.sum         plugin-tooling.mk
CODE_OF_CONDUCT.md  Makefile            SECURITY.md         cmd/                go.mod              hack/               rpm/
CONTRIBUTING.md     NOTICE              apis/               coverage.txt        go.sum              packages.bak/       test/
Dockerfile          README.md           artifacts/          discovery/          go.work             pkg/

$ tz config cert add --skip-cert-verify <TAB>
false  -- Perform TLS certificate verification
true   -- Skip TLS certificate verification (insecure)

$ tz config cert add --insecure <TAB>
false  -- Prevent the use of http when interacting with the host
true   -- Allow the use of http when interacting with the host (insecure)

##########################
# tanzu config cert update
##########################
# completion of available hosts
$ tz config cert update <TAB>
example.com     -- Insecure: false, Skip cert verification: false
localhost:9876  -- Insecure: true, Skip cert verification: true

# No completion after the first arg
$ tz config cert update localhost:9876 <TAB>

# File completion for --ca-certificate
$ tz config cert update --ca-certificate <TAB>
CODEOWNERS          LICENSE             ROADMAP.md          bin/                docs/               go.work.sum         plugin-tooling.mk
CODE_OF_CONDUCT.md  Makefile            SECURITY.md         cmd/                go.mod              hack/               rpm/
CONTRIBUTING.md     NOTICE              apis/               coverage.txt        go.sum              packages.bak/       test/
Dockerfile          README.md           artifacts/          discovery/          go.work             pkg/

$ tz config cert update --skip-cert-verify <TAB>
false  -- Perform TLS certificate verification
true   -- Skip TLS certificate verification (insecure)

$ tz config cert update --insecure <TAB>
false  -- Prevent the use of http when interacting with the host
true   -- Allow the use of http when interacting with the host (insecure)

##########################
# tanzu config cert delete
##########################
# completion of available hosts
$ tz config cert delete <TAB>
example.com     -- Insecure: false, Skip cert verification: false
localhost:9876  -- Insecure: true, Skip cert verification: true

# No completion after the first arg
$ tz config cert delete localhost:9876 <TAB>

##########################
# tanzu config get
##########################
# No completions since no args accepted
$ tz config get <TAB>

##########################
# tanzu config init
##########################
# No completions since no args accepted
$ tz config init <TAB>

##########################
# tanzu config unset
##########################
# Completion of all env. and features.
$ tz config unset <TAB>
env.TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY             -- Value: "harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inv
env.TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST  -- Value: "localhost:9876/tanzu-cli/plugins/central:small"
features.cluster.allow-legacy-cluster                                  -- Value: "false"
features.cluster.dual-stack-ipv4-primary                               -- Value: "false"
features.cluster.dual-stack-ipv6-primary                               -- Value: "false"
features.global.context-aware-cli-for-plugins                          -- Value: "true"
features.global.context-target-v2                                      -- Value: "true"
features.global.tkr-version-v1alpha3-beta                              -- Value: "false"
features.management-cluster.aws-instance-types-exclude-arm             -- Value: "true"
features.management-cluster.custom-nameservers                         -- Value: "false"
features.management-cluster.dual-stack-ipv4-primary                    -- Value: "false"
features.management-cluster.dual-stack-ipv6-primary                    -- Value: "false"
features.management-cluster.export-from-confirm                        -- Value: "true"
features.management-cluster.import                                     -- Value: "false"
features.management-cluster.package-based-cc                           -- Value: "true"
features.management-cluster.standalone-cluster-mode                    -- Value: "false"
features.package.kctrl-command-tree                                    -- Value: "true"
features.package.kctrl-package-command-tree                            -- Value: "false"

# No completions after the first arg
$ tz config unset env.TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY <TAB>

##########################
# tanzu config set
##########################

# Complete all existing env. and features.
# Although other values can be used, this approach helps avoid having
# remember and type long variable names.
# The Active Help text is meant to help understand this, although it
# does not show for the fish and powershell shells
$ tz config set <TAB>
You can modify the below entries, or provide a new one
--
env.TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY             -- Value: "harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inv
env.TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST  -- Value: "localhost:9876/tanzu-cli/plugins/central:small"
features.cluster.allow-legacy-cluster                                  -- Value: "false"
features.cluster.dual-stack-ipv4-primary                               -- Value: "false"
features.cluster.dual-stack-ipv6-primary                               -- Value: "false"
features.global.context-aware-cli-for-plugins                          -- Value: "true"
features.global.context-target-v2                                      -- Value: "true"
features.global.tkr-version-v1alpha3-beta                              -- Value: "false"
features.management-cluster.aws-instance-types-exclude-arm             -- Value: "true"
features.management-cluster.custom-nameservers                         -- Value: "false"
features.management-cluster.dual-stack-ipv4-primary                    -- Value: "false"
features.management-cluster.dual-stack-ipv6-primary                    -- Value: "false"
features.management-cluster.export-from-confirm                        -- Value: "true"
features.management-cluster.import                                     -- Value: "false"
features.management-cluster.package-based-cc                           -- Value: "true"
features.management-cluster.standalone-cluster-mode                    -- Value: "false"
features.package.kctrl-command-tree                                    -- Value: "true"
features.package.kctrl-package-command-tree                            -- Value: "false"

# Active help to mention adding the value argument
$ tz config set features.cluster.allow-legacy-cluster <TAB>
You must provide a value as a second argument

# No completion after the second arg
$ tz config set features.cluster.allow-legacy-cluster true <TAB>
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add dynamic shell completion for the commands `tanzu config` command tree.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
