### PR TITLE
Add support for "tanzu plugin delete all --target"

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -119,6 +119,7 @@ cloud.google.com/go/webrisk v1.8.0/go.mod h1:oJPDuamzHXgUc+b8SiHRcVInZQuybnvEW72
 cloud.google.com/go/websecurityscanner v1.5.0/go.mod h1:Y6xdCPy81yi0SQnDY1xdNTNpfY1oAgXUlcfN3B3eSng=
 cloud.google.com/go/workflows v1.10.0/go.mod h1:fZ8LmRmZQWacon9UCX1r/g/DfAXx5VcPALq2CxzdePw=
 contrib.go.opencensus.io/exporter/stackdriver v0.13.14/go.mod h1:5pSSGY0Bhuk7waTHuDf4aQ8D2DrhgETRo9fy6k3Xlzc=
+cuelang.org/go v0.5.0/go.mod h1:okjJBHFQFer+a41sAe2SaGm1glWS8oEb6CmJvn5Zdws=
 github.com/AliyunContainerService/ack-ram-tool/pkg/credentials/alibabacloudsdkgo/helper v0.2.0/go.mod h1:GgeIE+1be8Ivm7Sh4RgwI42aTtC9qrcj+Y9Y6CjJhJs=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Azure/go-ntlmssp v0.0.0-20220621081337-cb9428e4ac1e/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
@@ -162,6 +163,7 @@ github.com/beevik/ntp v1.0.0/go.mod h1:JN7/74B0Z4GUGO/1aUeRI2adARlfJGUeaJb0y0Wvn
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bmatcuk/doublestar v1.2.1/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
+github.com/buildkite/agent/v3 v3.46.1/go.mod h1:cOaDfQpz1a0icTRoXJp7Aoi/bbcEsh8kn4ZxS+QTO0o=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/cavaliercoder/badio v0.0.0-20160213150051-ce5280129e9e/go.mod h1:V284PjgVwSk4ETmz84rpu9ehpGg7swlIH8npP9k2bGw=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=
@@ -176,6 +178,7 @@ github.com/chzyer/test v0.0.0-20210722231415-061457976a23/go.mod h1:Q3SI9o4m/ZMn
 github.com/clbanning/mxj/v2 v2.5.6/go.mod h1:hNiWqW14h+kc+MdF9C6/YoRfjEJoR3ou6tn/Qo+ve2s=
 github.com/cncf/udpa/go v0.0.0-20220112060539-c52dc94e7fbe/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
 github.com/cncf/xds/go v0.0.0-20230310173818-32f1caf87195/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cockroachdb/apd/v2 v2.0.2/go.mod h1:DDxRlzC2lo3/vSlmSoS7JkqbbrARPuFOGr0B9pvN3Gw=
 github.com/cockroachdb/cockroach-go/v2 v2.3.3/go.mod h1:1wNJ45eSXW9AnOc3skntW9ZUZz6gxrQK3cOj3rK+BC8=
 github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be/go.mod h1:mk5IQ+Y0ZeO87b858TlA645sVcEcbiX6YqP98kt+7+w=
 github.com/coredns/caddy v1.1.1/go.mod h1:A6ntJQlAWuQfFlsd9hvigKbo2WS0VUs2l1e2F+BawD4=
@@ -198,6 +201,7 @@ github.com/eggsampler/acme/v3 v3.3.0/go.mod h1:/qh0rKC/Dh7Jj+p4So7DbWmFNzC4dpcpK
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/emicklei/proto v1.10.0/go.mod h1:rn1FgRS/FANiZdD2djyH7TMA9jdRDcYQ9IEN9yvjX0A=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.11.0/go.mod h1:VnHyVMpzcLvCFt9yUz1UnCwHLhwx1WguiVDV7pTG/tI=
 github.com/envoyproxy/protoc-gen-validate v0.10.0/go.mod h1:DRjgyB0I43LtJapqN6NiRwroiAU2PaFuvk/vjgh61ss=
@@ -222,6 +226,7 @@ github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbV
 github.com/go-piv/piv-go v1.11.0/go.mod h1:NZ2zmjVkfFaL/CF8cVQ/pXdXtuj110zEKGdJM6fJZZM=
 github.com/go-redis/redis v6.15.9+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-redis/redis/v8 v8.11.5/go.mod h1:gREzHqY1hg6oD9ngVRbLStwAWKhA0FEgq8Jd4h5lpwo=
+github.com/go-redis/redismock/v9 v9.0.3/go.mod h1:F6tJRfnU8R/NZ0E+Gjvoluk14MqMC5ueSZX6vVQypc0=
 github.com/go-rod/rod v0.112.9/go.mod h1:l0or0gEnZ7E5C0L/W7iD+yXBnm/OM3avP1ji74k8N9s=
 github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/gobuffalo/flect v1.0.2/go.mod h1:A5msMlrHtLqh9umBSnvabjsMrCcCpAyzglnDvkbYKHs=
@@ -296,6 +301,7 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+
 github.com/onsi/ginkgo/v2 v2.9.2/go.mod h1:WHcJJG2dIlcCqVfBAwUCrJxSPFb6v4azBwgxeMeDuts=
 github.com/onsi/ginkgo/v2 v2.11.0/go.mod h1:ZhrRA5XmEE3x3rhlzamx/JJvujdZoJ2uvgI7kR0iZvM=
 github.com/onsi/gomega v1.27.6/go.mod h1:PIQNjfQwkP3aQAH7lf7j87O/5FiNr+ZR8+ipb+qQlhg=
+github.com/open-policy-agent/opa v0.52.0/go.mod h1:2n99s7WY/BXZUWUOq10JdTgK+G6XM4FYGoe7kQ5Vg0s=
 github.com/ory/fosite v0.42.2/go.mod h1:qggrqm3ZWQF9i2f/d3RLH5mHHPtv44hsiltkVKLsCYo=
 github.com/ory/go-acc v0.2.8/go.mod h1:iCRZUdGb/7nqvSn8xWZkhfVrtXRZ9Wru2E5rabCjFPI=
 github.com/ory/go-convenience v0.1.0/go.mod h1:uEY/a60PL5c12nYz4V5cHY03IBmwIAEm8TWB0yn9KNs=
@@ -309,9 +315,11 @@ github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzL
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pquerna/cachecontrol v0.1.0/go.mod h1:NrUG3Z7Rdu85UNR3vm7SOsl1nFIeSiQnrHV5K9mBcUI=
 github.com/prometheus/prometheus v0.43.1/go.mod h1:2BA14LgBeqlPuzObSEbh+Y+JwLH2GcqDlJKbF2sA6FM=
+github.com/protocolbuffers/txtpbfmt v0.0.0-20220428173112-74888fd59c2b/go.mod h1:KjY0wibdYKc4DYkerHSbguaf3JeIPGhNJBp2BNiFH78=
 github.com/pseudomuto/protoc-gen-doc v1.5.1/go.mod h1:XpMKYg6zkcpgfpCfQ8GcWBDRtRxOmMR5w7pz4Xo+dYM=
 github.com/pseudomuto/protokit v0.2.0/go.mod h1:2PdH30hxVHsup8KpBTOXTBeMVhJZVio3Q8ViKSAXT0Q=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/redis/go-redis/v9 v9.0.4/go.mod h1:WqMKv5vnQbRuZstUwxQI195wHy+t4PuXDOjzMvcuQHk=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rs/cors v1.9.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
@@ -321,8 +329,11 @@ github.com/sclevine/spec v1.4.0/go.mod h1:LvpgJaFyvQzRvc1kaDs0bulYwzC70PbiYjC4Qn
 github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
+github.com/sigstore/fulcio v1.3.1/go.mod h1:/XfqazOec45ulJZpyL9sq+OsVQ8g2UOVoNVi7abFgqU=
+github.com/sigstore/protobuf-specs v0.1.0/go.mod h1:5shUCxf82hGnjUEFVWiktcxwzdtn6EfeeJssxZ5Q5HE=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
+github.com/spiffe/go-spiffe/v2 v2.1.4/go.mod h1:eVDqm9xFvyqao6C+eQensb9ZPkyNEeaUbqbBpOhBnNk=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/tchap/go-patricia/v2 v2.3.1/go.mod h1:VZRHKAb53DLaG+nA9EaYYiaEx6YztwDlLElMsnSHD4k=
 github.com/tdewolff/minify/v2 v2.12.2/go.mod h1:p5pwbvNs1ghbFED/ZW1towGsnnWwzvM8iz8l0eURi9g=
@@ -333,6 +344,7 @@ github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoi
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/valyala/fastjson v1.6.4/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
+github.com/veraison/go-cose v1.1.0/go.mod h1:7ziE85vSq4ScFTg6wyoMXjucIGOf4JkFEZi/an96Ct4=
 github.com/vincent-petithory/dataurl v1.0.0/go.mod h1:FHafX5vmDzyP+1CQATJn7WFKc9CvnvxyvZy6I1MrG/U=
 github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0-dev.0.20231011182819-6cabd029e112 h1:zTrAoW2vn6ap0WHJ5Jo/Vq9v5WYrVT455MtopOwzYNA=
 github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0-dev.0.20231011182819-6cabd029e112/go.mod h1:wMK/qpJjU7hytDAGt3FX5/iGdlUK8TsJLu36pCr+Zvk=
@@ -380,6 +392,7 @@ go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5/go.mod h1:nmDLcffg48OtT/PSW0H
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
 go4.org v0.0.0-20201209231011-d4a079459e60/go.mod h1:CIiUVy99QCPfoE13bO4EZaz5GZMZXMSBGhxRdsvzbkg=
+gocloud.dev v0.29.0/go.mod h1:E3dAjji80g+lIkq4CQeF/BTWqv1CBeTftmOb+gpyapQ=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.9.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=

--- a/pkg/pluginmanager/manager_helper_test.go
+++ b/pkg/pluginmanager/manager_helper_test.go
@@ -19,6 +19,7 @@ import (
 	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 
+	"github.com/vmware-tanzu/tanzu-cli/pkg/catalog"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/config"
@@ -50,6 +51,23 @@ var testPlugins = []plugininventory.PluginIdentifier{
 
 var testPluginsNoARM64 = []plugininventory.PluginIdentifier{
 	{Name: "pluginnoarm", Target: configtypes.TargetK8s, Version: "v1.0.0"},
+}
+
+var installedStandalonePlugins = []plugininventory.PluginIdentifier{
+	{Name: "management-cluster", Target: configtypes.TargetK8s, Version: "v0.1.0"},
+	{Name: "secret", Target: configtypes.TargetK8s, Version: "v0.3.0"},
+
+	{Name: "management-cluster", Target: configtypes.TargetTMC, Version: "v0.0.1"},
+}
+
+var installedContextPlugins = map[string][]plugininventory.PluginIdentifier{
+	"myK8sCtx": {
+		{Name: "cluster", Target: configtypes.TargetK8s, Version: "v0.0.1"},
+		{Name: "feature", Target: configtypes.TargetK8s, Version: "v0.0.2"},
+	},
+	"myTMCCtx": {
+		{Name: "cluster", Target: configtypes.TargetTMC, Version: "v0.0.5"},
+	},
 }
 
 const createGroupsStmt = `
@@ -288,6 +306,65 @@ func setupTestPluginInventory() {
 	_, err = db.Exec(createGroupsStmt)
 	if err != nil {
 		log.Fatal(err, "failed to create plugin groups for testing")
+	}
+}
+
+func setupTestPluginCatalog() {
+	// Create catalog for standalone plugins
+	cc, err := catalog.NewContextCatalogUpdater("")
+	if err != nil {
+		log.Fatal(err, "unable to create catalog updater")
+	}
+
+	for _, plugin := range installedStandalonePlugins {
+		entry := cli.PluginInfo{
+			Name:             plugin.Name,
+			Target:           plugin.Target,
+			Version:          plugin.Version,
+			Description:      fmt.Sprintf("Plugin %s/%s description", plugin.Name, plugin.Target),
+			InstallationPath: "/path/" + string(plugin.Target) + "/" + plugin.Name,
+		}
+
+		err = cc.Upsert(&entry)
+		if err != nil {
+			log.Fatal(err, "unable to insert into catalog")
+		}
+	}
+	cc.Unlock()
+
+	for ctxName, plugins := range installedContextPlugins {
+		cc, err := catalog.NewContextCatalogUpdater(ctxName)
+		if err != nil {
+			log.Fatal(err, "unable to create catalog updater")
+		}
+
+		var target configtypes.Target
+		for _, plugin := range plugins {
+			entry := cli.PluginInfo{
+				Name:             plugin.Name,
+				Target:           plugin.Target,
+				Version:          plugin.Version,
+				Description:      fmt.Sprintf("Plugin %s/%s description", plugin.Name, plugin.Target),
+				InstallationPath: "/path/" + string(plugin.Target) + "/" + plugin.Name,
+			}
+
+			err = cc.Upsert(&entry)
+			if err != nil {
+				log.Fatal(err, "unable to insert into catalog")
+			}
+
+			target = plugin.Target
+		}
+
+		err = configlib.SetContext(&configtypes.Context{
+			Name:   ctxName,
+			Target: target,
+		}, true)
+		if err != nil {
+			log.Fatal(err, "unable to set context")
+		}
+
+		cc.Unlock()
 	}
 }
 


### PR DESCRIPTION
### What this PR does / why we need it

This commit allows a user to delete all plugins for a specified target.
The commit teaches the CLI to accept the `all` argument for the `tanzu plugin delete ` command.  When the `all` argument is used however, the `--target` flag must be used.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

```
# Start with plugins for different targets
$ tz plugin list
Standalone Plugins
  NAME       DESCRIPTION                                                 TARGET  VERSION  STATUS
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  global  v1.1.0   installed

Plugins from Context:  tkg1
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v0.30.1  installed
  feature             Operate on features and featuregates  kubernetes  v0.30.1  installed
  kubernetes-release  Kubernetes release operations         kubernetes  v0.30.1  installed

Plugins from Context:  tmc
  NAME                  DESCRIPTION                                                     TARGET           VERSION  STATUS
  account               Account for tmc resources                                       mission-control  v0.1.10  installed
  agentartifacts        helm for tmc resources                                          mission-control  v0.1.9   installed
  aks-cluster           Manage and unmanage tmc aks clusters                            mission-control  v0.2.0   not installed
  apply                 Create/Update a resource with a resource file                   mission-control  v0.3.6   installed
  audit                 Run an audit request on an org                                  mission-control  v0.1.9   installed
  cluster                                                                               mission-control  v0.2.4   installed
  clustergroup          A group of Kubernetes clusters                                  mission-control  v0.1.9   installed
  continuousdelivery    Continuousdelivery for tmc resources                            mission-control  v0.1.9   installed
  data-protection       Data protection for tmc resources                               mission-control  v0.1.9   installed
  ekscluster                                                                            mission-control  v0.1.9   installed
  events                Events for any meaningful user activity or system state change  mission-control  v0.1.9   installed
  helm                  helm for tmc resources                                          mission-control  v0.1.9   installed
  iam                   IAM Policies for tmc resources                                  mission-control  v0.1.9   installed
  inspection            Inspection for tmc resources                                    mission-control  v0.1.9   installed
  integration           Get available integrations and their information from registry  mission-control  v0.1.9   installed
  management-cluster    A TMC registered Management cluster                             mission-control  v0.2.9   installed
  policy                Policy for tmc resources                                        mission-control  v0.1.9   installed
  provider-aks-cluster  Manage and unmanage tmc provider aks clusters                   mission-control  v0.1.10  installed
  provider-eks-cluster                                                                  mission-control  v0.1.9   installed
  secret                secret for tmc resources                                        mission-control  v0.1.9   installed
  setting               Setting plugin for tmc resources                                mission-control  v0.2.7   installed
  tanzupackage          Tanzupackage for tmc resources                                  mission-control  v0.2.8   installed
  workspace             A group of Kubernetes namespaces                                mission-control  v0.1.11  installed

[!] As shown above, some recommended plugins have not been installed or are outdated. To install them please run 'tanzu plugin sync'.

# Check the new help for the 'delete' command
$ tz plugin delete -h
Uninstall the specified plugin or specify 'all' to uninstall all plugins of a target

Usage:
tanzu plugin delete PLUGIN_NAME [flags]

Flags:
  -h, --help            help for delete
  -t, --target string   target of the plugin (kubernetes[k8s]/mission-control[tmc]/global)
  -y, --yes             delete the plugin without asking for confirmation

# Make sure 'all' cannot be used without '--target'
$ tz plugin delete all
[x] : the 'all' argument can only be used with the '--target' flag
$ tz plugin delete all --target ''
[x] : the 'all' argument can only be used with the '--target' flag

# Try to delete a single plugin (like before)
$ tz plugin delete cluster
[x] : unable to uniquely identify plugin 'cluster'. Please specify the target (kubernetes[k8s]/mission-control[tmc]/global) of the plugin using the `--target` flag

# Notice the new printout that specifies which plugin will be deleted.
# It was added because when using `all` it seemed a good thing to
# show the users all the plugins that were being uninstalled.
$ tz plugin delete cluster -t k8s
Deleting plugin 'cluster' for target 'kubernetes'. Are you sure? [y/N]: y
[i] Deleting plugin 'cluster' for target 'kubernetes'
[ok] successfully deleted plugin 'cluster'

# check the "cluster" plugin for the k8s target is no longer installed
$ tz plugin list
Standalone Plugins
  NAME       DESCRIPTION                                                 TARGET  VERSION  STATUS
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  global  v1.1.0   installed

Plugins from Context:  tkg1
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v0.30.1  not installed
  feature             Operate on features and featuregates  kubernetes  v0.30.1  installed
  kubernetes-release  Kubernetes release operations         kubernetes  v0.30.1  installed

Plugins from Context:  tmc
  NAME                  DESCRIPTION                                                     TARGET           VERSION  STATUS
  account               Account for tmc resources                                       mission-control  v0.1.10  installed
  agentartifacts        helm for tmc resources                                          mission-control  v0.1.9   installed
  aks-cluster           Manage and unmanage tmc aks clusters                            mission-control  v0.2.0   not installed
  apply                 Create/Update a resource with a resource file                   mission-control  v0.3.6   installed
  audit                 Run an audit request on an org                                  mission-control  v0.1.9   installed
  cluster                                                                               mission-control  v0.2.4   installed
  clustergroup          A group of Kubernetes clusters                                  mission-control  v0.1.9   installed
  continuousdelivery    Continuousdelivery for tmc resources                            mission-control  v0.1.9   installed
  data-protection       Data protection for tmc resources                               mission-control  v0.1.9   installed
  ekscluster                                                                            mission-control  v0.1.9   installed
  events                Events for any meaningful user activity or system state change  mission-control  v0.1.9   installed
  helm                  helm for tmc resources                                          mission-control  v0.1.9   installed
  iam                   IAM Policies for tmc resources                                  mission-control  v0.1.9   installed
  inspection            Inspection for tmc resources                                    mission-control  v0.1.9   installed
  integration           Get available integrations and their information from registry  mission-control  v0.1.9   installed
  management-cluster    A TMC registered Management cluster                             mission-control  v0.2.9   installed
  policy                Policy for tmc resources                                        mission-control  v0.1.9   installed
  provider-aks-cluster  Manage and unmanage tmc provider aks clusters                   mission-control  v0.1.10  installed
  provider-eks-cluster                                                                  mission-control  v0.1.9   installed
  secret                secret for tmc resources                                        mission-control  v0.1.9   installed
  setting               Setting plugin for tmc resources                                mission-control  v0.2.7   installed
  tanzupackage          Tanzupackage for tmc resources                                  mission-control  v0.2.8   installed
  workspace             A group of Kubernetes namespaces                                mission-control  v0.1.11  installed

[!] As shown above, some recommended plugins have not been installed or are outdated. To install them please run 'tanzu plugin sync'.

# Delete all plugins for the k8s target
$ tz plugin delete all -t k8s
All plugins for target 'kubernetes' will be deleted. Are you sure? [y/N]: y
[i] Deleting plugin 'kubernetes-release' for target 'kubernetes'
[i] Deleting plugin 'feature' for target 'kubernetes'
[ok] successfully deleted all plugins of target 'kubernetes'

# Check the list of installed plugins
$ tz plugin list
Standalone Plugins
  NAME       DESCRIPTION                                                 TARGET  VERSION  STATUS
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  global  v1.1.0   installed

Plugins from Context:  tkg1
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v0.30.1  not installed
  feature             Operate on features and featuregates  kubernetes  v0.30.1  not installed
  kubernetes-release  Kubernetes release operations         kubernetes  v0.30.1  not installed

Plugins from Context:  tmc
  NAME                  DESCRIPTION                                                     TARGET           VERSION  STATUS
  account               Account for tmc resources                                       mission-control  v0.1.10  installed
  agentartifacts        helm for tmc resources                                          mission-control  v0.1.9   installed
  aks-cluster           Manage and unmanage tmc aks clusters                            mission-control  v0.2.0   not installed
  apply                 Create/Update a resource with a resource file                   mission-control  v0.3.6   installed
  audit                 Run an audit request on an org                                  mission-control  v0.1.9   installed
  cluster                                                                               mission-control  v0.2.4   installed
  clustergroup          A group of Kubernetes clusters                                  mission-control  v0.1.9   installed
  continuousdelivery    Continuousdelivery for tmc resources                            mission-control  v0.1.9   installed
  data-protection       Data protection for tmc resources                               mission-control  v0.1.9   installed
  ekscluster                                                                            mission-control  v0.1.9   installed
  events                Events for any meaningful user activity or system state change  mission-control  v0.1.9   installed
  helm                  helm for tmc resources                                          mission-control  v0.1.9   installed
  iam                   IAM Policies for tmc resources                                  mission-control  v0.1.9   installed
  inspection            Inspection for tmc resources                                    mission-control  v0.1.9   installed
  integration           Get available integrations and their information from registry  mission-control  v0.1.9   installed
  management-cluster    A TMC registered Management cluster                             mission-control  v0.2.9   installed
  policy                Policy for tmc resources                                        mission-control  v0.1.9   installed
  provider-aks-cluster  Manage and unmanage tmc provider aks clusters                   mission-control  v0.1.10  installed
  provider-eks-cluster                                                                  mission-control  v0.1.9   installed
  secret                secret for tmc resources                                        mission-control  v0.1.9   installed
  setting               Setting plugin for tmc resources                                mission-control  v0.2.7   installed
  tanzupackage          Tanzupackage for tmc resources                                  mission-control  v0.2.8   installed
  workspace             A group of Kubernetes namespaces                                mission-control  v0.1.11  installed

[!] As shown above, some recommended plugins have not been installed or are outdated. To install them please run 'tanzu plugin sync'.

# Delete all plugins for the global target
$ tz plugin delete all -t global
All plugins for target 'global' will be deleted. Are you sure? [y/N]: y
[i] Deleting plugin 'telemetry' for target 'global'
[ok] successfully deleted all plugins of target 'global'

# Delete all plugins for the tmc target
$ tz plugin delete all -t tmc
[i] The tanzu cli essential plugins have not been installed and are being installed now. The install may take a few seconds.

All plugins for target 'mission-control' will be deleted. Are you sure? [y/N]: y
[i] Deleting plugin 'secret' for target 'mission-control'
[i] Deleting plugin 'provider-aks-cluster' for target 'mission-control'
[i] Deleting plugin 'workspace' for target 'mission-control'
[i] Deleting plugin 'account' for target 'mission-control'
[i] Deleting plugin 'agentartifacts' for target 'mission-control'
[i] Deleting plugin 'clustergroup' for target 'mission-control'
[i] Deleting plugin 'helm' for target 'mission-control'
[i] Deleting plugin 'iam' for target 'mission-control'
[i] Deleting plugin 'inspection' for target 'mission-control'
[i] Deleting plugin 'integration' for target 'mission-control'
[i] Deleting plugin 'policy' for target 'mission-control'
[i] Deleting plugin 'audit' for target 'mission-control'
[i] Deleting plugin 'cluster' for target 'mission-control'
[i] Deleting plugin 'continuousdelivery' for target 'mission-control'
[i] Deleting plugin 'events' for target 'mission-control'
[i] Deleting plugin 'provider-eks-cluster' for target 'mission-control'
[i] Deleting plugin 'setting' for target 'mission-control'
[i] Deleting plugin 'tanzupackage' for target 'mission-control'
[i] Deleting plugin 'apply' for target 'mission-control'
[i] Deleting plugin 'data-protection' for target 'mission-control'
[i] Deleting plugin 'ekscluster' for target 'mission-control'
[i] Deleting plugin 'management-cluster' for target 'mission-control'
[ok] successfully deleted all plugins of target 'mission-control'

# Check that only the essential plugin is installed
$ tz plugin list
Standalone Plugins
  NAME       DESCRIPTION                                                 TARGET  VERSION  STATUS
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  global  v1.1.0   installed

Plugins from Context:  tkg1
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v0.30.1  not installed
  feature             Operate on features and featuregates  kubernetes  v0.30.1  not installed
  kubernetes-release  Kubernetes release operations         kubernetes  v0.30.1  not installed

Plugins from Context:  tmc
  NAME                  DESCRIPTION                                                     TARGET           VERSION  STATUS
  account               Account for tmc resources                                       mission-control  v0.1.10  not installed
  agentartifacts        helm for tmc resources                                          mission-control  v0.1.9   not installed
  aks-cluster           Manage and unmanage tmc aks clusters                            mission-control  v0.2.0   not installed
  apply                 Create/Update a resource with a resource file                   mission-control  v0.3.6   not installed
  audit                 Run an audit request on an org                                  mission-control  v0.1.9   not installed
  cluster                                                                               mission-control  v0.2.4   not installed
  clustergroup          A group of Kubernetes clusters                                  mission-control  v0.1.9   not installed
  continuousdelivery    Continuousdelivery for tmc resources                            mission-control  v0.1.9   not installed
  data-protection       Data protection for tmc resources                               mission-control  v0.1.9   not installed
  ekscluster                                                                            mission-control  v0.1.9   not installed
  events                Events for any meaningful user activity or system state change  mission-control  v0.1.9   not installed
  helm                  helm for tmc resources                                          mission-control  v0.1.9   not installed
  iam                   IAM Policies for tmc resources                                  mission-control  v0.1.9   not installed
  inspection            Inspection for tmc resources                                    mission-control  v0.1.9   not installed
  integration           Get available integrations and their information from registry  mission-control  v0.1.9   not installed
  management-cluster    A TMC registered Management cluster                             mission-control  v0.2.9   not installed
  policy                Policy for tmc resources                                        mission-control  v0.1.9   not installed
  provider-aks-cluster  Manage and unmanage tmc provider aks clusters                   mission-control  v0.1.10  not installed
  provider-eks-cluster                                                                  mission-control  v0.1.9   not installed
  secret                secret for tmc resources                                        mission-control  v0.1.9   not installed
  setting               Setting plugin for tmc resources                                mission-control  v0.2.7   not installed
  tanzupackage          Tanzupackage for tmc resources                                  mission-control  v0.2.8   not installed
  workspace             A group of Kubernetes namespaces                                mission-control  v0.1.11  not installed

[!] As shown above, some recommended plugins have not been installed or are outdated. To install them please run 'tanzu plugin sync'.
```

Shell completion changes:
```
# Notice the 'all' completion as (always) the first one
$ tz plugin delete <TAB>
all                   -- All plugins for a target. You will need to use the --target flag.
account               -- Target: mission-control for account
aks-cluster           -- Target: mission-control for aks-cluster
apply                 -- Target: mission-control for apply
builder               -- Target: global for builder
cluster               -- Target: mission-control for cluster
continuousdelivery    -- Target: mission-control for continuousdelivery
iam                   -- Target: mission-control for iam
integration           -- Target: mission-control for integration
management-cluster    -- Target: mission-control for management-cluster
policy                -- Target: mission-control for policy
provider-eks-cluster  -- Target: mission-control for provider-eks-cluster
setting               -- Target: mission-control for setting
telemetry             -- Target: global for telemetry
workspace             -- Target: mission-control for workspace

$ tz plugin delete -t global <TAB>
all        -- All plugins of target global
builder    -- Target: global for builder
telemetry  -- Target: global for telemetry

# Automatically complete '--target' when using 'all'...
$ tz plugin delete all <TAB>
$ tz plugin delete all --target

# ... but not if --target is already on the command-line
$ tz plugin delete -t global all <TAB>

```
### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Allow a user to delete all plugins of a single target using `tanzu plugin delete all --target ...`
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

~The shell completion aspect of the `tanzu plugin delete` command will need to be adapted depending on which PR gets merged first, this PR or #513~ Done
