### PR TITLE
Do not use the CLIs sub-command help for the builder plugin

### DIFF
--- a/cmd/plugin/builder/inventory.go
+++ b/cmd/plugin/builder/inventory.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/inventory"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/carvelhelpers"
-	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 )
 
 // newInventoryCmd creates a new command for inventory operations.
@@ -17,8 +16,6 @@ func newInventoryCmd() *cobra.Command {
 		Use:   "inventory",
 		Short: "Inventory Operations",
 	}
-
-	inventoryCmd.SetUsageFunc(cli.SubCmdUsageFunc)
 
 	inventoryCmd.AddCommand(
 		newInventoryInitCmd(),

--- a/cmd/plugin/builder/inventory_plugin.go
+++ b/cmd/plugin/builder/inventory_plugin.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/inventory"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/carvelhelpers"
-	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 )
 
 // newInventoryPluginCmd creates a new command for plugin inventory operations.
@@ -17,8 +16,6 @@ func newInventoryPluginCmd() *cobra.Command {
 		Use:   "plugin",
 		Short: "Plugin Inventory Operations",
 	}
-
-	inventoryPluginCmd.SetUsageFunc(cli.SubCmdUsageFunc)
 
 	inventoryPluginCmd.AddCommand(
 		newInventoryPluginAddCmd(),

--- a/cmd/plugin/builder/inventory_plugin_group.go
+++ b/cmd/plugin/builder/inventory_plugin_group.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/inventory"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/carvelhelpers"
-	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 )
 
 // newInventoryPluginCmd creates a new command for plugin inventory operations.
@@ -17,8 +16,6 @@ func newInventoryPluginGroupCmd() *cobra.Command {
 		Use:   "plugin-group",
 		Short: "Plugin-Group Inventory Operations",
 	}
-
-	inventoryPluginCmd.SetUsageFunc(cli.SubCmdUsageFunc)
 
 	inventoryPluginCmd.AddCommand(
 		newInventoryPluginGroupAddCmd(),

--- a/cmd/plugin/builder/plugin.go
+++ b/cmd/plugin/builder/plugin.go
@@ -12,7 +12,6 @@ import (
 	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/command"
 	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/crane"
 	"github.com/vmware-tanzu/tanzu-cli/cmd/plugin/builder/plugin"
-	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/registry"
 )
 
@@ -22,8 +21,6 @@ func NewPluginCmd() *cobra.Command {
 		Use:   "plugin",
 		Short: "Plugin Operations",
 	}
-
-	pluginCmd.SetUsageFunc(cli.SubCmdUsageFunc)
 
 	pluginCmd.AddCommand(
 		newPluginBuildCmd(),


### PR DESCRIPTION
### What this PR does / why we need it

The 'builder' command is a plugin and therefore its help formatting is automatically done by the `tanzu-plugin-runtime` library.

Using `SetUsageFunc(cli.SubCmdUsageFunc)` formats the help without adding the `tanzu` root command in the help of the plugin.

This commit simply removes the use of `SetUsageFunc(cli.SubCmdUsageFunc)` for the `builder` plugin.


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #529 

### Describe testing done for PR

Before the PR, using `main`, build and test with the plugin:
```
# Install the plugins built from main
$ tz plugin install --local-source artifacts/plugins/darwin/arm64 all
[i] Installing plugin 'builder:v1.1.0-dev' with target 'global'
[i] Installing plugin 'test:v1.1.0-dev' with target 'global'
[ok] successfully installed all plugins

# Notice the `tanzu` prefix in Usage for the root builder command
$ tz builder -h
Build Tanzu components

Usage:
  tanzu builder [command]

[...]

# But below, the `tanzu` prefix is missing
$ tz builder inventory -h
Inventory Operations

Usage:
  builder inventory [command]

[...]

$ tz builder inventory plugin -h
Plugin Inventory Operations

Usage:
  builder inventory plugin [command]

[...]

$ tz builder inventory plugin-group -h
Plugin-Group Inventory Operations

Usage:
  builder inventory plugin-group [command]

[...]

$ tz builder inventory init -h
Initialize empty plugin inventory database and publish it to the remote repository

Usage:
builder inventory init [flags]

[...]

$ tz builder plugin -h
Plugin Operations

Usage:
  builder plugin [command]

[...]

$ tz builder plugin build -h
Build plugins

Usage:
builder plugin build [flags]

[...]

$ tz builder plugin build-package -h
Build plugin packages OCI image as tar.gz file that can be published to any repository

Usage:
builder plugin build-package [flags]

[...]

# Notice this last one is ok because that sub-command tree does
# not call `SetUsageFunc(cli.SubCmdUsageFunc)``
$ tz builder cli add-plugin -h
Add a plugin to a repository

Usage:
  tanzu builder cli add-plugin NAME [flags]

[...]
```

With this PR, re-install the plugins:
```
# Install the plugins built from this PR
$ tz plugin install --local-source artifacts/plugins/darwin/arm64 all
[i] Installing plugin 'builder:v1.1.0-dev' with target 'global'
[i] Installing plugin 'test:v1.1.0-dev' with target 'global'
[ok] successfully installed all plugins

# Notice the `tanzu` prefix in Usage
$ tz builder -h
Build Tanzu components

Usage:
  tanzu builder [command]

[...]

# But below, the `tanzu` prefix is missing
$ tz builder inventory -h
Inventory Operations

Usage:
  tanzu builder inventory [command]

[...]

$ tz builder inventory plugin -h
Plugin Inventory Operations

Usage:
  tanzu builder inventory plugin [command]

[...]

$ tz builder inventory plugin-group -h
Plugin-Group Inventory Operations

Usage:
  tanzu builder inventory plugin-group [command]

[...]

$ tz builder inventory init -h
Initialize empty plugin inventory database and publish it to the remote repository

Usage:
  tanzu builder inventory init [flags]

[...]

$ tz builder plugin -h
Plugin Operations

Usage:
  tanzu builder plugin [command]

[...]

$ tz builder plugin build -h
Build plugins

Usage:
  tanzu builder plugin build [flags]

[...]

$ tz builder plugin build-package -h
Build plugin packages OCI image as tar.gz file that can be published to any repository

Usage:
  tanzu builder plugin build-package [flags]

[...]

# Notice this last one is still ok of course because that sub-command tree does
# not call `SetUsageFunc(cli.SubCmdUsageFunc)``
$ tz builder cli add-plugin -h
Add a plugin to a repository

Usage:
  tanzu builder cli add-plugin NAME [flags]

[...]
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix the usage section of the help text for the builder plugin.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
