### PR TITLE
Add missing .PHONY target

### DIFF
--- a/cmd/plugin/builder/template/plugintemplates/plugin-tooling.mk.tmpl
+++ b/cmd/plugin/builder/template/plugintemplates/plugin-tooling.mk.tmpl
@@ -88,8 +88,9 @@ plugin-install-local:
 .PHONY: plugin-build
 plugin-build: $(PLUGIN_BUILD_TARGETS) generate-plugin-bundle ## Build all plugin binaries for all supported os-arch
 
+.PHONY: plugin-build-local
 plugin-build-local: plugin-build-$(GOHOSTOS)-$(GOHOSTARCH) ## Build all plugin binaries for local platform
-	
+
 plugin-build-%:
 	$(eval ARCH = $(word 2,$(subst -, ,$*)))
 	$(eval OS = $(word 1,$(subst -, ,$*)))

--- a/plugin-tooling.mk
+++ b/plugin-tooling.mk
@@ -92,8 +92,9 @@ plugin-install-local:
 .PHONY: plugin-build
 plugin-build: $(PLUGIN_BUILD_TARGETS) generate-plugin-bundle ## Build all plugin binaries for all supported os-arch
 
+.PHONY: plugin-build-local
 plugin-build-local: plugin-build-$(GOHOSTOS)-$(GOHOSTARCH) ## Build all plugin binaries for local platform
-	
+
 plugin-build-%:
 	$(eval ARCH = $(word 2,$(subst -, ,$*)))
 	$(eval OS = $(word 1,$(subst -, ,$*)))


### PR DESCRIPTION
### What this PR does / why we need it

Add a `.PHONY` make target for `plugin-build-local` to avoid risk of `make plugin-build-local` causing `plugin-build-%` to be tirggered.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #527

### Describe testing done for PR

Before this PR.
First remove the extra TAB in `plugin-tooling.mk`
```
$ PLUGIN_NAME=builder make plugin-build-local
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.1.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-10-08' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=faae59672-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.1.0-dev'" \
		--goflags "" \
		--os-arch darwin_arm64 \
		--match "builder" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-10-08T15:59:16-04:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.1.0-dev, [darwin_arm64]
2023-10-08T15:59:16-04:00 [i] 🐭 - building plugin at path "cmd/plugin/builder"
2023-10-08T15:59:18-04:00 [i] 🐭 - $ /Users/kmarc/.asdf/shims/go build -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/arm64/global/builder/v1.1.0-dev/tanzu-builder-darwin_arm64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-10-08' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=faae59672-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.1.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.1.0-dev' -tags  ./cmd/plugin/builder
2023-10-08T15:59:19-04:00 [i] ========
2023-10-08T15:59:19-04:00 [i] saving plugin manifest...
2023-10-08T15:59:19-04:00 [i] saving plugin group manifest...
2023-10-08T15:59:19-04:00 [ok] successfully built local repository
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.1.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-10-08' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=faae59672-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.1.0-dev'" \
		--goflags "" \
		--os-arch local_ \
		--match "builder" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-10-08T15:59:19-04:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.1.0-dev, [local_]
2023-10-08T15:59:19-04:00 [i] 🐮 - building plugin at path "cmd/plugin/builder"
2023-10-08T15:59:21-04:00 [x] "local_" build architecture is not supported
2023-10-08T15:59:21-04:00 [i] ========
2023-10-08T15:59:21-04:00 [i] saving plugin manifest...
Error: open /Users/kmarc/git/tanzu-cli/artifacts/plugins/local/plugin_manifest.yaml: no such file or directory
2023-10-08T15:59:21-04:00 [x] : open /Users/kmarc/git/tanzu-cli/artifacts/plugins/local/plugin_manifest.yaml: no such file or directory
make: *** [plugin-build-local] Error 1
```
Notice the extra attempt at building using the invalid `local_` os-arch.

With this PR (which also removes the extra TAB)
```
$ PLUGIN_NAME=builder make plugin-build-local
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.1.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-10-08' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=faae59672-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.1.0-dev'" \
		--goflags "" \
		--os-arch darwin_arm64 \
		--match "builder" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-10-08T15:59:51-04:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.1.0-dev, [darwin_arm64]
2023-10-08T15:59:51-04:00 [i] 🐼 - building plugin at path "cmd/plugin/builder"
2023-10-08T15:59:53-04:00 [i] 🐼 - $ /Users/kmarc/.asdf/shims/go build -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/arm64/global/builder/v1.1.0-dev/tanzu-builder-darwin_arm64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-10-08' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=faae59672-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.1.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.1.0-dev' -tags  ./cmd/plugin/builder
2023-10-08T15:59:54-04:00 [i] ========
2023-10-08T15:59:54-04:00 [i] saving plugin manifest...
2023-10-08T15:59:54-04:00 [i] saving plugin group manifest...
2023-10-08T15:59:54-04:00 [ok] successfully built local repository
```
Only the single local build is performed as expected.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix missing target in `plugin-tooling.mk` file
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
