### PR TITLE
Unhide --all flag for plugin group get

### DIFF
--- a/pkg/command/plugin_group.go
+++ b/pkg/command/plugin_group.go
@@ -145,8 +145,7 @@ func newGetCmd() *cobra.Command {
 	f.StringVarP(&outputFormat, "output", "o", "", "output format (yaml|json|table)")
 	utils.PanicOnErr(getCmd.RegisterFlagCompletionFunc("output", completionGetOutputFormats))
 
-	f.BoolVarP(&showNonMandatory, "all", "", false, "include the non-mandatory plugins")
-	_ = f.MarkHidden("all")
+	f.BoolVarP(&showNonMandatory, "all", "", false, "include the contextual plugins")
 
 	return getCmd
 }


### PR DESCRIPTION
### What this PR does / why we need it

Following the improvements to the output of `tanzu plugin group get --all` from #526 , this PR makes the `--all` flag un-hidden.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

```
# Notice the --all flag in the help
$ tz plugin group get  -h
Get the content of the specified plugin-group.  A plugin-group provides a list of plugin name/version combinations which can be installed in one step.  This command allows to see the list of plugins included in the specified group.

Usage:
tanzu plugin group get GROUP_NAME [flags]

Flags:
      --all             include the contextual plugins
  -h, --help            help for get
  -o, --output string   output format (yaml|json|table)

# Notice that shell completion now suggest the --all flag since it no longer hidden 
$ tz plugin group get vmware-tkg/default -<TAB>
--all         -- include the contextual plugins
--help    -h  -- help for get
--output  -o  -- output format (yaml|json|table)
```
### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Make the `--all` flag of `tanzu plugin group get` not hidden.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
