### PR TITLE
Replace 'plugin delete' with 'plugin uninstall'

### DIFF
--- a/pkg/command/plugin_test.go
+++ b/pkg/command/plugin_test.go
@@ -811,40 +811,40 @@ func TestCompletionPlugin(t *testing.T) {
 				":36\n",
 		},
 		{
-			test: "completion for the plugin delete command when the specified plugin name is not unique",
-			args: []string{"__complete", "plugin", "delete", "cluster", ""},
+			test: "completion for the plugin uninstall command when the specified plugin name is not unique",
+			args: []string{"__complete", "plugin", "uninstall", "cluster", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
 			expected: "--target\n" +
 				":4\n",
 		},
 		{
-			test: "no more completions for the plugin delete command when the specified plugin name is not unique and --target is specified",
-			args: []string{"__complete", "plugin", "delete", "cluster", "--target", "k8s", ""},
+			test: "no more completions for the plugin uninstall command when the specified plugin name is not unique and --target is specified",
+			args: []string{"__complete", "plugin", "uninstall", "cluster", "--target", "k8s", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
 			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		{
-			test: "no more completions after the first arg for the plugin delete command",
-			args: []string{"__complete", "plugin", "delete", "feature", ""},
+			test: "no more completions after the first arg for the plugin uninstall command",
+			args: []string{"__complete", "plugin", "uninstall", "feature", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
 			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		{
 			test: "completion of the --target flag if 'all' is specified",
-			args: []string{"__complete", "plugin", "delete", "all", ""},
+			args: []string{"__complete", "plugin", "uninstall", "all", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
 			expected: "--target\n" +
 				":4\n",
 		},
 		{
 			test: "no more completions after 'all' if --target is specified",
-			args: []string{"__complete", "plugin", "delete", "--target", "k8s", "all", ""},
+			args: []string{"__complete", "plugin", "uninstall", "--target", "k8s", "all", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
 			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		{
-			test: "completion for the --target flag value for the plugin delete command with no plugin name",
-			args: []string{"__complete", "plugin", "delete", "--target", ""},
+			test: "completion for the --target flag value for the plugin uninstall command with no plugin name",
+			args: []string{"__complete", "plugin", "uninstall", "--target", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
 			expected: compGlobalTarget + "\n" +
 				compK8sTarget + "\n" +
@@ -852,16 +852,16 @@ func TestCompletionPlugin(t *testing.T) {
 				":4\n",
 		},
 		{
-			test: "completion for the --target flag value for the plugin delete command with a plugin name",
-			args: []string{"__complete", "plugin", "delete", "cluster", "--target", ""},
+			test: "completion for the --target flag value for the plugin uninstall command with a plugin name",
+			args: []string{"__complete", "plugin", "uninstall", "cluster", "--target", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
 			expected: compK8sTarget + "\n" +
 				compTMCTarget + "\n" +
 				":4\n",
 		},
 		{
-			test: "completion for the --target flag value for the plugin delete command with 'all'",
-			args: []string{"__complete", "plugin", "delete", "all", "--target", ""},
+			test: "completion for the --target flag value for the plugin uninstall command with 'all'",
+			args: []string{"__complete", "plugin", "uninstall", "all", "--target", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
 			expected: compGlobalTarget + "\n" +
 				compK8sTarget + "\n" +
@@ -869,8 +869,8 @@ func TestCompletionPlugin(t *testing.T) {
 				":4\n",
 		},
 		{
-			test: "completion for the --target flag value for the plugin delete command with an invalid plugin",
-			args: []string{"__complete", "plugin", "delete", "invalid", "--target", ""},
+			test: "completion for the --target flag value for the plugin uninstall command with an invalid plugin",
+			args: []string{"__complete", "plugin", "uninstall", "invalid", "--target", ""},
 			// ":4" is the value of the ShellCompDirectiveNoFileComp
 			expected: compGlobalTarget + "\n" +
 				compK8sTarget + "\n" +

--- a/test/e2e/framework/framework_constants.go
+++ b/test/e2e/framework/framework_constants.go
@@ -45,7 +45,7 @@ const (
 	InstallPluginFromGroupCmd           = "%s plugin install %s --group %s"
 	InstallAllPluginsFromGroupCmd       = "%s plugin install --group %s"
 	DescribePluginCmd                   = "%s plugin describe %s"
-	UninstallPLuginCmd                  = "%s plugin delete %s --yes"
+	UninstallPLuginCmd                  = "%s plugin uninstall %s --yes"
 	CleanPluginsCmd                     = "%s plugin clean"
 	pluginSyncCmd                       = "%s plugin sync"
 	PluginDownloadBundleCmd             = "%s plugin download-bundle"

--- a/test/e2e/plugin_lifecycle/plugin_lifecycle_test.go
+++ b/test/e2e/plugin_lifecycle/plugin_lifecycle_test.go
@@ -145,9 +145,9 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-lifecycle]", func(
 			}
 
 			err := tf.PluginCmd.DeletePlugin(cli.AllPlugins, framework.KubernetesTarget)
-			Expect(err).To(BeNil(), "should not get any error for plugin delete all")
+			Expect(err).To(BeNil(), "should not get any error for plugin uninstall all")
 
-			// validate above plugin delete with plugin list command, plugin list should return 0 plugins of target kubernetes
+			// validate above plugin uninstall with plugin list command, plugin list should return 0 plugins of target kubernetes
 			pluginsList, err := framework.GetPluginsList(tf, true)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
 			Expect(len(pluginsList)).Should(Equal(count), "incorrect number of installed plugins after deleting")
@@ -164,7 +164,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-lifecycle]", func(
 					Expect(err).To(BeNil(), "should not get any error for plugin delete")
 				}
 			}
-			// validate above plugin delete with plugin list command, plugin list should return 1 plugin (the essential plugin)
+			// validate above plugin uninstall with plugin list command, plugin list should return 1 plugin (the essential plugin)
 			pluginsList, err := framework.GetPluginsList(tf, true)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
 			// This is because essential plugins will always be installed
@@ -211,11 +211,11 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-lifecycle]", func(
 		})
 	})
 
-	// use case: negative test cases for plugin install and plugin delete commands
+	// use case: negative test cases for plugin install
 	// a. install plugin with incorrect value target flag
 	// b. install plugin with incorrect plugin name
 	// c. install plugin with incorrect value for flag --version
-	Context("plugin use cases: negative test cases for plugin install and plugin delete commands", func() {
+	Context("plugin use cases: negative test cases for plugin install", func() {
 		// Test case: a. install plugin with incorrect value target flag
 		It("install plugin with random string for target flag", func() {
 			err := tf.PluginCmd.InstallPlugin(util.PluginsForLifeCycleTests[0].Name, framework.RandomString(5), util.PluginsForLifeCycleTests[0].Version)
@@ -244,8 +244,8 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-lifecycle]", func(
 	// a. plugin install help message
 	// b. plugin describe help message
 	// c. plugin upgrade help message
-	// d. plugin delete help message
-	Context("plugin use cases: negative test cases for plugin install and plugin delete commands", func() {
+	// d. plugin uninstall help message
+	Context("plugin use cases: negative test cases for plugin install and plugin uninstall commands", func() {
 		// Test case: a. plugin install help message
 		It("tanzu plugin install help message", func() {
 			out, _, err := tf.PluginCmd.RunPluginCmd("install -h")

--- a/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_test.go
+++ b/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_test.go
@@ -965,7 +965,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 	// Test case: h. TMC: list plugins and validate plugins info, make sure all plugins are installed as per mock response
 	// Test case: i. plugin search should work fine even though k8s context has issues
 	// Test case: j. plugin install should work fine even though k8s context has issues
-	// Test case: k. validate plugin has installed after above plugin delete and install operations
+	// Test case: k. validate plugin has installed after above plugin uninstall and install operations
 	// Test case: l. plugin sync should work fine even though k8s context has issues
 	// Test case: m. validate the plugin list after above plugin sync operation
 	// Test case: n. plugin group search and plugin group install when active context has issues
@@ -1086,8 +1086,8 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			Expect(err).To(BeNil(), noErrorForPluginInstall)
 		})
 
-		// Test case: k. validate plugin has installed after above plugin delete and install operations
-		It("plugin list validation after specific plugin delete and install", func() {
+		// Test case: k. validate plugin has installed after above plugin uninstall and install operations
+		It("plugin list validation after specific plugin uninstall and install", func() {
 			pluginList, err := tf.PluginCmd.ListPluginsForGivenContext(contextNameTMC, true)
 			Expect(err).NotTo(BeNil(), "there should be an error for plugin list as one of the active context has issues")
 			Expect(len(pluginList)).Should(Equal(len(installedPluginsListTMC[1:])), "recently installed plugin should be installed as standalone")


### PR DESCRIPTION
### What this PR does / why we need it

With #549 the CLI has moved to use `tanzu plugin uninstall` over `tanzu plugin delete` (which is kept as an alias for backwards-compatibility.

In certain PRs following #549 I didn't think to make the change in terminology.

This PR replaces the remaining `plugin delete` with `plugin uninstall`

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

CI 

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Replace a few remaining mention of `tanzu plugin delete` with `tanzu plugin uninstall`.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
