### PR TITLE
Automatically suggest `--target` when a plugin name is ambiguous

### DIFF
--- a/pkg/command/plugin_test.go
+++ b/pkg/command/plugin_test.go
@@ -663,6 +663,19 @@ func TestCompletionPlugin(t *testing.T) {
 				":36\n",
 		},
 		{
+			test: "completion for the plugin install command when the specified plugin name is not unique",
+			args: []string{"__complete", "plugin", "install", "cluster", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: "--target\n" +
+				":4\n",
+		},
+		{
+			test: "no more completions for the plugin install command when the specified plugin name is not unique and --target is specified",
+			args: []string{"__complete", "plugin", "install", "cluster", "--target", "k8s", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
+		},
+		{
 			test: "no completion after the first arg for the plugin install command",
 			args: []string{"__complete", "plugin", "install", "builder", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
@@ -694,6 +707,19 @@ func TestCompletionPlugin(t *testing.T) {
 				"package\tPlugin package/kubernetes description\n" +
 				"secret\tPlugin secret/kubernetes description\n" +
 				":4\n",
+		},
+		{
+			test: "completion for the plugin upgrade command when the specified plugin name is not unique",
+			args: []string{"__complete", "plugin", "upgrade", "cluster", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: "--target\n" +
+				":4\n",
+		},
+		{
+			test: "no more completions for the plugin upgrade command when the specified plugin name is not unique and --target is specified",
+			args: []string{"__complete", "plugin", "upgrade", "cluster", "--target", "k8s", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		{
 			test: "completion for the --target flag value for the plugin upgrade command",
@@ -733,6 +759,19 @@ func TestCompletionPlugin(t *testing.T) {
 				":36\n",
 		},
 		{
+			test: "completion for the plugin delete command when the specified plugin name is not unique",
+			args: []string{"__complete", "plugin", "delete", "cluster", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: "--target\n" +
+				":4\n",
+		},
+		{
+			test: "no more completions for the plugin delete command when the specified plugin name is not unique and --target is specified",
+			args: []string{"__complete", "plugin", "delete", "cluster", "--target", "k8s", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
+		},
+		{
 			test: "no more completions after the first arg for the plugin delete command",
 			args: []string{"__complete", "plugin", "delete", "feature", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
@@ -769,6 +808,19 @@ func TestCompletionPlugin(t *testing.T) {
 				"management-cluster\tMultiple entries for plugin management-cluster. You will need to use the --target flag.\n" +
 				"secret\tTarget: kubernetes for secret\n" +
 				":4\n",
+		},
+		{
+			test: "completion for the plugin describe command when the specified plugin name is not unique",
+			args: []string{"__complete", "plugin", "describe", "cluster", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: "--target\n" +
+				":4\n",
+		},
+		{
+			test: "no more completions for the plugin describe command when the specified plugin name is not unique and --target is specified",
+			args: []string{"__complete", "plugin", "describe", "cluster", "--target", "k8s", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		{
 			test: "completion for the plugin describe command using --target",


### PR DESCRIPTION
### What this PR does / why we need it

Complete `--target` when a plugin name is ambiguous.

Please see the testing section for examples.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

```
$ tz plugin install cluster <TAB>
$ tz plugin install cluster --target

$ tz plugin install cluster --target k8s <TAB>
This command does not take any more arguments (but may accept flags).

$ tz plugin upgrade cluster <TAB>
$ tz plugin upgrade cluster --target

$ tz plugin upgrade cluster --target tmc <TAB>
This command does not take any more arguments (but may accept flags).

$ tz plugin delete cluster <TAB>
$ tz plugin delete cluster --target

$ tz plugin delete cluster --target tmc <TAB>
This command does not take any more arguments (but may accept flags).

$ tz plugin describe cluster <TAB>
$ tz plugin describe cluster --target

$ tz plugin describe cluster --target tmc <TAB>
This command does not take any more arguments (but may accept flags).
```
### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Automatically suggest the `--target` flag in shell completion when a plugin name is ambiguous.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
