### PR TITLE
Perform plugin sync for single target only

### DIFF
--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -246,13 +246,13 @@ func createCtx(_ *cobra.Command, args []string) (err error) {
 	}
 
 	// Sync all required plugins
-	_ = syncContextPlugins()
+	_ = syncContextPlugins(ctx.ContextType)
 
 	return nil
 }
 
-func syncContextPlugins() error {
-	err := pluginmanager.SyncPlugins()
+func syncContextPlugins(contextType configtypes.ContextType) error {
+	err := pluginmanager.SyncPluginsForContextType(contextType)
 	if err != nil {
 		log.Warningf("unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually, error: '%v'", err.Error())
 	}
@@ -1006,7 +1006,7 @@ func useCtx(_ *cobra.Command, args []string) error {
 	}
 
 	// Sync all required plugins
-	_ = syncContextPlugins()
+	_ = syncContextPlugins(ctx.ContextType)
 
 	return nil
 }

--- a/pkg/pluginmanager/manager_test.go
+++ b/pkg/pluginmanager/manager_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
+	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
@@ -668,6 +669,90 @@ func Test_SyncPlugins(t *testing.T) {
 	assertions.Equal(len(installedServerPlugins), len(serverPlugins))
 
 	for _, isp := range installedServerPlugins {
+		p := findDiscoveredPlugin(serverPlugins, isp.Name, isp.Target)
+		assertions.NotNil(p)
+	}
+}
+
+// TestSyncPluginsForK8SSpecificContextType tests to sync plugins for k8s specific ContextType only
+func TestSyncPluginsForK8SSpecificContextType(t *testing.T) {
+	assertions := assert.New(t)
+	ctx, err := configlib.GetActiveContext("k8s")
+	fmt.Println(ctx, err)
+	defer setupPluginSourceForTesting()()
+	execCommand = fakeInfoExecCommand
+	defer func() { execCommand = exec.Command }()
+
+	// Get the server plugins (they are not installed yet)
+	serverPlugins, err := DiscoverServerPlugins()
+	assertions.NotNil(err)
+	// There is an error for the kubernetes discovery since we don't have a cluster
+	// but other server plugins will be found, so we use those
+	assertions.Contains(err.Error(), `Failed to load Kubeconfig file from "config"`)
+	assertions.Equal(len(expectedDiscoveredContextPlugins), len(serverPlugins))
+	var k8sContextPlugins []*discovery.Discovered
+	for _, edp := range expectedDiscoveredContextPlugins {
+		p := findDiscoveredPlugin(serverPlugins, edp.Name, edp.Target)
+		assertions.NotNil(p)
+		assertions.Equal(common.PluginStatusNotInstalled, p.Status)
+		if p.Target == configtypes.TargetK8s {
+			k8sContextPlugins = append(k8sContextPlugins, p)
+		}
+	}
+
+	// Sync all available plugins
+	err = SyncPluginsForContextType(configtypes.ContextTypeK8s)
+	assertions.NotNil(err)
+	// There is an error for the kubernetes discovery since we don't have a cluster
+	// but other server plugins will be found, so we use those
+	assertions.Contains(err.Error(), `Failed to load Kubeconfig file from "config"`)
+
+	installedServerPlugins, err := pluginsupplier.GetInstalledServerPlugins()
+	assertions.Nil(err)
+	assertions.Equal(len(installedServerPlugins), len(k8sContextPlugins))
+
+	for _, isp := range installedServerPlugins {
+		assertions.Equal(isp.Target, configtypes.TargetK8s)
+		p := findDiscoveredPlugin(serverPlugins, isp.Name, isp.Target)
+		assertions.NotNil(p)
+	}
+}
+
+// TestSyncPluginsForTMCSpecificContextType tests to sync plugins for tmc specific ContextType only
+func TestSyncPluginsForTMCSpecificContextType(t *testing.T) {
+	assertions := assert.New(t)
+
+	defer setupPluginSourceForTesting()()
+	execCommand = fakeInfoExecCommand
+	defer func() { execCommand = exec.Command }()
+
+	// Get the server plugins (they are not installed yet)
+	serverPlugins, err := DiscoverServerPlugins()
+	assertions.NotNil(err)
+	// There is an error for the kubernetes discovery since we don't have a cluster
+	// but other server plugins will be found, so we use those
+	assertions.Contains(err.Error(), `Failed to load Kubeconfig file from "config"`)
+	assertions.Equal(len(expectedDiscoveredContextPlugins), len(serverPlugins))
+	var tmcTargetPlugins []*discovery.Discovered
+	for _, edp := range expectedDiscoveredContextPlugins {
+		p := findDiscoveredPlugin(serverPlugins, edp.Name, edp.Target)
+		assertions.NotNil(p)
+		assertions.Equal(common.PluginStatusNotInstalled, p.Status)
+		if p.Target == configtypes.TargetTMC {
+			tmcTargetPlugins = append(tmcTargetPlugins, p)
+		}
+	}
+
+	// Sync all available plugins
+	err = SyncPluginsForContextType(configtypes.ContextTypeTMC)
+	assertions.Nil(err)
+
+	installedServerPlugins, err := pluginsupplier.GetInstalledServerPlugins()
+	assertions.Nil(err)
+	assertions.Equal(len(installedServerPlugins), len(tmcTargetPlugins))
+
+	for _, isp := range installedServerPlugins {
+		assertions.Equal(isp.Target, configtypes.TargetTMC)
 		p := findDiscoveredPlugin(serverPlugins, isp.Name, isp.Target)
 		assertions.NotNil(p)
 	}

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -57,7 +57,6 @@ TANZU_CLI_E2E_AIRGAPPED_REPO_WITH_AUTH_PASSWORD = testpassword
 endif
 
 
-
 # Set the plugin group name for the plugins used to execute E2E test cases.
 E2E_TEST_USE_PLGINS_FROM_PLUGIN_GROUP_FOR_TMC ?= vmware-tmc/tmc-user:v9.9.9
 E2E_TEST_USE_PLGINS_FROM_PLUGIN_GROUP_FOR_K8S ?= vmware-tkg/default:v9.9.9

--- a/test/e2e/framework/context_lifecycle_operations.go
+++ b/test/e2e/framework/context_lifecycle_operations.go
@@ -24,8 +24,8 @@ type ContextCmdOps interface {
 	ListContext(opts ...E2EOption) ([]*ContextListInfo, error)
 	// DeleteContext helps to run `context delete` command
 	DeleteContext(contextName string, opts ...E2EOption) (stdOutStr, stdErrStr string, err error)
-	// GetActiveContext returns current active context
-	GetActiveContext(targetType string, opts ...E2EOption) (string, error)
+	// GetActiveContext returns current active context for given context-type
+	GetActiveContext(contextType string, opts ...E2EOption) (string, error)
 	// GetActiveContexts returns all active contexts
 	GetActiveContexts(opts ...E2EOption) ([]*ContextListInfo, error)
 	// UnsetContext unsets the given context with 'tanzu context unset' and returns stdOut, stdErr and error
@@ -103,7 +103,7 @@ func (cc *contextCmdOps) GetActiveContexts(opts ...E2EOption) ([]*ContextListInf
 	if err != nil {
 		return contexts, err
 	}
-	for i, _ := range list {
+	for i := range list {
 		if list[i].Iscurrent == True {
 			contexts = append(contexts, list[i])
 		}

--- a/test/e2e/framework/framework_constants.go
+++ b/test/e2e/framework/framework_constants.go
@@ -193,14 +193,14 @@ const (
 	Config                      = "config"
 	TanzuCLIE2ETestBinaryPath   = "TANZU_CLI_E2E_TEST_BINARY_PATH"
 	WiredMockHTTPServerStartCmd = "docker run --rm -d -p 8080:8080 -p 8443:8443 --name %s -v %s:/home/wiremock rodolpheche/wiremock:2.25.1"
-	HttpMockServerStopCmd       = "docker container stop %s"
-	HttpMockServerName          = "wiremock"
+	HTTPMockServerStopCmd       = "docker container stop %s"
+	HTTPMockServerName          = "wiremock"
 	defaultTimeout              = 5 * time.Second
 
 	TMCEndpointForPlugins        = "/v1alpha1/system/binaries/plugins"
 	TMCMockServerEndpoint        = "http://localhost:8080"
 	TMCPluginsMockServerEndpoint = "http://localhost:8080/v1alpha1/system/binaries/plugins"
-	HttpContentType              = "application/json; charset=utf-8"
+	HTTPContentType              = "application/json; charset=utf-8"
 
 	// k8s CRD file
 	K8SCRDFilePath = "../../framework/config/cli.tanzu.vmware.com_cliplugins.yaml"

--- a/test/e2e/framework/framework_helper.go
+++ b/test/e2e/framework/framework_helper.go
@@ -410,7 +410,7 @@ func StartMockServer(tf *Framework, mappingDir, containerName string) error {
 
 // StopContainer stops the given docker container
 func StopContainer(tf *Framework, containerName string) error {
-	cmd := fmt.Sprintf(HttpMockServerStopCmd, containerName)
+	cmd := fmt.Sprintf(HTTPMockServerStopCmd, containerName)
 	_, _, err := tf.Exec.Exec(cmd)
 	return err
 }
@@ -420,7 +420,7 @@ func ConvertPluginsInfoToTMCEndpointMockResponse(plugins []*PluginInfo) (*TMCPlu
 	tmcPlugins := &TMCPluginsResponse{}
 	tmcPlugins.PluginsInfo = TMCPluginsInfo{}
 	tmcPlugins.PluginsInfo.Plugins = make([]TMCPlugin, 0)
-	for i, _ := range plugins {
+	for i := range plugins {
 		tmcPlugin := TMCPlugin{}
 		tmcPlugin.Name = plugins[i].Name
 		tmcPlugin.Description = plugins[i].Description
@@ -431,8 +431,8 @@ func ConvertPluginsInfoToTMCEndpointMockResponse(plugins []*PluginInfo) (*TMCPlu
 	m.Request.Method = "GET"
 	m.Request.URL = TMCEndpointForPlugins
 	m.Response.Status = 200
-	m.Response.Headers.ContentType = HttpContentType
-	m.Response.Headers.Accept = HttpContentType
+	m.Response.Headers.ContentType = HTTPContentType
+	m.Response.Headers.Accept = HTTPContentType
 	content, err := json.Marshal(tmcPlugins.PluginsInfo)
 	if err != nil {
 		log.Error(err, "error while processing input type to json")
@@ -521,8 +521,8 @@ func GetHTTPCall(url string, v interface{}) error {
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Content-Type", HttpContentType)
-	req.Header.Set("Accept", HttpContentType)
+	req.Header.Set("Content-Type", HTTPContentType)
+	req.Header.Set("Accept", HTTPContentType)
 	client := &http.Client{}
 	response, err := client.Do(req)
 	if err != nil {

--- a/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_test.go
+++ b/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_test.go
@@ -19,6 +19,8 @@ import (
 var stdOut string
 var stdErr string
 
+const thereShouldNotBeError = "there should be an error"
+
 // Below are the use cases executed in this suite
 // Use case 1: create context when there are no plugins to sync
 // Use case 2: created a context (make sure sync installs plugins), uninstall plugin, run plugins sync (should install uninstall plugins)
@@ -63,7 +65,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			Expect(err).To(BeNil(), noErrorForMockResponseFileUpdate)
 
 			// start http mock server
-			err = f.StartMockServer(tf, tmcConfigFolderPath, f.HttpMockServerName)
+			err = f.StartMockServer(tf, tmcConfigFolderPath, f.HTTPMockServerName)
 			Expect(err).To(BeNil(), mockServerShouldStartWithoutError)
 			var mockResPluginsInfo f.TMCPluginsInfo
 			// check the tmc mocked endpoint is working as expected
@@ -76,7 +78,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			contextName = f.ContextPrefixTMC + f.RandomString(4)
 			_, _, err = tf.ContextCmd.CreateContextWithEndPointStaging(contextName, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag))
 			Expect(err).To(BeNil(), noErrorWhileCreatingContext)
-			active, err := tf.ContextCmd.GetActiveContext(string(types.TargetTMC))
+			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeTMC))
 			Expect(err).To(BeNil(), activeContextShouldExists)
 			Expect(active).To(Equal(contextName), activeContextShouldBeRecentlyAddedOne)
 		})
@@ -90,7 +92,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		It("delete current context and stop mock server", func() {
 			_, _, err = tf.ContextCmd.DeleteContext(contextName)
 			Expect(err).To(BeNil(), deleteContextWithoutError)
-			err = f.StopContainer(tf, f.HttpMockServerName)
+			err = f.StopContainer(tf, f.HTTPMockServerName)
 			Expect(err).To(BeNil(), mockServerShouldStopWithoutError)
 		})
 	})
@@ -123,7 +125,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			Expect(err).To(BeNil(), noErrorForMockResponseFileUpdate)
 
 			// start http mock server
-			err = f.StartMockServer(tf, tmcConfigFolderPath, f.HttpMockServerName)
+			err = f.StartMockServer(tf, tmcConfigFolderPath, f.HTTPMockServerName)
 			Expect(err).To(BeNil(), mockServerShouldStartWithoutError)
 			var mockResPluginsInfo f.TMCPluginsInfo
 			// check the tmc mocked endpoint is working as expected
@@ -136,7 +138,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			contextName = f.ContextPrefixTMC + f.RandomString(4)
 			_, _, err = tf.ContextCmd.CreateContextWithEndPointStaging(contextName, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag))
 			Expect(err).To(BeNil(), noErrorWhileCreatingContext)
-			active, err := tf.ContextCmd.GetActiveContext(string(types.TargetTMC))
+			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeTMC))
 			Expect(err).To(BeNil(), activeContextShouldExists)
 			Expect(active).To(Equal(contextName), activeContextShouldBeRecentlyAddedOne)
 		})
@@ -180,7 +182,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			pluginsList, err = tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
 			Expect(err).To(BeNil(), noErrorForPluginList)
 			Expect(len(pluginsList)).Should(Equal(0), "all context plugins should be uninstalled as context delete")
-			err = f.StopContainer(tf, f.HttpMockServerName)
+			err = f.StopContainer(tf, f.HTTPMockServerName)
 			Expect(err).To(BeNil(), mockServerShouldStopWithoutError)
 		})
 	})
@@ -224,7 +226,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			// skip last plugin in the slice as it has incorrect version info, which is not available in the mock response
 			pluginsGeneratedMockResponseWithCorrectInfo = pluginsToGenerateMockResponse[:numberOfPluginsToInstall-1]
 			// start http mock server
-			err = f.StartMockServer(tf, tmcConfigFolderPath, f.HttpMockServerName)
+			err = f.StartMockServer(tf, tmcConfigFolderPath, f.HTTPMockServerName)
 			Expect(err).To(BeNil(), mockServerShouldStartWithoutError)
 			var mockResPluginsInfo f.TMCPluginsInfo
 			// check the tmc mocked endpoint is working as expected
@@ -240,7 +242,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			Expect(err).To(BeNil(), noErrorWhileCreatingContext)
 			Expect(stdErr).NotTo(BeNil(), "there should be stderr")
 			Expect(stdErr).To(ContainSubstring(f.UnableToSync), "there should be sync error as all plugins not available in repo")
-			active, err := tf.ContextCmd.GetActiveContext(string(types.TargetTMC))
+			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeTMC))
 			Expect(err).To(BeNil(), activeContextShouldExists)
 			Expect(active).To(Equal(contextName), activeContextShouldBeRecentlyAddedOne)
 		})
@@ -285,7 +287,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			for i := range installedPluginsList {
 				Expect(stdOut).To(ContainSubstring(fmt.Sprintf(f.DeactivatingPlugin, installedPluginsList[i].Name, installedPluginsList[i].Version, contextName)))
 			}
-			err = f.StopContainer(tf, f.HttpMockServerName)
+			err = f.StopContainer(tf, f.HTTPMockServerName)
 			Expect(err).To(BeNil(), mockServerShouldStopWithoutError)
 		})
 	})
@@ -324,7 +326,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			Expect(err).To(BeNil(), noErrorForMockResponseFileUpdate)
 
 			// start http mock server
-			err = f.StartMockServer(tf, tmcConfigFolderPath, f.HttpMockServerName)
+			err = f.StartMockServer(tf, tmcConfigFolderPath, f.HTTPMockServerName)
 			Expect(err).To(BeNil(), mockServerShouldStartWithoutError)
 
 			var mockResPluginsInfo f.TMCPluginsInfo
@@ -336,7 +338,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			contextNameOne = f.ContextPrefixTMC + f.RandomString(4)
 			_, _, err = tf.ContextCmd.CreateContextWithEndPointStaging(contextNameOne, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag))
 			Expect(err).To(BeNil(), noErrorWhileCreatingContext)
-			active, err := tf.ContextCmd.GetActiveContext(string(types.TargetTMC))
+			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeTMC))
 			Expect(err).To(BeNil(), activeContextShouldExists)
 			Expect(active).To(Equal(contextNameOne), activeContextShouldBeRecentlyAddedOne)
 
@@ -355,7 +357,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			Expect(err).To(BeNil(), noErrorForMockResponseFileUpdate)
 
 			// start http mock server
-			err = f.StartMockServer(tf, tmcConfigFolderPath, f.HttpMockServerName)
+			err = f.StartMockServer(tf, tmcConfigFolderPath, f.HTTPMockServerName)
 			Expect(err).To(BeNil(), mockServerShouldStartWithoutError)
 
 			// check the tmc mocked endpoint is working as expected
@@ -367,7 +369,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			contextNameTwo = f.ContextPrefixTMC + f.RandomString(4)
 			_, _, err = tf.ContextCmd.CreateContextWithEndPointStaging(contextNameTwo, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag))
 			Expect(err).To(BeNil(), noErrorWhileCreatingContext)
-			active, err := tf.ContextCmd.GetActiveContext(string(types.TargetTMC))
+			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeTMC))
 			Expect(err).To(BeNil(), activeContextShouldExists)
 			Expect(active).To(Equal(contextNameTwo), activeContextShouldBeRecentlyAddedOne)
 
@@ -383,7 +385,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			Expect(err).To(BeNil(), deleteContextWithoutError)
 			_, _, err = tf.ContextCmd.DeleteContext(contextNameTwo)
 			Expect(err).To(BeNil(), deleteContextWithoutError)
-			err = f.StopContainer(tf, f.HttpMockServerName)
+			err = f.StopContainer(tf, f.HTTPMockServerName)
 			Expect(err).To(BeNil(), mockServerShouldStopWithoutError)
 		})
 	})
@@ -422,7 +424,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			Expect(err).To(BeNil(), noErrorForMockResponseFileUpdate)
 
 			// start http mock server
-			err = f.StartMockServer(tf, tmcConfigFolderPath, f.HttpMockServerName)
+			err = f.StartMockServer(tf, tmcConfigFolderPath, f.HTTPMockServerName)
 			Expect(err).To(BeNil(), mockServerShouldStartWithoutError)
 
 			var mockResPluginsInfo f.TMCPluginsInfo
@@ -434,7 +436,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			contextNameOne = f.ContextPrefixTMC + f.RandomString(4)
 			_, _, err = tf.ContextCmd.CreateContextWithEndPointStaging(contextNameOne, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag))
 			Expect(err).To(BeNil(), noErrorWhileCreatingContext)
-			active, err := tf.ContextCmd.GetActiveContext(string(types.TargetTMC))
+			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeTMC))
 			Expect(err).To(BeNil(), activeContextShouldExists)
 			Expect(active).To(Equal(contextNameOne), activeContextShouldBeRecentlyAddedOne)
 
@@ -453,7 +455,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			Expect(err).To(BeNil(), noErrorForMockResponseFileUpdate)
 
 			// start http mock server
-			err = f.StartMockServer(tf, tmcConfigFolderPath, f.HttpMockServerName)
+			err = f.StartMockServer(tf, tmcConfigFolderPath, f.HTTPMockServerName)
 			Expect(err).To(BeNil(), mockServerShouldStartWithoutError)
 
 			// check the tmc mocked endpoint is working as expected
@@ -475,7 +477,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		It("delete current context", func() {
 			_, _, err = tf.ContextCmd.DeleteContext(contextNameOne)
 			Expect(err).To(BeNil(), deleteContextWithoutError)
-			err = f.StopContainer(tf, f.HttpMockServerName)
+			err = f.StopContainer(tf, f.HTTPMockServerName)
 			Expect(err).To(BeNil(), mockServerShouldStopWithoutError)
 		})
 	})
@@ -529,7 +531,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			contextNameK8s = f.ContextPrefixK8s + f.RandomString(4)
 			err := tf.ContextCmd.CreateContextWithKubeconfig(contextNameK8s, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
 			Expect(err).To(BeNil(), "context should create without any error")
-			active, err := tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
+			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeK8s))
 			Expect(err).To(BeNil(), "there should be a active context")
 			Expect(active).To(Equal(contextNameK8s), "the active context should be recently added context")
 			contexts = append(contexts, contextNameK8s)
@@ -559,7 +561,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			Expect(err).To(BeNil(), noErrorForMockResponseFileUpdate)
 
 			// start http mock server
-			err = f.StartMockServer(tf, tmcConfigFolderPath, f.HttpMockServerName)
+			err = f.StartMockServer(tf, tmcConfigFolderPath, f.HTTPMockServerName)
 			Expect(err).To(BeNil(), mockServerShouldStartWithoutError)
 			var mockResPluginsInfo f.TMCPluginsInfo
 			// check the tmc mocked endpoint is working as expected
@@ -573,7 +575,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			contextNameTMC = f.ContextPrefixTMC + f.RandomString(4)
 			_, _, err = tf.ContextCmd.CreateContextWithEndPointStaging(contextNameTMC, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag))
 			Expect(err).To(BeNil(), noErrorWhileCreatingContext)
-			active, err := tf.ContextCmd.GetActiveContext(string(types.TargetTMC))
+			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeTMC))
 			Expect(err).To(BeNil(), activeContextShouldExists)
 			Expect(active).To(Equal(contextNameTMC), activeContextShouldBeRecentlyAddedOne)
 			contexts = append(contexts, contextNameTMC)
@@ -603,7 +605,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		It("use first context, check plugin list", func() {
 			err = tf.ContextCmd.UseContext(contextNameK8s)
 			Expect(err).To(BeNil(), "use context should not return any error")
-			active, err := tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
+			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeK8s))
 			Expect(err).To(BeNil(), activeContextShouldExists)
 			Expect(active).To(Equal(contextNameK8s), active, "the active context should be the recently switched one")
 
@@ -641,7 +643,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 
 			err = tf.ContextCmd.UseContext(contextNameTMC)
 			Expect(err).To(BeNil(), "use context should not return any error")
-			active, err := tf.ContextCmd.GetActiveContext(string(types.TargetTMC))
+			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeTMC))
 			Expect(err).To(BeNil(), activeContextShouldExists)
 			Expect(active).To(Equal(contextNameTMC), activeContextShouldBeRecentlyAddedOne)
 
@@ -656,7 +658,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		It("delete tmc/k8s contexts and the KIND cluster", func() {
 			_, _, err = tf.ContextCmd.DeleteContext(contextNameTMC)
 			Expect(err).To(BeNil(), "context should be deleted without error")
-			err = f.StopContainer(tf, f.HttpMockServerName)
+			err = f.StopContainer(tf, f.HTTPMockServerName)
 			Expect(err).To(BeNil(), mockServerShouldStopWithoutError)
 
 			_, _, err = tf.ContextCmd.DeleteContext(contextNameK8s)
@@ -666,7 +668,284 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		})
 	})
 
-	// Use Case 7: Plugin List, sync, search and install functionalities with Context Issues
+	// Use case 7: Sync for single ContextType specific plugins, and validate the plugin list
+	// run context create (make sure another ContextType context is active, but yet to install plugins), it should not perform the sync for all active contexts
+	// run ContextType specific plugin sync (for k8s ContextType), make sync should not happen for tmc context even though its active
+	// run ContextType specific plugin sync (for tmc ContextType), make sync should not happen for k8s context even though its active
+	Context("Use case: create k8s and tmc specific contexts, validate plugins list and perform pluin sync, and perform context switch", func() {
+		var clusterInfo *f.ClusterInfo
+		var pluginCRFilePaths []string
+		var pluginsInfoForCRsApplied, installedPluginsListK8s []*f.PluginInfo
+		var contextNameK8s string
+		contexts := make([]string, 0)
+		totalInstalledPlugins := 1 // telemetry plugin that is part of essentials plugin group will always be installed
+		var err error
+		// Test case: a. k8s: create KIND cluster, apply CRD
+		It("create KIND cluster", func() {
+			// Create KIND cluster, which is used in test cases to create context's
+			clusterInfo, err = f.CreateKindCluster(tf, f.ContextPrefixK8s+f.RandomNumber(4))
+			Expect(err).To(BeNil(), "should not get any error for KIND cluster creation")
+		})
+		// Test case: b. k8s: apply CRD (cluster resource definition) and CR's (cluster resource) for few plugins
+		It("apply CRD and CRs to KIND cluster", func() {
+			err = f.ApplyConfigOnKindCluster(tf, clusterInfo, append(make([]string, 0), f.K8SCRDFilePath))
+			Expect(err).To(BeNil(), "should not get any error for config apply")
+
+			pluginsToGenerateCRs, ok := pluginGroupToPluginListMap[usePluginsFromK8sPluginGroup]
+			Expect(ok).To(BeTrue(), "plugin group is not exist in the map")
+			Expect(len(pluginsToGenerateCRs) > numberOfPluginsToInstall).To(BeTrue(), "we don't have enough plugins in local test central repo")
+			pluginsInfoForCRsApplied, pluginCRFilePaths, err = f.CreateTemporaryCRsFromPluginInfos(pluginsToGenerateCRs[:numberOfPluginsToInstall])
+			Expect(err).To(BeNil(), "should not get any error while generating CR files")
+			err = f.ApplyConfigOnKindCluster(tf, clusterInfo, pluginCRFilePaths)
+			Expect(err).To(BeNil(), "should not get any error for config apply")
+			totalInstalledPlugins += numberOfPluginsToInstall
+		})
+
+		// Test case: c. k8s: create context and make sure context has created
+		It("create context with kubeconfig and context", func() {
+			By("create context with kubeconfig and context")
+			contextNameK8s = f.ContextPrefixK8s + f.RandomString(4)
+			err := tf.ContextCmd.CreateContextWithKubeconfig(contextNameK8s, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
+			Expect(err).To(BeNil(), "context should create without any error")
+			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeK8s))
+			Expect(err).To(BeNil(), thereShouldNotBeError+" while getting active context")
+			Expect(active).To(Equal(contextNameK8s), "the active context should be recently added context")
+			contexts = append(contexts, contextNameK8s)
+		})
+		// Test case: d. k8s: list plugins and validate plugins info, make sure all plugins are installed for which CRs were present on the cluster
+		It("Test case: d; list plugins and validate plugins being installed after context being created", func() {
+			installedPluginsListK8s, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameK8s, true)
+			Expect(err).To(BeNil(), "should not get any error for plugin list")
+			Expect(f.CheckAllPluginsExists(installedPluginsListK8s, pluginsInfoForCRsApplied)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
+		})
+
+		var pluginsToGenerateMockResponseTMC, installedPluginsListTMC []*f.PluginInfo
+		var contextNameTMC string
+		var ok bool
+
+		// Test case: e. TMC: mock tmc endpoint with plugins info, start the mock server
+		It("mock tmc endpoint with expected plugins response and restart REST API mock server", func() {
+			// get plugins from a group
+			pluginsToGenerateMockResponseTMC, ok = pluginGroupToPluginListMap[usePluginsFromTmcPluginGroup]
+			Expect(ok).To(BeTrue(), pluginGroupShouldExists)
+			Expect(len(pluginsToGenerateMockResponseTMC) > numberOfPluginsToInstall).To(BeTrue(), testRepoDoesNotHaveEnoughPlugins)
+			// mock tmc endpoint with only specific number of plugins info
+			pluginsToGenerateMockResponseTMC = pluginsToGenerateMockResponseTMC[:numberOfPluginsToInstall]
+			mockReqResMapping, err := f.ConvertPluginsInfoToTMCEndpointMockResponse(pluginsToGenerateMockResponseTMC[:numberOfPluginsToInstall])
+			Expect(err).To(BeNil(), noErrorForMockResponsePreparation)
+			err = f.WriteToFileInJSONFormat(mockReqResMapping, tmcPluginsMockFilePath)
+			Expect(err).To(BeNil(), noErrorForMockResponseFileUpdate)
+
+			// start http mock server
+			err = f.StartMockServer(tf, tmcConfigFolderPath, f.HTTPMockServerName)
+			Expect(err).To(BeNil(), mockServerShouldStartWithoutError)
+			var mockResPluginsInfo f.TMCPluginsInfo
+			// check the tmc mocked endpoint is working as expected
+			err = f.GetHTTPCall(f.TMCPluginsMockServerEndpoint, &mockResPluginsInfo)
+			Expect(err).To(BeNil(), "there should not be any error for GET http call on mockapi endpoint:"+f.TMCPluginsMockServerEndpoint)
+			Expect(len(mockResPluginsInfo.Plugins)).Should(Equal(len(pluginsToGenerateMockResponseTMC)), "the number of plugins in endpoint response and initially mocked should be same")
+			totalInstalledPlugins += numberOfPluginsToInstall
+		})
+		// Test case: f. TMC: create context and make sure context has created
+		It("create context for TMC target with http mock server URL as endpoint", func() {
+			// Clean K8s context specific plugins
+			err = tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), thereShouldNotBeError+" while cleaning plugins")
+
+			contextNameTMC = f.ContextPrefixTMC + f.RandomString(4)
+			_, _, err = tf.ContextCmd.CreateContextWithEndPointStaging(contextNameTMC, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag))
+			Expect(err).To(BeNil(), noErrorWhileCreatingContext)
+			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeTMC))
+			Expect(err).To(BeNil(), activeContextShouldExists)
+			Expect(active).To(Equal(contextNameTMC), activeContextShouldBeRecentlyAddedOne)
+			contexts = append(contexts, contextNameTMC)
+		})
+
+		// Test case: g. TMC: list plugins and validate plugins info, make sure all plugins are installed as per mock response
+		// there should not be any k8s specific plugins should be installed/sync as part of tmc context creation
+		It("Test case: g: list plugins and validate plugins being installed after context being created", func() {
+			installedPluginsListTMC, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameTMC, true)
+			Expect(err).To(BeNil(), noErrorForPluginList)
+			Expect(len(installedPluginsListTMC)).Should(Equal(len(pluginsToGenerateMockResponseTMC)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
+			Expect(f.CheckAllPluginsExists(installedPluginsListTMC, pluginsToGenerateMockResponseTMC)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
+
+			// Sync should not happen for the k8s context specific plugins
+			installedPluginsListK8S, err := tf.PluginCmd.ListPluginsForGivenContext(contextNameK8s, true)
+			Expect(len(installedPluginsListK8S)).Should(Equal(0))
+			Expect(err).To(BeNil(), noErrorForPluginList)
+		})
+
+		// Test case: context use (K8S) - should sync only specific context not all active context's
+		// set both k8s and tmc context as active
+		// clean plugins
+		// unset k8s context
+		// perform 'tanzu context use' for k8s context
+		// sync should happen only for the specific context (k8s context), not for all active context's
+		// perform 'tanzu plugin clean' and 'tanzu context use' for k8s context again, and check plugins list, it should be same as previous
+		It("test context use for specific context-k8s", func() {
+			err = tf.ContextCmd.UseContext(contextNameK8s)
+			Expect(err).To(BeNil(), "use context should not return any error")
+
+			err = tf.ContextCmd.UseContext(contextNameTMC)
+			Expect(err).To(BeNil(), "use context should not return any error")
+
+			err = tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "plugin clean should not return any error")
+
+			_, _, err = tf.ContextCmd.UnsetContext(contextNameK8s)
+			Expect(err).To(BeNil(), "unset context should unset context without any error")
+
+			err = tf.ContextCmd.UseContext(contextNameK8s)
+			Expect(err).To(BeNil(), "use context should not return any error")
+
+			// k8s contextType specific plugins only should be installed
+			installedPluginsListK8s, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameK8s, true)
+			Expect(err).To(BeNil(), "should not get any error for plugin list")
+			Expect(f.CheckAllPluginsExists(installedPluginsListK8s, pluginsInfoForCRsApplied)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
+
+			// Sync should not happen for the tmc context specific plugins, as its contextType specific sync
+			installedPluginsListTMC, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameTMC, true)
+			Expect(len(installedPluginsListTMC)).Should(Equal(0))
+			Expect(err).To(BeNil(), noErrorForPluginList)
+
+			// perform 'tanzu plugin clean' and 'tanzu context use' for k8s context again, and check plugins list, it should be same as previous
+			err = tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "plugin clean should not return any error")
+
+			err = tf.ContextCmd.UseContext(contextNameK8s)
+			Expect(err).To(BeNil(), "use context should not return any error")
+
+			// k8s contextType specific plugins only should be installed
+			installedPluginsListK8s, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameK8s, true)
+			Expect(err).To(BeNil(), "should not get any error for plugin list")
+			Expect(f.CheckAllPluginsExists(installedPluginsListK8s, pluginsInfoForCRsApplied)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
+
+			// Sync should not happen for the tmc context specific plugins, as its contextType specific sync
+			installedPluginsListTMC, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameTMC, true)
+			Expect(len(installedPluginsListTMC)).Should(Equal(0))
+			Expect(err).To(BeNil(), noErrorForPluginList)
+		})
+
+		// Test case: context use (TMC) - should sync only specific context not all active context's
+		// set both tmc and tmc context as active
+		// clean plugins
+		// unset tmc context
+		// perform 'tanzu context use' for tmc context
+		// sync should happen only for the specific context (tmc context), not for all active context's
+		// perform 'tanzu plugin clean' and 'tanzu context use' for tmc context again, and check plugins list, it should be same as previous
+		It("test context use for specific context-TMC", func() {
+			err = tf.ContextCmd.UseContext(contextNameK8s)
+			Expect(err).To(BeNil(), "use context should not return any error")
+
+			err = tf.ContextCmd.UseContext(contextNameTMC)
+			Expect(err).To(BeNil(), "use context should not return any error")
+
+			err = tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "plugin clean should not return any error")
+
+			_, _, err = tf.ContextCmd.UnsetContext(contextNameTMC)
+			Expect(err).To(BeNil(), "unset context should unset context without any error")
+
+			err = tf.ContextCmd.UseContext(contextNameTMC)
+			Expect(err).To(BeNil(), "use context should not return any error")
+
+			// tmc contextType specific plugins only should be installed
+			installedPluginsListTMC, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameTMC, true)
+			Expect(err).To(BeNil(), noErrorForPluginList)
+			Expect(len(installedPluginsListTMC)).Should(Equal(len(pluginsToGenerateMockResponseTMC)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
+			Expect(f.CheckAllPluginsExists(installedPluginsListTMC, pluginsToGenerateMockResponseTMC)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
+
+			// Sync should not happen for the k8s context specific plugins, as its contextType specific sync
+			installedPluginsListK8s, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameK8s, true)
+			Expect(len(installedPluginsListK8s)).Should(Equal(0))
+			Expect(err).To(BeNil(), noErrorForPluginList)
+
+			// perform 'tanzu plugin clean' and 'tanzu context use' for tmc context again, and check plugins list, it should be same as previous
+			err = tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "plugin clean should not return any error")
+
+			err = tf.ContextCmd.UseContext(contextNameTMC)
+			Expect(err).To(BeNil(), "use context should not return any error")
+
+			// tmc contextType specific plugins only should be installed
+			installedPluginsListTMC, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameTMC, true)
+			Expect(err).To(BeNil(), noErrorForPluginList)
+			Expect(len(installedPluginsListTMC)).Should(Equal(len(pluginsToGenerateMockResponseTMC)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
+			Expect(f.CheckAllPluginsExists(installedPluginsListTMC, pluginsToGenerateMockResponseTMC)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
+
+			// Sync should not happen for the k8s context specific plugins, as its contextType specific sync
+			installedPluginsListK8s, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameK8s, true)
+			Expect(len(installedPluginsListK8s)).Should(Equal(0))
+			Expect(err).To(BeNil(), noErrorForPluginList)
+
+		})
+
+		// Test case: context use for TMC context and K8s context
+		// plugin should get sync for both tmc and k8s context
+		It("context use for both TMC and k8s contexts", func() {
+			err = tf.ContextCmd.UseContext(contextNameK8s)
+			Expect(err).To(BeNil(), "use context should not return any error")
+
+			err = tf.ContextCmd.UseContext(contextNameTMC)
+			Expect(err).To(BeNil(), "use context should not return any error")
+
+			// tmc contextType specific plugins should be installed
+			installedPluginsListTMC, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameTMC, true)
+			Expect(err).To(BeNil(), noErrorForPluginList)
+			Expect(len(installedPluginsListTMC)).Should(Equal(len(pluginsToGenerateMockResponseTMC)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
+			Expect(f.CheckAllPluginsExists(installedPluginsListTMC, pluginsToGenerateMockResponseTMC)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
+
+			// k8s contextType specific plugins should be installed
+			installedPluginsListK8s, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameK8s, true)
+			Expect(err).To(BeNil(), noErrorForPluginList)
+			Expect(f.CheckAllPluginsExists(installedPluginsListK8s, pluginsInfoForCRsApplied)).Should(BeTrue(), "plugins being installed and plugins info for which CRs applied should be same")
+		})
+
+		// Test case: plugin sync use case, make sure plugins for both contexts are synced
+		// plugin should get sync for both tmc and k8s context
+		It("test plugin sync", func() {
+
+			err = tf.ContextCmd.UseContext(contextNameK8s)
+			Expect(err).To(BeNil(), "use context should not return any error")
+
+			err = tf.ContextCmd.UseContext(contextNameTMC)
+			Expect(err).To(BeNil(), "use context should not return any error")
+
+			// perform plugin clean, then perform plugin sync
+			err = tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "plugin clean should not return any error")
+
+			_, _, err = tf.PluginCmd.Sync()
+			Expect(err).To(BeNil(), "plugin sync should not return any error")
+
+			// make sure plugins are synced for both contexts
+			// tmc contextType specific plugins should be installed
+			installedPluginsListTMC, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameTMC, true)
+			Expect(err).To(BeNil(), noErrorForPluginList)
+			Expect(len(installedPluginsListTMC)).Should(Equal(len(pluginsToGenerateMockResponseTMC)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
+			Expect(f.CheckAllPluginsExists(installedPluginsListTMC, pluginsToGenerateMockResponseTMC)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
+
+			// k8s contextType specific plugins should be installed
+			installedPluginsListK8s, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameK8s, true)
+			Expect(err).To(BeNil(), noErrorForPluginList)
+			Expect(f.CheckAllPluginsExists(installedPluginsListK8s, pluginsInfoForCRsApplied)).Should(BeTrue(), "plugins being installed and plugins info for which CRs applied should be same")
+		})
+
+		// Test case: l. delete tmc/k8s contexts and the KIND cluster
+		It("delete tmc/k8s contexts and the KIND cluster", func() {
+			_, _, err = tf.ContextCmd.DeleteContext(contextNameTMC)
+			Expect(err).To(BeNil(), "context should be deleted without error")
+			err = f.StopContainer(tf, f.HTTPMockServerName)
+			Expect(err).To(BeNil(), mockServerShouldStopWithoutError)
+
+			_, _, err = tf.ContextCmd.DeleteContext(contextNameK8s)
+			Expect(err).To(BeNil(), "context should be deleted without error")
+			_, err := tf.KindCluster.DeleteCluster(clusterInfo.Name)
+			Expect(err).To(BeNil(), "kind cluster should be deleted without any error")
+		})
+	})
+
+	// Use Case 8: Plugin List, sync, search and install functionalities with Context Issues
 	// Use case details: In this use case, we will create one Tanzu Mission Control (TMC) context and one Kubernetes contexts.
 	// The active K8s context will be associated with a kind cluster that has been deleted. As a result, there will be an issue
 	// when attempting to discover plugins for this context. However, despite the issue, the plugin list and plugin sync commands
@@ -727,7 +1006,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			contextNameK8s = f.ContextPrefixK8s + f.RandomString(4)
 			err := tf.ContextCmd.CreateContextWithKubeconfig(contextNameK8s, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
 			Expect(err).To(BeNil(), "context should create without any error")
-			active, err := tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
+			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeK8s))
 			Expect(err).To(BeNil(), "there should be a active context")
 			Expect(active).To(Equal(contextNameK8s), "the active context should be recently added context")
 			contexts = append(contexts, contextNameK8s)
@@ -764,7 +1043,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			Expect(err).To(BeNil(), noErrorForMockResponseFileUpdate)
 
 			// start http mock server
-			err = f.StartMockServer(tf, tmcConfigFolderPath, f.HttpMockServerName)
+			err = f.StartMockServer(tf, tmcConfigFolderPath, f.HTTPMockServerName)
 			Expect(err).To(BeNil(), mockServerShouldStartWithoutError)
 			var mockResPluginsInfo f.TMCPluginsInfo
 			// check the tmc mocked endpoint is working as expected
@@ -778,7 +1057,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			contextNameTMC = f.ContextPrefixTMC + f.RandomString(4)
 			_, _, err := tf.ContextCmd.CreateContextWithEndPointStaging(contextNameTMC, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag))
 			Expect(err).To(BeNil(), noErrorWhileCreatingContext)
-			active, err := tf.ContextCmd.GetActiveContext(string(types.TargetTMC))
+			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeTMC))
 			Expect(err).To(BeNil(), activeContextShouldExists)
 			Expect(active).To(Equal(contextNameTMC), activeContextShouldBeRecentlyAddedOne)
 			contexts = append(contexts, contextNameTMC)
@@ -842,7 +1121,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		It("delete tmc/k8s contexts", func() {
 			_, _, err = tf.ContextCmd.DeleteContext(contextNameTMC)
 			Expect(err).To(BeNil(), "context should be deleted without error")
-			err = f.StopContainer(tf, f.HttpMockServerName)
+			err = f.StopContainer(tf, f.HTTPMockServerName)
 			Expect(err).To(BeNil(), mockServerShouldStopWithoutError)
 
 			_, _, err = tf.ContextCmd.DeleteContext(contextNameK8s)


### PR DESCRIPTION
### What this PR does / why we need it

This pull request updates existing functionality:

Before this pull request, 'tanzu context create,' and 'tanzu context use' performed sync operations for all active contexts. As part of this PR, the functionality has been updated as follows:

- 'tanzu context create' now performs 'plugin sync' only for the newly created context, not for all active contexts.
- 'tanzu context use' now triggers 'plugin sync' only for the context being set as active, not for all active contexts."
- There is no change in 'tanzu plugin sync' command, it does performs the sync for all active contexts.


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

- 1)Use case # Context create, we can see while creating k8s context, the sync is not performed for TMC context even though its active.
```
❯ t context create --kubeconfig /Users/cpamuluri/.kube/config --kubecontext kind-kind11 --name k33
❯ t context list
  NAME         ISACTIVE  TYPE             ENDPOINT                               KUBECONFIGPATH                 KUBECONTEXT
  tmc1         true      mission-control  unstable.tmc-dev.cloud.vmware.com:443  n/a                            n/a
  kind-kind11  false     kubernetes                                              /Users/cpamuluri/.kube/config  kind-kind11
  tmc2         false     mission-control  unstable.tmc-dev.cloud.vmware.com:443  n/a                            n/a
  k22          false     kubernetes                                              /Users/cpamuluri/.kube/config  kind-kind11
❯ t context create --kubeconfig /Users/cpamuluri/.kube/config --kubecontext kind-kind11 --name k33
Flag --name has been deprecated, it has been replaced by using an argument to the command
[ok] successfully created a kubernetes context using the kubeconfig /Users/cpamuluri/.kube/config
[i] Checking for required plugins for context k33...
[i] All required plugins are already installed and up-to-date
❯ t plugin list
Standalone Plugins
  NAME  DESCRIPTION  TARGET  VERSION  STATUS

Plugins from Context:  tmc1
  NAME                  DESCRIPTION                                                     TARGET           VERSION  STATUS
  account               Account for tmc resources                                       mission-control  v0.1.10  not installed
  agentartifacts        helm for tmc resources                                          mission-control  v0.1.9   not installed
  aks-cluster           Manage and unmanage tmc aks clusters                            mission-control  v0.2.0   not installed
  apply                 Create/Update a resource with a resource file                   mission-control  v0.3.6   not installed
  audit                 Run an audit request on an org                                  mission-control  v0.1.9   not installed
  cluster                                                                               mission-control  v0.2.4   not installed
  clustergroup          A group of Kubernetes clusters                                  mission-control  v0.1.9   not installed
  continuousdelivery    Continuousdelivery for tmc resources                            mission-control  v0.1.9   not installed
  data-protection       Data protection for tmc resources                               mission-control  v0.1.9   not installed
  ekscluster                                                                            mission-control  v0.1.9   not installed
  events                Events for any meaningful user activity or system state change  mission-control  v0.1.9   not installed
  helm                  helm for tmc resources                                          mission-control  v0.1.9   not installed
  iam                   IAM Policies for tmc resources                                  mission-control  v0.1.9   not installed
  inspection            Inspection for tmc resources                                    mission-control  v0.1.9   not installed
  integration           Get available integrations and their information from registry  mission-control  v0.1.9   not installed
  management-cluster    A TMC registered Management cluster                             mission-control  v0.2.9   not installed
  policy                Policy for tmc resources                                        mission-control  v0.1.9   not installed
  provider-aks-cluster  Manage and unmanage tmc provider aks clusters                   mission-control  v0.1.10  not installed
  provider-eks-cluster                                                                  mission-control  v0.1.9   not installed
  secret                secret for tmc resources                                        mission-control  v0.1.9   not installed
  setting               Setting plugin for tmc resources                                mission-control  v0.2.7   not installed
  tanzupackage          Tanzupackage for tmc resources                                  mission-control  v0.2.8   not installed
  workspace             A group of Kubernetes namespaces                                mission-control  v0.1.11  not installed

[!] As shown above, some recommended plugins have not been installed or are outdated. To install them please run 'tanzu plugin sync'.
❯
❯ t context list
  NAME         ISACTIVE  TYPE             ENDPOINT                               KUBECONFIGPATH                 KUBECONTEXT
  tmc1         true      mission-control  unstable.tmc-dev.cloud.vmware.com:443  n/a                            n/a
  kind-kind11  false     kubernetes                                              /Users/cpamuluri/.kube/config  kind-kind11
  tmc2         false     mission-control  unstable.tmc-dev.cloud.vmware.com:443  n/a                            n/a
  k22          false     kubernetes                                              /Users/cpamuluri/.kube/config  kind-kind11
  k33          true      kubernetes                                              /Users/cpamuluri/.kube/config  kind-kind11
❯
```
- 2)Use case # Context use; We can see that when we perform 'tanzu context use' the sync is not performed for all context's, in this case, sync is not performed for the TMC context, its performed only for the k8s context for which 'tanzu context use' is performed.
```
❯
❯
❯ t context unset k33
The context 'k33' of type 'kubernetes' has been set as inactive
❯
❯
❯ t plugin list
Standalone Plugins
  NAME  DESCRIPTION  TARGET  VERSION  STATUS

Plugins from Context:  tmc1
  NAME                  DESCRIPTION                                                     TARGET           VERSION  STATUS
  account               Account for tmc resources                                       mission-control  v0.1.10  not installed
  agentartifacts        helm for tmc resources                                          mission-control  v0.1.9   not installed
  aks-cluster           Manage and unmanage tmc aks clusters                            mission-control  v0.2.0   not installed
  apply                 Create/Update a resource with a resource file                   mission-control  v0.3.6   not installed
  audit                 Run an audit request on an org                                  mission-control  v0.1.9   not installed
  cluster                                                                               mission-control  v0.2.4   not installed
  clustergroup          A group of Kubernetes clusters                                  mission-control  v0.1.9   not installed
  continuousdelivery    Continuousdelivery for tmc resources                            mission-control  v0.1.9   not installed
  data-protection       Data protection for tmc resources                               mission-control  v0.1.9   not installed
  ekscluster                                                                            mission-control  v0.1.9   not installed
  events                Events for any meaningful user activity or system state change  mission-control  v0.1.9   not installed
  helm                  helm for tmc resources                                          mission-control  v0.1.9   not installed
  iam                   IAM Policies for tmc resources                                  mission-control  v0.1.9   not installed
  inspection            Inspection for tmc resources                                    mission-control  v0.1.9   not installed
  integration           Get available integrations and their information from registry  mission-control  v0.1.9   not installed
  management-cluster    A TMC registered Management cluster                             mission-control  v0.2.9   not installed
  policy                Policy for tmc resources                                        mission-control  v0.1.9   not installed
  provider-aks-cluster  Manage and unmanage tmc provider aks clusters                   mission-control  v0.1.10  not installed
  provider-eks-cluster                                                                  mission-control  v0.1.9   not installed
  secret                secret for tmc resources                                        mission-control  v0.1.9   not installed
  setting               Setting plugin for tmc resources                                mission-control  v0.2.7   not installed
  tanzupackage          Tanzupackage for tmc resources                                  mission-control  v0.2.8   not installed
  workspace             A group of Kubernetes namespaces                                mission-control  v0.1.11  not installed

[!] As shown above, some recommended plugins have not been installed or are outdated. To install them please run 'tanzu plugin sync'.
❯ t context use k33
[i] Checking for required plugins for context k33...
[i] All required plugins are already installed and up-to-date
❯
❯
❯ t plugin list
Standalone Plugins
  NAME  DESCRIPTION  TARGET  VERSION  STATUS

Plugins from Context:  tmc1
  NAME                  DESCRIPTION                                                     TARGET           VERSION  STATUS
  account               Account for tmc resources                                       mission-control  v0.1.10  not installed
  agentartifacts        helm for tmc resources                                          mission-control  v0.1.9   not installed
  aks-cluster           Manage and unmanage tmc aks clusters                            mission-control  v0.2.0   not installed
  apply                 Create/Update a resource with a resource file                   mission-control  v0.3.6   not installed
  audit                 Run an audit request on an org                                  mission-control  v0.1.9   not installed
  cluster                                                                               mission-control  v0.2.4   not installed
  clustergroup          A group of Kubernetes clusters                                  mission-control  v0.1.9   not installed
  continuousdelivery    Continuousdelivery for tmc resources                            mission-control  v0.1.9   not installed
  data-protection       Data protection for tmc resources                               mission-control  v0.1.9   not installed
  ekscluster                                                                            mission-control  v0.1.9   not installed
  events                Events for any meaningful user activity or system state change  mission-control  v0.1.9   not installed
  helm                  helm for tmc resources                                          mission-control  v0.1.9   not installed
  iam                   IAM Policies for tmc resources                                  mission-control  v0.1.9   not installed
  inspection            Inspection for tmc resources                                    mission-control  v0.1.9   not installed
  integration           Get available integrations and their information from registry  mission-control  v0.1.9   not installed
  management-cluster    A TMC registered Management cluster                             mission-control  v0.2.9   not installed
  policy                Policy for tmc resources                                        mission-control  v0.1.9   not installed
  provider-aks-cluster  Manage and unmanage tmc provider aks clusters                   mission-control  v0.1.10  not installed
  provider-eks-cluster                                                                  mission-control  v0.1.9   not installed
  secret                secret for tmc resources                                        mission-control  v0.1.9   not installed
  setting               Setting plugin for tmc resources                                mission-control  v0.2.7   not installed
  tanzupackage          Tanzupackage for tmc resources                                  mission-control  v0.2.8   not installed
  workspace             A group of Kubernetes namespaces                                mission-control  v0.1.11  not installed

[!] As shown above, some recommended plugins have not been installed or are outdated. To install them please run 'tanzu plugin sync'.
❯
```


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

- For `tanzu plugin sync`, new optional parameter '--type' added, which takes valid context type, if user provides a input value and if it has active context then it performs the plug sync only for that context type only, not for all active contexts.
- The `tanzu contex create` functionality updated, after context create, it performs the sync operation only for the newly created context, not for all active contexts.
- The `tanzu context use` functionality updated, after activating the given context, it performs the sync operation only for the newly activated context, do not perform sync for all active contexts.

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
