### PR TITLE
Implements reprompt on updated EULA

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ replace cloud.google.com/go => cloud.google.com/go v0.102.1
 
 replace github.com/vmware-tanzu/tanzu-cli/test/e2e/framework => ./test/e2e/framework
 
+replace github.com/vmware-tanzu/tanzu-plugin-runtime => ../tanzu-plugin-runtime
+
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/Masterminds/semver v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,6 @@ replace cloud.google.com/go => cloud.google.com/go v0.102.1
 
 replace github.com/vmware-tanzu/tanzu-cli/test/e2e/framework => ./test/e2e/framework
 
-replace github.com/vmware-tanzu/tanzu-plugin-runtime => ../tanzu-plugin-runtime
-
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/Masterminds/semver v1.5.0
@@ -44,7 +42,7 @@ require (
 	github.com/vmware-tanzu/carvel-ytt v0.40.0
 	github.com/vmware-tanzu/tanzu-cli/test/e2e/framework v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686
-	github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0-dev.0.20231012220854-fa06151f040d
+	github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0-dev.0.20231020193057-c7a71fb36ee4
 	go.pinniped.dev v0.20.0
 	golang.org/x/mod v0.12.0
 	golang.org/x/oauth2 v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -735,8 +735,6 @@ github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502eb
 github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502ebf68/go.mod h1:e1Uef+Ux5BIHpYwqbeP2ZZmOzehBcez2vUEWXHe+xHE=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686 h1:VcuXqUXFxm5WDqWkzAlU/6cJXua0ozELnqD59fy7J6E=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686/go.mod h1:AFGOXZD4tH+KhpmtV0VjWjllXhr8y57MvOsIxTtywc4=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0-dev.0.20231012220854-fa06151f040d h1:O+F9NhOEsTc/LP0Ur/IqQNZ5FlSiC8G7XUEuvcHKUXI=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0-dev.0.20231012220854-fa06151f040d/go.mod h1:wMK/qpJjU7hytDAGt3FX5/iGdlUK8TsJLu36pCr+Zvk=
 github.com/xanzy/go-gitlab v0.83.0 h1:37p0MpTPNbsTMKX/JnmJtY8Ch1sFiJzVF342+RvZEGw=
 github.com/xanzy/go-gitlab v0.83.0/go.mod h1:5ryv+MnpZStBH8I/77HuQBsMbBGANtVpLWC15qOjWAw=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=

--- a/go.sum
+++ b/go.sum
@@ -735,6 +735,8 @@ github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502eb
 github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502ebf68/go.mod h1:e1Uef+Ux5BIHpYwqbeP2ZZmOzehBcez2vUEWXHe+xHE=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686 h1:VcuXqUXFxm5WDqWkzAlU/6cJXua0ozELnqD59fy7J6E=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686/go.mod h1:AFGOXZD4tH+KhpmtV0VjWjllXhr8y57MvOsIxTtywc4=
+github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0-dev.0.20231020193057-c7a71fb36ee4 h1:HCQL7DW377uZUbFERnklBRH2Q3UXHpFmcdld/MxvsdI=
+github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0-dev.0.20231020193057-c7a71fb36ee4/go.mod h1:M7WVZoItdyQp53tEprQIa6PZmhbrLe3CzuyQphWuRyI=
 github.com/xanzy/go-gitlab v0.83.0 h1:37p0MpTPNbsTMKX/JnmJtY8Ch1sFiJzVF342+RvZEGw=
 github.com/xanzy/go-gitlab v0.83.0/go.mod h1:5ryv+MnpZStBH8I/77HuQBsMbBGANtVpLWC15qOjWAw=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=

--- a/pkg/command/eula.go
+++ b/pkg/command/eula.go
@@ -52,7 +52,7 @@ func newAcceptEULACmd() *cobra.Command {
 		Long:              "Accept the EULA for Tanzu CLI non-interactively.",
 		ValidArgsFunction: cobra.NoFileCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := configlib.SetEULAStatus(configlib.EULAStatusAccepted)
+			err := config.UpdateEULAAcceptance(configlib.EULAStatusAccepted)
 			if err != nil {
 				return err
 			}

--- a/pkg/command/eula_test.go
+++ b/pkg/command/eula_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
+
+	cliconfig "github.com/vmware-tanzu/tanzu-cli/pkg/config"
 )
 
 // Executes the command and verify if prompt is expected to be shown or not
@@ -55,15 +57,28 @@ var _ = Describe("EULA command tests", func() {
 		})
 
 		Context("When invoking the accept command", func() {
-			It("should return successfully with agreement acceptance registered", func() {
-				eulaCmd := newEULACmd()
-				eulaCmd.SetArgs([]string{"accept"})
-				err = eulaCmd.Execute()
-				Expect(err).To(BeNil())
+			It("should return successfully with agreement acceptance and version registered", func() {
+				// run twice, to show second accept is idempotent, with no
+				// effect to the status or accepted EULA version
+				for i := 0; i < 2; i++ {
+					eulaCmd := newEULACmd()
+					eulaCmd.SetArgs([]string{"accept"})
+					err = eulaCmd.Execute()
+					Expect(err).To(BeNil())
 
-				eulaStatus, err := config.GetEULAStatus()
-				Expect(err).To(BeNil())
-				Expect(eulaStatus).To(Equal(config.EULAStatusAccepted))
+					eulaStatus, err := config.GetEULAStatus()
+					Expect(err).To(BeNil())
+					Expect(eulaStatus).To(Equal(config.EULAStatusAccepted))
+
+					acceptedVersions, err := config.GetEULAAcceptedVersions()
+					Expect(err).To(BeNil())
+
+					if cliconfig.CurrentEULAVersion != "" {
+						Expect(acceptedVersions).To(Equal([]string{cliconfig.CurrentEULAVersion}))
+					} else {
+						Expect(acceptedVersions).To(Equal([]string{}))
+					}
+				}
 			})
 		})
 		Context("When invoking the show command", func() {
@@ -107,6 +122,62 @@ var _ = Describe("EULA command tests", func() {
 			})
 		})
 	})
+})
+
+var _ = Describe("EULA version checking tests", func() {
+	var (
+		tanzuConfigFile   *os.File
+		tanzuConfigFileNG *os.File
+		err               error
+	)
+	BeforeEach(func() {
+		tanzuConfigFile, err = os.CreateTemp("", "config")
+		Expect(err).To(BeNil())
+		os.Setenv("TANZU_CONFIG", tanzuConfigFile.Name())
+
+		tanzuConfigFileNG, err = os.CreateTemp("", "config_ng")
+		Expect(err).To(BeNil())
+		os.Setenv("TANZU_CONFIG_NEXT_GEN", tanzuConfigFileNG.Name())
+
+		os.Setenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER", "No")
+	})
+	AfterEach(func() {
+		os.Unsetenv("TANZU_CONFIG")
+		os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
+		os.Unsetenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER")
+		os.RemoveAll(tanzuConfigFile.Name())
+		os.RemoveAll(tanzuConfigFileNG.Name())
+	})
+
+	DescribeTable("Running arbitrary command when EULA status is accepted", func(versionToAccept string, versionsAlreadyAccepted []string, expectToPrompt bool) {
+		cliconfig.CurrentEULAVersion = versionToAccept
+
+		err := config.SetEULAAcceptedVersions(versionsAlreadyAccepted)
+		Expect(err).To(BeNil())
+
+		err = config.SetEULAStatus(config.EULAStatusAccepted)
+		Expect(err).To(BeNil())
+
+		cmd, err := NewRootCmd()
+		Expect(err).To(BeNil())
+		cmd.SetArgs([]string{"context", "list"})
+		checkForPromptOnExecute(cmd, expectToPrompt)
+	},
+		Entry("still prompt when no accepted version found",
+			"v1.0.0", []string{}, true),
+		Entry("still prompt when no accepted version matches in major.minor",
+			"v1.0.0", []string{"v1.1.0", "v0.9.9"}, true),
+		Entry("do not prompt when accepted version found",
+			"v1.6.0", []string{"v1.6.0", "v0.9.9"}, false),
+		Entry("do not prompt when found accepted older version matching major.minor",
+			"v2.0.1", []string{"v2.0.0"}, false),
+		Entry("do not prompt when found accepted newer version matching major.minor",
+			"v2.0.0", []string{"v2.0.1"}, false),
+		Entry("do not prompt when no current EULA version is set",
+			"", []string{"v2.0.0"}, false),
+		Entry("do not prompt when no current EULA version is set, even with no accepted versions",
+			"", []string{}, false),
+	)
 })
 
 func TestCompletionEULA(t *testing.T) {

--- a/pkg/command/eula_test.go
+++ b/pkg/command/eula_test.go
@@ -5,7 +5,6 @@ package command
 import (
 	"bytes"
 	"os"
-	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -13,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 )
 
@@ -45,10 +43,6 @@ var _ = Describe("EULA command tests", func() {
 			tanzuConfigFileNG, err = os.CreateTemp("", "config_ng")
 			Expect(err).To(BeNil())
 			os.Setenv("TANZU_CONFIG_NEXT_GEN", tanzuConfigFileNG.Name())
-
-			featureArray := strings.Split(constants.FeatureContextCommand, ".")
-			err = config.SetFeature(featureArray[1], featureArray[2], "true")
-			Expect(err).To(BeNil())
 
 			os.Setenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER", "No")
 		})


### PR DESCRIPTION
### What this PR does / why we need it

This change depends on https://github.com/vmware-tanzu/tanzu-plugin-runtime/pull/126/files, so will be updated once it merges.

```
    Implement reprompt of updated EULA

    This change adds the capability to reprompt the user to accept an
    updated EULA, should it become available. At some point, the version of
    the EULA associated with the CLI will be versioned using semver. Once
    that happens, a reprompt will occur even if it was previously registered
    that a EULA was accepted if a EULA version compatible (matching
    major.minor) with the CLI's EULA version is not found is the list of
    accepted versions in the config file.

    Note that as of this change, the CLI has not designated a specific
    version, hence this compatibility check is not activated.
```

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Besides running updated unit tests, used the following

```
  > alias chkeula
  alias chkeula='grep eula ~/.config/tanzu/config-ng.yaml'

  > tz context list --type tmc
  ? You must agree to the VMware General Terms in order to download, install, or
  ...
  ...
  Do you agree to the VMware General Terms?
   Yes

  ==
    NAME   ISACTIVE  TYPE             ENDPOINT
    utmc5  true      mission-control  unstable.tmc-dev.cloud.vmware.com:443


  > # until CurrentEULAVersion is set to a semver, no accepted versions registered or checked
  > chkeula
      eulaStatus: accepted

  > # build with CurrentEULAVersion = v1.0.0
  > make build
  build darwin-arm64 CLI with version: v1.1.0-dev

  > tz context list --type tmc
  ? You must agree to the VMware General Terms in order to download, install, or
  ...
  ...
  Do you agree to the VMware General Terms?
   Yes

  ==
    NAME   ISACTIVE  TYPE             ENDPOINT
    utmc5  true      mission-control  unstable.tmc-dev.cloud.vmware.com:443

  > # accepted versions registered
  > chkeula
      eulaStatus: accepted
      eulaAcceptedVersions: v1.0.0

  > perl -pi.bak -e 's/eulaAcceptedVersions: v1.0.0/eulaAcceptedVersions: v1.1.0/' ~/.config/tanzu/config-ng.yaml
  > # accepted versions not compatible, reprompt
  > tz context list --type tmc
  ? You must agree to the VMware General Terms in order to download, install, or
  ...
  ...
  Do you agree to the VMware General Terms?
   Yes

  ==
    NAME   ISACTIVE  TYPE             ENDPOINT
    utmc5  true      mission-control  unstable.tmc-dev.cloud.vmware.com:443

  > chkeula
      eulaStatus: accepted
      eulaAcceptedVersions: v1.0.0,v1.1.0

  > # compatible version found, skips, reprompt
  > perl -pi.bak -e 's/eulaAcceptedVersions: .*$/eulaAcceptedVersions: v0.9.0,v1.0.1/' ~/.config/tanzu/config-ng.yaml
  > tz context list --type tmc
    NAME   ISACTIVE  TYPE             ENDPOINT
    utmc5  true      mission-control  unstable.tmc-dev.cloud.vmware.com:443

  > chkeula
      eulaStatus: accepted
      eulaAcceptedVersions: v0.9.0,v1.0.1
N.
  > # eula accept will nonetheless registers version as accepted, even if there is a compatible one in the accepted list
  > tz config eula accept
  [ok] Marking agreement as accepted.

  > chkeula
      eulaStatus: accepted
      eulaAcceptedVersions: v0.9.0,v1.0.0,v1.0.1
```



<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
