### PR TITLE
Fix typo in output when deleting a context

### DIFF
--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -850,7 +850,7 @@ func deleteCtx(_ *cobra.Command, args []string) error {
 		}
 	}
 	installed, _, _, _ := getInstalledAndMissingContextPlugins() //nolint:dogsled
-	log.Infof("Deleting entry for cluster %s", name)
+	log.Infof("Deleting entry for context '%s'", name)
 	err := config.RemoveContext(name)
 	if err != nil {
 		return err


### PR DESCRIPTION
### What this PR does / why we need it

The output of `tanzu context delete` was mentioning `Deleting entry for cluster`, using the word `cluster` instead of `context`.  This PR fixes this and also adds quotes around the context name.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Before PR, notice the word `cluster`.
```
$ tz context delete tkg1 -y
[i] Deleting entry for cluster tkg1
```

With the PR, notice the word `context` in the first line of output:
```
$ tz context delete tkg2 -y
[i] Deleting entry for context 'tkg2'
Deactivating plugin 'feature:v0.30.1' for context 'tkg2'
Deactivating plugin 'cluster:v0.30.1' for context 'tkg2'
Deactivating plugin 'kubernetes-release:v0.30.1' for context 'tkg2'
```
### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix output text when deleting a context.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
