### PR TITLE
Clarify the output of "plugin group get --all" and add unit tests

### DIFF
--- a/pkg/command/plugin_group.go
+++ b/pkg/command/plugin_group.go
@@ -98,6 +98,8 @@ func newGetCmd() *cobra.Command {
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completeGroupGet,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			var specifiedVersion string
+
 			gID := args[0]
 
 			groupIdentifier := plugininventory.PluginGroupIdentifierFromID(gID)
@@ -107,6 +109,8 @@ func newGetCmd() *cobra.Command {
 
 			if groupIdentifier.Version == "" {
 				groupIdentifier.Version = cli.VersionLatest
+			} else {
+				specifiedVersion = ":" + groupIdentifier.Version
 			}
 
 			criteria := &discovery.GroupDiscoveryCriteria{
@@ -128,7 +132,7 @@ func newGetCmd() *cobra.Command {
 			}
 
 			if outputFormat == "" || outputFormat == string(component.TableOutputType) {
-				displayGroupContentAsTable(groups[0], cmd.OutOrStdout())
+				displayGroupContentAsTable(groups[0], specifiedVersion, cmd.OutOrStdout())
 			} else {
 				displayGroupContentAsList(groups[0], cmd.OutOrStdout())
 			}
@@ -210,29 +214,52 @@ func displayGroupDetails(groups []*plugininventory.PluginGroup, writer io.Writer
 	component.NewObjectWriter(writer, outputFormat, details).Render()
 }
 
-func displayGroupContentAsTable(group *plugininventory.PluginGroup, writer io.Writer) {
+func displayGroupContentAsTable(group *plugininventory.PluginGroup, specifiedVersion string, writer io.Writer) {
 	cyanBold := color.New(color.FgCyan).Add(color.Bold)
 	cyanBoldItalic := color.New(color.FgCyan).Add(color.Bold, color.Italic)
-	output := component.NewOutputWriterWithOptions(writer, outputFormat, []component.OutputWriterOption{}, "Name", "Target", "Version")
+	outputStandalone := component.NewOutputWriterWithOptions(writer, outputFormat, []component.OutputWriterOption{}, "Name", "Target", "Version")
 
 	gID := plugininventory.PluginGroupToID(group)
 	_, _ = cyanBold.Println("Plugins in Group: ", cyanBoldItalic.Sprintf("%s:%s", gID, group.RecommendedVersion))
 
+	if showNonMandatory {
+		fmt.Println("")
+		_, _ = cyanBold.Println("Standalone Plugins")
+	}
+
 	for _, plugin := range group.Versions[group.RecommendedVersion] {
-		if showNonMandatory || plugin.Mandatory {
-			output.AddRow(plugin.Name, plugin.Target, plugin.Version)
+		if plugin.Mandatory {
+			outputStandalone.AddRow(plugin.Name, plugin.Target, plugin.Version)
 		}
 	}
-	output.Render()
+	outputStandalone.Render()
+
+	if showNonMandatory {
+		fmt.Println("")
+		log.Infof("The standalone plugins in this plugin group are installed when the 'tanzu plugin install --group %s%s' command is invoked.", gID, specifiedVersion)
+
+		fmt.Println("")
+		outputContext := component.NewOutputWriterWithOptions(writer, outputFormat, []component.OutputWriterOption{}, "Name", "Target", "Version")
+		_, _ = cyanBold.Println("Contextual Plugins")
+		for _, plugin := range group.Versions[group.RecommendedVersion] {
+			if !plugin.Mandatory {
+				outputContext.AddRow(plugin.Name, plugin.Target, plugin.Version)
+			}
+		}
+		outputContext.Render()
+
+		fmt.Println("")
+		log.Info("The contextual plugins in this plugin group are automatically installed, and only available for use, when a Tanzu context which supports them is created or activated/used.")
+	}
 }
 
 func displayGroupContentAsList(group *plugininventory.PluginGroup, writer io.Writer) {
-	output := component.NewOutputWriterWithOptions(writer, outputFormat, []component.OutputWriterOption{}, "Group", "PluginName", "PluginTarget", "PluginVersion")
+	output := component.NewOutputWriterWithOptions(writer, outputFormat, []component.OutputWriterOption{}, "Group", "PluginName", "PluginTarget", "PluginVersion", "Context-Scoped")
 
 	gID := fmt.Sprintf("%s:%s", plugininventory.PluginGroupToID(group), group.RecommendedVersion)
 	for _, plugin := range group.Versions[group.RecommendedVersion] {
 		if showNonMandatory || plugin.Mandatory {
-			output.AddRow(gID, plugin.Name, plugin.Target, plugin.Version)
+			output.AddRow(gID, plugin.Name, plugin.Target, plugin.Version, !plugin.Mandatory)
 		}
 	}
 	output.Render()

--- a/pkg/command/plugin_group_test.go
+++ b/pkg/command/plugin_group_test.go
@@ -5,10 +5,214 @@ package command
 
 import (
 	"bytes"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestPluginGroupSearch(t *testing.T) {
+	tests := []struct {
+		test            string
+		args            []string
+		expected        string
+		expectedFailure bool
+	}{
+		{
+			test:            "search for all groups",
+			args:            []string{"plugin", "group", "search"},
+			expectedFailure: false,
+			expected:        "GROUP DESCRIPTION LATEST vmware-tap/default Plugins for TAP v3.3.3 vmware-tkg/default Plugins for TKG v2.2.2",
+		},
+		{
+			test:            "search for group with --name",
+			args:            []string{"plugin", "group", "search", "--name", "vmware-tap/default"},
+			expectedFailure: false,
+			expected:        "GROUP DESCRIPTION LATEST vmware-tap/default Plugins for TAP v3.3.3",
+		},
+		{
+			test:            "search for invalid group with --name",
+			args:            []string{"plugin", "group", "search", "--name", "invalid"},
+			expectedFailure: true,
+			expected:        `incorrect plugin-group "invalid" specified`,
+		},
+		{
+			test:            "search for group with --show-details",
+			args:            []string{"plugin", "group", "search", "--show-details"},
+			expectedFailure: false,
+			expected:        "name: vmware-tap/default description: Plugins for TAP latest: v3.3.3 versions: - v3.3.3 name: vmware-tkg/default description: Plugins for TKG latest: v2.2.2 versions: - v1.1.1 - v2.2.2-beta - v2.2.2",
+		},
+		{
+			test:            "search for group with --show-details and --name",
+			args:            []string{"plugin", "group", "search", "--show-details", "--name", "vmware-tap/default"},
+			expectedFailure: false,
+			expected:        "name: vmware-tap/default description: Plugins for TAP latest: v3.3.3 versions: - v3.3.3",
+		},
+		{
+			test:            "search for all groups with json",
+			args:            []string{"plugin", "group", "search", "-o", "json"},
+			expectedFailure: false,
+			expected:        "[ { \"description\": \"Plugins for TAP\", \"group\": \"vmware-tap/default\", \"latest\": \"v3.3.3\" }, { \"description\": \"Plugins for TKG\", \"group\": \"vmware-tkg/default\", \"latest\": \"v2.2.2\" } ]",
+		},
+		{
+			test:            "search for group with --name with json",
+			args:            []string{"plugin", "group", "search", "--name", "vmware-tap/default", "-o", "json"},
+			expectedFailure: false,
+			expected:        "[ { \"description\": \"Plugins for TAP\", \"group\": \"vmware-tap/default\", \"latest\": \"v3.3.3\" } ]",
+		},
+		{
+			test:            "search for group with --show-details with json",
+			args:            []string{"plugin", "group", "search", "--show-details", "-o", "json"},
+			expectedFailure: false,
+			expected:        "[ { \"Name\": \"vmware-tap/default\", \"Description\": \"Plugins for TAP\", \"Latest\": \"v3.3.3\", \"Versions\": [ \"v3.3.3\" ] }, { \"Name\": \"vmware-tkg/default\", \"Description\": \"Plugins for TKG\", \"Latest\": \"v2.2.2\", \"Versions\": [ \"v1.1.1\", \"v2.2.2-beta\", \"v2.2.2\" ] } ]",
+		},
+		{
+			test:            "search for group with --show-details and --name with json",
+			args:            []string{"plugin", "group", "search", "--show-details", "--name", "vmware-tap/default", "-o", "json"},
+			expectedFailure: false,
+			expected:        "[ { \"Name\": \"vmware-tap/default\", \"Description\": \"Plugins for TAP\", \"Latest\": \"v3.3.3\", \"Versions\": [ \"v3.3.3\" ] } ]",
+		},
+	}
+
+	// Setup a plugin source and a set of installed plugins
+	defer setupPluginSourceForTesting(t)()
+
+	// For these tests, we force using the cache.
+	// Normal behavior of the CLI verifies the cache validity
+	// which we don't want for unit tests.
+	os.Setenv("TEST_TANZU_CLI_USE_DB_CACHE_ONLY", "1")
+
+	for _, spec := range tests {
+		t.Run(spec.test, func(t *testing.T) {
+			assert := assert.New(t)
+
+			rootCmd, err := NewRootCmd()
+			assert.Nil(err)
+
+			var out bytes.Buffer
+			rootCmd.SetOut(&out)
+			rootCmd.SetArgs(spec.args)
+
+			err = rootCmd.Execute()
+			assert.Equal(err != nil, spec.expectedFailure)
+			if spec.expected != "" {
+				if spec.expectedFailure {
+					assert.Equal(spec.expected, err.Error())
+				} else {
+					// whitespace-agnostic match
+					assert.Equal(spec.expected, strings.Join(strings.Fields(out.String()), " "))
+				}
+			}
+		})
+	}
+
+	os.Unsetenv("TEST_TANZU_CLI_USE_DB_CACHE_ONLY")
+}
+
+func TestPluginGroupGet(t *testing.T) {
+	tests := []struct {
+		test            string
+		args            []string
+		expected        string
+		expectedFailure bool
+	}{
+		{
+			test:            "get a plugin group",
+			args:            []string{"plugin", "group", "get", "vmware-tkg/default"},
+			expectedFailure: false,
+			expected:        "Plugins in Group: vmware-tkg/default:v2.2.2 NAME TARGET VERSION isolated-cluster global v1.3",
+		},
+		{
+			test:            "get a plugin group with version",
+			args:            []string{"plugin", "group", "get", "vmware-tkg/default:v1.1.1"},
+			expectedFailure: false,
+			expected:        "Plugins in Group: vmware-tkg/default:v1.1.1 NAME TARGET VERSION isolated-cluster global v1.2.3 login global v1.2.0 management-cluster kubernetes v0.1.0 package kubernetes v0.2.0 secret kubernetes v0.3.0",
+		},
+		{
+			test:            "get a plugin group in json",
+			args:            []string{"plugin", "group", "get", "vmware-tkg/default", "-o", "json"},
+			expectedFailure: false,
+			expected:        "[ { \"context-scoped\": false, \"group\": \"vmware-tkg/default:v2.2.2\", \"pluginname\": \"isolated-cluster\", \"plugintarget\": \"global\", \"pluginversion\": \"v1.3\" } ]",
+		},
+		{
+			test:            "get a plugin group with --all with no context-scoped",
+			args:            []string{"plugin", "group", "get", "vmware-tkg/default", "--all"},
+			expectedFailure: false,
+			expected:        "Plugins in Group: vmware-tkg/default:v2.2.2 Standalone Plugins NAME TARGET VERSION isolated-cluster global v1.3 [i] The standalone plugins in this plugin group are installed when the 'tanzu plugin install --group vmware-tkg/default' command is invoked. Contextual Plugins NAME TARGET VERSION [i] The contextual plugins in this plugin group are automatically installed, and only available for use, when a Tanzu context which supports them is created or activated/used.",
+		},
+		{
+			test:            "get a plugin group with --all with context-scoped",
+			args:            []string{"plugin", "group", "get", "vmware-tkg/default:v1.1.1", "--all"},
+			expectedFailure: false,
+			expected:        "Plugins in Group: vmware-tkg/default:v1.1.1 Standalone Plugins NAME TARGET VERSION isolated-cluster global v1.2.3 login global v1.2.0 management-cluster kubernetes v0.1.0 package kubernetes v0.2.0 secret kubernetes v0.3.0 [i] The standalone plugins in this plugin group are installed when the 'tanzu plugin install --group vmware-tkg/default:v1.1.1' command is invoked. Contextual Plugins NAME TARGET VERSION cluster kubernetes v1.1.1 [i] The contextual plugins in this plugin group are automatically installed, and only available for use, when a Tanzu context which supports them is created or activated/used.",
+		},
+		{
+			test:            "get a plugin group in json with --all with no context-scoped",
+			args:            []string{"plugin", "group", "get", "vmware-tkg/default", "-o", "json", "--all"},
+			expectedFailure: false,
+			expected:        "[ { \"context-scoped\": false, \"group\": \"vmware-tkg/default:v2.2.2\", \"pluginname\": \"isolated-cluster\", \"plugintarget\": \"global\", \"pluginversion\": \"v1.3\" } ]",
+		},
+		{
+			test:            "get a plugin group in json with --all with context-scoped",
+			args:            []string{"plugin", "group", "get", "vmware-tkg/default:v1.1.1", "-o", "json", "--all"},
+			expectedFailure: false,
+			expected:        "[ { \"context-scoped\": true, \"group\": \"vmware-tkg/default:v1.1.1\", \"pluginname\": \"cluster\", \"plugintarget\": \"kubernetes\", \"pluginversion\": \"v1.1.1\" }, { \"context-scoped\": false, \"group\": \"vmware-tkg/default:v1.1.1\", \"pluginname\": \"isolated-cluster\", \"plugintarget\": \"global\", \"pluginversion\": \"v1.2.3\" }, { \"context-scoped\": false, \"group\": \"vmware-tkg/default:v1.1.1\", \"pluginname\": \"login\", \"plugintarget\": \"global\", \"pluginversion\": \"v1.2.0\" }, { \"context-scoped\": false, \"group\": \"vmware-tkg/default:v1.1.1\", \"pluginname\": \"management-cluster\", \"plugintarget\": \"kubernetes\", \"pluginversion\": \"v0.1.0\" }, { \"context-scoped\": false, \"group\": \"vmware-tkg/default:v1.1.1\", \"pluginname\": \"package\", \"plugintarget\": \"kubernetes\", \"pluginversion\": \"v0.2.0\" }, { \"context-scoped\": false, \"group\": \"vmware-tkg/default:v1.1.1\", \"pluginname\": \"secret\", \"plugintarget\": \"kubernetes\", \"pluginversion\": \"v0.3.0\" } ]",
+		},
+		{
+			test:            "get a plugin group with version in json",
+			args:            []string{"plugin", "group", "get", "vmware-tkg/default:v1.1.1", "-o", "json"},
+			expectedFailure: false,
+			expected:        "[ { \"context-scoped\": false, \"group\": \"vmware-tkg/default:v1.1.1\", \"pluginname\": \"isolated-cluster\", \"plugintarget\": \"global\", \"pluginversion\": \"v1.2.3\" }, { \"context-scoped\": false, \"group\": \"vmware-tkg/default:v1.1.1\", \"pluginname\": \"login\", \"plugintarget\": \"global\", \"pluginversion\": \"v1.2.0\" }, { \"context-scoped\": false, \"group\": \"vmware-tkg/default:v1.1.1\", \"pluginname\": \"management-cluster\", \"plugintarget\": \"kubernetes\", \"pluginversion\": \"v0.1.0\" }, { \"context-scoped\": false, \"group\": \"vmware-tkg/default:v1.1.1\", \"pluginname\": \"package\", \"plugintarget\": \"kubernetes\", \"pluginversion\": \"v0.2.0\" }, { \"context-scoped\": false, \"group\": \"vmware-tkg/default:v1.1.1\", \"pluginname\": \"secret\", \"plugintarget\": \"kubernetes\", \"pluginversion\": \"v0.3.0\" } ]",
+		},
+		{
+			test:            "get an invalid plugin group",
+			args:            []string{"plugin", "group", "get", "invalid"},
+			expectedFailure: true,
+			expected:        "incorrect plugin-group \"invalid\" specified",
+		},
+		{
+			test:            "get a plugin group with an invalid version",
+			args:            []string{"plugin", "group", "get", "vmware-tkg/default:v0.888.0"},
+			expectedFailure: true,
+			expected:        "plugin-group \"vmware-tkg/default:v0.888.0\" cannot be found",
+		},
+	}
+
+	// Setup a plugin source and a set of installed plugins
+	defer setupPluginSourceForTesting(t)()
+
+	// For these tests, we force using the cache.
+	// Normal behavior of the CLI verifies the cache validity
+	// which we don't want for unit tests.
+	os.Setenv("TEST_TANZU_CLI_USE_DB_CACHE_ONLY", "1")
+
+	for _, spec := range tests {
+		t.Run(spec.test, func(t *testing.T) {
+			assert := assert.New(t)
+
+			rootCmd, err := NewRootCmd()
+			assert.Nil(err)
+
+			var out bytes.Buffer
+			rootCmd.SetOut(&out)
+			rootCmd.SetArgs(spec.args)
+
+			err = rootCmd.Execute()
+			assert.Equal(err != nil, spec.expectedFailure)
+			if spec.expected != "" {
+				if spec.expectedFailure {
+					assert.Equal(spec.expected, err.Error())
+				} else {
+					// whitespace-agnostic match
+					assert.Equal(spec.expected, strings.Join(strings.Fields(out.String()), " "))
+				}
+			}
+		})
+	}
+
+	os.Unsetenv("TEST_TANZU_CLI_USE_DB_CACHE_ONLY")
+}
 
 func TestCompletionPluginGroup(t *testing.T) {
 	tests := []struct {
@@ -69,6 +273,10 @@ func TestCompletionPluginGroup(t *testing.T) {
 
 	// Setup a plugin source and a set of installed plugins
 	defer setupPluginSourceForTesting(t)()
+
+	// Do NOT force using the cache with TEST_TANZU_CLI_USE_DB_CACHE_ONLY
+	// because we need to test that the shell completion code itself
+	// forces the use of the cache.
 
 	for _, spec := range tests {
 		t.Run(spec.test, func(t *testing.T) {

--- a/pkg/command/plugin_helper_test.go
+++ b/pkg/command/plugin_helper_test.go
@@ -295,6 +295,9 @@ func setupPluginSourceForTesting(t *testing.T) func() {
 	assert.Nil(t, err)
 	os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
 
+	os.Setenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER", "No")
+	os.Setenv("TANZU_CLI_EULA_PROMPT_ANSWER", "Yes")
+
 	// Setup a temporary cache directory
 	dir, err := os.MkdirTemp("", "cache")
 	assert.Nil(t, err)
@@ -321,6 +324,7 @@ func setupPluginSourceForTesting(t *testing.T) func() {
 		os.Unsetenv("TANZU_CONFIG")
 		os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
 		os.Unsetenv("TEST_CUSTOM_CATALOG_CACHE_DIR")
-		os.Unsetenv("TEST_TANZU_CLI_USE_DB_CACHE_ONLY")
+		os.Unsetenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER")
+		os.Unsetenv("TANZU_CLI_EULA_PROMPT_ANSWER")
 	}
 }

--- a/pkg/plugininventory/plugin_inventory.go
+++ b/pkg/plugininventory/plugin_inventory.go
@@ -205,3 +205,12 @@ type PluginGroupFilter struct {
 	// IncludeHidden indicates if hidden plugin groups should be included
 	IncludeHidden bool
 }
+
+// PluginGroupSorter sorts PluginGroup objects.
+type PluginGroupSorter []*PluginGroup
+
+func (p PluginGroupSorter) Len() int      { return len(p) }
+func (p PluginGroupSorter) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
+func (p PluginGroupSorter) Less(i, j int) bool {
+	return PluginGroupToID(p[i]) < PluginGroupToID(p[j])
+}


### PR DESCRIPTION
### What this PR does / why we need it

This PR enhances the output of `tanzu plugin group get --all` to make it clear which plugins are standalone and which are context-scoped.

Please refer to the section "testing done" for the new output.

The top-most commit of this PR provides general unit tests for the `tanzu plugin group` sub-commands.
The testing coverage for `plugin_group.go` has gone up from 0% to 93%. 

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #525

### Describe testing done for PR

```
# Same output as before without the --all flag
$ tz plugin group get vmware-tkg/default
Plugins in Group:  vmware-tkg/default:v2.4.0
  NAME                TARGET      VERSION
  isolated-cluster    global      v0.31.0
  management-cluster  kubernetes  v0.31.0
  package             kubernetes  v0.31.0
  pinniped-auth       global      v0.31.0
  secret              kubernetes  v0.31.0
  telemetry           kubernetes  v0.31.0

# Enhanced output with the --all flag
# Notice the information line that mentions the `tanzu plugin install -group`
# command mentions the plugin group that the user used
$ tz plugin group get vmware-tkg/default --all
Plugins in Group:  vmware-tkg/default:v2.4.0

Standalone Plugins
  NAME                TARGET      VERSION
  isolated-cluster    global      v0.31.0
  management-cluster  kubernetes  v0.31.0
  package             kubernetes  v0.31.0
  pinniped-auth       global      v0.31.0
  secret              kubernetes  v0.31.0
  telemetry           kubernetes  v0.31.0

[i] The standalone plugins in this plugin group are installed when the 'tanzu plugin install --group vmware-tkg/default' command is invoked.

Contextual Plugins
  NAME                TARGET      VERSION
  cluster             kubernetes  v0.31.0
  feature             kubernetes  v0.31.0
  kubernetes-release  kubernetes  v0.31.0

[i] The contextual plugins in this plugin group are automatically installed, and only available for use, when a Tanzu context which supports them is created or activated/used.

# Notice the information line that mentions the `tanzu plugin install -group`
# command mentions the plugin group that the user used
$ tz plugin group get vmware-tkg/default:v2.4.0 --all
Plugins in Group:  vmware-tkg/default:v2.4.0

Standalone Plugins
  NAME                TARGET      VERSION
  isolated-cluster    global      v0.31.0
  management-cluster  kubernetes  v0.31.0
  package             kubernetes  v0.31.0
  pinniped-auth       global      v0.31.0
  secret              kubernetes  v0.31.0
  telemetry           kubernetes  v0.31.0

[i] The standalone plugins in this plugin group are installed when the 'tanzu plugin install --group vmware-tkg/default:v2.4.0' command is invoked.

Contextual Plugins
  NAME                TARGET      VERSION
  cluster             kubernetes  v0.31.0
  feature             kubernetes  v0.31.0
  kubernetes-release  kubernetes  v0.31.0

[i] The contextual plugins in this plugin group are automatically installed, and only available for use, when a Tanzu context which supports them is created or activated/used.

# The json/yaml format always includes a new line "context-scoped"
# which is always false when --all is NOT used
$ tz plugin group get vmware-tkg/default -o json
[
  {
    "context-scoped": false,
    "group": "vmware-tkg/default:v2.4.0",
    "pluginname": "isolated-cluster",
    "plugintarget": "global",
    "pluginversion": "v0.31.0"
  },
  {
    "context-scoped": false,
    "group": "vmware-tkg/default:v2.4.0",
    "pluginname": "management-cluster",
    "plugintarget": "kubernetes",
    "pluginversion": "v0.31.0"
  },
  {
    "context-scoped": false,
    "group": "vmware-tkg/default:v2.4.0",
    "pluginname": "package",
    "plugintarget": "kubernetes",
    "pluginversion": "v0.31.0"
  },
  {
    "context-scoped": false,
    "group": "vmware-tkg/default:v2.4.0",
    "pluginname": "pinniped-auth",
    "plugintarget": "global",
    "pluginversion": "v0.31.0"
  },
  {
    "context-scoped": false,
    "group": "vmware-tkg/default:v2.4.0",
    "pluginname": "secret",
    "plugintarget": "kubernetes",
    "pluginversion": "v0.31.0"
  },
  {
    "context-scoped": false,
    "group": "vmware-tkg/default:v2.4.0",
    "pluginname": "telemetry",
    "plugintarget": "kubernetes",
    "pluginversion": "v0.31.0"
  }
]


$ tz plugin group get vmware-tkg/default -o json --all
[
  {
    "context-scoped": true,
    "group": "vmware-tkg/default:v2.4.0",
    "pluginname": "cluster",
    "plugintarget": "kubernetes",
    "pluginversion": "v0.31.0"
  },
  {
    "context-scoped": true,
    "group": "vmware-tkg/default:v2.4.0",
    "pluginname": "feature",
    "plugintarget": "kubernetes",
    "pluginversion": "v0.31.0"
  },
  {
    "context-scoped": false,
    "group": "vmware-tkg/default:v2.4.0",
    "pluginname": "isolated-cluster",
    "plugintarget": "global",
    "pluginversion": "v0.31.0"
  },
  {
    "context-scoped": true,
    "group": "vmware-tkg/default:v2.4.0",
    "pluginname": "kubernetes-release",
    "plugintarget": "kubernetes",
    "pluginversion": "v0.31.0"
  },
  {
    "context-scoped": false,
    "group": "vmware-tkg/default:v2.4.0",
    "pluginname": "management-cluster",
    "plugintarget": "kubernetes",
    "pluginversion": "v0.31.0"
  },
  {
    "context-scoped": false,
    "group": "vmware-tkg/default:v2.4.0",
    "pluginname": "package",
    "plugintarget": "kubernetes",
    "pluginversion": "v0.31.0"
  },
  {
    "context-scoped": false,
    "group": "vmware-tkg/default:v2.4.0",
    "pluginname": "pinniped-auth",
    "plugintarget": "global",
    "pluginversion": "v0.31.0"
  },
  {
    "context-scoped": false,
    "group": "vmware-tkg/default:v2.4.0",
    "pluginname": "secret",
    "plugintarget": "kubernetes",
    "pluginversion": "v0.31.0"
  },
  {
    "context-scoped": false,
    "group": "vmware-tkg/default:v2.4.0",
    "pluginname": "telemetry",
    "plugintarget": "kubernetes",
    "pluginversion": "v0.31.0"
  }
]
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Enhance the output of `tanzu plugin group get --all` to show the type of plugins.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
