### PR TITLE
Ensure the k8s and application-engine current contexts are mutual exclusive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/vmware-tanzu/carvel-ytt v0.40.0
 	github.com/vmware-tanzu/tanzu-cli/test/e2e/framework v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686
-	github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0-dev.0.20231002160823-1da8552a1589
+	github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0-dev.0.20231010050932-6807eb0c63cf
 	go.pinniped.dev v0.20.0
 	golang.org/x/mod v0.12.0
 	golang.org/x/oauth2 v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -735,8 +735,8 @@ github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502eb
 github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502ebf68/go.mod h1:e1Uef+Ux5BIHpYwqbeP2ZZmOzehBcez2vUEWXHe+xHE=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686 h1:VcuXqUXFxm5WDqWkzAlU/6cJXua0ozELnqD59fy7J6E=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686/go.mod h1:AFGOXZD4tH+KhpmtV0VjWjllXhr8y57MvOsIxTtywc4=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0-dev.0.20231002160823-1da8552a1589 h1:D6B0U5whz3LZvMokKpxYBBHNzkdbhPQOpNKBuJ/B+ho=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0-dev.0.20231002160823-1da8552a1589/go.mod h1:wMK/qpJjU7hytDAGt3FX5/iGdlUK8TsJLu36pCr+Zvk=
+github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0-dev.0.20231010050932-6807eb0c63cf h1:eOz25sffy6W5w+2O86U/49aXH8POX+RODbvkF1CC9mI=
+github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0-dev.0.20231010050932-6807eb0c63cf/go.mod h1:wMK/qpJjU7hytDAGt3FX5/iGdlUK8TsJLu36pCr+Zvk=
 github.com/xanzy/go-gitlab v0.83.0 h1:37p0MpTPNbsTMKX/JnmJtY8Ch1sFiJzVF342+RvZEGw=
 github.com/xanzy/go-gitlab v0.83.0/go.mod h1:5ryv+MnpZStBH8I/77HuQBsMbBGANtVpLWC15qOjWAw=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=

--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -514,14 +514,14 @@ func doCSPAuthAndUpdateContext(c *configtypes.Context, endpointType string) (cla
 	if apiTokenExists {
 		log.Info("API token env var is set")
 	} else {
-		apiTokenValue, err = promptAPIToken("TAE")
+		apiTokenValue, err = promptAPIToken(endpointType)
 		if err != nil {
 			return nil, err
 		}
 	}
 	token, err := csp.GetAccessTokenFromAPIToken(apiTokenValue, issuer)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get token from CSP for TAE")
+		return nil, errors.Wrapf(err, "failed to get token from CSP for %s", endpointType)
 	}
 	claims, err = csp.ParseToken(&oauth2.Token{AccessToken: token.AccessToken})
 	if err != nil {

--- a/pkg/fakes/config/tanzu_config_ng_2.yaml
+++ b/pkg/fakes/config/tanzu_config_ng_2.yaml
@@ -1,0 +1,55 @@
+contexts:
+  - name: test-mc-context
+    target: kubernetes
+    clusterOpts:
+      isManagementCluster: true
+      endpoint: test-endpoint
+      path: test-path
+      context: test-mc-context
+    discoverySources:
+      - gcp:
+          name: test
+          bucket: test-bucket
+          manifestPath: test-manifest-path
+  - name: test-use-context
+    target: mission-control
+    globalOpts:
+      endpoint: test-endpoint2
+      auth:
+        IDToken: test-id-token
+        accessToken: test-access-token
+        type: api-token
+        userName: test-user-name
+        refresh_token: test-refresh-token
+  - name: test-tmc-context
+    target: mission-control
+    globalOpts:
+      endpoint: test-endpoint3
+      auth:
+        IDToken: test-id-token2
+        accessToken: test-access-token2
+        type: api-token2
+        userName: test-user-name2
+        refresh_token: test-refresh-token2
+  - name: test-tae-context
+    target: application-engine
+    globalOpts:
+      endpoint: tae-endpoint
+      auth:
+        IDToken: test-id-token
+        accessToken: test-access-token
+        type: api-token
+        userName: test-user-name
+        refresh_token: test-refresh-token
+    clusterOpts:
+      isManagementCluster: false
+      endpoint: kube-endpoint
+      path: dummy/path
+      context: dummy-context
+    additionalMetadata:
+      taeProjectName: dummyP
+      taeOrgID: dummyO
+currentContext:
+  kubernetes: test-mc-context
+  mission-control: test-tmc-context
+  application-engine: test-tae-context


### PR DESCRIPTION
### What this PR does / why we need it
This PR ensures the k8s and application-engine current contexts are mutual exclusive at the end of end cli command/plugin invocation and also specifically for `SyncPlugin()` command as this command can be invoked by plugin through plugin-runtime API before finishing plugin command execution(eg: management-cluster create command creates management cluster and would invoke SyncPlugins within the command)

**TODO:**
- This PR has dependency on plugin-runtime PR #https://github.com/vmware-tanzu/tanzu-plugin-runtime/pull/113 and this PR needs to be updated once the other PR is merged.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
Unit test ran locally passed 
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Ensure the kubernetes and application-engine current contexts are mutual exclusive
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information


#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
