### PR TITLE
fix for interface conversion at metrics helper

### DIFF
--- a/pkg/telemetry/metrics_helper.go
+++ b/pkg/telemetry/metrics_helper.go
@@ -61,7 +61,7 @@ func hashString(str string) string {
 func computeEndpointSHAForTAEContext(ctx *configtypes.Context) string {
 	var orgID, project, space string
 	if ctx.AdditionalMetadata[tae.OrgIDKey] != nil {
-		orgID = ctx.AdditionalMetadata[tae.ProjectNameKey].(string)
+		orgID = ctx.AdditionalMetadata[tae.OrgIDKey].(string)
 	}
 	if ctx.AdditionalMetadata[tae.ProjectNameKey] != nil {
 		project = ctx.AdditionalMetadata[tae.ProjectNameKey].(string)


### PR DESCRIPTION
### What this PR does / why we need it
PR fixes a interface conversion issue that was causing the plugin commands to fail with error `interface conversion: interface {} is nil, not string` when the user has just orgID as the active context.
Tanzu CLI version : `1.1.0-alpha.0`

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

make test was successful. Also validated the changes in local with just OrgId as active context.
![image](https://github.com/vmware-tanzu/tanzu-cli/assets/108013945/3fcb7c87-b506-4e73-9f7e-86cc8d8aac47)

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->

Upon running plugin commands core CLI was throwing error below

```
panic: interface conversion: interface {} is nil, not string

goroutine 1 [running]:
github.com/vmware-tanzu/tanzu-cli/pkg/telemetry.computeEndpointSHAForTAEContext(0x1400010d980)
	/go/src/cayman_tanzu-cli/tanzu-cli/src/pkg/telemetry/metrics_helper.go:64 +0x1f8
github.com/vmware-tanzu/tanzu-cli/pkg/telemetry.computeEndpointSHAForContext(0x14001607ae0?, {0x14001308816?, 0x14001607b28?})
	/go/src/cayman_tanzu-cli/tanzu-cli/src/pkg/telemetry/metrics_helper.go:41 +0xa0
github.com/vmware-tanzu/tanzu-cli/pkg/telemetry.getEndpointSHA(0x14000d84ab0)
	/go/src/cayman_tanzu-cli/tanzu-cli/src/pkg/telemetry/metrics_helper.go:27 +0x54
github.com/vmware-tanzu/tanzu-cli/pkg/telemetry.(*telemetryClient).updateMetricsForPlugin(0x1400068e9c0, 0x14000d86600, {0x14000d834d0, 0x1, 0x1}, {0x140005ce450?, 0x10602349b?})
	/go/src/cayman_tanzu-cli/tanzu-cli/src/pkg/telemetry/client.go:221 +0x268
github.com/vmware-tanzu/tanzu-cli/pkg/telemetry.(*telemetryClient).UpdateCmdPreRunMetrics(0x14001607c98?, 0x14000d86600, {0x14000d834d0, 0x1, 0x1})
	/go/src/cayman_tanzu-cli/tanzu-cli/src/pkg/telemetry/client.go:116 +0x258
github.com/vmware-tanzu/tanzu-cli/pkg/command.newRootCmd.func1(0x14001607d68?, {0x14000d834d0, 0x1, 0x1})
	/go/src/cayman_tanzu-cli/tanzu-cli/src/pkg/command/root.go:145 +0x60
github.com/spf13/cobra.(*Command).execute(0x14000d86600, {0x14000d834d0, 0x1, 0x1})
	/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:915 +0x4fc
github.com/spf13/cobra.(*Command).ExecuteC(0x1400062cc00)
	/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x35c
github.com/spf13/cobra.(*Command).Execute(...)
	/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
github.com/vmware-tanzu/tanzu-cli/pkg/command.Execute()
	/go/src/cayman_tanzu-cli/tanzu-cli/src/pkg/command/root.go:369 +0x28
main.main()
	/go/src/cayman_tanzu-cli/tanzu-cli/src/cmd/tanzu/main.go:15 +0x1c
```

