### PR TITLE
Complete valid values for --target

### DIFF
--- a/pkg/command/plugin_helper_test.go
+++ b/pkg/command/plugin_helper_test.go
@@ -42,6 +42,7 @@ var availablePlugins = []plugininventory.PluginIdentifier{
 	{Name: "management-cluster", Target: configtypes.TargetTMC, Version: "v0.0.3"},
 	{Name: "management-cluster", Target: configtypes.TargetTMC, Version: "v0.2.0"},
 	{Name: "cluster", Target: configtypes.TargetTMC, Version: "v0.0.5"},
+	{Name: "secret", Target: configtypes.TargetK8s, Version: "v0.0.6"},
 }
 
 var installedStandalonePlugins = []plugininventory.PluginIdentifier{

--- a/pkg/command/plugin_test.go
+++ b/pkg/command/plugin_test.go
@@ -476,8 +476,6 @@ func TestCompletionPlugin(t *testing.T) {
 	// Test local discovery
 	localSourcePath := filepath.Join("..", "fakes", "plugins", cli.GOOS, cli.GOARCH)
 
-	expectedOutforTargetFlag := compGlobalTarget + "\n" + compK8sTarget + "\n" + compTMCTarget + "\n"
-
 	tests := []struct {
 		test     string
 		args     []string
@@ -543,6 +541,15 @@ func TestCompletionPlugin(t *testing.T) {
 				"management-cluster\n" +
 				"package\n" +
 				"secret\n" +
+				":4\n",
+		},
+		{
+			test: "completion for the plugin install command using --group with no version",
+			args: []string{"__complete", "plugin", "install", "--group", "vmware-tkg/default", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			// There are no descriptions in this case because the plugin group only contains plugin names
+			expected: "all\n" +
+				"isolated-cluster\n" +
 				":4\n",
 		},
 		{
@@ -619,11 +626,31 @@ func TestCompletionPlugin(t *testing.T) {
 			expected: ":0\n",
 		},
 		{
-			test: "completion for the --target flag value for the plugin install command",
+			test: "completion for the --target flag value for the plugin install command with no plugin name",
 			args: []string{"__complete", "plugin", "install", "--target", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: expectedOutforTargetFlag + ":4\n",
+			expected: compGlobalTarget + "\n" +
+				compK8sTarget + "\n" +
+				compTMCTarget + "\n" +
+				":4\n",
 		},
+		{
+			test: "completion for the --target flag value for the plugin install command with a plugin name",
+			args: []string{"__complete", "plugin", "install", "isolated-cluster", "--target", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: compGlobalTarget + "\n" +
+				":4\n",
+		},
+		{
+			test: "completion for the --target flag value for the plugin install command with an invalid plugin",
+			args: []string{"__complete", "plugin", "install", "invalid", "--target", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: compGlobalTarget + "\n" +
+				compK8sTarget + "\n" +
+				compTMCTarget + "\n" +
+				":4\n",
+		},
+
 		{
 			test: "no completion for the --version flag value for the plugin install command with no plugin name",
 			args: []string{"__complete", "plugin", "install", "--version", ""},
@@ -722,11 +749,32 @@ func TestCompletionPlugin(t *testing.T) {
 			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		{
-			test: "completion for the --target flag value for the plugin upgrade command",
+			test: "completion for the --target flag value for the plugin upgrade command with no plugin name",
 			args: []string{"__complete", "plugin", "upgrade", "--target", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: expectedOutforTargetFlag + ":4\n",
+			expected: compGlobalTarget + "\n" +
+				compK8sTarget + "\n" +
+				compTMCTarget + "\n" +
+				":4\n",
 		},
+		{
+			test: "completion for the --target flag value for the plugin upgrade command with a plugin name",
+			args: []string{"__complete", "plugin", "upgrade", "management-cluster", "--target", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: compK8sTarget + "\n" +
+				compTMCTarget + "\n" +
+				":4\n",
+		},
+		{
+			test: "completion for the --target flag value for the plugin upgrade command with an invalid plugin",
+			args: []string{"__complete", "plugin", "upgrade", "invalid", "--target", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: compGlobalTarget + "\n" +
+				compK8sTarget + "\n" +
+				compTMCTarget + "\n" +
+				":4\n",
+		},
+
 		{
 			test: "no completion after the first arg for the plugin upgrade command",
 			args: []string{"__complete", "plugin", "upgrade", "builder", ""},
@@ -791,10 +839,39 @@ func TestCompletionPlugin(t *testing.T) {
 			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		{
-			test: "completion for the --target flag value for the plugin delete command",
+			test: "completion for the --target flag value for the plugin delete command with no plugin name",
 			args: []string{"__complete", "plugin", "delete", "--target", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: expectedOutforTargetFlag + ":4\n",
+			expected: compGlobalTarget + "\n" +
+				compK8sTarget + "\n" +
+				compTMCTarget + "\n" +
+				":4\n",
+		},
+		{
+			test: "completion for the --target flag value for the plugin delete command with a plugin name",
+			args: []string{"__complete", "plugin", "delete", "cluster", "--target", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: compK8sTarget + "\n" +
+				compTMCTarget + "\n" +
+				":4\n",
+		},
+		{
+			test: "completion for the --target flag value for the plugin delete command with 'all'",
+			args: []string{"__complete", "plugin", "delete", "all", "--target", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: compGlobalTarget + "\n" +
+				compK8sTarget + "\n" +
+				compTMCTarget + "\n" +
+				":4\n",
+		},
+		{
+			test: "completion for the --target flag value for the plugin delete command with an invalid plugin",
+			args: []string{"__complete", "plugin", "delete", "invalid", "--target", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: compGlobalTarget + "\n" +
+				compK8sTarget + "\n" +
+				compTMCTarget + "\n" +
+				":4\n",
 		},
 		// =====================
 		// tanzu plugin describe
@@ -839,10 +916,29 @@ func TestCompletionPlugin(t *testing.T) {
 			expected: expectedOutForOutputFlag + ":4\n",
 		},
 		{
-			test: "completion for the --target flag value for the plugin describe command",
+			test: "completion for the --target flag value for the plugin describe command with no plugin name",
 			args: []string{"__complete", "plugin", "describe", "--target", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
-			expected: expectedOutforTargetFlag + ":4\n",
+			expected: compGlobalTarget + "\n" +
+				compK8sTarget + "\n" +
+				compTMCTarget + "\n" +
+				":4\n",
+		},
+		{
+			test: "completion for the --target flag value for the plugin describe command with a plugin name",
+			args: []string{"__complete", "plugin", "describe", "secret", "--target", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: compK8sTarget + "\n" +
+				":4\n",
+		},
+		{
+			test: "completion for the --target flag value for the plugin describe command with an invalid plugin",
+			args: []string{"__complete", "plugin", "describe", "invalid", "--target", ""},
+			// ":4" is the value of the ShellCompDirectiveNoFileComp
+			expected: compGlobalTarget + "\n" +
+				compK8sTarget + "\n" +
+				compTMCTarget + "\n" +
+				":4\n",
 		},
 	}
 


### PR DESCRIPTION
### What this PR does / why we need it

When using the `--target` flag, the shell completion logic is now smarter and only specifies the valid targets for the current command-line.

For example:
```
$ tanzu plugin install cluster --target <TAB>
k8s  -- For interactions with a Kubernetes cluster
tmc  -- For interactions with a Tanzu Mission Control endpoint
```

Notice the `global` target was not suggested because there is no `cluster` plugin for it.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

```
# Show all targets when no plugin name is specified
$ tz plugin install -t <TAB>
global  -- Applicable globally
k8s     -- For interactions with a Kubernetes cluster
tmc     -- For interactions with a Tanzu Mission Control endpoint

# No global target for the 'cluster' plugin
$ tz plugin install cluster --target <TAB>
k8s  -- For interactions with a Kubernetes cluster
tmc  -- For interactions with a Tanzu Mission Control endpoint

$ tz plugin upgrade -t <TAB>
global  -- Applicable globally
k8s     -- For interactions with a Kubernetes cluster
tmc     -- For interactions with a Tanzu Mission Control endpoint

$ tz plugin upgrade management-cluster --target <TAB>
k8s  -- For interactions with a Kubernetes cluster
tmc  -- For interactions with a Tanzu Mission Control endpoint

$ tz plugin delete -t <TAB>
global  -- Applicable globally
k8s     -- For interactions with a Kubernetes cluster
tmc     -- For interactions with a Tanzu Mission Control endpoint

$ tz plugin delete cluster --target <TAB>
k8s  -- For interactions with a Kubernetes cluster
tmc  -- For interactions with a Tanzu Mission Control endpoint

$ tz plugin describe -t
global  -- Applicable globally
k8s     -- For interactions with a Kubernetes cluster
tmc     -- For interactions with a Tanzu Mission Control endpoint

$ tz plugin describe cluster --target global
k8s  -- For interactions with a Kubernetes cluster
tmc  -- For interactions with a Tanzu Mission Control endpoint


```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Shell completion now only suggests currently valid values for the `--target` flag. 
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
