### PR TITLE
Update `tanzu config set/unset` help message

### DIFF
--- a/pkg/command/config.go
+++ b/pkg/command/config.go
@@ -83,16 +83,16 @@ var getConfigCmd = &cobra.Command{
 }
 
 var setConfigCmd = &cobra.Command{
-	Use:               "set <path> <value>",
-	Short:             "Set config values at the given path",
-	Long:              "Set config values at the given path. path values: [unstable-versions, cli.edition, features.global.<feature>, features.<plugin>.<feature>, env.<variable>]",
+	Use:               "set PATH <value>",
+	Short:             "Set config values at the given PATH",
+	Long:              "Set config values at the given PATH. Supported PATH values: [features.global.<feature>, features.<plugin>.<feature>, env.<variable>]",
 	ValidArgsFunction: completeSetConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
-			return errors.Errorf("both path and value are required")
+			return errors.Errorf("both PATH and <value> are required")
 		}
 		if len(args) > 2 {
-			return errors.Errorf("only path and value are allowed")
+			return errors.Errorf("only PATH and <value> are allowed")
 		}
 
 		// Acquire tanzu config lock
@@ -322,16 +322,16 @@ var deleteServersCmd = &cobra.Command{
 }
 
 var unsetConfigCmd = &cobra.Command{
-	Use:               "unset <path>",
-	Short:             "Unset config values at the given path",
-	Long:              "Unset config values at the given path. path values: [features.global.<feature>, features.<plugin>.<feature>, env.global.<variable>, env.<plugin>.<variable>]",
+	Use:               "unset PATH",
+	Short:             "Unset config values at the given PATH",
+	Long:              "Unset config values at the given PATH. Supported PATH values: [features.global.<feature>, features.<plugin>.<feature>, env.<variable>]",
 	ValidArgsFunction: completeUnsetConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
-			return errors.Errorf("path is required")
+			return errors.Errorf("PATH is required")
 		}
 		if len(args) > 1 {
-			return errors.Errorf("only path is allowed")
+			return errors.Errorf("only PATH is allowed")
 		}
 
 		return unsetConfiguration(args[0])

--- a/test/e2e/config/config_init_feature_flag_test.go
+++ b/test/e2e/config/config_init_feature_flag_test.go
@@ -79,4 +79,16 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:config]", func() {
 			})
 		})
 	})
+	Context("config help message", func() {
+		It("validate `config set --help` output", func() {
+			stdout, _, err := tf.Config.ConfigWithOptions(framework.AddAdditionalFlagAndValue("set --help"))
+			Expect(err).To(BeNil())
+			Expect(stdout.String()).To(ContainSubstring("Set config values at the given PATH. Supported PATH values: [features.global.<feature>, features.<plugin>.<feature>, env.<variable>]"))
+		})
+		It("validate `config unset --help` output", func() {
+			stdout, _, err := tf.Config.ConfigWithOptions(framework.AddAdditionalFlagAndValue("unset --help"))
+			Expect(err).To(BeNil())
+			Expect(stdout.String()).To(ContainSubstring("Unset config values at the given PATH. Supported PATH values: [features.global.<feature>, features.<plugin>.<feature>, env.<variable>]"))
+		})
+	})
 })

--- a/test/e2e/framework/config_lifecycle_operations.go
+++ b/test/e2e/framework/config_lifecycle_operations.go
@@ -4,6 +4,7 @@
 package framework
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -25,6 +26,8 @@ const (
 
 // ConfigLifecycleOps performs "tanzu config" command operations
 type ConfigLifecycleOps interface {
+	// ConfigWithOptions performs config command with given options
+	ConfigWithOptions(opts ...E2EOption) (stdOut, stdErr *bytes.Buffer, err error)
 	// ConfigSetFeatureFlag sets the tanzu config feature flag
 	ConfigSetFeatureFlag(path, value string, opts ...E2EOption) error
 	// ConfigGetFeatureFlag gets the tanzu config feature flag
@@ -99,6 +102,11 @@ func (co *configOps) ConfigSetFeatureFlag(path, value string, opts ...E2EOption)
 	confSetCmd := ConfigSet + path + " " + value
 	_, _, err = co.cmdExe.TanzuCmdExec(confSetCmd, opts...)
 	return err
+}
+
+// ConfigWithOptions performs config command with given options
+func (co *configOps) ConfigWithOptions(opts ...E2EOption) (stdOut, stdErr *bytes.Buffer, err error) {
+	return co.cmdExe.TanzuCmdExec(ConfigCmd, opts...)
 }
 
 // ConfigGetFeatureFlag gets the given tanzu config feature flag

--- a/test/e2e/framework/framework_constants.go
+++ b/test/e2e/framework/framework_constants.go
@@ -21,6 +21,7 @@ const (
 	TzPrefix         = "tz"
 
 	// Config commands
+	ConfigCmd          = "%s config"
 	ConfigSet          = "%s config set "
 	ConfigGet          = "%s config get "
 	ConfigUnset        = "%s config unset "


### PR DESCRIPTION
### What this PR does / why we need it
As part of this pull request, the tanzu config set and tanzu config unset commands' --help messages have been updated to be consistent with the help messages of all other Tanzu Core commands.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
- E2E tests are added
Before Fix
```
❯ tanzu config set --help
Set config values at the given path. path values: [unstable-versions, cli.edition, features.global.<feature>, features.<plugin>.<feature>, env.<variable>]

Usage:
tanzu config set <path> <value> [flags]

Flags:
  -h, --help   help for set
❯ tanzu config unset --help
Unset config values at the given path. path values: [features.global.<feature>, features.<plugin>.<feature>, env.global.<variable>, env.<plugin>.<variable>]

Usage:
tanzu config unset <path> [flags]

Flags:
  -h, --help   help for unset
❯ 
```
After the fix
```
❯ t config set --help  
Set config values at the given PATH. Supported PATH values: [features.global.<feature>, features.<plugin>.<feature>, env.<variable>]

Usage:
tanzu config set PATH <value> [flags]

Flags:
  -h, --help   help for set
❯ t config unset --help
Unset config values at the given PATH. Supported PATH values: [features.global.<feature>, features.<plugin>.<feature>, env.<variable>]

Usage:
tanzu config unset PATH [flags]

Flags:
  -h, --help   help for unset
❯ 
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
`tanzu config set` and `tanzu config unset` commands `--help` messages are updated.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
