### PR TITLE
Update telemetry metrics collection to account for application-engine context type 

### DIFF
--- a/pkg/telemetry/client.go
+++ b/pkg/telemetry/client.go
@@ -222,7 +222,7 @@ func (tc *telemetryClient) updateMetricsForPlugin(cmd *cobra.Command, args []str
 		tc.currentOperationMetrics.PluginName = plugin.Name
 		tc.currentOperationMetrics.PluginVersion = plugin.Version
 		tc.currentOperationMetrics.Target = string(plugin.Target)
-		tc.currentOperationMetrics.Endpoint = getEndpointSHA(plugin)
+		tc.currentOperationMetrics.Endpoint = getEndpointSHAWithCtxTypePrefix(plugin)
 		// for plugins, cobra can only parse the command upto the plugin name,
 		// and the rest of the subcommands and args would be captured as args
 		// ex: tanzu cluster kubeconfig get testCluster --export-file /path/to/file

--- a/pkg/telemetry/client_test.go
+++ b/pkg/telemetry/client_test.go
@@ -158,7 +158,7 @@ var _ = Describe("Unit tests for UpdateCmdPreRunMetrics()", func() {
 
 			})
 		})
-		Context("when the core command (not requiring hashed values) has arguments and flags provided", func() {
+		Context("when the core command (not requiring hashed values for args and flags) has arguments and flags provided", func() {
 			It("should return success and the metrics should have name arg(first argument) hashed and flags values should be hashed", func() {
 				// change the command name to "plugin" since CLI wouldn't hash the flag values for plugin LCM commands
 				cmd.Use = "plugin"
@@ -175,7 +175,7 @@ var _ = Describe("Unit tests for UpdateCmdPreRunMetrics()", func() {
 				Expect(err).ToNot(HaveOccurred())
 				metricsPayload := tc.currentOperationMetrics
 				Expect(metricsPayload.CommandName).To(Equal("plugin"))
-				Expect(metricsPayload.NameArg).To(Equal(hashString("arg1")))
+				Expect(metricsPayload.NameArg).To(Equal("arg1"))
 				Expect(metricsPayload.CliID).ToNot(BeEmpty())
 				Expect(metricsPayload.StartTime.IsZero()).To(BeFalse())
 

--- a/pkg/telemetry/metrics_helper_test.go
+++ b/pkg/telemetry/metrics_helper_test.go
@@ -1,0 +1,136 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package telemetry
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/otiai10/copy"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
+	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
+	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
+	taert "github.com/vmware-tanzu/tanzu-plugin-runtime/tae"
+)
+
+var _ = Describe("metrics helper tests", func() {
+	var (
+		configFile   *os.File
+		configFileNG *os.File
+		err          error
+	)
+	const (
+		testProjectName = "project-A"
+		testSpaceName   = "space-A"
+	)
+	BeforeEach(func() {
+		configFile, err = os.CreateTemp("", "config")
+		Expect(err).To(BeNil())
+		err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config.yaml"), configFile.Name())
+		Expect(err).To(BeNil(), "Error while copying tanzu config file for testing")
+		os.Setenv("TANZU_CONFIG", configFile.Name())
+
+		configFileNG, err = os.CreateTemp("", "config_ng")
+		Expect(err).To(BeNil())
+		os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
+		err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config_ng.yaml"), configFileNG.Name())
+		Expect(err).To(BeNil(), "Error while copying tanzu-ng config file for testing")
+	})
+	AfterEach(func() {
+		os.Unsetenv("TANZU_CONFIG")
+		os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
+		os.RemoveAll(configFile.Name())
+		os.RemoveAll(configFileNG.Name())
+	})
+
+	Context("when the plugin target is k8s and the current active context is of type 'kubernetes'", func() {
+		It("should return the hash of kubernetes active context prefixed with 'kubernetes'", func() {
+			pluginInfo := &cli.PluginInfo{
+				Name:    "k8s-plugin",
+				Version: "1.0.0",
+				Target:  configtypes.TargetK8s,
+			}
+			epHashStr := getEndpointSHAWithCtxTypePrefix(pluginInfo)
+			Expect(epHashStr).ToNot(BeEmpty())
+
+			ctx, err := configlib.GetActiveContext(configtypes.ContextTypeK8s)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(epHashStr).To(Equal(string(configtypes.ContextTypeK8s) + ":" + computeEndpointSHAForK8sContext(ctx)))
+		})
+	})
+	Context("when the plugin target is k8s and the current active context is of type 'application-engine'", func() {
+		It("should return the hash of application-engine active context prefixed with 'application-engine'", func() {
+			pluginInfo := &cli.PluginInfo{
+				Name:    "k8s-plugin",
+				Version: "1.0.0",
+				Target:  configtypes.TargetK8s,
+			}
+			// when TAE context has active org
+			ctx, err := configlib.GetContext("test-tae-context")
+			Expect(err).ToNot(HaveOccurred())
+			ctx.AdditionalMetadata[taert.ProjectNameKey] = ""
+			ctx.AdditionalMetadata[taert.SpaceNameKey] = ""
+			err = configlib.SetContext(ctx, true)
+			Expect(err).ToNot(HaveOccurred())
+
+			epHashStr := getEndpointSHAWithCtxTypePrefix(pluginInfo)
+			Expect(epHashStr).ToNot(BeEmpty())
+			Expect(epHashStr).To(Equal(string(configtypes.ContextTypeTAE) + ":" + computeEndpointSHAForTAEContext(ctx)))
+
+			// when TAE context has active project
+			ctx.AdditionalMetadata[taert.ProjectNameKey] = testProjectName
+			ctx.AdditionalMetadata[taert.SpaceNameKey] = ""
+			err = configlib.SetContext(ctx, true)
+			Expect(err).ToNot(HaveOccurred())
+
+			epHashStr = getEndpointSHAWithCtxTypePrefix(pluginInfo)
+			Expect(epHashStr).ToNot(BeEmpty())
+			Expect(epHashStr).To(Equal(string(configtypes.ContextTypeTAE) + ":" + computeEndpointSHAForTAEContext(ctx)))
+
+			// when TAE context has active space
+			ctx.AdditionalMetadata[taert.ProjectNameKey] = testProjectName
+			ctx.AdditionalMetadata[taert.SpaceNameKey] = testSpaceName
+			err = configlib.SetContext(ctx, true)
+			Expect(err).ToNot(HaveOccurred())
+
+			epHashStr = getEndpointSHAWithCtxTypePrefix(pluginInfo)
+			Expect(epHashStr).ToNot(BeEmpty())
+			Expect(epHashStr).To(Equal(string(configtypes.ContextTypeTAE) + ":" + computeEndpointSHAForTAEContext(ctx)))
+		})
+	})
+	Context("when the plugin target is k8s and there is no active context of type kubernetes/application-engine", func() {
+		It("should return the empty string", func() {
+			pluginInfo := &cli.PluginInfo{
+				Name:    "k8s-plugin",
+				Version: "1.0.0",
+				Target:  configtypes.TargetK8s,
+			}
+			// remove the active contexts of type k8s
+			err := configlib.RemoveActiveContext(configtypes.ContextTypeK8s)
+			Expect(err).ToNot(HaveOccurred())
+
+			epHashStr := getEndpointSHAWithCtxTypePrefix(pluginInfo)
+			Expect(epHashStr).To(BeEmpty())
+		})
+	})
+	Context("when the plugin target is mission-control and the current active context is of context type 'mission-control'", func() {
+		It("should return the hash of mission-control active context prefixed with 'mission-control'", func() {
+			pluginInfo := &cli.PluginInfo{
+				Name:    "tmc-plugin",
+				Version: "1.0.0",
+				Target:  configtypes.TargetTMC,
+			}
+			epHashStr := getEndpointSHAWithCtxTypePrefix(pluginInfo)
+			Expect(epHashStr).ToNot(BeEmpty())
+
+			ctx, err := configlib.GetActiveContext(configtypes.ContextTypeTMC)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(epHashStr).To(Equal(string(configtypes.ContextTypeTMC) + ":" + computeEndpointSHAForTMCContext(ctx)))
+		})
+	})
+})


### PR DESCRIPTION
### What this PR does / why we need it
This PR updates telemetry metrics collection to account for application-engine context type and also fixed the issue to unmask the plugin name in  "tanzu plugin"  subcommands.

Changes Summary:
- updated telemetry metrics collection to account for application-engine context type
- fixed the issue to unmask the plugin name in  "tanzu plugin"  subcommands.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Tested the telemetry collection with plugin install command and could see the plugin name is not hashed out and is visible in clear text
```
Before change
❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db "select * from tanzu_cli_operations;"
cli_version|os_name|os_arch|plugin_name|plugin_version|command|cli_id|command_start_ts|command_end_ts|target|name_arg|endpoint|flags|exit_status|is_internal|error
v1.1.0-dev|darwin|amd64|||plugin install|7dbe3b36-f07b-4206-bd77-0f7728e75cc2|1697498867263|1697498869535||25adc7841d0262f21255d6823db9edeceedba68078a89a5be3829ac75b556c40||{"version":"v0.28.0"}|0|0|

After change
❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db
select * from tanzu_cli_operations;
cli_version|os_name|os_arch|plugin_name|plugin_version|command|cli_id|command_start_ts|command_end_ts|target|name_arg|endpoint|flags|exit_status|is_internal|error
v1.1.0-dev|darwin|amd64|||plugin install|7dbe3b36-f07b-4206-bd77-0f7728e75cc2|1697497996453|1697498009167||management-cluster||{"version":"v0.28.0"}|0|0|
```

Tested with TMC context type and ran the TMC plugin command and the validated the metrics data has endpoint prefixed with `mission-control`
```
❯ rm ~/.config/tanzu-cli-telemetry/cli_metrics.db
❯ ./bin/tanzu context use mytmc2
[i] Checking for required plugins...
[i] Installing plugin 'events:v0.1.11' with target 'mission-control'
[i] Installing plugin 'cluster:v0.2.6' with target 'mission-control’

❯ ./bin/tanzu tmc cluster list
  NAME                                                                                      MANAGEMENTCLUSTER  PROVISIONER  LABELS
  111                                                                                       attached           attached     tmc.cloud.vmware.com/creator:lmarzocco
  54535435                                                                                  attached           attached     tmc.cloud.vmware.com/creator:yoanag
❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db "select * from tanzu_cli_operations;"
cli_version|os_name|os_arch|plugin_name|plugin_version|command|cli_id|command_start_ts|command_end_ts|target|name_arg|endpoint|flags|exit_status|is_internal|error
v1.1.0-dev|darwin|amd64|||context list|7dbe3b36-f07b-4206-bd77-0f7728e75cc2|1697670160199|1697670160279|||||0|0|
v1.1.0-dev|darwin|amd64|||context use|7dbe3b36-f07b-4206-bd77-0f7728e75cc2|1697670513810|1697670711919||ea4b4e217d8b707390635ffcf09aecd77a17d7c538f7becfe8e39dfa1bdeeb7b|||0|0|
v1.1.0-dev|darwin|amd64|cluster|v0.2.6|mission-control cluster list|7dbe3b36-f07b-4206-bd77-0f7728e75cc2|1697670729649|1697670730218|mission-control||mission-control:8987548e08bb9b23db8920c2e6f5d417977b1ca8350c66737cdd48ac3f1f26c4||0|0|

```
Ran the test to use the k8s context created for TKG management cluster and ran the `tanzu mc get` command. Verified the metrics endpoint is suffixed with kubernetes.
```
❯ ./bin/tanzu context use tkg-mgmt-vc
[i] Checking for required plugins...
[i] All required plugins are already installed and up-to-date

❯ ./bin/tanzu mc get --show-details
  NAME         NAMESPACE   STATUS   CONTROLPLANE  WORKERS  KUBERNETES        ROLES       PLAN  TKR
  tkg-mgmt-vc  tkg-system  running  1/1           1/1      v1.24.9+vmware.1  management  dev   v1.24.9---vmware.1-tkg.1
<SNAPPED>

❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db "select * from tanzu_cli_operations;"
cli_version|os_name|os_arch|plugin_name|plugin_version|command|cli_id|command_start_ts|command_end_ts|target|name_arg|endpoint|flags|exit_status|is_internal|error
v1.1.0-dev|darwin|amd64|||context use|7dbe3b36-f07b-4206-bd77-0f7728e75cc2|1697671107503|1697671108974||86fde1e81453c0fa397ddee030f932e2e6e4f2a06fc49e53b23bda225860b3a8|||0|0|
v1.1.0-dev|darwin|amd64|management-cluster|v0.28.0|management-cluster get|7dbe3b36-f07b-4206-bd77-0f7728e75cc2|1697671113440|1697671116324|kubernetes||kubernetes:96b91a0440319a9cc5ff30d7f4eb056fce3bd64e4025afb16be03b71238318f1|{"show-details":""}|0|0|
```


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Updated telemetry metrics collection to account for application-engine context type. Also, fixed the issue to ignore hashing the plugin name as args in "tanzu plugin" subcommand 
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
