### PR TITLE
Add arch type to the output of "tanzu version"

### DIFF
--- a/pkg/command/version.go
+++ b/pkg/command/version.go
@@ -23,7 +23,9 @@ func newVersionCmd() *cobra.Command {
 		},
 		ValidArgsFunction: cobra.NoFileCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Printf("version: %s\nbuildDate: %s\nsha: %s\n", buildinfo.Version, buildinfo.Date, buildinfo.SHA)
+			fmt.Printf(
+				"version: %s\nbuildDate: %s\nsha: %s\narch: %s\n",
+				buildinfo.Version, buildinfo.Date, buildinfo.SHA, cli.GOARCH)
 			return nil
 		},
 	}

--- a/pkg/command/version_test.go
+++ b/pkg/command/version_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/buildinfo"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 )
 
 func readOutput(t *testing.T, r io.Reader, c chan<- []byte) {
@@ -45,10 +46,13 @@ func TestVersion(t *testing.T) {
 	buildinfo.Version = "1.2.3"
 	buildinfo.Date = "today"
 	buildinfo.SHA = "cafecafe"
+	originalArch := cli.GOARCH
+	cli.GOARCH = "amd64"
 	defer func() {
 		buildinfo.Version = ""
 		buildinfo.Date = ""
 		buildinfo.SHA = ""
+		cli.GOARCH = originalArch
 	}()
 
 	err = newVersionCmd().Execute()
@@ -56,7 +60,7 @@ func TestVersion(t *testing.T) {
 	w.Close()
 
 	got := <-c
-	expected := "version: 1.2.3\nbuildDate: today\nsha: cafecafe\n"
+	expected := "version: 1.2.3\nbuildDate: today\nsha: cafecafe\narch: amd64\n"
 	assert.Equal(expected, string(got))
 }
 


### PR DESCRIPTION
### What this PR does / why we need it

On Darwin ARM64 machines, the CLI can be run using either an ARM64 or and AMD64 build.  Showing the arch type in the output of `tanzu version` will help in troubleshooting.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

```
# build for ARM64
$ make build
build darwin-arm64 CLI with version: v1.1.0-dev
mkdir -p bin
cp /Users/kmarc/git/tanzu-cli/artifacts/darwin/arm64/cli/core/v1.1.0-dev/tanzu-cli-darwin_arm64 ./bin/tanzu
$ file bin/tanzu
bin/tanzu: Mach-O 64-bit executable arm64
$ bin/tanzu version
version: v1.1.0-dev
buildDate: 2023-10-12
sha: 1f176396a
arch: arm64

# Build for AMD64 
$ PATH=/usr/local/go/bin:$PATH make build
build darwin-amd64 CLI with version: v1.1.0-dev
mkdir -p bin
cp /Users/kmarc/git/tanzu-cli/artifacts/darwin/amd64/cli/core/v1.1.0-dev/tanzu-cli-darwin_amd64 ./bin/tanzu
$ file bin/tanzu
bin/tanzu: Mach-O 64-bit executable x86_64
$ bin/tanzu version
version: v1.1.0-dev
buildDate: 2023-10-12
sha: 1f176396a
arch: amd64
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Display the machine architecture of the CLI in the output of `tanzu version`
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
