### PR TITLE
Add ActiveHelp when no completions are provided

### DIFF
--- a/pkg/command/ceip_participation.go
+++ b/pkg/command/ceip_participation.go
@@ -74,7 +74,7 @@ func newCEIPParticipationGetCmd() *cobra.Command {
 		Use:               "get",
 		Short:             "Get the current CEIP opt-in status (subject to change)",
 		Long:              "Get the current CEIP opt-in status (subject to change)",
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction: noMoreCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			optInVal, err := configlib.GetCEIPOptIn()
 			if err != nil {
@@ -98,7 +98,7 @@ func newCEIPParticipationGetCmd() *cobra.Command {
 
 func completeCeipSet(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) > 0 {
-		return nil, cobra.ShellCompDirectiveNoFileComp
+		return activeHelpNoMoreArgs(nil), cobra.ShellCompDirectiveNoFileComp
 	}
 
 	// Keep the "true" choice first by using ShellCompDirectiveKeepOrder (may not work for all shells)

--- a/pkg/command/ceip_participation_test.go
+++ b/pkg/command/ceip_participation_test.go
@@ -137,7 +137,7 @@ func TestCompletionCeip(t *testing.T) {
 			test: "no completion after the first arg for the ceip set command",
 			args: []string{"__complete", "ceip", "set", "true", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		// =====================
 		// tanzu ceip get
@@ -146,7 +146,7 @@ func TestCompletionCeip(t *testing.T) {
 			test: "no completion for the ceip get command",
 			args: []string{"__complete", "ceip", "get", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 	}
 

--- a/pkg/command/cert.go
+++ b/pkg/command/cert.go
@@ -94,7 +94,7 @@ func newListCertCmd() *cobra.Command {
 	var listCertsCmd = &cobra.Command{
 		Use:               "list",
 		Short:             "List available certificate configurations",
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction: noMoreCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			output := component.NewOutputWriterWithOptions(cmd.OutOrStdout(), outputFormat, []component.OutputWriterOption{}, "host", "ca-certificate", "skip-cert-verification", "insecure")
 			certs, _ := configlib.GetCerts()
@@ -137,7 +137,7 @@ func newAddCertCmd() *cobra.Command {
 
     # Set to allow insecure (http) connection while interacting with host
     tanzu config cert add --host test.vmware.com  --insecure true`,
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction: completeAddCert,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if skipCertVerifyForAdd != "" {
 				if !strings.EqualFold(skipCertVerifyForAdd, "true") && !strings.EqualFold(skipCertVerifyForAdd, "false") {
@@ -283,7 +283,7 @@ func createCert(host, caCertPath, skipCertVerify, insecure string) (*configtypes
 // ====================================
 func completeCertHosts(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) > 0 {
-		return nil, cobra.ShellCompDirectiveNoFileComp
+		return activeHelpNoMoreArgs(nil), cobra.ShellCompDirectiveNoFileComp
 	}
 
 	var comps []string
@@ -297,4 +297,14 @@ func completeCertHosts(cmd *cobra.Command, args []string, toComplete string) ([]
 	sort.Strings(comps)
 
 	return comps, cobra.ShellCompDirectiveNoFileComp
+}
+
+func completeAddCert(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	if host == "" {
+		// This flag is required, so completion will be provided for it
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	// The user has provided enough information
+	return activeHelpNoMoreArgs(nil), cobra.ShellCompDirectiveNoFileComp
 }

--- a/pkg/command/cert_test.go
+++ b/pkg/command/cert_test.go
@@ -284,7 +284,7 @@ func TestCompletionCert(t *testing.T) {
 			test: "no completion for the cert list command",
 			args: []string{"__complete", "config", "cert", "list", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		{
 			test: "completion for the --output flag value of the cert list command",
@@ -305,7 +305,7 @@ func TestCompletionCert(t *testing.T) {
 			test: "no completion for the cert add command once the --host flag is present",
 			args: []string{"__complete", "config", "cert", "add", "--host", "example.com", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		{
 			test: "completion for the --host flag value of the cert add command",
@@ -350,7 +350,7 @@ func TestCompletionCert(t *testing.T) {
 			test: "no completion after the first arg for the cert update command",
 			args: []string{"__complete", "config", "cert", "update", "localhost:9876", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		{
 			test: "completion for the --ca-certificate flag value of the cert update command",
@@ -389,7 +389,7 @@ func TestCompletionCert(t *testing.T) {
 			test: "no completion after the first arg for the cert delete command",
 			args: []string{"__complete", "config", "cert", "delete", "localhost:9876", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 	}
 

--- a/pkg/command/completion.go
+++ b/pkg/command/completion.go
@@ -16,6 +16,8 @@ import (
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/plugin"
 )
 
+const compNoMoreArgsMsg = "This command does not take any more arguments (but may accept flags)."
+
 var (
 	completionShells = []string{
 		"bash",
@@ -83,7 +85,7 @@ var completionCmd = &cobra.Command{
 		if len(args) == 0 {
 			return completionShells, cobra.ShellCompDirectiveNoFileComp
 		}
-		return nil, cobra.ShellCompDirectiveNoFileComp
+		return activeHelpNoMoreArgs(nil), cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runCompletion(os.Stdout, cmd, args)
@@ -112,4 +114,16 @@ func runCompletion(out io.Writer, cmd *cobra.Command, args []string) error {
 	default:
 		return errors.New("unrecognized shell type specified")
 	}
+}
+
+// noMoreCompletions can be used to disable file completion for commands that should
+// not trigger file completions.  It also provides some ActiveHelp to indicate no more
+// arguments are accepted
+func noMoreCompletions(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return activeHelpNoMoreArgs(nil), cobra.ShellCompDirectiveNoFileComp
+}
+
+// activeHelpNoMoreArgs provides some ActiveHelp to indicate no more arguments are accepted
+func activeHelpNoMoreArgs(comps []string) []string {
+	return cobra.AppendActiveHelp(comps, "This command does not take any more arguments (but may accept flags).")
 }

--- a/pkg/command/completion_test.go
+++ b/pkg/command/completion_test.go
@@ -142,7 +142,7 @@ func TestCompletionCompletion(t *testing.T) {
 			test: "no completion after the first arg for the completion command",
 			args: []string{"__complete", "completion", "fish", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 	}
 

--- a/pkg/command/config.go
+++ b/pkg/command/config.go
@@ -66,7 +66,7 @@ var configCmd = &cobra.Command{
 var getConfigCmd = &cobra.Command{
 	Use:               "get",
 	Short:             "Get the current configuration",
-	ValidArgsFunction: cobra.NoFileCompletions,
+	ValidArgsFunction: noMoreCompletions,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg, err := configlib.GetClientConfig()
 		if err != nil {
@@ -213,7 +213,7 @@ var initConfigCmd = &cobra.Command{
 	Use:               "init",
 	Short:             "Initialize config with defaults",
 	Long:              "Initialize config with defaults including plugin specific defaults such as default feature flags for all active and installed plugins",
-	ValidArgsFunction: cobra.NoFileCompletions,
+	ValidArgsFunction: noMoreCompletions,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Acquire tanzu config lock
 		configlib.AcquireTanzuConfigLock()
@@ -384,7 +384,7 @@ func unsetEnvs(paramArray []string) error {
 
 func completeSetConfig(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) > 1 {
-		return nil, cobra.ShellCompDirectiveNoFileComp
+		return activeHelpNoMoreArgs(nil), cobra.ShellCompDirectiveNoFileComp
 	}
 
 	if len(args) == 1 {
@@ -399,7 +399,7 @@ func completeSetConfig(cmd *cobra.Command, args []string, toComplete string) ([]
 
 func completeUnsetConfig(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) > 0 {
-		return nil, cobra.ShellCompDirectiveNoFileComp
+		return activeHelpNoMoreArgs(nil), cobra.ShellCompDirectiveNoFileComp
 	}
 	return completionGetEnvAndFeatures(), cobra.ShellCompDirectiveNoFileComp
 }

--- a/pkg/command/config_test.go
+++ b/pkg/command/config_test.go
@@ -212,7 +212,7 @@ func TestCompletionConfig(t *testing.T) {
 			test: "no completion for the config get command",
 			args: []string{"__complete", "config", "get", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		// ======================
 		// tanzu config set
@@ -238,7 +238,7 @@ func TestCompletionConfig(t *testing.T) {
 			test: "no completion after the second arg for the config set command",
 			args: []string{"__complete", "config", "set", "env.VAR", "val", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		// ======================
 		// tanzu config unset
@@ -257,7 +257,7 @@ func TestCompletionConfig(t *testing.T) {
 			test: "no completion after the first arg for the config unset command",
 			args: []string{"__complete", "config", "unset", "env.VAR", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		// ======================
 		// tanzu config init
@@ -266,7 +266,7 @@ func TestCompletionConfig(t *testing.T) {
 			test: "no completion for the config init command",
 			args: []string{"__complete", "config", "init", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 	}
 

--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -185,10 +185,14 @@ func initCreateCtxCmd() {
 	utils.PanicOnErr(createCtxCmd.Flags().MarkDeprecated("name", "it has been replaced by using an argument to the command"))
 
 	createCtxCmd.Flags().StringVar(&endpoint, "endpoint", "", "endpoint to create a context for")
-	utils.PanicOnErr(createCtxCmd.RegisterFlagCompletionFunc("endpoint", cobra.NoFileCompletions))
+	utils.PanicOnErr(createCtxCmd.RegisterFlagCompletionFunc("endpoint", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return cobra.AppendActiveHelp(nil, "Please enter the endpoint for which to create the context"), cobra.ShellCompDirectiveNoFileComp
+	}))
 
 	createCtxCmd.Flags().StringVar(&apiToken, "api-token", "", "API token for the SaaS context")
-	utils.PanicOnErr(createCtxCmd.RegisterFlagCompletionFunc("api-token", cobra.NoFileCompletions))
+	utils.PanicOnErr(createCtxCmd.RegisterFlagCompletionFunc("api-token", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return cobra.AppendActiveHelp(nil, fmt.Sprintf("Please enter your api-token (you can instead set the variable %s)", config.EnvAPITokenKey)), cobra.ShellCompDirectiveNoFileComp
+	}))
 
 	// Shell completion for this flag is the default behavior of doing file completion
 	createCtxCmd.Flags().StringVar(&kubeConfig, "kubeconfig", "", "path to the kubeconfig file; valid only if user doesn't choose 'endpoint' option.(See [*])")
@@ -777,7 +781,7 @@ func vSphereSupervisorLogin(endpoint string) (mergeFilePath, currentContext stri
 var listCtxCmd = &cobra.Command{
 	Use:               "list",
 	Short:             "List contexts",
-	ValidArgsFunction: cobra.NoFileCompletions,
+	ValidArgsFunction: noMoreCompletions,
 	RunE:              listCtx,
 }
 
@@ -1373,7 +1377,7 @@ func getContextType() configtypes.ContextType {
 // ====================================
 func completeAllContexts(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 	if len(args) > 0 {
-		return nil, cobra.ShellCompDirectiveNoFileComp
+		return activeHelpNoMoreArgs(nil), cobra.ShellCompDirectiveNoFileComp
 	}
 
 	cfg, err := config.GetClientConfig()
@@ -1394,7 +1398,7 @@ func completeAllContexts(_ *cobra.Command, args []string, _ string) ([]string, c
 
 func completeTAEContexts(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 	if len(args) > 0 {
-		return nil, cobra.ShellCompDirectiveNoFileComp
+		return activeHelpNoMoreArgs(nil), cobra.ShellCompDirectiveNoFileComp
 	}
 
 	cfg, err := config.GetClientConfig()
@@ -1413,7 +1417,7 @@ func completeTAEContexts(_ *cobra.Command, args []string, _ string) ([]string, c
 
 func completeActiveContexts(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 	if len(args) > 0 {
-		return nil, cobra.ShellCompDirectiveNoFileComp
+		return activeHelpNoMoreArgs(nil), cobra.ShellCompDirectiveNoFileComp
 	}
 
 	currentCtxMap, err := config.GetAllActiveContextsMap()

--- a/pkg/command/context_test.go
+++ b/pkg/command/context_test.go
@@ -1023,7 +1023,7 @@ func Test_completionContext(t *testing.T) {
 			test: "no completion after the list command",
 			args: []string{"__complete", "context", "list", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		{
 			test: "completion for the --type flag value of the list command",
@@ -1050,7 +1050,7 @@ func Test_completionContext(t *testing.T) {
 			test: "no completion after the first argument of the delete command",
 			args: []string{"__complete", "context", "delete", "tkg1", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		// =====================
 		// tanzu context get
@@ -1065,7 +1065,7 @@ func Test_completionContext(t *testing.T) {
 			test: "no completion after the first argument of the get command",
 			args: []string{"__complete", "context", "get", "tkg1", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		{
 			test: "completion for the --output flag value of the get command",
@@ -1086,7 +1086,7 @@ func Test_completionContext(t *testing.T) {
 			test: "no completion after the first argument of the use command",
 			args: []string{"__complete", "context", "use", "tkg1", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		// =====================
 		// tanzu context unset
@@ -1101,7 +1101,7 @@ func Test_completionContext(t *testing.T) {
 			test: "no completion after the first argument of the unset command",
 			args: []string{"__complete", "context", "unset", "tkg1", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		{
 			test: "complete active context matching the --type flag for the unset command",
@@ -1152,13 +1152,13 @@ func Test_completionContext(t *testing.T) {
 			test: "completion for the --endpoint flag value of the create command",
 			args: []string{"__complete", "context", "create", "--endpoint", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ Please enter the endpoint for which to create the context\n:4\n",
 		},
 		{
 			test: "completion for the --api-token flag value of the create command",
 			args: []string{"__complete", "context", "create", "--api-token", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ Please enter your api-token (you can instead set the variable TANZU_API_TOKEN)\n:4\n",
 		},
 		{
 			test: "completion for the --kubeconfig flag value of the create command",
@@ -1196,14 +1196,26 @@ func Test_completionContext(t *testing.T) {
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
 			expected: expectedOutForTAECtxs + ":4\n",
 		},
+		{
+			test: "no completion after the first argument of the context get-token command",
+			args: []string{"__complete", "context", "get-token", "tae", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
+		},
 		// =====================
 		// tanzu context update
 		// =====================
 		{
-			test: "completion for the context get-token tae command",
+			test: "completion for the context update tae command",
 			args: []string{"__complete", "context", "update", "tae-active-resource", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
 			expected: expectedOutForTAECtxs + ":4\n",
+		},
+		{
+			test: "no completion after the first argument of the context update tae command",
+			args: []string{"__complete", "context", "update", "tae-active-resource", "tae", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 	}
 

--- a/pkg/command/discovery_source_test.go
+++ b/pkg/command/discovery_source_test.go
@@ -400,17 +400,23 @@ func TestCompletionPluginSource(t *testing.T) {
 		args     []string
 		expected string
 	}{
+		// ========================
+		// tanzu plugin source init
+		// ========================
 		{
 			test: "no completion after the source init command",
 			args: []string{"__complete", "plugin", "source", "init", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
+		// ========================
+		// tanzu plugin source list
+		// ========================
 		{
 			test: "no completion after the source list command",
 			args: []string{"__complete", "plugin", "source", "list", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		{
 			test: "completion for the --output flag value",
@@ -418,6 +424,9 @@ func TestCompletionPluginSource(t *testing.T) {
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
 			expected: expectedOutForOutputFlag + ":4\n",
 		},
+		// ==========================
+		// tanzu plugin source update
+		// ==========================
 		{
 			test: "completion for the source update command",
 			args: []string{"__complete", "plugin", "source", "update", ""},
@@ -428,11 +437,29 @@ func TestCompletionPluginSource(t *testing.T) {
 				":4\n",
 		},
 		{
-			test: "no completion after the first arg of the source update command",
-			args: []string{"__complete", "plugin", "source", "update", "default", "-u", "someURI", ""},
+			test: "completion after the first arg of the source update command without --uri",
+			args: []string{"__complete", "plugin", "source", "update", "default", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "--uri\tURI for discovery source. The URI must be of an OCI image\n" +
+				"-u\tURI for discovery source. The URI must be of an OCI image\n" +
+				":4\n",
 		},
+		{
+			test: "no completion after the first arg of the source update command with --uri",
+			args: []string{"__complete", "plugin", "source", "update", "default", "--uri", "someURI", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
+		},
+		{
+			test: "completion of the --uri flag value for the source update command",
+			args: []string{"__complete", "plugin", "source", "update", "default", "--uri", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: "_activeHelp_ Please enter the uri of the OCI image for plugin discovery\n:4\n",
+		},
+		// ==========================
+		// tanzu plugin source delete
+		// ==========================
+
 		{
 			test: "completion for the source delete command",
 			args: []string{"__complete", "plugin", "source", "delete", ""},
@@ -444,7 +471,7 @@ func TestCompletionPluginSource(t *testing.T) {
 			test: "no completion after the first arg of the source delete command",
 			args: []string{"__complete", "plugin", "source", "delete", "default", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 	}
 

--- a/pkg/command/doc.go
+++ b/pkg/command/doc.go
@@ -36,7 +36,7 @@ var genAllDocsCmd = &cobra.Command{
 	Use:               "generate-all-docs",
 	Short:             "Generate Cobra CLI docs for all plugins installed",
 	Hidden:            true,
-	ValidArgsFunction: cobra.NoFileCompletions,
+	ValidArgsFunction: noMoreCompletions,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if docsDir == "" {

--- a/pkg/command/doc_test.go
+++ b/pkg/command/doc_test.go
@@ -19,7 +19,7 @@ func TestCompletionGenerateDocs(t *testing.T) {
 			test: "no completion for the generate-all-docs command",
 			args: []string{"__complete", "generate-all-docs", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		{
 			test: "file completion for the generate-all-docs --docs-dir flag",

--- a/pkg/command/eula.go
+++ b/pkg/command/eula.go
@@ -37,7 +37,7 @@ func newShowEULACmd() *cobra.Command {
 		Use:               "show",
 		Short:             "Present EULA",
 		Long:              "Present EULA for review",
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction: noMoreCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return config.ConfigureEULA(true)
 		},
@@ -50,7 +50,7 @@ func newAcceptEULACmd() *cobra.Command {
 		Use:               "accept",
 		Short:             "Accept the EULA",
 		Long:              "Accept the EULA for Tanzu CLI non-interactively.",
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction: noMoreCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := configlib.SetEULAStatus(configlib.EULAStatusAccepted)
 			if err != nil {

--- a/pkg/command/eula_test.go
+++ b/pkg/command/eula_test.go
@@ -128,7 +128,7 @@ func TestCompletionEULA(t *testing.T) {
 			test: "no completion for the eula accept command",
 			args: []string{"__complete", "config", "eula", "accept", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		// =====================
 		// tanzu config eula show
@@ -137,7 +137,7 @@ func TestCompletionEULA(t *testing.T) {
 			test: "no completion for the eula show command",
 			args: []string{"__complete", "config", "eula", "show", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 	}
 

--- a/pkg/command/init.go
+++ b/pkg/command/init.go
@@ -23,7 +23,7 @@ var initCmd = &cobra.Command{
 		"group": string(plugin.SystemCmdGroup),
 	},
 	SilenceErrors:     true,
-	ValidArgsFunction: cobra.NoFileCompletions,
+	ValidArgsFunction: noMoreCompletions,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Currently nothing to initialize.
 		// We are keeping this command as it may become useful

--- a/pkg/command/init_test.go
+++ b/pkg/command/init_test.go
@@ -19,7 +19,7 @@ func TestCompletionInit(t *testing.T) {
 			test: "no completion for the init command",
 			args: []string{"__complete", "init", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 	}
 

--- a/pkg/command/plugin.go
+++ b/pkg/command/plugin.go
@@ -135,7 +135,7 @@ func newListPluginCmd() *cobra.Command {
 		Use:               "list",
 		Short:             "List installed plugins",
 		Long:              "List installed standalone plugins or plugins recommended by the contexts being used",
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction: noMoreCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			errorList := make([]error, 0)
 			// List installed standalone plugins
@@ -391,7 +391,7 @@ func newCleanPluginCmd() *cobra.Command {
 		Use:               "clean",
 		Short:             "Clean the plugins",
 		Long:              "Remove all installed plugins from the system",
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction: noMoreCompletions,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			err = pluginmanager.Clean()
 			if err != nil {
@@ -410,7 +410,7 @@ func newSyncPluginCmd() *cobra.Command {
 		Short: "Installs all plugins recommended by the active contexts",
 		Long: `Installs all plugins recommended by the active contexts.
 Plugins installed with this command will only be available while the context remains active.`,
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction: noMoreCompletions,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			err = pluginmanager.SyncPlugins()
 			if err != nil {
@@ -581,21 +581,23 @@ func getTarget() configtypes.Target {
 // Shell completion functions
 // ====================================
 func completeInstalledPlugins(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return activeHelpNoMoreArgs(nil), cobra.ShellCompDirectiveNoFileComp
+	}
+
 	installedPlugins, err := pluginsupplier.GetInstalledPlugins()
 	if err != nil {
-		return nil, cobra.ShellCompDirectiveError
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	var comps []string
 	target := getTarget()
-	if len(args) == 0 {
-		// Complete all plugin names as long as the target matches and let the shell filter
-		for i := range installedPlugins {
-			if target == configtypes.TargetUnknown || target == installedPlugins[i].Target {
-				// Make sure the name of the plugin is part of the description so that
-				// zsh does not lump many plugins that have the same description
-				comps = append(comps, fmt.Sprintf("%[1]s\tTarget: %[2]s for %[1]s", installedPlugins[i].Name, installedPlugins[i].Target))
-			}
+	// Complete all plugin names as long as the target matches and let the shell filter
+	for i := range installedPlugins {
+		if target == configtypes.TargetUnknown || target == installedPlugins[i].Target {
+			// Make sure the name of the plugin is part of the description so that
+			// zsh does not lump many plugins that have the same description
+			comps = append(comps, fmt.Sprintf("%[1]s\tTarget: %[2]s for %[1]s", installedPlugins[i].Name, installedPlugins[i].Target))
 		}
 	}
 
@@ -606,7 +608,7 @@ func completeInstalledPlugins(_ *cobra.Command, args []string, _ string) ([]stri
 
 func completeAllPlugins(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 	if len(args) > 0 {
-		return nil, cobra.ShellCompDirectiveNoFileComp
+		return activeHelpNoMoreArgs(nil), cobra.ShellCompDirectiveNoFileComp
 	}
 	return completionAllPlugins(), cobra.ShellCompDirectiveNoFileComp
 }
@@ -664,7 +666,7 @@ func completePluginVersions(_ *cobra.Command, args []string, _ string) ([]string
 
 func completeDeletePlugin(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) > 1 {
-		return nil, cobra.ShellCompDirectiveNoFileComp
+		return activeHelpNoMoreArgs(nil), cobra.ShellCompDirectiveNoFileComp
 	}
 
 	targetFlag := cmd.Flags().Lookup("target")
@@ -676,7 +678,7 @@ func completeDeletePlugin(cmd *cobra.Command, args []string, toComplete string) 
 				return []string{"--target"}, cobra.ShellCompDirectiveNoFileComp
 			}
 		}
-		return nil, cobra.ShellCompDirectiveNoFileComp
+		return activeHelpNoMoreArgs(nil), cobra.ShellCompDirectiveNoFileComp
 	}
 
 	var comps []string

--- a/pkg/command/plugin_bundle_test.go
+++ b/pkg/command/plugin_bundle_test.go
@@ -40,13 +40,13 @@ func TestCompletionPluginBundle(t *testing.T) {
 			test: "no completion after the download-bundle command with --to-tar",
 			args: []string{"__complete", "plugin", "download-bundle", "--to-tar", "plugin.tar", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		{
 			test: "no completion after the download-bundle command with --dry-run",
 			args: []string{"__complete", "plugin", "download-bundle", "--dry-run", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		{
 			test: "completion of flags after the download-bundle command with --image",
@@ -59,7 +59,7 @@ func TestCompletionPluginBundle(t *testing.T) {
 			test: "no completion for the --image flag value of the download-bundle command",
 			args: []string{"__complete", "plugin", "download-bundle", "--image", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ Please enter the URI of the plugin discovery image providing the plugins\n:4\n",
 		},
 		{
 			test: "file completion for the --to-tar flag value of the download-bundle command",
@@ -68,8 +68,9 @@ func TestCompletionPluginBundle(t *testing.T) {
 			expected: ":0\n",
 		},
 		{
-			test:                  "completion for the --group flag value for the group name part of the download-bundle command",
-			args:                  []string{"__complete", "plugin", "download-bundle", "--group", ""},
+			test: "completion for the --group flag value for the group name part of the download-bundle command",
+			args: []string{"__complete", "plugin", "download-bundle", "--group", ""},
+			// This command should trigger downloading an OCI plugin inventory image
 			imageMustBeDownloaded: true,
 			// ":6" is the value of the ShellCompDirectiveNoFileComp | ShellCompDirectiveNoSpace
 			expected: "vmware-tap/default\tPlugins for TAP\n" +
@@ -77,8 +78,9 @@ func TestCompletionPluginBundle(t *testing.T) {
 				":6\n",
 		},
 		{
-			test:                  "completion for the --group flag value for the version part of the download-bundle command",
-			args:                  []string{"__complete", "plugin", "download-bundle", "--group", "vmware-tkg/default:"},
+			test: "completion for the --group flag value for the version part of the download-bundle command",
+			args: []string{"__complete", "plugin", "download-bundle", "--group", "vmware-tkg/default:"},
+			// This command should trigger downloading an OCI plugin inventory image
 			imageMustBeDownloaded: true,
 			// ":36" is the value of the ShellCompDirectiveNoFileComp | ShellCompDirectiveKeepOrder
 			expected: "vmware-tkg/default:v2.2.2\n" +
@@ -87,8 +89,18 @@ func TestCompletionPluginBundle(t *testing.T) {
 				":36\n",
 		},
 		{
-			test:                  "completion for the --group flag value for the group name part of the download-bundle command with --image",
-			args:                  []string{"__complete", "plugin", "download-bundle", "--image", "example.com/image:latest", "--group", ""},
+			test: "completion for the --group flag value for the version part of an invalid group for the download-bundle command",
+			args: []string{"__complete", "plugin", "download-bundle", "--group", "invalid:"},
+			// This command should trigger downloading an OCI plugin inventory image
+			imageMustBeDownloaded: true,
+			// ":36" is the value of the ShellCompDirectiveNoFileComp | ShellCompDirectiveKeepOrder
+			expected: "_activeHelp_ There is no group named: 'invalid'\n" +
+				":36\n",
+		},
+		{
+			test: "completion for the --group flag value for the group name part of the download-bundle command with --image",
+			args: []string{"__complete", "plugin", "download-bundle", "--image", "example.com/image:latest", "--group", ""},
+			// This command should trigger downloading an OCI plugin inventory image
 			imageMustBeDownloaded: true,
 			// ":6" is the value of the ShellCompDirectiveNoFileComp | ShellCompDirectiveNoSpace
 			expected: "vmware-tap/default\tPlugins for TAP\n" +
@@ -96,8 +108,9 @@ func TestCompletionPluginBundle(t *testing.T) {
 				":6\n",
 		},
 		{
-			test:                  "completion for the --group flag value for the version part of the download-bundle command with --image",
-			args:                  []string{"__complete", "plugin", "download-bundle", "--image", "example.com/image:latest", "--group", "vmware-tkg/default:"},
+			test: "completion for the --group flag value for the version part of the download-bundle command with --image",
+			args: []string{"__complete", "plugin", "download-bundle", "--image", "example.com/image:latest", "--group", "vmware-tkg/default:"},
+			// This command should trigger downloading an OCI plugin inventory image
 			imageMustBeDownloaded: true,
 			// ":36" is the value of the ShellCompDirectiveNoFileComp | ShellCompDirectiveKeepOrder
 			expected: "vmware-tkg/default:v2.2.2\n" +
@@ -115,10 +128,10 @@ func TestCompletionPluginBundle(t *testing.T) {
 			expected: ":0\n",
 		},
 		{
-			test: "completion for the --group flag value for the version part of the download-bundle command",
+			test: "completion for the --to-repo flag value for the upload-bundle command",
 			args: []string{"__complete", "plugin", "upload-bundle", "--tar", "plugin.tar", "--to-repo", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ Please enter the URI of the destination repository for publishing plugins\n:4\n",
 		},
 		{
 			test: "flag completion after the upload-bundle command when no flags are present",
@@ -139,7 +152,7 @@ func TestCompletionPluginBundle(t *testing.T) {
 			test: "no completion after the upload-bundle command when all flags are present",
 			args: []string{"__complete", "plugin", "upload-bundle", "--tar", "plugin.tar", "--to-repo", "repo", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 	}
 

--- a/pkg/command/plugin_group_test.go
+++ b/pkg/command/plugin_group_test.go
@@ -220,11 +220,14 @@ func TestCompletionPluginGroup(t *testing.T) {
 		args     []string
 		expected string
 	}{
+		// ============================
+		// tanzu plugin group search
+		// ============================
 		{
 			test: "no completion after the group search command",
 			args: []string{"__complete", "plugin", "group", "search", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		{
 			test: "completion for the --output flag value of the group search command",
@@ -240,6 +243,9 @@ func TestCompletionPluginGroup(t *testing.T) {
 				"vmware-tkg/default\tPlugins for TKG\n" +
 				":4\n",
 		},
+		// ============================
+		// tanzu plugin group get
+		// ============================
 		{
 			test: "completion for the group name part of the group get command",
 			args: []string{"__complete", "plugin", "group", "get", ""},
@@ -258,10 +264,24 @@ func TestCompletionPluginGroup(t *testing.T) {
 				":36\n",
 		},
 		{
+			test: "completion for the version name part of an invalid group for the group get command",
+			args: []string{"__complete", "plugin", "group", "get", "invalid:"},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: "_activeHelp_ Invalid group format: 'invalid'\n" +
+				":4\n",
+		},
+		{
+			test: "completion for the version name part of an missing group for the group get command",
+			args: []string{"__complete", "plugin", "group", "get", "vmware-tkg/invalid:"},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: "_activeHelp_ There is no group named: 'vmware-tkg/invalid'\n" +
+				":4\n",
+		},
+		{
 			test: "no completion after the first arg of the group get command",
 			args: []string{"__complete", "plugin", "group", "get", "vmware-tkg/default", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		{
 			test: "completion for the --output flag value for the group get command",

--- a/pkg/command/plugin_search.go
+++ b/pkg/command/plugin_search.go
@@ -37,7 +37,7 @@ func newSearchPluginCmd() *cobra.Command {
 		Short:             "Search for available plugins",
 		Long:              searchLongDesc,
 		Args:              cobra.MaximumNArgs(0),
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction: noMoreCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !configtypes.IsValidTarget(targetStr, true, true) {
 				return errors.New(invalidTargetMsg)

--- a/pkg/command/plugin_search_test.go
+++ b/pkg/command/plugin_search_test.go
@@ -112,7 +112,7 @@ func TestCompletionPluginSearch(t *testing.T) {
 			test: "no completion after the plugin search command",
 			args: []string{"__complete", "plugin", "search", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		{
 			test: "completion for the --name flag value",

--- a/pkg/command/plugin_test.go
+++ b/pkg/command/plugin_test.go
@@ -490,7 +490,7 @@ func TestCompletionPlugin(t *testing.T) {
 			test: "no completion after the plugin list command",
 			args: []string{"__complete", "plugin", "list", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		{
 			test: "completion for the --output flag value of the plugin list command",
@@ -505,7 +505,7 @@ func TestCompletionPlugin(t *testing.T) {
 			test: "no completions for the plugin clean command",
 			args: []string{"__complete", "plugin", "clean", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		// =====================
 		// tanzu plugin sync
@@ -514,7 +514,7 @@ func TestCompletionPlugin(t *testing.T) {
 			test: "no completions for the plugin sync command",
 			args: []string{"__complete", "plugin", "sync", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		// =====================
 		// tanzu plugin install
@@ -597,6 +597,21 @@ func TestCompletionPlugin(t *testing.T) {
 				":36\n",
 		},
 		{
+			test: "completion for the --group flag value for the version part of an invalid group for the plugin install command",
+			args: []string{"__complete", "plugin", "install", "--group", "invalid:"},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: "_activeHelp_ Invalid group format: 'invalid'\n" +
+				":4\n",
+		},
+		{
+			test: "completion for the --group flag value for the version part of a missing group for the plugin install command",
+			args: []string{"__complete", "plugin", "install", "--group", "vmware-tkg/invalid:"},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: "_activeHelp_ There is no group named: 'vmware-tkg/invalid'\n" +
+				":4\n",
+		},
+
+		{
 			test: "completion for the --local-source flag value",
 			args: []string{"__complete", "plugin", "install", "--local-source", ""},
 			// ":0" is the value of the ShellCompDirectiveDefault which indicates
@@ -651,7 +666,7 @@ func TestCompletionPlugin(t *testing.T) {
 			test: "no completion after the first arg for the plugin install command",
 			args: []string{"__complete", "plugin", "install", "builder", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		// =====================
 		// tanzu plugin upgrade
@@ -690,7 +705,7 @@ func TestCompletionPlugin(t *testing.T) {
 			test: "no completion after the first arg for the plugin upgrade command",
 			args: []string{"__complete", "plugin", "upgrade", "builder", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		// =====================
 		// tanzu plugin delete
@@ -721,7 +736,7 @@ func TestCompletionPlugin(t *testing.T) {
 			test: "no more completions after the first arg for the plugin delete command",
 			args: []string{"__complete", "plugin", "delete", "feature", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		{
 			test: "completion of the --target flag if 'all' is specified",
@@ -734,7 +749,7 @@ func TestCompletionPlugin(t *testing.T) {
 			test: "no more completions after 'all' if --target is specified",
 			args: []string{"__complete", "plugin", "delete", "--target", "k8s", "all", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		{
 			test: "completion for the --target flag value for the plugin delete command",

--- a/pkg/command/version.go
+++ b/pkg/command/version.go
@@ -21,7 +21,7 @@ func newVersionCmd() *cobra.Command {
 		Annotations: map[string]string{
 			"group": string(plugin.SystemCmdGroup),
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction: noMoreCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Printf(
 				"version: %s\nbuildDate: %s\nsha: %s\narch: %s\n",

--- a/pkg/command/version_test.go
+++ b/pkg/command/version_test.go
@@ -74,7 +74,7 @@ func TestCompletionVersion(t *testing.T) {
 			test: "no completion for the version command",
 			args: []string{"__complete", "version", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: ":4\n",
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 	}
 


### PR DESCRIPTION
### What this PR does / why we need it

Add and ActiveHelp printout to shell completion when no completions are provided.

Please see the testing section for examples.

**Reminder:** ActiveHelp printouts are only shown in `bash` and `zsh`

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # 

### Describe testing done for PR

I tried all the cases manually, but the unit test also cover every case.

```
$ tz ceip get <TAB>
This command does not take any more arguments (but may accept flags).

$ tz ceip set true <TAB>
This command does not take any more arguments (but may accept flags).

$ tz config cert list <TAB>
This command does not take any more arguments (but may accept flags).

$ tz config cert add --host localhost:9876 <TAB>
This command does not take any more arguments (but may accept flags).

$ tz config cert update localhost:9876 <TAB>
This command does not take any more arguments (but may accept flags).

$ tz config cert delete localhost:9876 <TAB>
This command does not take any more arguments (but may accept flags).

$ tz completion bash <TAB>
This command does not take any more arguments (but may accept flags).

$ tz config get <TAB>
This command does not take any more arguments (but may accept flags).

$ tz config set env.VAR val <TAB>
This command does not take any more arguments (but may accept flags).

$ tz config unset env.VAR <TAB>
This command does not take any more arguments (but may accept flags).

$ tz config init <TAB>
This command does not take any more arguments (but may accept flags).

$ tz context list <TAB>
This command does not take any more arguments (but may accept flags).

$ tz context delete tkg1 <TAB>
This command does not take any more arguments (but may accept flags).

$ tz context get tkg1 <TAB>
This command does not take any more arguments (but may accept flags).

$ tz context use tkg1 <TAB>
This command does not take any more arguments (but may accept flags).

$ tz context unset tkg1 <TAB>
This command does not take any more arguments (but may accept flags).

$ tz context create tkg1 --endpoint <TAB>
Please enter the endpoint for which to create the context

$ tz context create tkg1 --api-token <TAB>
Please enter your api-token (you can instead set the variable TANZU_API_TOKEN)

$ tz context get-token tae <TAB>
This command does not take any more arguments (but may accept flags).

$ tz context update tae-active-resource tae <TAB>
This command does not take any more arguments (but may accept flags).

$ tz plugin source init <TAB>
This command does not take any more arguments (but may accept flags).

$ tz plugin source list <TAB>
This command does not take any more arguments (but may accept flags).

$ tz plugin source update default -u someURI <TAB>
This command does not take any more arguments (but may accept flags).

$ tz plugin source update default -u <TAB>
Please enter the uri of the OCI image for plugin discovery

$ tz plugin source delete default <TAB>
This command does not take any more arguments (but may accept flags).

$ tz generate-all-docs <TAB>
This command does not take any more arguments (but may accept flags).

$ tz config eula accept <TAB>
This command does not take any more arguments (but may accept flags).

$ tz config eula show <TAB>
This command does not take any more arguments (but may accept flags).

$ tz init <TAB>
This command does not take any more arguments (but may accept flags).

$ tz plugin download-bundle --to-tar plugin_bundle.tar <TAB>
This command does not take any more arguments (but may accept flags).

$ tz plugin download-bundle --dry-run <TAB>
This command does not take any more arguments (but may accept flags).

$ tz plugin download-bundle --image <TAB>
Please enter the URI of the plugin discovery image providing the plugins

$ tz plugin download-bundle --group invalid:<TAB>
There is no group named: 'invalid'

$ tz plugin upload-bundle --to-repo <TAB>
Please enter the URI of the destination repository for publishing plugins

$ tz plugin upload-bundle --tar plugin_bundle.tar --to-repo localhost:9876/test/airgapped/v1/tanzu-cli/plugins/ <TAB>
This command does not take any more arguments (but may accept flags).

$ tz plugin group search <TAB>
This command does not take any more arguments (but may accept flags).

$ tz plugin group get invalid:<TAB>
Invalid group format: 'invalid'

$ tz plugin group get vmware-tkg/invalid:<TAB>
There is no group named: 'vmware-tkg/invalid'

$ tz plugin search <TAB>
This command does not take any more arguments (but may accept flags).

$ tz plugin list <TAB>
This command does not take any more arguments (but may accept flags).

$ tz plugin clean <TAB>
This command does not take any more arguments (but may accept flags).

$ tz plugin sync <TAB>
This command does not take any more arguments (but may accept flags).

$ tz plugin install builder <TAB
This command does not take any more arguments (but may accept flags).

$ tz plugin install --group invalid:<TAB>
Invalid group format: 'invalid'

$ tz plugin install --group vmware-tkg/invalid:<TAB>
There is no group named: 'vmware-tkg/invalid'

$ tz plugin upgrade builder <TAB>
This command does not take any more arguments (but may accept flags).

$ tz plugin delete builder <TAB>
This command does not take any more arguments (but may accept flags).

$ tz version <TAB>
This command does not take any more arguments (but may accept flags).
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add ActiveHelp to shell completion when no completions are suggested.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
