### PR TITLE
Update the telemetry send timeout and cleanup the pinniped kubecontext from user's kubeconfig file

### DIFF
--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -385,7 +385,7 @@ func Execute() error {
 		telemetry.LogError(updateErr, "")
 	} else if saveErr := telemetry.Client().SaveMetrics(); saveErr != nil {
 		telemetry.LogError(saveErr, "")
-	} else if sendErr := telemetry.Client().SendMetrics(context.Background(), 2); sendErr != nil {
+	} else if sendErr := telemetry.Client().SendMetrics(context.Background(), 0); sendErr != nil {
 		telemetry.LogError(sendErr, "")
 	}
 	return executionErr

--- a/pkg/fakes/config/tanzu_config_ng.yaml
+++ b/pkg/fakes/config/tanzu_config_ng.yaml
@@ -11,6 +11,8 @@ contexts:
           name: test
           bucket: test-bucket
           manifestPath: test-manifest-path
+    additionalMetadata:
+      isPinnipedEndpoint: true
   - name: test-tmc-context
     target: mission-control
     globalOpts:

--- a/pkg/telemetry/client_test.go
+++ b/pkg/telemetry/client_test.go
@@ -694,8 +694,7 @@ func TestTelemetryClient_isCoreCommand(t *testing.T) {
 }
 
 func TestTelemetryClient_getTimeout(t *testing.T) {
-	var metricsDB *mockMetricsDB
-	metricsDB = &mockMetricsDB{}
+	metricsDB := &mockMetricsDB{}
 	tc := &telemetryClient{
 		currentOperationMetrics: &OperationMetricsPayload{
 			StartTime: time.Time{},


### PR DESCRIPTION
### What this PR does / why we need it
This PR updates the telemetry send timeout to factor in the metrics DB size. Also this PR has another change that removes the kubecontext from users kubeconfig file for pinniped endpoint during `tanzu context delete` command execution

Changes Summary:
- Updated the telemetry send operation timeout to be adaptive instead of fixed timeout. The timeout would be calculated based on the metrics DB rows count.
-  Delete the kubecontext in the kubeconfig file during context delete command execution. This kubecontext was created by CLI during context creation for Kubernetes cluster endpoint(pinniped endpoint) so it should be deleted while deleting the associated CLI context. This change is only applicable to the contexts created after this change. The pinniped context created in the prior releases were not stored in the users kubeconfig file, so deletion of kubecontext is not applicable to CLI context created for pinniped endpoint in the prior releases.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #567 #543

### Describe testing done for PR

Created the fake rows in the metrics DB using the script and verified the timeout was set accordingly

```
❯ ~/temp/db_load.sh
❯ ~/temp/db_load.sh
❯ ~/temp/db_load.sh
❯ cp /tmp/test.db $HOME/.config/tanzu-cli-telemetry/cli_metrics.db
❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db "select count(*) from tanzu_cli_operations;"
count(*)
3000
❯ ./bin/tanzu context list
  NAME            ISACTIVE  TYPE             ENDPOINT                                                                                           KUBECONFIGPATH                           KUBECONTEXT
  tt-test-selfmg  false     mission-control  tmc-sm-main.local-dev.7infra.com:443                                                               n/a                                      n/a
  mytmc           false     mission-control  https://unstable.tmc-dev.cloud.vmware.com                                                          n/a                                      n/a
  tkg-mgmt-vc     false     kubernetes                                                                                                          /Users/pkalle/temp/tkgCluster_admin.kfg  tkg-mgmt-vc-admin@tkg-mgmt-vc
  mydemotanzu     true      tanzu            https://ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com/org/ee04bfae-a665-4f20-a5b9-d8b043180252  /Users/pkalle/.kube/config               tanzu-cli-mydemotanzu

❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db "select count(*) from tanzu_cli_operations;"
count(*)
0




## tried with 6002 records and verified it works
❯ ~/temp/db_load.sh
❯ ~/temp/db_load.sh
❯ ~/temp/db_load.sh
❯ vim ~/temp/db_load.sh
❯ ~/temp/db_load.sh
❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db "select count(*) from tanzu_cli_operations;"
count(*)
0
❯ cp /tmp/test.db $HOME/.config/tanzu-cli-telemetry/cli_metrics.db
❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db "select count(*) from tanzu_cli_operations;"
count(*)
6002
❯ time ./bin/tanzu context list
  NAME            ISACTIVE  TYPE             ENDPOINT                                                                                           KUBECONFIGPATH                           KUBECONTEXT
  tt-test-selfmg  false     mission-control  tmc-sm-main.local-dev.7infra.com:443                                                               n/a                                      n/a
  mytmc           false     mission-control  https://unstable.tmc-dev.cloud.vmware.com                                                          n/a                                      n/a
  tkg-mgmt-vc     false     kubernetes                                                                                                          /Users/pkalle/temp/tkgCluster_admin.kfg  tkg-mgmt-vc-admin@tkg-mgmt-vc
  mydemotanzu     true      tanzu            https://ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com/org/ee04bfae-a665-4f20-a5b9-d8b043180252  /Users/pkalle/.kube/config               tanzu-cli-mydemotanzu
Telemetry send timeout is:6 secs
./bin/tanzu context list  0.45s user 0.10s system 21% cpu 2.544 total
❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db "select count(*) from tanzu_cli_operations;"
count(*)
0

```
Tested the telemetry timeout on Mac laptop without internet to check if the timeout would be blocked for the long duration(if the timeout is long enough due to huge data in metric DB). Verified the telemetry plugin returns immediately if the host is not reachable

```
❯ ~/temp/db_load.sh
❯ ~/temp/db_load.sh
❯ ~/temp/db_load.sh
❯ ping www.google.com
PING www.google.com (142.251.32.36): 56 data bytes
64 bytes from 142.251.32.36: icmp_seq=0 ttl=116 time=23.749 ms
64 bytes from 142.251.32.36: icmp_seq=1 ttl=116 time=15.943 ms
64 bytes from 142.251.32.36: icmp_seq=2 ttl=116 time=15.287 ms
^C
--- www.google.com ping statistics ---
3 packets transmitted, 3 packets received, 0.0% packet loss
round-trip min/avg/max/stddev = 15.287/18.326/23.749/3.844 ms

### disconnected from the internet
❯ ping www.google.com
ping: cannot resolve www.google.com: Unknown host
❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db "select count(*) from tanzu_cli_operations;"
count(*)
1
❯ cp /tmp/test.db $HOME/.config/tanzu-cli-telemetry/cli_metrics.db
❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db "select count(*) from tanzu_cli_operations;"
count(*)
9002
❯ export TANZU_CLI_SUPERCOLLIDER_ENVIRONMENT=staging
❯ time ./bin/tanzu context list
  NAME            ISACTIVE  TYPE             ENDPOINT                                                                                           KUBECONFIGPATH                           KUBECONTEXT
  tt-test-selfmg  false     mission-control  tmc-sm-main.local-dev.7infra.com:443                                                               n/a                                      n/a
  mytmc           false     mission-control  https://unstable.tmc-dev.cloud.vmware.com                                                          n/a                                      n/a
  tkg-mgmt-vc     false     kubernetes                                                                                                          /Users/pkalle/temp/tkgCluster_admin.kfg  tkg-mgmt-vc-admin@tkg-mgmt-vc
  mydemotanzu     false     tanzu            https://ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com/org/ee04bfae-a665-4f20-a5b9-d8b043180252  /Users/pkalle/.kube/config               tanzu-cli-mydemotanzu
./bin/tanzu context list  0.50s user 0.12s system 85% cpu 0.713 total

#### Later connected mac to internet and tried againg and verified the time took to post the 9k records is within 6sec and the telemetry metrics was posted successfully
❯ ping www.google.com
PING www.google.com (142.251.32.36): 56 data bytes
64 bytes from 142.251.32.36: icmp_seq=0 ttl=116 time=19.837 ms
64 bytes from 142.251.32.36: icmp_seq=1 ttl=116 time=23.166 ms
^C
--- www.google.com ping statistics ---
2 packets transmitted, 2 packets received, 0.0% packet loss
round-trip min/avg/max/stddev = 19.837/21.502/23.166/1.664 ms
❯ time ./bin/tanzu context list
  NAME            ISACTIVE  TYPE             ENDPOINT                                                                                           KUBECONFIGPATH                           KUBECONTEXT
  tt-test-selfmg  false     mission-control  tmc-sm-main.local-dev.7infra.com:443                                                               n/a                                      n/a
  mytmc           false     mission-control  https://unstable.tmc-dev.cloud.vmware.com                                                          n/a                                      n/a
  tkg-mgmt-vc     false     kubernetes                                                                                                          /Users/pkalle/temp/tkgCluster_admin.kfg  tkg-mgmt-vc-admin@tkg-mgmt-vc
  mydemotanzu     false     tanzu            https://ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com/org/ee04bfae-a665-4f20-a5b9-d8b043180252  /Users/pkalle/.kube/config               tanzu-cli-mydemotanzu
./bin/tanzu context list  0.54s user 0.17s system 11% cpu 6.436 total

❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db "select count(*) from tanzu_cli_operations;"
count(*)
0
```

Tested the pinniped kubecontext was deleted from user's kubeconfig successfully

-Installed the pinniped-auth plugin and created a context and deleted the context. Verified the context created and added to user default kubeconfig was deleted when the CLI context was deleted.
```

❯ ./bin/tanzu plugin install pinniped-auth -v v0.28.0
[i] Installing plugin 'pinniped-auth:v0.28.0' with target 'global'
[ok] successfully installed 'pinniped-auth' plugin
❯ ./bin/tanzu context create test-pinnniped-ctx --type k8s --endpoint  https://10.180.196.201:6443 --insecure-skip-tls-verify
[i] Could not get login banner from server, response code = 403
Log in by visiting this link:

    https://10.180.197.222/oauth2/authorize?access_type=offline&client_id=pinniped-cli&code_challenge=AXWLXaZpCKkDa12LTh1oEd30NHd5Aar_5CwYtzuUZyg&code_challenge_method=S256&nonce=d870d8635db4930582a0f197f09c44d6&redirect_uri=http%3A%2F%2F127.0.0.1%3A59376%2Fcallback&response_mode=form_post&response_type=code&scope=offline_access+openid+pinniped%3Arequest-audience&state=6b34a2efeea2cedbc2d500ee28c84f60

    Optionally, paste your authorization code: [...]

[ok] successfully created a kubernetes context using the kubeconfig /Users/pkalle/.kube/config
[i] Checking for required plugins for context test-pinnniped-ctx...
[i] All required plugins are already installed and up-to-date
[!] unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually, error: 'unable to list plugins from discovery source 'default-test-pinnniped-ctx': cliplugins.cli.tanzu.vmware.com is forbidden: User "pkalle" cannot list resource "cliplugins" in API group "cli.tanzu.vmware.com" at the cluster scope'
❯ vim ~/.config/tanzu/config-ng.yaml
❯ ./bin/tanzu context list
  NAME                ISACTIVE  TYPE             ENDPOINT                                                                                           KUBECONFIGPATH                           KUBECONTEXT
  tt-test-selfmg      false     mission-control  tmc-sm-main.local-dev.7infra.com:443                                                               n/a                                      n/a
  mytmc               false     mission-control  https://unstable.tmc-dev.cloud.vmware.com                                                          n/a                                      n/a
  tkg-mgmt-vc         false     kubernetes                                                                                                          /Users/pkalle/temp/tkgCluster_admin.kfg  tkg-mgmt-vc-admin@tkg-mgmt-vc
  mydemotanzu         false     tanzu            https://ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com/org/ee04bfae-a665-4f20-a5b9-d8b043180252  /Users/pkalle/.kube/config               tanzu-cli-mydemotanzu
  test-pinnniped-ctx  true      kubernetes       https://10.180.196.201:6443                                                                        /Users/pkalle/.kube/config               tanzu-cli-tkg-mgmt-vc@tkg-mgmt-vc
❯ kubectl config get-contexts
CURRENT   NAME                                  CLUSTER                         AUTHINFO                     NAMESPACE
          tanzu-cli-fake-cluster@fake-cluster   fake-cluster                    tanzu-cli-fake-cluster
          tanzu-cli-mydemotanzu                 tanzu-cli-mydemotanzu/current   tanzu-cli-mydemotanzu-user
*         tanzu-cli-tkg-mgmt-vc@tkg-mgmt-vc     tkg-mgmt-vc                     tanzu-cli-tkg-mgmt-vc
❯ ./bin/tanzu context delete test-pinnniped-ctx
Deleting the context entry from the config will remove it from the list of tracked contexts. You will need to use `tanzu context create` to re-create this context. Are you sure you want to continue? [y/N]: y
[!] there was an error while discovering plugins, error information: 'unable to list plugins from discovery source 'default-test-pinnniped-ctx': cliplugins.cli.tanzu.vmware.com is forbidden: User "pkalle" cannot list resource "cliplugins" in API group "cli.tanzu.vmware.com" at the cluster scope'
[i] Deleting entry for context 'test-pinnniped-ctx'
[i] Deleting kubeconfig context 'tanzu-cli-tkg-mgmt-vc@tkg-mgmt-vc' from the file '/Users/pkalle/.kube/config'
[!] warning: this removed your active context, use "kubectl config use-context" to select a different one
❯ kubectl config get-contexts
CURRENT   NAME                                  CLUSTER                         AUTHINFO                     NAMESPACE
          tanzu-cli-fake-cluster@fake-cluster   fake-cluster                    tanzu-cli-fake-cluster
          tanzu-cli-mydemotanzu                 tanzu-cli-mydemotanzu/current   tanzu-cli-mydemotanzu-user
❯ ./bin/tanzu context list
  NAME            ISACTIVE  TYPE             ENDPOINT                                                                                           KUBECONFIGPATH                           KUBECONTEXT
  tt-test-selfmg  false     mission-control  tmc-sm-main.local-dev.7infra.com:443                                                               n/a                                      n/a
  mytmc           false     mission-control  https://unstable.tmc-dev.cloud.vmware.com                                                          n/a                                      n/a
  tkg-mgmt-vc     false     kubernetes                                                                                                          /Users/pkalle/temp/tkgCluster_admin.kfg  tkg-mgmt-vc-admin@tkg-mgmt-vc
  mydemotanzu     false     tanzu            https://ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com/org/ee04bfae-a665-4f20-a5b9-d8b043180252  /Users/pkalle/.kube/config               tanzu-cli-mydemotanzu
```


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Delete the pinniped endpoint's kubecontext in the user's kubeconfig file during context delete command which was generated by CLI during context creation.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
