### PR TITLE
Use `uninstall` as a `tanzu plugin delete` alternative and make it primary command

### DIFF
--- a/docs/full/cli-architecture.md
+++ b/docs/full/cli-architecture.md
@@ -108,7 +108,7 @@ tanzu <plugin> info
 To remove a plugin:
 
 ```sh
-tanzu plugin delete <plugin-name>
+tanzu plugin uninstall <plugin-name>
 ```
 
 ## Context

--- a/docs/quickstart/quickstart.md
+++ b/docs/quickstart/quickstart.md
@@ -241,7 +241,7 @@ plugin was previously installed through a legacy version of the CLI.
 If the user needs to continue using any legacy Tanzu CLI for a while,
 it is preferable to keep the `login` plugin installed, as it is needed
 for such CLIs.  Once the user no longer needs any legacy CLI, they
-can run `tanzu plugin delete login` to remove this plugin for the new CLI.
+can run `tanzu plugin uninstall login` to remove this plugin for the new CLI.
 
 The second change to the `tanzu login` command is that it is now deprecated
 and therefore no longer shown in the help text when running `tanzu -h`.

--- a/pkg/command/plugin.go
+++ b/pkg/command/plugin.go
@@ -343,8 +343,9 @@ func newUpgradePluginCmd() *cobra.Command {
 
 func newDeletePluginCmd() *cobra.Command {
 	var deleteCmd = &cobra.Command{
-		Use:               "delete " + pluginNameCaps,
-		Short:             "Delete a plugin",
+		Use:               "uninstall " + pluginNameCaps,
+		Aliases:           []string{"delete"},
+		Short:             "Uninstall a plugin",
 		Long:              "Uninstall the specified plugin or specify 'all' to uninstall all plugins of a target",
 		ValidArgsFunction: completeDeletePlugin,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/pkg/command/plugin.go
+++ b/pkg/command/plugin.go
@@ -89,7 +89,7 @@ func newPluginCmd() *cobra.Command {
 	installPluginCmd.Flags().StringVarP(&version, "version", "v", cli.VersionLatest, "version of the plugin")
 	utils.PanicOnErr(installPluginCmd.RegisterFlagCompletionFunc("version", completePluginVersions))
 
-	deletePluginCmd.Flags().BoolVarP(&forceDelete, "yes", "y", false, "delete the plugin without asking for confirmation")
+	deletePluginCmd.Flags().BoolVarP(&forceDelete, "yes", "y", false, "uninstall the plugin without asking for confirmation")
 
 	completeTargets := func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{compGlobalTarget, compK8sTarget, compTMCTarget}, cobra.ShellCompDirectiveNoFileComp
@@ -377,9 +377,9 @@ func newDeletePluginCmd() *cobra.Command {
 			}
 
 			if pluginName == cli.AllPlugins {
-				log.Successf("successfully deleted all plugins of target '%s'", target)
+				log.Successf("successfully uninstalled all plugins of target '%s'", target)
 			} else {
-				log.Successf("successfully deleted plugin '%s'", pluginName)
+				log.Successf("successfully uninstalled plugin '%s'", pluginName)
 			}
 			return nil
 		},

--- a/pkg/command/plugin_test.go
+++ b/pkg/command/plugin_test.go
@@ -318,7 +318,7 @@ func TestDeletePlugin(t *testing.T) {
 						assert.Equal(false, exists)
 					}
 
-					// tanzu plugin delete does not remove the binary
+					// tanzu plugin uninstall does not remove the binary
 					_, err := os.Stat(filepath.Join(dir, fmt.Sprintf("%s_%s", spec.plugins[i], string(spec.targets[i]))))
 					assert.Nil(err)
 				}
@@ -693,11 +693,11 @@ func TestCompletionPlugin(t *testing.T) {
 			expected: ":4\n",
 		},
 		// =====================
-		// tanzu plugin delete
+		// tanzu plugin uninstall
 		// =====================
 		{
-			test: "completion for the plugin delete command",
-			args: []string{"__complete", "plugin", "delete", ""},
+			test: "completion for the plugin uninstall command",
+			args: []string{"__complete", "plugin", "uninstall", ""},
 			// ":36" is the value of the ShellCompDirectiveNoFileComp | ShellCompDirectiveKeepOrder
 			expected: "all\tAll plugins for a target. You will need to use the --target flag.\n" +
 				"cluster\tMultiple entries for plugin cluster. You will need to use the --target flag.\n" +
@@ -707,8 +707,8 @@ func TestCompletionPlugin(t *testing.T) {
 				":36\n",
 		},
 		{
-			test: "completion for the plugin delete command using --target",
-			args: []string{"__complete", "plugin", "delete", "--target", "k8s", ""},
+			test: "completion for the plugin uninstall command using --target",
+			args: []string{"__complete", "plugin", "uninstall", "--target", "k8s", ""},
 			// ":36" is the value of the ShellCompDirectiveNoFileComp | ShellCompDirectiveKeepOrder
 			expected: "all\tAll plugins of target kubernetes\n" +
 				"cluster\tTarget: kubernetes for cluster\n" +

--- a/pkg/pluginmanager/manager.go
+++ b/pkg/pluginmanager/manager.go
@@ -954,19 +954,19 @@ func DeletePlugin(options DeletePluginOptions) error {
 	if !options.ForceDelete {
 		if options.PluginName == cli.AllPlugins {
 			if options.Target == configtypes.TargetUnknown {
-				if err := component.AskForConfirmation("All plugins will be deleted. Are you sure?"); err != nil {
+				if err := component.AskForConfirmation("All plugins will be uninstalled. Are you sure?"); err != nil {
 					return err
 				}
 			} else {
 				if err := component.AskForConfirmation(
-					fmt.Sprintf("All plugins for target '%s' will be deleted. Are you sure?",
+					fmt.Sprintf("All plugins for target '%s' will be uninstalled. Are you sure?",
 						string(options.Target))); err != nil {
 					return err
 				}
 			}
 		} else {
 			if err := component.AskForConfirmation(
-				fmt.Sprintf("Deleting plugin '%s' for target '%s'. Are you sure?",
+				fmt.Sprintf("Uninstalling plugin '%s' for target '%s'. Are you sure?",
 					options.PluginName, string(uniqueTarget))); err != nil {
 				return err
 			}
@@ -1014,7 +1014,7 @@ func doDeletePluginsFromCatalog(plugins []cli.PluginInfo) error {
 	}
 
 	for i := range plugins {
-		log.Infof("Deleting plugin '%s' for target '%s'", plugins[i].Name, plugins[i].Target)
+		log.Infof("Uninstalling plugin '%s' for target '%s'", plugins[i].Name, plugins[i].Target)
 	}
 	return kerrors.NewAggregate(errList)
 }

--- a/test/e2e/plugin_lifecycle/plugin_lifecycle_test.go
+++ b/test/e2e/plugin_lifecycle/plugin_lifecycle_test.go
@@ -263,11 +263,11 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-lifecycle]", func(
 			Expect(err).To(BeNil())
 			Expect(out).To(ContainSubstring("tanzu plugin upgrade PLUGIN_NAME [flags]"))
 		})
-		// Test case: d. plugin delete help message
-		It("tanzu plugin delete help message", func() {
-			out, _, err := tf.PluginCmd.RunPluginCmd("delete -h")
+		// Test case: d. plugin uninstall help message
+		It("tanzu plugin uninstall help message", func() {
+			out, _, err := tf.PluginCmd.RunPluginCmd("uninstall -h")
 			Expect(err).To(BeNil())
-			Expect(out).To(ContainSubstring("tanzu plugin delete PLUGIN_NAME [flags]"))
+			Expect(out).To(ContainSubstring("tanzu plugin uninstall PLUGIN_NAME [flags]"))
 		})
 	})
 


### PR DESCRIPTION
### What this PR does / why we need it

* This PR uses `tanzu plugin uninstall` as a primary command to delete the installed tanzu cli plugin.
* Note: The `tanzu plugin delete` command still works as `delete` is now configured as an alias for this command.
* Updated help text:
```
$ tz plugin uninstall --help
Uninstall the specified plugin or specify 'all' to uninstall all plugins of a target

Usage:
tanzu plugin uninstall PLUGIN_NAME [flags]

Aliases:
  uninstall, delete

Flags:
  -h, --help            help for uninstall
  -t, --target string   target of the plugin (kubernetes[k8s]/mission-control[tmc]/global)
  -y, --yes             uninstall the plugin without asking for confirmation
```

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
```
$ tz plugin --help
Provides all lifecycle operations for plugins

Usage:
  tanzu plugin [command]

Available Commands:
  clean           Clean the plugins
  describe        Describe a plugin
  download-bundle Download plugin bundle to the local system
  group           Manage plugin-groups
  install         Install a plugin
  list            List installed plugins
  search          Search for available plugins
  source          Manage plugin discovery sources
  sync            Installs all plugins recommended by the active contexts
  uninstall       Uninstall a plugin
  upgrade         Upgrade a plugin
  upload-bundle   Upload plugin bundle to a repository

Flags:
  -h, --help   help for plugin

Use "tanzu plugin [command] --help" for more information about a command.
```

```
$ tz plugin list
Standalone Plugins
  NAME       DESCRIPTION                                                 TARGET      VERSION  STATUS     
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  global      v1.1.0   installed  
  package    Tanzu package management                                    kubernetes  v0.31.0  installed  
```
```
$ tz plugin uninstall package
Uninstalling plugin 'package' for target 'kubernetes'. Are you sure? [y/N]: y
[i] Uninstalling plugin 'package' for target 'kubernetes'
[ok] successfully deleted plugin 'package'
```
```
$ tz plugin uninstall --help
Uninstall the specified plugin or specify 'all' to uninstall all plugins of a target

Usage:
tanzu plugin uninstall PLUGIN_NAME [flags]

Aliases:
  uninstall, delete

Flags:
  -h, --help            help for uninstall
  -t, --target string   target of the plugin (kubernetes[k8s]/mission-control[tmc]/global)
  -y, --yes             uninstall the plugin without asking for confirmation
```
```
$ tz plugin delete telemetry
Uninstalling plugin 'telemetry' for target 'global'. Are you sure? [y/N]: y
[i] Uninstalling plugin 'telemetry' for target 'global'
[ok] successfully uninstalled plugin 'telemetry'
```
```
$ tz plugin list
[i] The tanzu cli essential plugins have not been installed and are being installed now. The install may take a few seconds.

Standalone Plugins
  NAME       DESCRIPTION                                                 TARGET  VERSION  STATUS     
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  global  v1.1.0   installed
```
```  
$ tz plugin uninstall --help
Uninstall the specified plugin or specify 'all' to uninstall all plugins of a target

Usage:
tanzu plugin uninstall PLUGIN_NAME [flags]

Aliases:
  uninstall, delete

Flags:
  -h, --help            help for uninstall
  -t, --target string   target of the plugin (kubernetes[k8s]/mission-control[tmc]/global)
  -y, --yes             uninstall the plugin without asking for confirmation
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Use the `tanzu plugin uninstall` command as a `tanzu plugin delete` alternative
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
