### PR TITLE
Show a core command's short text in ActiveHelp when completing arguments

### DIFF
--- a/pkg/command/ceip_participation_test.go
+++ b/pkg/command/ceip_participation_test.go
@@ -118,6 +118,10 @@ var _ = Describe("ceip-participation command tests", func() {
 })
 
 func TestCompletionCeip(t *testing.T) {
+	// This is global logic and needs not be tested for each
+	// command.  Let's deactivate it.
+	os.Setenv("TANZU_ACTIVE_HELP", "no_short_help")
+
 	tests := []struct {
 		test     string
 		args     []string
@@ -167,4 +171,6 @@ func TestCompletionCeip(t *testing.T) {
 			assert.Equal(spec.expected, out.String())
 		})
 	}
+
+	os.Unsetenv("TANZU_ACTIVE_HELP")
 }

--- a/pkg/command/cert_test.go
+++ b/pkg/command/cert_test.go
@@ -252,6 +252,10 @@ func TestCompletionCert(t *testing.T) {
 	assert.Nil(t, err)
 	os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
 
+	// This is global logic and needs not be tested for each
+	// command.  Let's deactivate it.
+	os.Setenv("TANZU_ACTIVE_HELP", "no_short_help")
+
 	// Create some test certs
 	cert1 := configtypes.Cert{
 		Host:           "example.com",
@@ -417,6 +421,7 @@ func TestCompletionCert(t *testing.T) {
 	os.RemoveAll(configFileNG.Name())
 	os.Unsetenv("TANZU_CONFIG")
 	os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
+	os.Unsetenv("TANZU_ACTIVE_HELP")
 }
 
 func resetCertCommandFlags() {

--- a/pkg/command/completion_test.go
+++ b/pkg/command/completion_test.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"bytes"
+	"os"
 	"strings"
 	"testing"
 
@@ -127,6 +128,10 @@ func Test_runCompletion_Pwsh(t *testing.T) {
 }
 
 func TestCompletionCompletion(t *testing.T) {
+	// This is global logic and needs not be tested for each
+	// command.  Let's deactivate it.
+	os.Setenv("TANZU_ACTIVE_HELP", "no_short_help")
+
 	tests := []struct {
 		test     string
 		args     []string
@@ -163,4 +168,6 @@ func TestCompletionCompletion(t *testing.T) {
 			assert.Equal(spec.expected, out.String())
 		})
 	}
+
+	os.Unsetenv("TANZU_ACTIVE_HELP")
 }

--- a/pkg/command/config_test.go
+++ b/pkg/command/config_test.go
@@ -192,6 +192,10 @@ func TestCompletionConfig(t *testing.T) {
 	assert.Nil(t, err)
 	os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
 
+	// This is global logic and needs not be tested for each
+	// command.  Let's deactivate it.
+	os.Setenv("TANZU_ACTIVE_HELP", "no_short_help")
+
 	// Set some env vars
 	_ = config.SetEnv("VAR1", "value1")
 	_ = config.SetEnv("VAR2", "value2")
@@ -294,4 +298,5 @@ func TestCompletionConfig(t *testing.T) {
 	os.RemoveAll(configFileNG.Name())
 	os.Unsetenv("TANZU_CONFIG")
 	os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
+	os.Unsetenv("TANZU_ACTIVE_HELP")
 }

--- a/pkg/command/context_test.go
+++ b/pkg/command/context_test.go
@@ -947,7 +947,7 @@ var _ = Describe("testing context use", func() {
 	})
 })
 
-func Test_completionContext(t *testing.T) {
+func TestCompletionContext(t *testing.T) {
 	ctxK8s1 := &configtypes.Context{
 		Name:        "tkg1",
 		ContextType: configtypes.ContextTypeK8s,
@@ -1010,6 +1010,10 @@ func Test_completionContext(t *testing.T) {
 
 	// Set the default config file to the second file
 	os.Setenv("KUBECONFIG", kubeconfigFile2.Name())
+
+	// This is global logic and needs not be tested for each
+	// command.  Let's deactivate it.
+	os.Setenv("TANZU_ACTIVE_HELP", "no_short_help")
 
 	tests := []struct {
 		test     string
@@ -1263,6 +1267,8 @@ func Test_completionContext(t *testing.T) {
 	os.Unsetenv("KUBECONFIG")
 	os.RemoveAll(kubeconfigFile1.Name())
 	os.RemoveAll(kubeconfigFile2.Name())
+
+	os.Unsetenv("TANZU_ACTIVE_HELP")
 }
 
 func resetContextCommandFlags() {

--- a/pkg/command/discovery_source_test.go
+++ b/pkg/command/discovery_source_test.go
@@ -395,6 +395,10 @@ func Test_deleteDiscoverySource(t *testing.T) {
 }
 
 func TestCompletionPluginSource(t *testing.T) {
+	// This is global logic and needs not be tested for each
+	// command.  Let's deactivate it.
+	os.Setenv("TANZU_ACTIVE_HELP", "no_short_help")
+
 	tests := []struct {
 		test     string
 		args     []string
@@ -497,4 +501,6 @@ func TestCompletionPluginSource(t *testing.T) {
 			resetPluginCommandFlags()
 		})
 	}
+
+	os.Unsetenv("TANZU_ACTIVE_HELP")
 }

--- a/pkg/command/doc_test.go
+++ b/pkg/command/doc_test.go
@@ -4,12 +4,17 @@ package command
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCompletionGenerateDocs(t *testing.T) {
+	// This is global logic and needs not be tested for each
+	// command.  Let's deactivate it.
+	os.Setenv("TANZU_ACTIVE_HELP", "no_short_help")
+
 	tests := []struct {
 		test     string
 		args     []string
@@ -46,4 +51,6 @@ func TestCompletionGenerateDocs(t *testing.T) {
 			assert.Equal(spec.expected, out.String())
 		})
 	}
+
+	os.Unsetenv("TANZU_ACTIVE_HELP")
 }

--- a/pkg/command/eula_test.go
+++ b/pkg/command/eula_test.go
@@ -181,6 +181,10 @@ var _ = Describe("EULA version checking tests", func() {
 })
 
 func TestCompletionEULA(t *testing.T) {
+	// This is global logic and needs not be tested for each
+	// command.  Let's deactivate it.
+	os.Setenv("TANZU_ACTIVE_HELP", "no_short_help")
+
 	tests := []struct {
 		test     string
 		args     []string
@@ -223,4 +227,6 @@ func TestCompletionEULA(t *testing.T) {
 			assert.Equal(spec.expected, out.String())
 		})
 	}
+
+	os.Unsetenv("TANZU_ACTIVE_HELP")
 }

--- a/pkg/command/init_test.go
+++ b/pkg/command/init_test.go
@@ -4,12 +4,17 @@ package command
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCompletionInit(t *testing.T) {
+	// This is global logic and needs not be tested for each
+	// command.  Let's deactivate it.
+	os.Setenv("TANZU_ACTIVE_HELP", "no_short_help")
+
 	tests := []struct {
 		test     string
 		args     []string
@@ -40,4 +45,6 @@ func TestCompletionInit(t *testing.T) {
 			assert.Equal(spec.expected, out.String())
 		})
 	}
+
+	os.Unsetenv("TANZU_ACTIVE_HELP")
 }

--- a/pkg/command/plugin_bundle_test.go
+++ b/pkg/command/plugin_bundle_test.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"bytes"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -18,6 +19,10 @@ import (
 )
 
 func TestCompletionPluginBundle(t *testing.T) {
+	// This is global logic and needs not be tested for each
+	// command.  Let's deactivate it.
+	os.Setenv("TANZU_ACTIVE_HELP", "no_short_help")
+
 	var downloadImageCalled bool
 
 	tests := []struct {
@@ -205,4 +210,6 @@ func TestCompletionPluginBundle(t *testing.T) {
 			resetPluginCommandFlags()
 		})
 	}
+
+	os.Unsetenv("TANZU_ACTIVE_HELP")
 }

--- a/pkg/command/plugin_group_test.go
+++ b/pkg/command/plugin_group_test.go
@@ -215,6 +215,10 @@ func TestPluginGroupGet(t *testing.T) {
 }
 
 func TestCompletionPluginGroup(t *testing.T) {
+	// This is global logic and needs not be tested for each
+	// command.  Let's deactivate it.
+	os.Setenv("TANZU_ACTIVE_HELP", "no_short_help")
+
 	tests := []struct {
 		test     string
 		args     []string
@@ -317,4 +321,6 @@ func TestCompletionPluginGroup(t *testing.T) {
 			resetPluginCommandFlags()
 		})
 	}
+
+	os.Unsetenv("TANZU_ACTIVE_HELP")
 }

--- a/pkg/command/plugin_search_test.go
+++ b/pkg/command/plugin_search_test.go
@@ -101,6 +101,10 @@ func TestPluginSearch(t *testing.T) {
 }
 
 func TestCompletionPluginSearch(t *testing.T) {
+	// This is global logic and needs not be tested for each
+	// command.  Let's deactivate it.
+	os.Setenv("TANZU_ACTIVE_HELP", "no_short_help")
+
 	expectedOutforTargetFlag := compGlobalTarget + "\n" + compK8sTarget + "\n" + compTMCTarget + "\n"
 
 	tests := []struct {
@@ -178,4 +182,6 @@ func TestCompletionPluginSearch(t *testing.T) {
 			resetPluginCommandFlags()
 		})
 	}
+
+	os.Unsetenv("TANZU_ACTIVE_HELP")
 }

--- a/pkg/command/plugin_test.go
+++ b/pkg/command/plugin_test.go
@@ -473,6 +473,10 @@ func TestUpgradePlugin(t *testing.T) {
 }
 
 func TestCompletionPlugin(t *testing.T) {
+	// This is global logic and needs not be tested for each
+	// command.  Let's deactivate it.
+	os.Setenv("TANZU_ACTIVE_HELP", "no_short_help")
+
 	// Test local discovery
 	localSourcePath := filepath.Join("..", "fakes", "plugins", cli.GOOS, cli.GOARCH)
 
@@ -964,6 +968,8 @@ func TestCompletionPlugin(t *testing.T) {
 			resetPluginCommandFlags()
 		})
 	}
+
+	os.Unsetenv("TANZU_ACTIVE_HELP")
 }
 
 func resetPluginCommandFlags() {

--- a/pkg/command/version_test.go
+++ b/pkg/command/version_test.go
@@ -65,6 +65,10 @@ func TestVersion(t *testing.T) {
 }
 
 func TestCompletionVersion(t *testing.T) {
+	// This is global logic and needs not be tested for each
+	// command.  Let's deactivate it.
+	os.Setenv("TANZU_ACTIVE_HELP", "no_short_help")
+
 	tests := []struct {
 		test     string
 		args     []string
@@ -95,4 +99,6 @@ func TestCompletionVersion(t *testing.T) {
 			assert.Equal(spec.expected, out.String())
 		})
 	}
+
+	os.Unsetenv("TANZU_ACTIVE_HELP")
 }


### PR DESCRIPTION
### What this PR does / why we need it

Setup a generic ValidArgsFunction to add a command's 'short' string as activeHelp when doing arg completion for any command.

Doing something like "tanzu context <TAB>" will show normal shell completions but will now also print the short help for "tanzu context".

Note that activeHelp only gets shown for `bash` and `zsh`.

```
$ tanzu context <TAB>
Command help: Configure and manage contexts for the Tanzu CLI
--
create  -- Create a Tanzu CLI context
delete  -- Delete a context from the config
get     -- Display a context from the config
list    -- List contexts
unset   -- Unset the active context so that it is not used by default.
use     -- Set the context to be used by default
```

The prefix added before the help text is to deal with situation like the following:

```
$ tz context create tmc --endpoint unstable.tmc-dev.cloud.vmware.com <TAB>
Command help: Create a Tanzu CLI context
```

Without the prefix the text "Create a Tanzu CLI context" could be interpreted as an action the user must do, instead of the description of the command.

Because this change would affect most of the shell completion unit tests, each batch of such test was updated to disable this feature using TANZU_ACTIVE_HELP=no_short_help.

A unit test specific to this feature was added in root_test.go.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Extensive unit test for shell completion show that nothing was broken.

New feature:
```
$ tz plugin <TAB>
Command help: Manage CLI plugins
--
clean            -- Clean the plugins
describe         -- Describe a plugin
download-bundle  -- Download plugin bundle to the local system
group            -- Manage plugin-groups
install          -- Install a plugin
list             -- List installed plugins
search           -- Search for available plugins
source           -- Manage plugin discovery sources
sync             -- Installs all plugins recommended by the active contexts
uninstall        -- Uninstall a plugin
upgrade          -- Upgrade a plugin
upload-bundle    -- Upload plugin bundle to a repository

$ tz plugin group <TAB>
Command help: Manage plugin-groups
--
get     -- Get the content of the specified plugin-group
search  -- Search for available plugin-groups

$ tz version
Command help: Version information
This command does not take any more arguments (but may accept flags).
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Show a core command's short text in ActiveHelp when completing arguments
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

Although this feature was added as part of the PersistentPreRun so that it can affect all commands, it only applies to _core_ commands.  To apply to plugins, we need to make a similar change in tanzu-plugin-runtime.  And the change would only affect plugins that have been re-compiled with this new tanzu-plugin-runtime.

Although I have actually coded the required change, I feel the change is too risky so late in the cycle.  This is because it mucks around replacing `PersistentPreRuns` and such.

If it is felt that the change for plugins must be available before merging this PR than we should delay this PR.