### PR TITLE
UX: Enhance UX for `plugin sync` to list plugins before installation

### DIFF
--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -254,14 +254,14 @@ func createCtx(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	// Sync all required plugins
-	_ = syncContextPlugins(cmd, ctx.ContextType, true)
+	_ = syncContextPlugins(cmd, ctx.ContextType, ctxName, true)
 
 	return nil
 }
 
 // syncContextPlugins syncs the plugins for the given context type
 // if listPlugins is true, it will list the plugins that will be installed for the given context type
-func syncContextPlugins(cmd *cobra.Command, contextType configtypes.ContextType, listPlugins bool) error {
+func syncContextPlugins(cmd *cobra.Command, contextType configtypes.ContextType, ctxName string, listPlugins bool) error {
 	plugins, err := pluginmanager.DiscoverPluginsForContextType(contextType)
 	errList := make([]error, 0)
 	if err != nil {
@@ -280,7 +280,7 @@ func syncContextPlugins(cmd *cobra.Command, contextType configtypes.ContextType,
 			}
 		}
 		if pluginsNeedstoBeInstalled > 0 {
-			log.Infof("The following plugins will be installed for context '%s': ", ctxName)
+			log.Infof("The following plugins will be installed for context '%s' of contextType '%s': ", ctxName, contextType)
 			displayUninstalledPluginsContentAsTable(plugins, cmd.ErrOrStderr())
 		}
 	}
@@ -1074,7 +1074,7 @@ func useCtx(cmd *cobra.Command, args []string) error {
 	log.Infof("Successfully activated context '%s'", ctxName)
 
 	// Sync all required plugins
-	_ = syncContextPlugins(cmd, ctx.ContextType, true)
+	_ = syncContextPlugins(cmd, ctx.ContextType, ctxName, true)
 
 	return nil
 }

--- a/pkg/command/plugin.go
+++ b/pkg/command/plugin.go
@@ -26,6 +26,7 @@ import (
 	"github.com/vmware-tanzu/tanzu-cli/pkg/pluginmanager"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/pluginsupplier"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/utils"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
 
@@ -425,7 +426,7 @@ func newSyncPluginCmd() *cobra.Command {
 Plugins installed with this command will only be available while the context remains active.`,
 		ValidArgsFunction: noMoreCompletions,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			err = pluginmanager.SyncPlugins()
+			err = syncPlugins(cmd)
 			if err != nil {
 				return err
 			}
@@ -434,6 +435,39 @@ Plugins installed with this command will only be available while the context rem
 		},
 	}
 	return syncCmd
+}
+
+// syncPlugins installs all plugins recommended by the active contexts and lists the plugins it's going to install
+func syncPlugins(cmd *cobra.Command) error {
+	contextMap, err := config.GetAllActiveContextsMap()
+	if err != nil {
+		return err
+	}
+	errList := make([]error, 0)
+	contextNames := ""
+	count := 0
+	for _, context := range contextMap {
+		if contextNames != "" {
+			contextNames += ", "
+		}
+		contextNames += fmt.Sprintf("'%s'", context.Name)
+		count++
+	}
+	if count == 0 {
+		log.Warning("No active contexts available to perform plugin sync")
+		return nil
+	} else if count == 1 {
+		log.Infof("Plugin sync will be performed for context: %s", contextNames)
+	} else if count > 1 {
+		log.Infof("Plugin sync will be performed for contexts: %s", contextNames)
+	}
+	for contextType, context := range contextMap {
+		err = syncContextPlugins(cmd, contextType, context.Name, true)
+		if err != nil {
+			errList = append(errList, err)
+		}
+	}
+	return kerrors.NewAggregate(errList)
 }
 
 // getInstalledAndMissingContextPlugins returns any context plugins that are not installed

--- a/test/e2e/plugin_sync/k8s/plugin_sync_k8s_lifecycle_test.go
+++ b/test/e2e/plugin_sync/k8s/plugin_sync_k8s_lifecycle_test.go
@@ -264,7 +264,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 		It("create context with kubeconfig and context", func() {
 			By("create context with kubeconfig and context")
 			contextName = f.ContextPrefixK8s + f.RandomString(4)
-			err := tf.ContextCmd.CreateContextWithKubeconfig(contextName, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
+			err = tf.ContextCmd.CreateContextWithKubeconfig(contextName, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
 			Expect(err).To(BeNil(), "context should create without any error")
 			active, err := tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
 			Expect(err).To(BeNil(), "there should be a active context")
@@ -280,7 +280,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 
 		const (
 			ContextActivated         = "Successfully activated context '%s'"
-			PluginWillBeInstalled    = "The following plugins will be installed for context '%s':"
+			PluginWillBeInstalled    = "The following plugins will be installed for context '%s' of contextType '%s':"
 			PluginsTableHeaderRegExp = "NAME\\s+TARGET\\s+VERSION"
 			PluginsRow               = "%s\\s+%s\\s+%s"
 			PluginInstallingRegExp   = "Installing plugin '%s:.+' with target '%s'"
@@ -300,7 +300,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 			pluginsList, err = tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
 			Expect(stdErr).To(ContainSubstring(fmt.Sprintf(ContextActivated, contextName)))
-			Expect(stdErr).To(ContainSubstring(fmt.Sprintf(PluginWillBeInstalled, contextName)))
+			Expect(stdErr).To(ContainSubstring(fmt.Sprintf(PluginWillBeInstalled, contextName, types.TargetK8s)))
 			Expect(stdErr).To(MatchRegexp(PluginsTableHeaderRegExp))
 			for i := range pluginsList {
 				Expect(stdErr).To(MatchRegexp(fmt.Sprintf(PluginsRow, pluginsList[i].Name, pluginsList[i].Target, pluginsList[i].Version)))


### PR DESCRIPTION
### What this PR does / why we need it

Before this pull request, the `tanzu plugin sync` command sync (install) the required plugins for each active context, but it did not list the plugins before the installation. As a result, end-users did not know how many plugins were going to be installed as part of the command execution. This lack of information led to a suboptimal user experience. Sometimes, it took time to install all the required plugins for all active contexts, and users had no visibility into the progress.

After this fix, the `tanzu plugin sync` command will still synchronize the required plugins for each active context, but it will now list the plugins that will be installed before the actual installation begins. This enhancement provides insights for the end user, ensuring that they are aware of the list of plugins and the progress of the installation. It significantly enhances the user experience.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Manual testing outputs by use case:
Use case: There are two active contexts and plugins need to install:
```
❯
❯ t plugin sync
[i] Plugin sync will be performed for contexts: 'remote22', 'tmc45'
[i] Checking for required plugins for context 'remote22'...
[i] The following plugins will be installed for context 'remote22' of contextType 'kubernetes':
  NAME     TARGET      VERSION
  cluster  kubernetes  v0.28.0
  feature  kubernetes  v0.28.0
[i] Installing plugin 'cluster:v0.28.0' with target 'kubernetes' (from cache)
[i] Installing plugin 'feature:v0.28.0' with target 'kubernetes' (from cache)
[i] Successfully installed all required plugins
[i] Checking for required plugins for context 'tmc45'...
[i] The following plugins will be installed for context 'tmc45' of contextType 'mission-control':
  NAME       TARGET           VERSION
  workspace  mission-control  v0.1.13
  setting    mission-control  v0.2.9
  secret     mission-control  v0.1.11
[i] Installing plugin 'workspace:v0.1.13' with target 'mission-control' (from cache)
[i] Installing plugin 'setting:v0.2.9' with target 'mission-control' (from cache)
[i] Installing plugin 'secret:v0.1.11' with target 'mission-control' (from cache)
[i] Successfully installed all required plugins
[ok] Done
❯
```

Use case: When only one context active and plugins need to sync:
```
❯
❯
❯ t plugin sync
[i] Plugin sync will be performed for context: 'tmc45'
[i] Checking for required plugins for context 'tmc45'...
[i] The following plugins will be installed for context 'tmc45' of contextType 'mission-control':
  NAME       TARGET           VERSION
  workspace  mission-control  v0.1.13
  setting    mission-control  v0.2.9
[i] Installing plugin 'workspace:v0.1.13' with target 'mission-control' (from cache)
[i] Installing plugin 'setting:v0.2.9' with target 'mission-control' (from cache)
[i] Successfully installed all required plugins
[ok] Done
❯
❯
```
Use case: When only one context is active and no plugins need to sync:
```
❯
❯ t plugin sync
[i] Plugin sync will be performed for context: 'tmc45'
[i] Checking for required plugins for context 'tmc45'...
[i] All required plugins are already installed and up-to-date
[ok] Done
❯
❯
```
Use case: When two contexts are active and no plugins need to sync:
```
❯
❯ t plugin sync
[i] Plugin sync will be performed for contexts: 'tmc45', 'remote22'
[i] Checking for required plugins for context 'remote22'...
[i] All required plugins are already installed and up-to-date
[i] Checking for required plugins for context 'tmc45'...
[i] All required plugins are already installed and up-to-date
[ok] Done
❯
```
Use case: When no active context available:
```
❯
❯ t plugin sync
[!] No active contexts available to perform plugin sync
[ok] Done
❯
❯
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The `tanzu plugin sync` command user experience has been updated to list the plugins it's going to install for each active context.

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
