### PR TITLE
Enhance UX for plugin group install 

### DIFF
--- a/pkg/command/plugin.go
+++ b/pkg/command/plugin.go
@@ -200,7 +200,7 @@ func newDescribePluginCmd() *cobra.Command {
 	return describeCmd
 }
 
-func newInstallPluginCmd() *cobra.Command { //nolint:funlen
+func newInstallPluginCmd() *cobra.Command {
 	var installCmd = &cobra.Command{
 		Use:   "install [" + pluginNameCaps + "]",
 		Short: "Install a plugin",
@@ -244,26 +244,7 @@ func newInstallPluginCmd() *cobra.Command { //nolint:funlen
 			}
 
 			if group != "" {
-				// We are installing from a group
-				if len(args) == 0 {
-					// Default to 'all' when installing from a group
-					pluginName = cli.AllPlugins
-				} else {
-					pluginName = args[0]
-				}
-
-				groupWithVersion, err := pluginmanager.InstallPluginsFromGroup(pluginName, group)
-				if err != nil {
-					return err
-				}
-
-				if pluginName == cli.AllPlugins {
-					log.Successf("successfully installed all plugins from group '%s'", groupWithVersion)
-				} else {
-					log.Successf("successfully installed '%s' from group '%s'", pluginName, groupWithVersion)
-				}
-
-				return nil
+				return installPluginsForPluginGroup(cmd, args)
 			}
 
 			// Invoke install plugin from local source if local files are provided
@@ -309,6 +290,40 @@ func newInstallPluginCmd() *cobra.Command { //nolint:funlen
 		},
 	}
 	return installCmd
+}
+
+func installPluginsForPluginGroup(cmd *cobra.Command, args []string) error {
+	var pluginName string
+	// We are installing from a group
+	if len(args) == 0 {
+		// Default to 'all' when installing from a group
+		pluginName = cli.AllPlugins
+	} else {
+		pluginName = args[0]
+	}
+
+	if pluginName == cli.AllPlugins {
+		pg, err := pluginmanager.GetPluginGroup(group)
+		if err != nil {
+			return err
+		}
+		groupIDAndVersion := fmt.Sprintf("%s-%s/%s:%s", pg.Vendor, pg.Publisher, pg.Name, pg.RecommendedVersion)
+		log.Infof("The following plugins will be installed from plugin group '%s'", groupIDAndVersion)
+		// list plugins if we are installing all plugins from the plugin group
+		displayGroupContentAsTable(pg, pg.RecommendedVersion, "", false, false, cmd.ErrOrStderr())
+		groupWithVersion, err := pluginmanager.InstallPluginsFromGivenPluginGroup(pluginName, groupIDAndVersion, pg)
+		if err != nil {
+			return err
+		}
+		log.Successf("successfully installed all plugins from group '%s'", groupWithVersion)
+	} else {
+		groupWithVersion, err := pluginmanager.InstallPluginsFromGroup(pluginName, group)
+		if err != nil {
+			return err
+		}
+		log.Successf("successfully installed '%s' from group '%s'", pluginName, groupWithVersion)
+	}
+	return nil
 }
 
 func newUpgradePluginCmd() *cobra.Command {

--- a/pkg/command/plugin_group.go
+++ b/pkg/command/plugin_group.go
@@ -133,7 +133,7 @@ func newGetCmd() *cobra.Command {
 			}
 
 			if outputFormat == "" || outputFormat == string(component.TableOutputType) {
-				displayGroupContentAsTable(groups[0], specifiedVersion, cmd.OutOrStdout())
+				displayGroupContentAsTable(groups[0], specifiedVersion, outputFormat, true, showNonMandatory, cmd.OutOrStdout())
 			} else {
 				displayGroupContentAsList(groups[0], cmd.OutOrStdout())
 			}
@@ -215,14 +215,14 @@ func displayGroupDetails(groups []*plugininventory.PluginGroup, writer io.Writer
 	component.NewObjectWriter(writer, outputFormat, details).Render()
 }
 
-func displayGroupContentAsTable(group *plugininventory.PluginGroup, specifiedVersion string, writer io.Writer) {
+func displayGroupContentAsTable(group *plugininventory.PluginGroup, specifiedVersion, outputFormat string, showPreText, showNonMandatory bool, writer io.Writer) {
 	cyanBold := color.New(color.FgCyan).Add(color.Bold)
 	cyanBoldItalic := color.New(color.FgCyan).Add(color.Bold, color.Italic)
 	outputStandalone := component.NewOutputWriterWithOptions(writer, outputFormat, []component.OutputWriterOption{}, "Name", "Target", "Version")
-
 	gID := plugininventory.PluginGroupToID(group)
-	_, _ = cyanBold.Fprintln(writer, "Plugins in Group: ", cyanBoldItalic.Sprintf("%s:%s", gID, group.RecommendedVersion))
-
+	if showPreText {
+		_, _ = cyanBold.Fprintln(writer, "Plugins in Group: ", cyanBoldItalic.Sprintf("%s:%s", gID, group.RecommendedVersion))
+	}
 	if showNonMandatory {
 		_, _ = cyanBold.Fprintln(writer, "\nStandalone Plugins")
 	}

--- a/pkg/pluginmanager/manager.go
+++ b/pkg/pluginmanager/manager.go
@@ -566,67 +566,29 @@ func UpgradePlugin(pluginName, version string, target configtypes.Target) error 
 // InstallPluginsFromGroup installs either the specified plugin or all plugins from the specified group version.
 // If the group version is not specified, the latest available version will be used.
 // The group identifier including the version used is returned.
-func InstallPluginsFromGroup(pluginName, groupIDAndVersion string, options ...PluginManagerOptions) (string, error) { //nolint:gocyclo,funlen
-	// Initialize plugin manager options and enable logs by default
-	opts := NewPluginManagerOpts()
-	for _, option := range options {
-		option(opts)
-	}
-
-	// Enable or Disable logs
-	opts.SetLogMode()
-	defer opts.ResetLogMode()
-
-	discoveries, err := getPluginDiscoveries()
+func InstallPluginsFromGroup(pluginName, groupIDAndVersion string, options ...PluginManagerOptions) (string, error) {
+	// get plugins from the specific plugin group
+	pg, err := GetPluginGroup(groupIDAndVersion, options...)
 	if err != nil {
 		return "", err
 	}
-	if len(discoveries) == 0 {
-		return "", errors.New(errorNoDiscoverySourcesFound)
-	}
-
-	groupIdentifier := plugininventory.PluginGroupIdentifierFromID(groupIDAndVersion)
-	if groupIdentifier == nil {
-		return "", fmt.Errorf("could not find group '%s'", groupIDAndVersion)
-	}
-	if groupIdentifier.Version == "" {
-		// If the version is not specified to install from, we use the latest
-		groupIdentifier.Version = cli.VersionLatest
-	}
-	criteria := &discovery.GroupDiscoveryCriteria{
-		Vendor:    groupIdentifier.Vendor,
-		Publisher: groupIdentifier.Publisher,
-		Name:      groupIdentifier.Name,
-		Version:   groupIdentifier.Version,
-	}
-
-	groups, err := discoverSpecificPluginGroups(discoveries, discovery.WithGroupDiscoveryCriteria(criteria))
-	if err != nil {
-		return "", err
-	}
-
-	if len(groups) == 0 {
-		return "", errors.Errorf("unable to find plugin group with name '%s-%s/%s' matching version '%s'", groupIdentifier.Vendor, groupIdentifier.Publisher, groupIdentifier.Name, groupIdentifier.Version)
-	}
-
-	if len(groups) > 1 {
-		log.Warningf("unexpected: group '%s' was found more than once.  Using the first one.", groupIDAndVersion)
-	}
-
-	pg := groups[0]
 
 	// It is possible that user has provided plugin group version in form of vMAJOR or vMAJOR.MINOR
 	// So always update the groupIdentifier and groupIDAndVersion to the recommendedVersion we got
 	// from the database
-	groupIdentifier.Version = pg.RecommendedVersion
-	groupIDAndVersion = fmt.Sprintf("%s-%s/%s:%s", groupIdentifier.Vendor, groupIdentifier.Publisher, groupIdentifier.Name, groupIdentifier.Version)
+	groupIDAndVersion = fmt.Sprintf("%s-%s/%s:%s", pg.Vendor, pg.Publisher, pg.Name, pg.RecommendedVersion)
 	log.Infof("Installing plugins from plugin group '%s'", groupIDAndVersion)
 
+	return InstallPluginsFromGivenPluginGroup(pluginName, groupIDAndVersion, pg)
+}
+
+// InstallPluginsFromGivenPluginGroup installs either the specified plugin or all plugins from given plugin group plugins.
+func InstallPluginsFromGivenPluginGroup(pluginName, groupIDAndVersion string, pg *plugininventory.PluginGroup) (string, error) {
 	numErrors := 0
 	numInstalled := 0
 	mandatoryPluginsExist := false
 	pluginExist := false
-	for _, plugin := range pg.Versions[groupIdentifier.Version] {
+	for _, plugin := range pg.Versions[pg.RecommendedVersion] {
 		if pluginName == cli.AllPlugins || pluginName == plugin.Name {
 			pluginExist = true
 			if plugin.Mandatory {
@@ -662,6 +624,59 @@ func InstallPluginsFromGroup(pluginName, groupIDAndVersion string, options ...Pl
 	}
 
 	return groupIDAndVersion, nil
+}
+
+// GetPluginGroup returns the plugin group for the specified groupIDAndVersion.
+func GetPluginGroup(groupIDAndVersion string, options ...PluginManagerOptions) (*plugininventory.PluginGroup, error) {
+	// Initialize plugin manager options and enable logs by default
+	opts := NewPluginManagerOpts()
+	for _, option := range options {
+		option(opts)
+	}
+
+	// Enable or Disable logs
+	opts.SetLogMode()
+	defer opts.ResetLogMode()
+
+	discoveries, err := getPluginDiscoveries()
+	if err != nil {
+		return nil, err
+	}
+	if len(discoveries) == 0 {
+		return nil, errors.New(errorNoDiscoverySourcesFound)
+	}
+
+	groupIdentifier := plugininventory.PluginGroupIdentifierFromID(groupIDAndVersion)
+	if groupIdentifier == nil {
+		return nil, fmt.Errorf("could not find group '%s'", groupIDAndVersion)
+	}
+	if groupIdentifier.Version == "" {
+		// If the version is not specified to install from, we use the latest
+		groupIdentifier.Version = cli.VersionLatest
+	}
+	criteria := &discovery.GroupDiscoveryCriteria{
+		Vendor:    groupIdentifier.Vendor,
+		Publisher: groupIdentifier.Publisher,
+		Name:      groupIdentifier.Name,
+		Version:   groupIdentifier.Version,
+	}
+
+	groups, err := discoverSpecificPluginGroups(discoveries, discovery.WithGroupDiscoveryCriteria(criteria))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(groups) == 0 {
+		return nil, errors.Errorf("unable to find plugin group with name '%s-%s/%s' matching version '%s'", groupIdentifier.Vendor, groupIdentifier.Publisher, groupIdentifier.Name, groupIdentifier.Version)
+	}
+
+	if len(groups) > 1 {
+		log.Warningf("unexpected: group '%s' was found more than once.  Using the first one.", groupIDAndVersion)
+	}
+
+	pg := groups[0]
+
+	return pg, nil
 }
 
 func logPluginInstallationMessage(p *discovery.Discovered, version string, isPluginInCache, isPluginAlreadyInstalled bool) {
@@ -737,7 +752,7 @@ func getPluginFromCache(p *discovery.Discovered, version string) *cli.PluginInfo
 	if cli.BuildArch().IsWindows() {
 		pluginPath += exe
 	}
-	if _, err := os.Stat(pluginPath); err != nil {
+	if _, err = os.Stat(pluginPath); err != nil {
 		return nil
 	}
 

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -68,6 +68,7 @@ E2E_TEST_USE_PLGINS_FROM_PLUGIN_GROUP_FOR_K8S ?= vmware-tkg/default:v9.9.9
 .PHONY: e2e-cli-core-all ## Execute all CLI Core E2E Tests
 e2e-cli-core-all: e2e-cli-lifecycle e2e-cli-config e2e-plugin-compatibility-tests e2e-plugin-lifecycle-tests  e2e-plugin-sync-tmc e2e-plugin-sync-k8s e2e-context-tmc-tests e2e-context-k8s-tests e2e-airgapped-tests e2e-catalog-tests e2e-extra-column-tests
 
+
 .PHONY: e2e-cli-lifecycle ## Execute CLI life cycle specific e2e tests
 e2e-cli-lifecycle:
 	export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="No" ; \

--- a/test/e2e/airgapped/airgapped_test.go
+++ b/test/e2e/airgapped/airgapped_test.go
@@ -86,7 +86,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Airgapped-Plugin-Download
 		// Test case: Validate that the plugins can be installed from the plugin-group
 		It("validate that plugins can be installed from group 'vmware-tkg/default:v0.0.1'", func() {
 			// All plugins should get installed from the group
-			err := tf.PluginCmd.InstallPluginsFromGroup("", "vmware-tkg/default:v0.0.1")
+			_, _, err := tf.PluginCmd.InstallPluginsFromGroup("", "vmware-tkg/default:v0.0.1")
 			Expect(err).To(BeNil())
 
 			// Verify all plugins got installed with `tanzu plugin list`
@@ -141,7 +141,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Airgapped-Plugin-Download
 
 		It("validate that plugins can be installed from group 'vmware-tmc/tmc-user:v9.9.9'", func() {
 			// All plugins should get installed from the group
-			err := tf.PluginCmd.InstallPluginsFromGroup("", "vmware-tmc/tmc-user:v9.9.9")
+			_, _, err := tf.PluginCmd.InstallPluginsFromGroup("", "vmware-tmc/tmc-user:v9.9.9")
 			Expect(err).To(BeNil())
 
 			// Verify all plugins got installed with `tanzu plugin list`
@@ -188,7 +188,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Airgapped-Plugin-Download
 
 		It("validate that plugins can be installed from group 'vmware-tmc/tmc-user:v0.0.1'", func() {
 			// All plugins should get installed from the group
-			err := tf.PluginCmd.InstallPluginsFromGroup("", "vmware-tmc/tmc-user:v0.0.1")
+			_, _, err := tf.PluginCmd.InstallPluginsFromGroup("", "vmware-tmc/tmc-user:v0.0.1")
 			Expect(err).To(BeNil())
 
 			// Verify all plugins got installed with `tanzu plugin list`
@@ -239,7 +239,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Airgapped-Plugin-Download
 		// Test case: validate that plugins can be installed from group newly added plugin-group 'vmware-tkg/default:v9.9.9'
 		It("validate that plugins can be installed from group newly added plugin-group 'vmware-tkg/default:v9.9.9'", func() {
 			// All plugins should get installed from the group
-			err := tf.PluginCmd.InstallPluginsFromGroup("", "vmware-tkg/default:v9.9.9")
+			_, _, err := tf.PluginCmd.InstallPluginsFromGroup("", "vmware-tkg/default:v9.9.9")
 			Expect(err).To(BeNil())
 
 			// Verify all plugins got installed with `tanzu plugin list`

--- a/test/e2e/cataloge2e/catalog_update_parallel_test.go
+++ b/test/e2e/cataloge2e/catalog_update_parallel_test.go
@@ -28,7 +28,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Catalog-Update]", func() 
 
 			// Install "vmware-tkg/default" plugin group because it contains
 			// telemetry plugin with kubernetes target
-			err = tf.PluginCmd.InstallPluginsFromGroup("", "vmware-tkg/default")
+			_, _, err = tf.PluginCmd.InstallPluginsFromGroup("", "vmware-tkg/default")
 			Expect(err).To(BeNil(), "should not get any error for installing all plugins from plugin group")
 
 			pluginsList, err = framework.GetPluginsList(tf, true)

--- a/test/e2e/plugin_lifecycle/plugin_lifecycle_suite_test.go
+++ b/test/e2e/plugin_lifecycle/plugin_lifecycle_suite_test.go
@@ -117,7 +117,7 @@ func testWithoutPluginDiscoverySources(tf *framework.Framework) {
 	err = tf.PluginCmd.InstallPlugin("unknowPlugin", "", "")
 	Expect(err.Error()).To(ContainSubstring(errorNoDiscoverySourcesFound))
 
-	err = tf.PluginCmd.InstallPluginsFromGroup("", "unknowGroup")
+	_, _, err = tf.PluginCmd.InstallPluginsFromGroup("", "unknowGroup")
 	Expect(err.Error()).To(ContainSubstring(errorNoDiscoverySourcesFound))
 
 	_, err = tf.PluginCmd.SearchPluginGroups("")

--- a/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_test.go
+++ b/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_test.go
@@ -834,7 +834,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		It("plugin group search and plugin install by group when active context has issues", func() {
 			pgs, err := pl.SearchAllPluginGroups(tf)
 			Expect(err).To(BeNil())
-			err = tf.PluginCmd.InstallPluginsFromGroup("", pgs[0].Name)
+			_, _, err = tf.PluginCmd.InstallPluginsFromGroup("", pgs[0].Name)
 			Expect(err).To(BeNil(), "should be no error for plugin install by group")
 		})
 


### PR DESCRIPTION
### What this PR does / why we need it

This pull request enhances the user experience (UX) for the `tanzu plugin install --group PLUGIN-GROUP-NAME` command. Before this change, the `tanzu plugin install --group` command installs plugins from the specified group without listing them, which was not a great user experience.

This pull request improves the UX by listing the plugins that it's going to install. This change provides a better user experience for the end user.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
Use case 1: `tanzu plugin install --group PLUGIN-GROUP-NAME` when plugins are not installed from the plugin group:
```
❯ t plugin install --group vmware-tkg/default 
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
[i] The following plugins will be installed from plugin group 'vmware-tkg/default:v2.4.0'
  NAME                TARGET      VERSION  
  isolated-cluster    global      v0.31.0  
  management-cluster  kubernetes  v0.31.0  
  package             kubernetes  v0.31.0  
  pinniped-auth       global      v0.31.0  
  secret              kubernetes  v0.31.0  
  telemetry           kubernetes  v0.31.0  
[i] Installing plugin 'isolated-cluster:v0.31.0' with target 'global' 
[i] Installing plugin 'management-cluster:v0.31.0' with target 'kubernetes' 
[i] Installing plugin 'package:v0.31.0' with target 'kubernetes' 
[i] Installing plugin 'pinniped-auth:v0.31.0' with target 'global' 
[i] Installing plugin 'secret:v0.31.0' with target 'kubernetes' 
[i] Installing plugin 'telemetry:v0.31.0' with target 'kubernetes' 
[ok] successfully installed all plugins from group 'vmware-tkg/default:v2.4.0'
❯ 
```
Use case 2: `tanzu plugin install PLUGIN-NAME --group PLUGIN-GROUP-NAME` when few plugins are not installed:
```
❯ 
❯ t plugin delete secret
[i] The tanzu cli essential plugins have not been installed and are being installed now. The install may take a few seconds.

[i] Installing plugins from plugin group 'vmware-tanzucli/essentials:v1.0.0'
[i] Installing plugin 'telemetry:v1.1.0' with target 'global' 
Deleting plugin 'secret' for target 'kubernetes'. Are you sure? [y/N]: y
[i] Deleting plugin 'secret' for target 'kubernetes'
[ok] successfully deleted plugin 'secret'
❯ 
❯ t plugin install secret --group vmware-tkg/default 
[i] Installing plugins from plugin group 'vmware-tkg/default:v2.4.0'
[i] Installing plugin 'secret:v0.31.0' with target 'kubernetes' (from cache)
[ok] successfully installed 'secret' from group 'vmware-tkg/default:v2.4.0'
❯ 
```
Use case 3: `tanzu plugin install --group PLUGIN-GROUP-NAME` when plugins are installed already from the plugin group:
```
❯ t plugin install --group vmware-tkg/default        
[i] The following plugins will be installed from plugin group 'vmware-tkg/default:v2.4.0'
  NAME                TARGET      VERSION  
  isolated-cluster    global      v0.31.0  
  management-cluster  kubernetes  v0.31.0  
  package             kubernetes  v0.31.0  
  pinniped-auth       global      v0.31.0  
  secret              kubernetes  v0.31.0  
  telemetry           kubernetes  v0.31.0  
[i] Plugin 'isolated-cluster:v0.31.0' with target 'global' is already installed. Reinitializing...
[i] Plugin 'management-cluster:v0.31.0' with target 'kubernetes' is already installed. Reinitializing...
[i] Plugin 'package:v0.31.0' with target 'kubernetes' is already installed. Reinitializing...
[i] Plugin 'pinniped-auth:v0.31.0' with target 'global' is already installed. Reinitializing...
[i] Plugin 'secret:v0.31.0' with target 'kubernetes' is already installed. Reinitializing...
[i] Plugin 'telemetry:v0.31.0' with target 'kubernetes' is already installed. Reinitializing...
[ok] successfully installed all plugins from group 'vmware-tkg/default:v2.4.0'
❯ 
```
Use case 2: `tanzu plugin install PLUGIN-NAME --group PLUGIN-GROUP-NAME` when plugin is installed already:
```
❯ 
❯ t plugin install secret --group vmware-tkg/default 
[i] Installing plugins from plugin group 'vmware-tkg/default:v2.4.0'
[i] Plugin 'secret:v0.31.0' with target 'kubernetes' is already installed. Reinitializing...
[ok] successfully installed 'secret' from group 'vmware-tkg/default:v2.4.0'
❯ 
❯ 
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The `tanzu plugin install --group PLUGIN-GROUP-NAME` command has been updated to list the plugins it's going to install.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
