### PR TITLE
Kubeconfig path changes in context create

### DIFF
--- a/pkg/auth/tkg/kube_config_test.go
+++ b/pkg/auth/tkg/kube_config_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strconv"
 	"testing"
 
@@ -232,21 +231,6 @@ var _ = Describe("Unit tests for tkg auth", func() {
 
 			})
 		})
-		Describe("Get Tanzu local Kubeconfig path", func() {
-			var localPath string
-			Context("When TanzuLocalKubeConfigPath() is called", func() {
-				BeforeEach(func() {
-					localPath, err = tkgauth.TanzuLocalKubeConfigPath()
-				})
-				It("should return the tanzu local kubeconfig path", func() {
-					Expect(err).ToNot(HaveOccurred())
-					home, err := os.UserHomeDir()
-					Expect(err).ToNot(HaveOccurred())
-					Expect(localPath).Should(Equal(filepath.Join(home, tkgauth.TanzuLocalKubeDir, tkgauth.TanzuKubeconfigFile)))
-				})
-			})
-		})
-
 	})
 })
 

--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -296,7 +296,7 @@ func createContextWithKubeconfig() (context *configtypes.Context, err error) {
 			return
 		}
 	} else if kubeConfig == "" {
-		kubeConfig = getDefaultKubeconfigPath()
+		kubeConfig = kubecfg.GetDefaultKubeConfigFile()
 	}
 	kubeConfig = strings.TrimSpace(kubeConfig)
 
@@ -661,15 +661,6 @@ func sanitizeEndpoint(endpoint string) string {
 		return fmt.Sprintf("%s:443", endpoint)
 	}
 	return endpoint
-}
-
-func getDefaultKubeconfigPath() string {
-	kubeConfigPath := os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
-	// fallback to default kubeconfig file location if no env variable set
-	if kubeConfigPath == "" {
-		kubeConfigPath = clientcmd.RecommendedHomeFile
-	}
-	return kubeConfigPath
 }
 
 func getDiscoveryHTTPClient(tlsConfig *tls.Config) *http.Client {

--- a/pkg/command/login.go
+++ b/pkg/command/login.go
@@ -16,13 +16,14 @@ import (
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/component"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/plugin"
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/auth/csp"
 	tkgauth "github.com/vmware-tanzu/tanzu-cli/pkg/auth/tkg"
+	kubecfg "github.com/vmware-tanzu/tanzu-cli/pkg/auth/utils/kubeconfig"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/pluginmanager"
-	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
 
 var (
@@ -243,7 +244,7 @@ func createServerWithKubeconfig() (server *configtypes.Server, err error) { //no
 	}
 	kubeConfig = strings.TrimSpace(kubeConfig)
 	if kubeConfig == "" {
-		kubeConfig = getDefaultKubeconfigPath()
+		kubeConfig = kubecfg.GetDefaultKubeConfigFile()
 	}
 
 	if kubeConfig != "" && kubeContext == "" {


### PR DESCRIPTION
### What this PR does / why we need it
This PR implements kubeconfig path changes in context create command.

Changes Summary:
- Support multi-file KUBECONFIG path in context creation (e.g. export KUBECONFIG=~/temp/non-existing.kfg:~/temp/tkgCluster_admin.kfg)
- Modify kubeconfig file path to use default kubeconfig path instead of $HOME/.kube-tanzu/config while creating context for TKG pinniped endpoint

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

Created the context by exporting KUBECONFIG environment variable with single kubeconfig file
```
❯ export KUBECONFIG=~/temp/tkgCluster_admin.kfg
❯ ./bin/tanzu context create tkg-mgmt-vc  --kubecontext tkg-mgmt-vc-admin@tkg-mgmt-vc
[ok] successfully created a kubernetes context using the kubeconfig /Users/pkalle/temp/tkgCluster_admin.kfg
[i] Checking for required plugins...
[i] All required plugins are already installed and up-to-date

```
Created the context by exporting KUBECONFIG environment variable with multiple kubeconfig files and the first one is non-existent. Verified the second file path is considered for context creation as expected

```
❯ export KUBECONFIG=~/temp/non-existing.kfg:~/temp/tkgCluster_admin.kfg
❯ ./bin/tanzu context create tkg-mgmt-vc  --kubecontext tkg-mgmt-vc-admin@tkg-mgmt-vc
[ok] successfully created a kubernetes context using the kubeconfig /Users/pkalle/temp/tkgCluster_admin.kfg
[i] Checking for required plugins...
[i] All required plugins are already installed and up-to-date
```
Created the context by exporting KUBECONFIG environment variable with multiple kubeconfig files and the first file path one is valid. Verified the first file path is considered for context creation as expected

```
❯ export KUBECONFIG=~/temp/tkgCluster_admin.kfg:/Users/pkalle/temp/mc-kubeconfig
❯ ./bin/tanzu context create tkg-mgmt-vc  --kubecontext tkg-mgmt-vc-admin@tkg-mgmt-vc
[ok] successfully created a kubernetes context using the kubeconfig /Users/pkalle/temp/tkgCluster_admin.kfg
[i] Checking for required plugins...
[i] All required plugins are already installed and up-to-date
```
Tried to create the context by exporting KUBECONFIG environment variable with multiple kubeconfig files and the first file path one is valid file path but the context provided doesn't exist. Verified the context creation failed as expected

```
❯ export KUBECONFIG=/Users/pkalle/temp/mc-kubeconfig:~/temp/tkgCluster_admin.kfg
❯ ./bin/tanzu context create tkg-mgmt-vc  --kubecontext tkg-mgmt-vc-admin@tkg-mgmt-vc
[x] : failed to create context "tkg-mgmt-vc" for a kubernetes cluster, Unable to set up rest config due to : invalid configuration: [context was not found for specified context: tkg-mgmt-vc-admin@tkg-mgmt-vc, cluster has no server defined]
[x] : failed to create context "tkg-mgmt-vc" for a kubernetes cluster, Unable to set up rest config due to : invalid configuration: [context was not found for specified context: tkg-mgmt-vc-admin@tkg-mgmt-vc, cluster has no server defined]
```

Testing for updated kubeconfig path (using default kubeconfig path for context creation given TKG endpoint with pinniped support)


```
####Before the change

❯ ./bin/tanzu context create tkg-mgmt-vc-pin --endpoint  https://10.180.68.150:6443  --insecure-skip-tls-verify
[i] Could not get login banner from server, response code = 403
[ok] successfully created a kubernetes context using the kubeconfig /Users/pkalle/.kube-tanzu/config
[i] Checking for required plugins...
[!] unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually, error: 'unable to list plugins from discovery source 'default-tkg-mgmt-vc-pin': cliplugins.cli.tanzu.vmware.com is forbidden: User "pkalle" cannot list resource "cliplugins" in API group "cli.tanzu.vmware.com" at the cluster scope'


#### After the change
// modified the default kubeconfig path and executed the context create and verified the pinniped kubeconfig generated is merged into default kubeconfig
❯ export KUBECONFIG=/Users/pkalle/temp/tkgCluster_admin.kfg:/Users/pkalle/temp/mc-kubeconfig
❯ ./bin/tanzu context create tkg-mgmt-vc-pin --endpoint  https://10.180.68.150:6443  --insecure-skip-tls-verify
[i] Could not get login banner from server, response code = 403
Log in by visiting this link:

    https://10.180.68.237/oauth2/authorize?access_type=offline&client_id=pinniped-cli&code_challenge=yzGTYuTmVYcmZ4d2TzAFHpw2-HqNpVIiIxmTVIh50QA&code_challenge_method=S256&nonce=0e4ee2e1bae20be363ef3c8b08fd2ffc&redirect_uri=http%3A%2F%2F127.0.0.1%3A52147%2Fcallback&response_mode=form_post&response_type=code&scope=offline_access+openid+pinniped%3Arequest-audience&state=c03c3d1d3ed2455aa017b2a79b22bed1

    Optionally, paste your authorization code: [...]

[ok] successfully created a kubernetes context using the kubeconfig /Users/pkalle/temp/tkgCluster_admin.kfg
[i] Checking for required plugins...
[!] unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually, error: 'unable to list plugins from discovery source 'default-tkg-mgmt-vc-pin': cliplugins.cli.tanzu.vmware.com is forbidden: User "pkalle" cannot list resource "cliplugins" in API group "cli.tanzu.vmware.com" at the cluster scope'


// Tested after unsetting the KUBECONFIG variable
// the kubeconfig is stored in the default kubeconfig file ( /Users/pkalle/.kube/config)
❯ unset KUBECONFIG
❯ ./bin/tanzu context create tkg-mgmt-vc-pin --endpoint  https://10.180.68.150:6443  --insecure-skip-tls-verify
[i] Could not get login banner from server, response code = 403
Log in by visiting this link:

    https://10.180.68.237/oauth2/authorize?access_type=offline&client_id=pinniped-cli&code_challenge=CXQV3t62gFqanK6aMSFaa6pp69HZzg5cXQvuHCjMElA&code_challenge_method=S256&nonce=2acf3b7649c2cb27216e0670b63d893b&redirect_uri=http%3A%2F%2F127.0.0.1%3A59276%2Fcallback&response_mode=form_post&response_type=code&scope=offline_access+openid+pinniped%3Arequest-audience&state=638a56deee7833c2fd85308539d8d77f

    Optionally, paste your authorization code: [...]

[ok] successfully created a kubernetes context using the kubeconfig /Users/pkalle/.kube/config
```




### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Support multi-file KUBECONFIG path in context creation and updated kubeconfig file path to use default kubeconfig path instead of $HOME/.kube-tanzu/config while creating context for TKG pinniped endpoint

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
