### PR TITLE
Detailed error when failing to access central repo

### DIFF
--- a/pkg/discovery/oci_dbbacked.go
+++ b/pkg/discovery/oci_dbbacked.go
@@ -272,7 +272,7 @@ func (od *DBBackedOCIDiscovery) checkImageCache() (string, string, error) {
 	_, hashHexValInventoryImage, err := carvelhelpers.GetImageDigest(od.image)
 	if err != nil {
 		// This will happen when the user has configured an invalid image discovery URI
-		return "", "", fmt.Errorf("plugins discovery image resolution failed. Please check that the repository image URL %q is correct ", od.image)
+		return "", "", errors.Wrapf(err, "plugins discovery image resolution failed. Please check that the repository image URL %q is correct", od.image)
 	}
 
 	correctHashFileForInventoryImage := od.checkDigestFileExistence(hashHexValInventoryImage, "")


### PR DESCRIPTION
### What this PR does / why we need it

This PR bubbles up the error received when failing to verify the digest of the plugin source.
This is meant to make it easier for users to realize what is the underlying cause of the error, such as invalid certificates versus and invalid URI.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #533

### Describe testing done for PR

Before the PR.
Notice the unhelpful error messages.
```
# Test when not having configured certificates
$ make start-test-central-repo
[...]
[ok] deleted certificate data for host localhost:9876
/Users/kmarc/git/tanzu-cli/bin/tanzu config cert add --host localhost:9876 --ca-certificate /Users/kmarc/git/tanzu-cli/hack/central-repo/certs/localhost.crt
[ok] successfully added certificate data for host localhost:9876
[...]
$ tz config cert list
  HOST            CA-CERTIFICATE  SKIP-CERT-VERIFICATION  INSECURE
  localhost:9876  <REDACTED>      false                   false
$ tz config cert delete localhost:9876
[ok] deleted certificate data for host localhost:9876
$ tz config set env.TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST localhost:9876/tanzu-cli/plugins/central:small
$ tz plugin source update default -u localhost:9876/tanzu-cli/plugins/central:small
[x] : unable to fetch the inventory of discovery 'default' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "localhost:9876/tanzu-cli/plugins/central:small" is correct 

# Create an invalid certificate (the file used does not contain a certificate)
$ tz config cert add --host localhost:9876 --ca-certificate hack/central-repo/certs/localhost.key
[ok] successfully added certificate data for host localhost:9876
$ tz plugin source update default -u localhost:9876/tanzu-cli/plugins/central:small
[x] : unable to fetch the inventory of discovery 'default' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "localhost:9876/tanzu-cli/plugins/central:small" is correct
```

With this PR, the error message provides some guidance:
```
# Valid URI but certificates not installed
$ tz config cert list
  HOST  CA-CERTIFICATE  SKIP-CERT-VERIFICATION  INSECURE
$ tz plugin source update default -u localhost:9876/tanzu-cli/plugins/central:small
[x] : unable to fetch the inventory of discovery 'default' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "localhost:9876/tanzu-cli/plugins/central:small" is correct: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://localhost:9876/v2/": tls: failed to verify certificate: x509: “localhost.local” certificate is not standards compliant; GET http://localhost:9876/v2/: unexpected status code 400 Bad Request: Client sent an HTTP request to an HTTPS server.

# With an invalid URI (certificates installed)
tz plugin source update default -u projects.registry.vmware.com/invalid/plugin-inventory:latest
[x] : unable to fetch the inventory of discovery 'default' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "projects.registry.vmware.com/invalid/plugin-inventory:latest" is correct: error getting the image digest: GET https://projects.registry.vmware.com/v2/invalid/plugin-inventory/manifests/latest: UNAUTHORIZED: project invalid not found: project invalid not found

# Create an invalid certificate (the file used does not contain a certificate)
$ tz config cert add --host localhost:9876 --ca-certificate hack/central-repo/certs/localhost.key
[ok] successfully added certificate data for host localhost:9876
$ tz plugin source update default -u localhost:9876/tanzu-cli/plugins/central:small
[x] : unable to fetch the inventory of discovery 'default' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "localhost:9876/tanzu-cli/plugins/central:small" is correct : unable to initialize registry: failed to initialize registry client: Creating registry HTTP transport: Adding CA certificates from '/Users/kmarc/registry_certs': failed

# Error printout with multiple plugin sources of which 2 are incorrect
# one is invalid and the other does not have the certs configured.
$ tz config set env.TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST localhost:9876/tanzu-cli/plugins/central:small,projects.registry.vmware.com/invalid/plugin-inventory:latest
$ tz config set env.TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY localhost:9876/tanzu-cli/plugins/central:small,projects.registry.vmware.com/invalid/plugin-inventory:latest
$ tz plugin source list
  NAME                IMAGE
  default             projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest
  disc_0 (test only)  localhost:9876/tanzu-cli/plugins/central:small
  disc_1 (test only)  projects.registry.vmware.com/invalid/plugin-inventory:latest
$ tz config cert list
  HOST            CA-CERTIFICATE  SKIP-CERT-VERIFICATION  INSECURE
$ tz plugin search
  NAME                  DESCRIPTION                                                                       TARGET           LATEST
  builder               Build Tanzu components                                                            global           v1.0.0
  isolated-cluster      Prepopulating images/bundle for internet-restricted environments                  global           v0.31.0
[...]
  workspace             A group of Kubernetes namespaces                                                  mission-control  v0.1.11
[x] : there was an error while discovering standalone plugins, error information: '[unable to list plugins from discovery source 'disc_0': unable to fetch the inventory of discovery 'disc_0' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "localhost:9876/tanzu-cli/plugins/central:small" is correct: error getting the image digest: Error while preparing a transport to talk with the registry: Unable to create round tripper: Get "https://localhost:9876/v2/": tls: failed to verify certificate: x509: “localhost.local” certificate is not standards compliant; GET http://localhost:9876/v2/: unexpected status code 400 Bad Request: Client sent an HTTP request to an HTTPS server.
, unable to list plugins from discovery source 'disc_1': unable to fetch the inventory of discovery 'disc_1' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "projects.registry.vmware.com/invalid/plugin-inventory:latest" is correct: error getting the image digest: GET https://projects.registry.vmware.com/v2/invalid/plugin-inventory/manifests/latest: UNAUTHORIZED: project invalid not found: project invalid not found]'
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Provide a more detailed error when failing to read the central repository of plugins
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
