### PR TITLE
UX update for 'context use' to list plugins will be installed

### DIFF
--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -23,9 +23,11 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	clientauthv1 "k8s.io/client-go/pkg/apis/clientauthentication/v1"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/component"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
@@ -47,8 +49,9 @@ import (
 var (
 	stderrOnly, forceCSP, staging, onlyCurrent, skipTLSVerify                              bool
 	ctxName, endpoint, apiToken, kubeConfig, kubeContext, getOutputFmt, endpointCACertPath string
-	projectStr, spaceStr                                                                   string
-	contextTypeStr                                                                         string
+
+	projectStr, spaceStr string
+	contextTypeStr       string
 )
 
 const (
@@ -219,7 +222,7 @@ func initCreateCtxCmd() {
 	createCtxCmd.MarkFlagsMutuallyExclusive("endpoint-ca-certificate", "insecure-skip-tls-verify")
 }
 
-func createCtx(_ *cobra.Command, args []string) (err error) {
+func createCtx(cmd *cobra.Command, args []string) (err error) {
 	// The context name is an optional argument to allow for the prompt to be used
 	if len(args) > 0 {
 		if ctxName != "" {
@@ -250,17 +253,57 @@ func createCtx(_ *cobra.Command, args []string) (err error) {
 	}
 
 	// Sync all required plugins
-	_ = syncContextPlugins(ctx.ContextType)
+	_ = syncContextPlugins(cmd, ctx.ContextType, true)
 
 	return nil
 }
 
-func syncContextPlugins(contextType configtypes.ContextType) error {
-	err := pluginmanager.SyncPluginsForContextType(contextType)
+// syncContextPlugins syncs the plugins for the given context type
+// if listPlugins is true, it will list the plugins that will be installed for the given context type
+func syncContextPlugins(cmd *cobra.Command, contextType configtypes.ContextType, listPlugins bool) error {
+	plugins, err := pluginmanager.DiscoverPluginsForContextType(contextType)
+	errList := make([]error, 0)
+	if err != nil {
+		errList = append(errList, err)
+	}
+
+	// update plugins installation status
+	pluginmanager.UpdatePluginsInstallationStatus(plugins)
+
+	// list plugins only if listPlugins is true and there are plugins to be installed
+	if listPlugins {
+		pluginsNeedstoBeInstalled := 0
+		for idx := range plugins {
+			if plugins[idx].Status == common.PluginStatusNotInstalled || plugins[idx].Status == common.PluginStatusUpdateAvailable {
+				pluginsNeedstoBeInstalled++
+			}
+		}
+		if pluginsNeedstoBeInstalled > 0 {
+			log.Infof("The following plugins will be installed for context '%s': ", ctxName)
+			displayUninstalledPluginsContentAsTable(plugins, cmd.ErrOrStderr())
+		}
+	}
+
+	err = pluginmanager.InstallDiscoveredContextPlugins(plugins)
+	if err != nil {
+		errList = append(errList, err)
+	}
+	err = kerrors.NewAggregate(errList)
 	if err != nil {
 		log.Warningf("unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually, error: '%v'", err.Error())
 	}
 	return err
+}
+
+// displayUninstalledPluginsContentAsTable takes a list of plugins and writes the uninstalled plugins as a table
+func displayUninstalledPluginsContentAsTable(plugins []discovery.Discovered, writer io.Writer) {
+	outputUninstalledPlugins := component.NewOutputWriterWithOptions(writer, outputFormat, []component.OutputWriterOption{}, "Name", "Target", "Version")
+	for i := range plugins {
+		if plugins[i].Status == common.PluginStatusNotInstalled || plugins[i].Status == common.PluginStatusUpdateAvailable {
+			outputUninstalledPlugins.AddRow(plugins[i].Name, plugins[i].Target, plugins[i].RecommendedVersion)
+		}
+	}
+	outputUninstalledPlugins.Render()
 }
 
 func isGlobalContext(endpoint string) bool {
@@ -982,8 +1025,7 @@ var useCtxCmd = &cobra.Command{
 	RunE:              useCtx,
 }
 
-func useCtx(_ *cobra.Command, args []string) error {
-	var name string
+func useCtx(cmd *cobra.Command, args []string) error {
 	var ctx *configtypes.Context
 	var err error
 
@@ -992,12 +1034,12 @@ func useCtx(_ *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		name = ctx.Name
+		ctxName = ctx.Name
 	} else {
-		name = args[0]
+		ctxName = args[0]
 	}
 
-	ctx, err = config.GetContext(name)
+	ctx, err = config.GetContext(ctxName)
 	if err != nil {
 		return err
 	}
@@ -1009,13 +1051,15 @@ func useCtx(_ *cobra.Command, args []string) error {
 		}
 	}
 
-	err = config.SetActiveContext(name)
+	err = config.SetActiveContext(ctxName)
 	if err != nil {
 		return err
 	}
 
+	log.Infof("Successfully activated context '%s'", ctxName)
+
 	// Sync all required plugins
-	_ = syncContextPlugins(ctx.ContextType)
+	_ = syncContextPlugins(cmd, ctx.ContextType, true)
 
 	return nil
 }

--- a/pkg/pluginmanager/manager_test.go
+++ b/pkg/pluginmanager/manager_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
-	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
@@ -718,90 +717,6 @@ func Test_SyncPlugins(t *testing.T) {
 	assertions.Equal(len(installedServerPlugins), len(serverPlugins))
 
 	for _, isp := range installedServerPlugins {
-		p := findDiscoveredPlugin(serverPlugins, isp.Name, isp.Target)
-		assertions.NotNil(p)
-	}
-}
-
-// TestSyncPluginsForK8SSpecificContextType tests to sync plugins for k8s specific ContextType only
-func TestSyncPluginsForK8SSpecificContextType(t *testing.T) {
-	assertions := assert.New(t)
-	ctx, err := configlib.GetActiveContext("k8s")
-	fmt.Println(ctx, err)
-	defer setupPluginSourceForTesting()()
-	execCommand = fakeInfoExecCommand
-	defer func() { execCommand = exec.Command }()
-
-	// Get the server plugins (they are not installed yet)
-	serverPlugins, err := DiscoverServerPlugins()
-	assertions.NotNil(err)
-	// There is an error for the kubernetes discovery since we don't have a cluster
-	// but other server plugins will be found, so we use those
-	assertions.Contains(err.Error(), `Failed to load Kubeconfig file from "config"`)
-	assertions.Equal(len(expectedDiscoveredContextPlugins), len(serverPlugins))
-	var k8sContextPlugins []*discovery.Discovered
-	for _, edp := range expectedDiscoveredContextPlugins {
-		p := findDiscoveredPlugin(serverPlugins, edp.Name, edp.Target)
-		assertions.NotNil(p)
-		assertions.Equal(common.PluginStatusNotInstalled, p.Status)
-		if p.Target == configtypes.TargetK8s {
-			k8sContextPlugins = append(k8sContextPlugins, p)
-		}
-	}
-
-	// Sync all available plugins
-	err = SyncPluginsForContextType(configtypes.ContextTypeK8s)
-	assertions.NotNil(err)
-	// There is an error for the kubernetes discovery since we don't have a cluster
-	// but other server plugins will be found, so we use those
-	assertions.Contains(err.Error(), `Failed to load Kubeconfig file from "config"`)
-
-	installedServerPlugins, err := pluginsupplier.GetInstalledServerPlugins()
-	assertions.Nil(err)
-	assertions.Equal(len(installedServerPlugins), len(k8sContextPlugins))
-
-	for _, isp := range installedServerPlugins {
-		assertions.Equal(isp.Target, configtypes.TargetK8s)
-		p := findDiscoveredPlugin(serverPlugins, isp.Name, isp.Target)
-		assertions.NotNil(p)
-	}
-}
-
-// TestSyncPluginsForTMCSpecificContextType tests to sync plugins for tmc specific ContextType only
-func TestSyncPluginsForTMCSpecificContextType(t *testing.T) {
-	assertions := assert.New(t)
-
-	defer setupPluginSourceForTesting()()
-	execCommand = fakeInfoExecCommand
-	defer func() { execCommand = exec.Command }()
-
-	// Get the server plugins (they are not installed yet)
-	serverPlugins, err := DiscoverServerPlugins()
-	assertions.NotNil(err)
-	// There is an error for the kubernetes discovery since we don't have a cluster
-	// but other server plugins will be found, so we use those
-	assertions.Contains(err.Error(), `Failed to load Kubeconfig file from "config"`)
-	assertions.Equal(len(expectedDiscoveredContextPlugins), len(serverPlugins))
-	var tmcTargetPlugins []*discovery.Discovered
-	for _, edp := range expectedDiscoveredContextPlugins {
-		p := findDiscoveredPlugin(serverPlugins, edp.Name, edp.Target)
-		assertions.NotNil(p)
-		assertions.Equal(common.PluginStatusNotInstalled, p.Status)
-		if p.Target == configtypes.TargetTMC {
-			tmcTargetPlugins = append(tmcTargetPlugins, p)
-		}
-	}
-
-	// Sync all available plugins
-	err = SyncPluginsForContextType(configtypes.ContextTypeTMC)
-	assertions.Nil(err)
-
-	installedServerPlugins, err := pluginsupplier.GetInstalledServerPlugins()
-	assertions.Nil(err)
-	assertions.Equal(len(installedServerPlugins), len(tmcTargetPlugins))
-
-	for _, isp := range installedServerPlugins {
-		assertions.Equal(isp.Target, configtypes.TargetTMC)
 		p := findDiscoveredPlugin(serverPlugins, isp.Name, isp.Target)
 		assertions.NotNil(p)
 	}

--- a/test/e2e/context/k8s/context_k8s_lifecycle_test.go
+++ b/test/e2e/context/k8s/context_k8s_lifecycle_test.go
@@ -18,6 +18,8 @@ import (
 
 const ContextNameConfigPrefix = "context-config-k8s-"
 
+var stdOut string
+
 // This test suite focuses on testing context use cases for the Kubernetes (K8s) target,
 // as well as stress test cases specifically for the K8s target.
 var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Context-k8s-tests]", func() {
@@ -82,7 +84,7 @@ func k8sContextLifeCycleTests() bool {
 		})
 		// Test case: test 'tanzu context use' command with the specific context name (not the recently created one)
 		It("use context command", func() {
-			err = tf.ContextCmd.UseContext(contextNames[0])
+			_, _, err = tf.ContextCmd.UseContext(contextNames[0])
 			Expect(err).To(BeNil(), "use context should set context without any error")
 			active, err = tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
 			Expect(err).To(BeNil(), "there should be a active context")
@@ -90,13 +92,13 @@ func k8sContextLifeCycleTests() bool {
 		})
 		// Test case: context unset command: test 'tanzu context unset' command with active context name
 		It("unset context command: by context name", func() {
-			err = tf.ContextCmd.UseContext(contextNames[0])
+			_, _, err = tf.ContextCmd.UseContext(contextNames[0])
 			Expect(err).To(BeNil(), "use context should set context without any error")
 			active, err = tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
 			Expect(err).To(BeNil(), "there should be a active context")
 			Expect(active).To(Equal(contextNames[0]), "the active context should be recently set context")
 
-			stdOut, _, err := tf.ContextCmd.UnsetContext(contextNames[0])
+			stdOut, _, err = tf.ContextCmd.UnsetContext(contextNames[0])
 			Expect(err).To(BeNil(), "unset context should unset context without any error")
 			Expect(stdOut).To(ContainSubstring(fmt.Sprintf(framework.ContextForContextTypeSetInactive, contextNames[0], framework.KubernetesTarget)))
 			active, err = tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
@@ -105,25 +107,24 @@ func k8sContextLifeCycleTests() bool {
 		})
 		// Test case: context unset command: test 'tanzu context unset' command with random context name
 		It("unset context command: negative use case: by random context name", func() {
-			err = tf.ContextCmd.UseContext(contextNames[0])
+			_, _, err = tf.ContextCmd.UseContext(contextNames[0])
 			Expect(err).To(BeNil(), "use context should set context without any error")
 			active, err = tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
 			Expect(err).To(BeNil(), "there should be a active context")
 			Expect(active).To(Equal(contextNames[0]), "the active context should be recently set context")
 
 			name := framework.RandomString(5)
-			_, _, err := tf.ContextCmd.UnsetContext(name)
+			_, _, err = tf.ContextCmd.UnsetContext(name)
 			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(framework.ContextNotActiveOrNotExists, name)))
 		})
 		// Test case: context unset command: test 'tanzu context unset' command by providing target
 		It("unset context command: by target", func() {
-			err = tf.ContextCmd.UseContext(contextNames[0])
+			_, _, err = tf.ContextCmd.UseContext(contextNames[0])
 			Expect(err).To(BeNil(), "use context should set context without any error")
 			active, err = tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
 			Expect(err).To(BeNil(), "there should be a active context")
 			Expect(active).To(Equal(contextNames[0]), "the active context should be recently set context")
-
-			stdOut, _, err := tf.ContextCmd.UnsetContext("", framework.AddAdditionalFlagAndValue("--type k8s"))
+			stdOut, _, err = tf.ContextCmd.UnsetContext("", framework.AddAdditionalFlagAndValue("--type k8s"))
 			Expect(err).To(BeNil(), "unset context should unset context without any error")
 			Expect(stdOut).To(ContainSubstring(fmt.Sprintf(framework.ContextForContextTypeSetInactive, contextNames[0], framework.KubernetesTarget)))
 			active, err = tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
@@ -132,13 +133,12 @@ func k8sContextLifeCycleTests() bool {
 		})
 		// Test case: context unset command: test 'tanzu context unset' by providing target and context name
 		It("unset context command: by target and context name", func() {
-			err = tf.ContextCmd.UseContext(contextNames[0])
+			_, _, err = tf.ContextCmd.UseContext(contextNames[0])
 			Expect(err).To(BeNil(), "use context should set context without any error")
 			active, err = tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
 			Expect(err).To(BeNil(), "there should be a active context")
 			Expect(active).To(Equal(contextNames[0]), "the active context should be recently set context")
-
-			stdOut, _, err := tf.ContextCmd.UnsetContext(contextNames[0], framework.AddAdditionalFlagAndValue("--type k8s"))
+			stdOut, _, err = tf.ContextCmd.UnsetContext(contextNames[0], framework.AddAdditionalFlagAndValue("--type k8s"))
 			Expect(err).To(BeNil(), "unset context should unset context without any error")
 			Expect(stdOut).To(ContainSubstring(fmt.Sprintf(framework.ContextForContextTypeSetInactive, contextNames[0], framework.KubernetesTarget)))
 			active, err = tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
@@ -147,13 +147,13 @@ func k8sContextLifeCycleTests() bool {
 		})
 		// Test case: context unset command: test 'tanzu context unset' command with incorrect target
 		It("unset context command: negative use case: by target and context name: incorrect target", func() {
-			err = tf.ContextCmd.UseContext(contextNames[0])
+			_, _, err = tf.ContextCmd.UseContext(contextNames[0])
 			Expect(err).To(BeNil(), "use context should set context without any error")
 			active, err = tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
 			Expect(err).To(BeNil(), "there should be a active context")
 			Expect(active).To(Equal(contextNames[0]), "the active context should be recently set context")
 
-			_, _, err := tf.ContextCmd.UnsetContext(contextNames[0], framework.AddAdditionalFlagAndValue("--type tmc"))
+			_, _, err = tf.ContextCmd.UnsetContext(contextNames[0], framework.AddAdditionalFlagAndValue("--type tmc"))
 			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(framework.ContextNotExistsForTarget, contextNames[0], framework.MissionControlTarget)))
 			active, err = tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
 			Expect(err).To(BeNil(), "there should not be any error for the get context")
@@ -161,7 +161,7 @@ func k8sContextLifeCycleTests() bool {
 		})
 		// Test case: (negative test) test 'tanzu context use' command with the specific context name (incorrect, which is not exists)
 		It("use context command with incorrect context as input", func() {
-			err := tf.ContextCmd.UseContext(framework.RandomString(4))
+			_, _, err = tf.ContextCmd.UseContext(framework.RandomString(4))
 			Expect(err).ToNot(BeNil())
 		})
 		// Test case: test 'tanzu context list' command, should list all contexts created
@@ -174,7 +174,7 @@ func k8sContextLifeCycleTests() bool {
 		It("delete context command", func() {
 			By("delete all contexts created in previous tests")
 			for _, ctx := range contextNames {
-				_, _, err := tf.ContextCmd.DeleteContext(ctx)
+				_, _, err = tf.ContextCmd.DeleteContext(ctx)
 				Expect(framework.IsContextExists(tf, ctx)).To(BeFalse(), fmt.Sprintf(framework.ContextShouldNotExists, ctx))
 				Expect(err).To(BeNil(), "delete context should delete context without any error")
 			}
@@ -182,7 +182,7 @@ func k8sContextLifeCycleTests() bool {
 		// Test case: (negative test) test 'tanzu context delete' command for context name which is not exists
 		It("delete context command", func() {
 			By("delete context command with random string")
-			_, _, err := tf.ContextCmd.DeleteContext(framework.RandomString(4))
+			_, _, err = tf.ContextCmd.DeleteContext(framework.RandomString(4))
 			Expect(err).ToNot(BeNil())
 		})
 	})
@@ -206,7 +206,7 @@ func k8sContextStressTests() bool {
 			list, err := tf.ContextCmd.ListContext()
 			Expect(err).To(BeNil(), "list context should not return any error")
 			for _, ctx := range list {
-				_, _, err := tf.ContextCmd.DeleteContext(ctx.Name)
+				_, _, err = tf.ContextCmd.DeleteContext(ctx.Name)
 				Expect(err).To(BeNil(), "delete context should delete context without any error")
 				Expect(framework.IsContextExists(tf, ctx.Name)).To(BeFalse(), fmt.Sprintf(framework.ContextShouldNotExists, ctx.Name))
 			}
@@ -219,7 +219,7 @@ func k8sContextStressTests() bool {
 			By("create multiple contexts with kubeconfig and context")
 			for i := 0; i < ContextCreateLimit; i++ {
 				ctxName := ContextNameConfigPrefix + framework.RandomString(4)
-				err := tf.ContextCmd.CreateContextWithKubeconfig(ctxName, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
+				err = tf.ContextCmd.CreateContextWithKubeconfig(ctxName, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
 				Expect(err).To(BeNil(), "context should create without any error")
 				log.Info("context: " + ctxName + " added")
 				Expect(framework.IsContextExists(tf, ctxName)).To(BeTrue(), fmt.Sprintf(framework.ContextShouldExistsAsCreated, ctxName))
@@ -231,7 +231,7 @@ func k8sContextStressTests() bool {
 		It("use context command", func() {
 			By("use context command")
 			for i := 0; i < len(contextNamesStress); i++ {
-				err := tf.ContextCmd.UseContext(contextNamesStress[i])
+				_, _, err = tf.ContextCmd.UseContext(contextNamesStress[i])
 				log.Info("set the corrent context as:" + contextNamesStress[i])
 				Expect(err).To(BeNil(), "use context should set context without any error")
 				active, err := tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
@@ -249,7 +249,7 @@ func k8sContextStressTests() bool {
 		It("delete context command", func() {
 			By("delete all contexts created in previous tests")
 			for _, ctx := range contextNamesStress {
-				_, _, err := tf.ContextCmd.DeleteContext(ctx)
+				_, _, err = tf.ContextCmd.DeleteContext(ctx)
 				log.Infof("context: %s deleted", ctx)
 				Expect(framework.IsContextExists(tf, ctx)).To(BeFalse(), fmt.Sprintf(framework.ContextShouldNotExists, ctx))
 				Expect(err).To(BeNil(), "delete context should delete context without any error")

--- a/test/e2e/context/tmc/context_tmc_lifecycle_test.go
+++ b/test/e2e/context/tmc/context_tmc_lifecycle_test.go
@@ -63,7 +63,7 @@ func tmcStressTestCases() bool {
 		It("use context command", func() {
 			By("use context command")
 			for i := 0; i < len(contextNamesStress); i++ {
-				err := tf.ContextCmd.UseContext(contextNamesStress[i])
+				_, _, err := tf.ContextCmd.UseContext(contextNamesStress[i])
 				Expect(err).To(BeNil(), "use context should set context without any error")
 				active, err := tf.ContextCmd.GetActiveContext(string(types.TargetTMC))
 				Expect(err).To(BeNil(), "there should be a active context")
@@ -296,7 +296,7 @@ func tmcLifeCycleTests() bool {
 		})
 		// Test case: f. test 'tanzu context use' command with the specific context name (not the recently created one)
 		It("use context command", func() {
-			err := tf.ContextCmd.UseContext(contextNames[0])
+			_, _, err := tf.ContextCmd.UseContext(contextNames[0])
 			Expect(err).To(BeNil(), "use context should set context without any error")
 			activeCtx, err := tf.ContextCmd.GetActiveContext(string(types.TargetTMC))
 			Expect(err).To(BeNil(), "there should be a active context")
@@ -305,7 +305,7 @@ func tmcLifeCycleTests() bool {
 		// context unset command related use cases:::
 		// Test case: g. context unset command: test 'tanzu context unset' command with active context name
 		It("unset context command: by context name", func() {
-			err = tf.ContextCmd.UseContext(contextNames[0])
+			_, _, err = tf.ContextCmd.UseContext(contextNames[0])
 			Expect(err).To(BeNil(), "use context should set context without any error")
 			active, err = tf.ContextCmd.GetActiveContext(string(types.TargetTMC))
 			Expect(err).To(BeNil(), "there should be a active context")
@@ -320,7 +320,7 @@ func tmcLifeCycleTests() bool {
 		})
 		// Test case: h. context unset command: test 'tanzu context unset' command with random context name
 		It("unset context command: negative use case: by random context name", func() {
-			err = tf.ContextCmd.UseContext(contextNames[0])
+			_, _, err = tf.ContextCmd.UseContext(contextNames[0])
 			Expect(err).To(BeNil(), "use context should set context without any error")
 			active, err = tf.ContextCmd.GetActiveContext(string(types.TargetTMC))
 			Expect(err).To(BeNil(), "there should be a active context")
@@ -332,7 +332,7 @@ func tmcLifeCycleTests() bool {
 		})
 		// Test case: i.context unset command: test 'tanzu context unset' command by providing valid target
 		It("unset context command: by target", func() {
-			err = tf.ContextCmd.UseContext(contextNames[0])
+			_, _, err = tf.ContextCmd.UseContext(contextNames[0])
 			Expect(err).To(BeNil(), "use context should set context without any error")
 			active, err = tf.ContextCmd.GetActiveContext(string(types.TargetTMC))
 			Expect(err).To(BeNil(), "there should be a active context")
@@ -347,7 +347,7 @@ func tmcLifeCycleTests() bool {
 		})
 		// Test case: j. context unset command: test 'tanzu context unset' by providing target and context name
 		It("unset context command: by target and context name", func() {
-			err = tf.ContextCmd.UseContext(contextNames[0])
+			_, _, err = tf.ContextCmd.UseContext(contextNames[0])
 			Expect(err).To(BeNil(), "use context should set context without any error")
 			active, err = tf.ContextCmd.GetActiveContext(string(types.TargetTMC))
 			Expect(err).To(BeNil(), "there should be a active context")
@@ -362,7 +362,7 @@ func tmcLifeCycleTests() bool {
 		})
 		// Test case: k. context unset command: test 'tanzu context unset' command with incorrect target
 		It("unset context command: negative use case: by target and context name: incorrect target", func() {
-			err = tf.ContextCmd.UseContext(contextNames[0])
+			_, _, err = tf.ContextCmd.UseContext(contextNames[0])
 			Expect(err).To(BeNil(), "use context should set context without any error")
 			active, err = tf.ContextCmd.GetActiveContext(string(types.TargetTMC))
 			Expect(err).To(BeNil(), "there should be a active context")
@@ -376,7 +376,7 @@ func tmcLifeCycleTests() bool {
 		})
 		// Test case: l. (negative test) test 'tanzu context use' command with the specific context name (incorrect, which is not exists)
 		It("use context command with incorrect context as input", func() {
-			err := tf.ContextCmd.UseContext(framework.RandomString(4))
+			_, _, err := tf.ContextCmd.UseContext(framework.RandomString(4))
 			Expect(err).ToNot(BeNil())
 		})
 		// Test case: m. test 'tanzu context list' command, should list all contexts created

--- a/test/e2e/framework/context_lifecycle_operations.go
+++ b/test/e2e/framework/context_lifecycle_operations.go
@@ -17,7 +17,7 @@ type ContextCmdOps interface {
 	// ContextCreateOps helps context create operations
 	ContextCreateOps
 	// UseContext helps to run 'context use' command
-	UseContext(contextName string, opts ...E2EOption) error
+	UseContext(contextName string, opts ...E2EOption) (stdOutStr, stdErrStr string, err error)
 	// GetContext helps to run `context get` command
 	GetContext(contextName string, opts ...E2EOption) (ContextInfo, error)
 	// ListContext helps to run `context list` command
@@ -45,10 +45,10 @@ func NewContextCmdOps() ContextCmdOps {
 	}
 }
 
-func (cc *contextCmdOps) UseContext(contextName string, opts ...E2EOption) error {
+func (cc *contextCmdOps) UseContext(contextName string, opts ...E2EOption) (stdOutStr, stdErrStr string, err error) {
 	useContextCmd := fmt.Sprintf(UseContext, "%s", contextName)
-	_, _, err := cc.cmdExe.TanzuCmdExec(useContextCmd, opts...)
-	return err
+	stdOutBuff, stdErrBuff, err := cc.cmdExe.TanzuCmdExec(useContextCmd, opts...)
+	return stdOutBuff.String(), stdErrBuff.String(), err
 }
 
 func (cc *contextCmdOps) UnsetContext(contextName string, opts ...E2EOption) (string, string, error) {

--- a/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_test.go
+++ b/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_test.go
@@ -274,7 +274,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			for i := range installedPluginsList {
 				Expect(stdOut).To(ContainSubstring(fmt.Sprintf(f.DeactivatingPlugin, installedPluginsList[i].Name, installedPluginsList[i].Version, contextName)))
 			}
-			err = tf.ContextCmd.UseContext(contextName)
+			_, _, err = tf.ContextCmd.UseContext(contextName)
 			Expect(err).To(BeNil(), "use context should set context without any error")
 		})
 		// e.2 delete current context and stop mock server
@@ -603,7 +603,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 
 		// Test case: i. k8s: use first k8s context and check plugin list
 		It("use first context, check plugin list", func() {
-			err = tf.ContextCmd.UseContext(contextNameK8s)
+			_, _, err = tf.ContextCmd.UseContext(contextNameK8s)
 			Expect(err).To(BeNil(), "use context should not return any error")
 			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeK8s))
 			Expect(err).To(BeNil(), activeContextShouldExists)
@@ -641,7 +641,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		// Test case: k. tmc: use tmc context and check plugin list
 		It("use second context again, check plugin list", func() {
 
-			err = tf.ContextCmd.UseContext(contextNameTMC)
+			_, _, err = tf.ContextCmd.UseContext(contextNameTMC)
 			Expect(err).To(BeNil(), "use context should not return any error")
 			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeTMC))
 			Expect(err).To(BeNil(), activeContextShouldExists)
@@ -705,7 +705,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		It("create context with kubeconfig and context", func() {
 			By("create context with kubeconfig and context")
 			contextNameK8s = f.ContextPrefixK8s + f.RandomString(4)
-			err := tf.ContextCmd.CreateContextWithKubeconfig(contextNameK8s, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
+			err = tf.ContextCmd.CreateContextWithKubeconfig(contextNameK8s, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
 			Expect(err).To(BeNil(), "context should create without any error")
 			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeK8s))
 			Expect(err).To(BeNil(), thereShouldNotBeError+" while getting active context")
@@ -783,10 +783,10 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		// sync should happen only for the specific context (k8s context), not for all active context's
 		// perform 'tanzu plugin clean' and 'tanzu context use' for k8s context again, and check plugins list, it should be same as previous
 		It("test context use for specific context-k8s", func() {
-			err = tf.ContextCmd.UseContext(contextNameK8s)
+			_, _, err = tf.ContextCmd.UseContext(contextNameK8s)
 			Expect(err).To(BeNil(), "use context should not return any error")
 
-			err = tf.ContextCmd.UseContext(contextNameTMC)
+			_, _, err = tf.ContextCmd.UseContext(contextNameTMC)
 			Expect(err).To(BeNil(), "use context should not return any error")
 
 			err = tf.PluginCmd.CleanPlugins()
@@ -795,7 +795,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			_, _, err = tf.ContextCmd.UnsetContext(contextNameK8s)
 			Expect(err).To(BeNil(), "unset context should unset context without any error")
 
-			err = tf.ContextCmd.UseContext(contextNameK8s)
+			_, _, err = tf.ContextCmd.UseContext(contextNameK8s)
 			Expect(err).To(BeNil(), "use context should not return any error")
 
 			// k8s contextType specific plugins only should be installed
@@ -812,7 +812,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			err = tf.PluginCmd.CleanPlugins()
 			Expect(err).To(BeNil(), "plugin clean should not return any error")
 
-			err = tf.ContextCmd.UseContext(contextNameK8s)
+			_, _, err = tf.ContextCmd.UseContext(contextNameK8s)
 			Expect(err).To(BeNil(), "use context should not return any error")
 
 			// k8s contextType specific plugins only should be installed
@@ -834,10 +834,10 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		// sync should happen only for the specific context (tmc context), not for all active context's
 		// perform 'tanzu plugin clean' and 'tanzu context use' for tmc context again, and check plugins list, it should be same as previous
 		It("test context use for specific context-TMC", func() {
-			err = tf.ContextCmd.UseContext(contextNameK8s)
+			_, _, err = tf.ContextCmd.UseContext(contextNameK8s)
 			Expect(err).To(BeNil(), "use context should not return any error")
 
-			err = tf.ContextCmd.UseContext(contextNameTMC)
+			_, _, err = tf.ContextCmd.UseContext(contextNameTMC)
 			Expect(err).To(BeNil(), "use context should not return any error")
 
 			err = tf.PluginCmd.CleanPlugins()
@@ -846,7 +846,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			_, _, err = tf.ContextCmd.UnsetContext(contextNameTMC)
 			Expect(err).To(BeNil(), "unset context should unset context without any error")
 
-			err = tf.ContextCmd.UseContext(contextNameTMC)
+			_, _, err = tf.ContextCmd.UseContext(contextNameTMC)
 			Expect(err).To(BeNil(), "use context should not return any error")
 
 			// tmc contextType specific plugins only should be installed
@@ -864,7 +864,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			err = tf.PluginCmd.CleanPlugins()
 			Expect(err).To(BeNil(), "plugin clean should not return any error")
 
-			err = tf.ContextCmd.UseContext(contextNameTMC)
+			_, _, err = tf.ContextCmd.UseContext(contextNameTMC)
 			Expect(err).To(BeNil(), "use context should not return any error")
 
 			// tmc contextType specific plugins only should be installed
@@ -883,10 +883,10 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		// Test case: context use for TMC context and K8s context
 		// plugin should get sync for both tmc and k8s context
 		It("context use for both TMC and k8s contexts", func() {
-			err = tf.ContextCmd.UseContext(contextNameK8s)
+			_, _, err = tf.ContextCmd.UseContext(contextNameK8s)
 			Expect(err).To(BeNil(), "use context should not return any error")
 
-			err = tf.ContextCmd.UseContext(contextNameTMC)
+			_, _, err = tf.ContextCmd.UseContext(contextNameTMC)
 			Expect(err).To(BeNil(), "use context should not return any error")
 
 			// tmc contextType specific plugins should be installed
@@ -905,10 +905,10 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		// plugin should get sync for both tmc and k8s context
 		It("test plugin sync", func() {
 
-			err = tf.ContextCmd.UseContext(contextNameK8s)
+			_, _, err = tf.ContextCmd.UseContext(contextNameK8s)
 			Expect(err).To(BeNil(), "use context should not return any error")
 
-			err = tf.ContextCmd.UseContext(contextNameTMC)
+			_, _, err = tf.ContextCmd.UseContext(contextNameTMC)
 			Expect(err).To(BeNil(), "use context should not return any error")
 
 			// perform plugin clean, then perform plugin sync


### PR DESCRIPTION
### What this PR does / why we need it
Before this change, the `tanzu context create context-name` and `tanzu context use context-name` commands created and activated the given context and installed the required plugins. However, they did not list all the plugins they would install as part of the command execution, resulting in a suboptimal user experience. Users were unaware of how many plugins would be installed or which ones were included. Sometimes, the installation process took a considerable amount of time, leaving users in the dark about the installation progress.

After this PR, the `tanzu context create context-name` and `tanzu context use context-name` commands will list the plugins they are going to install. This enhancement provides a great user experience, as users will know in advance which plugins are being installed. This makes it easier for users to track the progress.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
1) Use case: No plugins are installed for a context
``` 
❯ t context use tmc1
[i] Successfully activated context 'tmc1'
[i] Checking for required plugins for context tmc1...
[i] The following plugins will be installed for context 'tmc1': 
  NAME                  TARGET           VERSION  
  clustergroup          mission-control  v0.1.11  
  integration           mission-control  v0.1.11  
  ekscluster            mission-control  v0.1.11  
  account               mission-control  v0.1.12  
  setting               mission-control  v0.2.9   
  iam                   mission-control  v0.1.11  
  workspace             mission-control  v0.1.13  
  tanzupackage          mission-control  v0.2.10  
  data-protection       mission-control  v0.1.11  
  provider-aks-cluster  mission-control  v0.1.12  
  events                mission-control  v0.1.11  
  aks-cluster           mission-control  v0.2.1   
  apply                 mission-control  v0.3.8   
  secret                mission-control  v0.1.11  
  helm                  mission-control  v0.1.11  
  provider-eks-cluster  mission-control  v0.1.11  
  audit                 mission-control  v0.1.11  
  agentartifacts        mission-control  v0.1.11  
  management-cluster    mission-control  v0.2.11  
  continuousdelivery    mission-control  v0.1.11  
  inspection            mission-control  v0.1.11  
  policy                mission-control  v0.1.11  
  cluster               mission-control  v0.2.6   
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Installing plugin 'clustergroup:v0.1.11' with target 'mission-control' 
[i] Installing plugin 'integration:v0.1.11' with target 'mission-control' 
[i] Installing plugin 'ekscluster:v0.1.11' with target 'mission-control' 
[i] Installing plugin 'account:v0.1.12' with target 'mission-control' 
[i] Installing plugin 'setting:v0.2.9' with target 'mission-control' 
[i] Installing plugin 'iam:v0.1.11' with target 'mission-control' 
[i] Installing plugin 'workspace:v0.1.13' with target 'mission-control' 
[i] Installing plugin 'tanzupackage:v0.2.10' with target 'mission-control' 
[i] Installing plugin 'data-protection:v0.1.11' with target 'mission-control' 
[i] Installing plugin 'provider-aks-cluster:v0.1.12' with target 'mission-control' 
[i] Installing plugin 'events:v0.1.11' with target 'mission-control' 
[i] Installing plugin 'aks-cluster:v0.2.1' with target 'mission-control' 
[i] Installing plugin 'apply:v0.3.8' with target 'mission-control' 
[i] Installing plugin 'secret:v0.1.11' with target 'mission-control' 
[i] Installing plugin 'helm:v0.1.11' with target 'mission-control' 
[i] Installing plugin 'provider-eks-cluster:v0.1.11' with target 'mission-control' 
[i] Installing plugin 'audit:v0.1.11' with target 'mission-control' 
[i] Installing plugin 'agentartifacts:v0.1.11' with target 'mission-control' 
[i] Installing plugin 'management-cluster:v0.2.11' with target 'mission-control' 
[i] Installing plugin 'continuousdelivery:v0.1.11' with target 'mission-control' 
[i] Installing plugin 'inspection:v0.1.11' with target 'mission-control' 
[i] Installing plugin 'policy:v0.1.11' with target 'mission-control' 
[i] Installing plugin 'cluster:v0.2.6' with target 'mission-control' 
[i] Successfully installed all required plugins
❯ 
```

2) Use case: When all plugins are installed for a context:

```
❯ t context unset tmc1
[i] The tanzu cli essential plugins have not been installed and are being installed now. The install may take a few seconds.

The context 'tmc1' of type 'mission-control' has been set as inactive
Deactivating plugin 'iam:v0.1.11' for context 'tmc1'
Deactivating plugin 'workspace:v0.1.13' for context 'tmc1'
Deactivating plugin 'agentartifacts:v0.1.11' for context 'tmc1'
Deactivating plugin 'data-protection:v0.1.11' for context 'tmc1'
Deactivating plugin 'events:v0.1.11' for context 'tmc1'
Deactivating plugin 'cluster:v0.2.6' for context 'tmc1'
Deactivating plugin 'aks-cluster:v0.2.1' for context 'tmc1'
Deactivating plugin 'ekscluster:v0.1.11' for context 'tmc1'
Deactivating plugin 'provider-eks-cluster:v0.1.11' for context 'tmc1'
Deactivating plugin 'integration:v0.1.11' for context 'tmc1'
Deactivating plugin 'apply:v0.3.8' for context 'tmc1'
Deactivating plugin 'audit:v0.1.11' for context 'tmc1'
Deactivating plugin 'secret:v0.1.11' for context 'tmc1'
Deactivating plugin 'helm:v0.1.11' for context 'tmc1'
Deactivating plugin 'clustergroup:v0.1.11' for context 'tmc1'
Deactivating plugin 'management-cluster:v0.2.11' for context 'tmc1'
Deactivating plugin 'policy:v0.1.11' for context 'tmc1'
Deactivating plugin 'account:v0.1.12' for context 'tmc1'
Deactivating plugin 'inspection:v0.1.11' for context 'tmc1'
Deactivating plugin 'provider-aks-cluster:v0.1.12' for context 'tmc1'
Deactivating plugin 'setting:v0.2.9' for context 'tmc1'
Deactivating plugin 'tanzupackage:v0.2.10' for context 'tmc1'
Deactivating plugin 'continuousdelivery:v0.1.11' for context 'tmc1'
❯ 
❯ 
❯ t context use tmc1
[i] Successfully activated context 'tmc1'
[i] Checking for required plugins for context tmc1...
[i] All required plugins are already installed and up-to-date
❯ 
❯
```

3) Use case: When some plug plugins are installed, some are not installed for a context:

```
❯ 
❯ t plugin delete workspace --target tmc
Uninstalling plugin 'workspace' for target 'mission-control'. Are you sure? [y/N]: y
[i] Uninstalling plugin 'workspace' for target 'mission-control'
[ok] successfully uninstalled plugin 'workspace'
❯ 
❯ t plugin delete secret --target tmc   
Uninstalling plugin 'secret' for target 'mission-control'. Are you sure? [y/N]: y
[i] Uninstalling plugin 'secret' for target 'mission-control'
[ok] successfully uninstalled plugin 'secret'
❯ 
❯ 
❯ t context unset tmc1
The context 'tmc1' of type 'mission-control' has been set as inactive
Deactivating plugin 'provider-aks-cluster:v0.1.12' for context 'tmc1'
Deactivating plugin 'iam:v0.1.11' for context 'tmc1'
Deactivating plugin 'continuousdelivery:v0.1.11' for context 'tmc1'
Deactivating plugin 'helm:v0.1.11' for context 'tmc1'
Deactivating plugin 'agentartifacts:v0.1.11' for context 'tmc1'
Deactivating plugin 'tanzupackage:v0.2.10' for context 'tmc1'
Deactivating plugin 'ekscluster:v0.1.11' for context 'tmc1'
Deactivating plugin 'account:v0.1.12' for context 'tmc1'
Deactivating plugin 'events:v0.1.11' for context 'tmc1'
Deactivating plugin 'aks-cluster:v0.2.1' for context 'tmc1'
Deactivating plugin 'setting:v0.2.9' for context 'tmc1'
Deactivating plugin 'audit:v0.1.11' for context 'tmc1'
Deactivating plugin 'cluster:v0.2.6' for context 'tmc1'
Deactivating plugin 'inspection:v0.1.11' for context 'tmc1'
Deactivating plugin 'apply:v0.3.8' for context 'tmc1'
Deactivating plugin 'integration:v0.1.11' for context 'tmc1'
Deactivating plugin 'management-cluster:v0.2.11' for context 'tmc1'
Deactivating plugin 'data-protection:v0.1.11' for context 'tmc1'
Deactivating plugin 'clustergroup:v0.1.11' for context 'tmc1'
Deactivating plugin 'policy:v0.1.11' for context 'tmc1'
Deactivating plugin 'provider-eks-cluster:v0.1.11' for context 'tmc1'
❯ 
❯ t context use tmc1                    
[i] Successfully activated context 'tmc1'
[i] Checking for required plugins for context tmc1...
[i] The following plugins will be installed for context 'tmc1': 
  NAME       TARGET           VERSION  
  secret     mission-control  v0.1.11  
  workspace  mission-control  v0.1.13  
[i] Installing plugin 'secret:v0.1.11' with target 'mission-control' (from cache)
[i] Installing plugin 'workspace:v0.1.13' with target 'mission-control' (from cache)
[i] Successfully installed all required plugins
❯ 
❯ 
❯ t plugin list
Standalone Plugins
  NAME       DESCRIPTION                                                 TARGET  VERSION  STATUS     
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  global  v1.1.0   installed  

Plugins from Context:  tmc1
  NAME                  DESCRIPTION                                                     TARGET           VERSION  STATUS     
  account               Account for tmc resources                                       mission-control  v0.1.12  installed  
  agentartifacts        helm for tmc resources                                          mission-control  v0.1.11  installed  
  aks-cluster           Manage and unmanage tmc aks clusters                            mission-control  v0.2.1   installed  
  apply                 Create/Update a resource with a resource file                   mission-control  v0.3.8   installed  
  audit                 Run an audit request on an org                                  mission-control  v0.1.11  installed  
  cluster                                                                               mission-control  v0.2.6   installed  
  clustergroup          A group of Kubernetes clusters                                  mission-control  v0.1.11  installed  
  continuousdelivery    Continuousdelivery for tmc resources                            mission-control  v0.1.11  installed  
  data-protection       Data protection for tmc resources                               mission-control  v0.1.11  installed  
  ekscluster                                                                            mission-control  v0.1.11  installed  
  events                Events for any meaningful user activity or system state change  mission-control  v0.1.11  installed  
  helm                  helm for tmc resources                                          mission-control  v0.1.11  installed  
  iam                   IAM Policies for tmc resources                                  mission-control  v0.1.11  installed  
  inspection            Inspection for tmc resources                                    mission-control  v0.1.11  installed  
  integration           Get available integrations and their information from registry  mission-control  v0.1.11  installed  
  management-cluster    A TMC registered Management cluster                             mission-control  v0.2.11  installed  
  policy                Policy for tmc resources                                        mission-control  v0.1.11  installed  
  provider-aks-cluster  Manage and unmanage tmc provider aks clusters                   mission-control  v0.1.12  installed  
  provider-eks-cluster                                                                  mission-control  v0.1.11  installed  
  secret                secret for tmc resources                                        mission-control  v0.1.11  installed  
  setting               Setting plugin for tmc resources                                mission-control  v0.2.9   installed  
  tanzupackage          Tanzupackage for tmc resources                                  mission-control  v0.2.10  installed  
  workspace             A group of Kubernetes namespaces                                mission-control  v0.1.13  installed  
❯
```
4. Use case: Context create for k8s:
```
❯ t context create
? Select context creation type Kubernetes (Local Kubeconfig)
? Enter path to kubeconfig (if any) /Users/cpamuluri/tkg/tasks/k8s_remote_server/k8s_remote
? Enter kube context to use tkg-mgmt-vc-admin@tkg-mgmt-vc
? Give the context a name remote22
[ok] successfully created a kubernetes context using the kubeconfig /Users/cpamuluri/tkg/tasks/k8s_remote_server/k8s_remote
[i] Checking for required plugins for context 'remote22'...
[i] The following plugins will be installed for context 'remote22':
  NAME                TARGET      VERSION
  cluster             kubernetes  v0.28.0
  feature             kubernetes  v0.28.0
  kubernetes-release  kubernetes  v0.28.0
[i] Installing plugin 'cluster:v0.28.0' with target 'kubernetes' (from cache)
[i] Installing plugin 'feature:v0.28.0' with target 'kubernetes' (from cache)
[i] Installing plugin 'kubernetes-release:v0.28.0' with target 'kubernetes' (from cache)
[i] Successfully installed all required plugins
❯

```
5. Use case: Context create: TMC:
```
❯ t context create --name tmc45 --endpoint unstable.tmc-dev.cloud.vmware.com --staging
Flag --name has been deprecated, it has been replaced by using an argument to the command
[i] API token env var is set

[ok] successfully created a TMC context
[i] Checking for required plugins for context 'tmc45'...
[i] The following plugins will be installed for context 'tmc45':
  NAME                  TARGET           VERSION
  ekscluster            mission-control  v0.1.11
  audit                 mission-control  v0.1.11
  continuousdelivery    mission-control  v0.1.11
  provider-eks-cluster  mission-control  v0.1.11
  apply                 mission-control  v0.3.8
  tanzupackage          mission-control  v0.2.10
  helm                  mission-control  v0.1.11
  iam                   mission-control  v0.1.11
  events                mission-control  v0.1.11
  account               mission-control  v0.1.14
  agentartifacts        mission-control  v0.1.11
  inspection            mission-control  v0.1.11
  integration           mission-control  v0.1.11
  cluster               mission-control  v0.2.6
  data-protection       mission-control  v0.1.11
  workspace             mission-control  v0.1.13
  clustergroup          mission-control  v0.1.11
  policy                mission-control  v0.1.11
  provider-aks-cluster  mission-control  v0.1.12
  aks-cluster           mission-control  v0.2.1
  setting               mission-control  v0.2.9
  management-cluster    mission-control  v0.2.11
  secret                mission-control  v0.1.11
[i] Installing plugin 'ekscluster:v0.1.11' with target 'mission-control' (from cache)
[i] Installing plugin 'audit:v0.1.11' with target 'mission-control' (from cache)
[i] Installing plugin 'continuousdelivery:v0.1.11' with target 'mission-control' (from cache)
[i] Installing plugin 'provider-eks-cluster:v0.1.11' with target 'mission-control' (from cache)
[i] Installing plugin 'apply:v0.3.8' with target 'mission-control' (from cache)
[i] Installing plugin 'tanzupackage:v0.2.10' with target 'mission-control' (from cache)
[i] Installing plugin 'helm:v0.1.11' with target 'mission-control' (from cache)
[i] Installing plugin 'iam:v0.1.11' with target 'mission-control' (from cache)
[i] Installing plugin 'events:v0.1.11' with target 'mission-control' (from cache)
[i] Installing plugin 'account:v0.1.14' with target 'mission-control' (from cache)
[i] Installing plugin 'agentartifacts:v0.1.11' with target 'mission-control' (from cache)
[i] Installing plugin 'inspection:v0.1.11' with target 'mission-control' (from cache)
[i] Installing plugin 'integration:v0.1.11' with target 'mission-control' (from cache)
[i] Installing plugin 'cluster:v0.2.6' with target 'mission-control' (from cache)
[i] Installing plugin 'data-protection:v0.1.11' with target 'mission-control' (from cache)
[i] Installing plugin 'workspace:v0.1.13' with target 'mission-control' (from cache)
[i] Installing plugin 'clustergroup:v0.1.11' with target 'mission-control' (from cache)
[i] Installing plugin 'policy:v0.1.11' with target 'mission-control' (from cache)
[i] Installing plugin 'provider-aks-cluster:v0.1.12' with target 'mission-control' (from cache)
[i] Installing plugin 'aks-cluster:v0.2.1' with target 'mission-control' (from cache)
[i] Installing plugin 'setting:v0.2.9' with target 'mission-control' (from cache)
[i] Installing plugin 'management-cluster:v0.2.11' with target 'mission-control' (from cache)
[i] Installing plugin 'secret:v0.1.11' with target 'mission-control' (from cache)
[i] Successfully installed all required plugins

```
### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The `tanzu context use` and `tanzu context create` commands' UX have been updated to list the plugins they're going to install.

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
