### PR TITLE
Add some examples to tanzu config set

### DIFF
--- a/pkg/command/config.go
+++ b/pkg/command/config.go
@@ -87,6 +87,13 @@ var setConfigCmd = &cobra.Command{
 	Short:             "Set config values at the given PATH",
 	Long:              "Set config values at the given PATH. Supported PATH values: [features.global.<feature>, features.<plugin>.<feature>, env.<variable>]",
 	ValidArgsFunction: completeSetConfig,
+	Example: `
+    # Sets a custom CA cert for a proxy that requires it
+    tanzu config set env.PROXY_CA_CERT b329baa034afn3.....
+    # Enables a specific plugin feature
+    tanzu config set features.management-cluster.custom_nameservers true
+    # Enables a general CLI feature
+    tanzu config set features.global.abcd true`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
 			return errors.Errorf("both PATH and <value> are required")


### PR DESCRIPTION
### What this PR does / why we need it

trivial change to add some examples to the `tanzu config set` help output

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

```
> tanzu config set --help
Set config values at the given PATH. Supported PATH values: [features.global.<feature>, features.<plugin>.<feature>, env.<variable>]

Usage:
tanzu config set PATH <value> [flags]

Examples:

    # Sets a custom CA cert for a proxy that requires it
    tanzu config set env.PROXY_CA_CERT b329baa034afn3.....
    # Enables a specific plugin feature
    tanzu config set features.management-cluster.custom_nameservers true
    # Enables a general CLI feature
    tanzu config set features.global.abcd true

Flags:
  -h, --help   help for set
```


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
