### PR TITLE
Update `tanzu context create --type` UX to align `--type` options with other commands

### DIFF
--- a/pkg/command/context_test.go
+++ b/pkg/command/context_test.go
@@ -793,12 +793,7 @@ var _ = Describe("create new context", func() {
 
 var _ = Describe("testing context use", func() {
 	const (
-		existingContext    = "test-mc"
-		testKubeContext    = "test-k8s-context"
-		testKubeConfigPath = "/fake/path/kubeconfig"
-		testContextName    = "fake-context-name"
-		fakeTMCEndpoint    = "https://cloud.vmware.com/auth"
-		fakeTAEEndpoint    = "https://fake.api.tanzu.cloud.vmware.com"
+		existingContext = "test-mc"
 	)
 	var (
 		tkgConfigFile   *os.File
@@ -1132,10 +1127,9 @@ func Test_completionContext(t *testing.T) {
 			test: "completion for the --type flag",
 			args: []string{"__complete", "context", "create", "--type", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: "mission-control\tContext for a Tanzu Mission Control endpoint\n" +
-				"application-engine\tContext for a Tanzu Application Engine endpoint\n" +
-				"k8s-cluster-endpoint\tContext for a Kubernetes Cluster endpoint\n" +
-				"k8s-local-kubeconfig\tContext using a Kubernetes local kubeconfig file\n" +
+			expected: "tmc\tContext for a Tanzu Mission Control endpoint\n" +
+				"tae\tContext for a Tanzu Application Engine endpoint\n" +
+				"k8s\tContext for a Kubernetes cluster\n" +
 				":4\n",
 		},
 		// =====================


### PR DESCRIPTION
### What this PR does / why we need it
This PR updates the `tanzu context create --type` UX (options) to align `--type` with other commands
Changes Summary:
- update the values of the --type flags to align with 3 context type values
- add another level of prompt when user only specifies --type kubernetes without any other flags.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
Tested with kubeconfig path kubecontext option provided
```
❯ ./bin/tanzu context create tkg-mgmt-vc --kubeconfig ~/temp/tkgCluster_admin.kfg --kubecontext tkg-mgmt-vc-admin@tkg-mgmt-vc
[ok] successfully created a kubernetes context using the kubeconfig /Users/pkalle/temp/tkgCluster_admin.kfg
[i] Checking for required plugins...
[i] All required plugins are already installed and up-to-date
```
Tested with TKG endpoint with pinniped
```
❯ ./bin/tanzu context create tkg-mgmt-vc-pin --endpoint  https://10.180.68.150:6443  --insecure-skip-tls-verify
[i] Could not get login banner from server, response code = 403
Log in by visiting this link:

    https://10.180.68.237/oauth2/authorize?access_type=offline&client_id=pinniped-cli&code_challenge=yzGTYuTmVYcmZ4d2TzAFHpw2-HqNpVIiIxmTVIh50QA&code_challenge_method=S256&nonce=0e4ee2e1bae20be363ef3c8b08fd2ffc&redirect_uri=http%3A%2F%2F127.0.0.1%3A52147%2Fcallback&response_mode=form_post&response_type=code&scope=offline_access+openid+pinniped%3Arequest-audience&state=c03c3d1d3ed2455aa017b2a79b22bed1

    Optionally, paste your authorization code: [...]

[ok] successfully created a kubernetes context using the kubeconfig /Users/pkalle/temp/tkgCluster_admin.kfg
[i] Checking for required plugins...
[!] unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually, error: 'unable to list plugins from discovery source 'default-tkg-mgmt-vc-pin': cliplugins.cli.tanzu.vmware.com is forbidden: User "pkalle" cannot list resource "cliplugins" in API group "cli.tanzu.vmware.com" at the cluster scope’
```
Tested creating TAE context with prompt option
```
❯ ./bin/tanzu context create --staging
? Select context creation type Application Engine
? Enter control plane endpoint https://ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com
? Give the context a name mytestTAE
[i] API token env var is set

[ok] successfully created a Application Engine(TAE) context
[i] Checking for required plugins...
[i] All required plugins are already installed and up-to-date
```
Tested when user provides —type as k8s and not provide --kubecontext or —endpoint to infer the right kubernetes context type, prompt should show up asking user for Kubernetes context type. 
```
❯ ./bin/tanzu context create  --type k8s
? Select the kubernetes context type  [Use arrows to move, type to filter]
❯ Kubernetes (Local Kubeconfig)
  Kubernetes (Cluster Endpoint)
## if user select the local kubeconfig CLI would prompt for the right options as shown below
❯ ./bin/tanzu context create  --type k8s
? Select the kubernetes context type Kubernetes (Local Kubeconfig)
? Enter path to kubeconfig (if any) /Users/pkalle/temp/tkgCluster_admin.kfg
? Enter kube context to use tkg-mgmt-vc-admin@tkg-mgmt-vc
? Give the context a name tkg-mgmt-vc
[ok] successfully created a kubernetes context using the kubeconfig /Users/pkalle/temp/tkgCluster_admin.kfg
[i] Checking for required plugins...
[i] All required plugins are already installed and up-to-date
```



<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Update "tanzu context create --type" UX to align "--type" options with other commands
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
