### PR TITLE
Include aliases in the main help

### DIFF
--- a/pkg/cli/usage.go
+++ b/pkg/cli/usage.go
@@ -69,7 +69,10 @@ func (u *MainUsage) GenerateDescriptor(c *cobra.Command, w io.Writer) error {
 // Template returns the template for the main usage.
 func (u *MainUsage) Template() string {
 	return `{{ bold "Usage:" }}
-  {{.Command.CommandPath}} [command]{{if .HasExample}}
+  {{.Command.CommandPath}} [command]{{if gt (len .Aliases) 0}}
+
+{{ bold "Aliases:" }}
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
 
 {{ bold "Examples:" }}
   {{.Example}}{{end}}


### PR DESCRIPTION
### What this PR does / why we need it

The CLI has two types of help format:
1- for the main command
2- for sub-commands

Type 1 is for the help of the "tanzu" command itself, but also for the help of the targets: "tanzu kubernetes" and "tanzu tmc".  We do this because such targets are commands that have plugins as sub-commands, and plugins can choose in which help group they want to be shown.

Type 2 is for all core sub-commands of the CLI.

This commit adds an "Aliases:" section to help type 1 just like there is already for type 2.  If there are no aliases, that section is not shown, therefore, the help of the root command will not be changed since the root command does not have aliases.  On the other hand, with this commit the two "tanzu kubernetes" and "tanzu tmc" help texts will show the "k8s" and "tmc" aliases, respectively.

This should help the user realize such aliases are available.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #564 

### Describe testing done for PR

```
$ ~/bin/tanzu.v1.0.0 version
version: v1.0.0
buildDate: 2023-08-08
sha: 006d0429

# Verify the root help is not changed
$ diff <(~/bin/tanzu.v1.0.0 -h) <(tz -h)

# Verify the help help for "tanzu k8s" shows aliases
$ tz k8s
Tanzu CLI plugins that target a Kubernetes cluster

Usage:
  tanzu kubernetes [command]

Aliases:
  kubernetes, k8s
[...]

$ diff <(~/bin/tanzu.v1.0.0 k8s -h) <(tz k8s -h)
5a6,8
> Aliases:
>   kubernetes, k8s
>

# Verify the help help for "tanzu tmc" shows aliases
$ tz tmc
Tanzu CLI plugins that target a Tanzu Mission Control endpoint

Usage:
  tanzu mission-control [command]

Aliases:
  mission-control, tmc
[...]

$ diff <(~/bin/tanzu.v1.0.0 tmc -h) <(tz tmc -h)
5a6,8
> Aliases:
>   mission-control, tmc
>

# Verify other sub-commands are not changed
$ diff <(~/bin/tanzu.v1.0.0 context -h) <(tz context -h)
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Show aliases in the help of `tanzu kubernetes` and `tanzu tmc`
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
