### PR TITLE
Rename --ca-certificate option to --ca-cert in "tanzu config cert add" and "tanzu config cert update" commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ setup-custom-cert-for-test-central-repo: ## Setup up the custom ca cert for test
 	fi
 	echo "Adding docker test central repo cert to the config file"
 	TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="No" TANZU_CLI_EULA_PROMPT_ANSWER="Yes" $(ROOT_DIR)/bin/tanzu config cert delete localhost:9876 || true
-	$(ROOT_DIR)/bin/tanzu config cert add --host localhost:9876 --ca-certificate $(ROOT_DIR)/hack/central-repo/certs/localhost.crt
+	$(ROOT_DIR)/bin/tanzu config cert add --host localhost:9876 --ca-cert $(ROOT_DIR)/hack/central-repo/certs/localhost.crt
 
 .PHONY: start-test-central-repo
 start-test-central-repo: stop-test-central-repo setup-custom-cert-for-test-central-repo ## Starts up a test central repository locally with docker

--- a/docs/cli/commands/tanzu_config_cert_add.md
+++ b/docs/cli/commands/tanzu_config_cert_add.md
@@ -15,10 +15,10 @@ tanzu config cert add [flags]
 ```
 
     # Add CA certificate for a host
-    tanzu config cert add --host test.vmware.com --ca-certificate path/to/ca/ert
+    tanzu config cert add --host test.vmware.com --ca-cert path/to/ca/ert
 
     # Add CA certificate for a host:port
-    tanzu config cert add --host test.vmware.com:8443 --ca-certificate path/to/ca/ert
+    tanzu config cert add --host test.vmware.com:8443 --ca-cert path/to/ca/ert
 
     # Set to skip verifying the certificate while interacting with host
     tanzu config cert add --host test.vmware.com  --skip-cert-verify true
@@ -30,7 +30,7 @@ tanzu config cert add [flags]
 ### Options
 
 ```
-      --ca-certificate string     path to the public certificate
+      --ca-cert string            path to the public certificate
   -h, --help                      help for add
       --host string               host or host:port
       --insecure string           allow the use of http when interacting with the host (default "false")

--- a/docs/cli/commands/tanzu_config_cert_update.md
+++ b/docs/cli/commands/tanzu_config_cert_update.md
@@ -11,10 +11,10 @@ tanzu config cert update HOST [flags]
 ```
 
     # Update CA certificate for a host,
-    tanzu config cert update test.vmware.com --ca-certificate path/to/ca/ert
+    tanzu config cert update test.vmware.com --ca-cert path/to/ca/ert
 
     # Update CA certificate for a host:port,
-    tanzu config cert update test.vmware.com:5443 --ca-certificate path/to/ca/ert
+    tanzu config cert update test.vmware.com:5443 --ca-cert path/to/ca/ert
 
     # Update whether to skip verifying the certificate while interacting with host
     tanzu config cert update test.vmware.com  --skip-cert-verify true
@@ -26,7 +26,7 @@ tanzu config cert update HOST [flags]
 ### Options
 
 ```
-      --ca-certificate string     path to the public certificate
+      --ca-cert string            path to the public certificate
   -h, --help                      help for update
       --insecure string           allow the use of http when interacting with the host (true|false)
       --skip-cert-verify string   skip server's TLS certificate verification (true|false)

--- a/docs/quickstart/install.md
+++ b/docs/quickstart/install.md
@@ -476,10 +476,10 @@ the registry host.
 ```shell
 
     # If the registry host is self-signed add CA certificate for the registry
-    tanzu config cert add --host test.registry.com --ca-certificate path/to/ca/cert
+    tanzu config cert add --host test.registry.com --ca-cert path/to/ca/cert
 
     # If the registry is self-signed and is serving on non-default port add CA certificate for the registry
-    tanzu config cert add --host test.registry.com:8443 --ca-certificate path/to/ca/cert
+    tanzu config cert add --host test.registry.com:8443 --ca-cert path/to/ca/cert
 
     # If the registry is self-signed or CA cert is expired, add cert configuration for the registry host with
     # skip-cert-verify option

--- a/pkg/command/cert.go
+++ b/pkg/command/cert.go
@@ -59,8 +59,13 @@ func newCertCmd() *cobra.Command {
 		return cobra.AppendActiveHelp(nil, "Please provide 'host' or 'host:port'"), cobra.ShellCompDirectiveNoFileComp
 	}))
 
-	// The completion for this flag is simple file completion, which is configured by default
+	// --ca-certificate is renamed to --ca-cert
 	addCertCmd.Flags().StringVarP(&caCertPathForAdd, "ca-certificate", "", "", "path to the public certificate")
+	caCertificateDeprecationMsg := "this was done in the v1.1.0 release, it will be removed following the deprecation policy (6 months). Use the --ca-cert flag instead.\n"
+	utils.PanicOnErr(addCertCmd.Flags().MarkDeprecated("ca-certificate", caCertificateDeprecationMsg))
+	// The completion for this flag is simple file completion, which is configured by default
+	addCertCmd.Flags().StringVarP(&caCertPathForAdd, "ca-cert", "", "", "path to the public certificate")
+
 	addCertCmd.Flags().StringVarP(&skipCertVerifyForAdd, "skip-cert-verify", "", "false", "skip server's TLS certificate verification")
 	utils.PanicOnErr(addCertCmd.RegisterFlagCompletionFunc("skip-cert-verify", compSkipFlag))
 
@@ -69,8 +74,12 @@ func newCertCmd() *cobra.Command {
 
 	utils.PanicOnErr(cobra.MarkFlagRequired(addCertCmd.Flags(), "host"))
 
-	// The completion for this flag is simple file completion, which is configured by default
+	// --ca-certificate is renamed to --ca-cert
 	updateCertCmd.Flags().StringVarP(&caCertPathForUpdate, "ca-certificate", "", "", "path to the public certificate")
+	utils.PanicOnErr(updateCertCmd.Flags().MarkDeprecated("ca-certificate", caCertificateDeprecationMsg))
+	// The completion for this flag is simple file completion, which is configured by default
+	updateCertCmd.Flags().StringVarP(&caCertPathForUpdate, "ca-cert", "", "", "path to the public certificate")
+
 	updateCertCmd.Flags().StringVarP(&skipCertVerifyForUpdate, "skip-cert-verify", "", "", "skip server's TLS certificate verification (true|false)")
 	utils.PanicOnErr(updateCertCmd.RegisterFlagCompletionFunc("skip-cert-verify", compSkipFlag))
 
@@ -127,10 +136,10 @@ func newAddCertCmd() *cobra.Command {
 		Long:  "Add a certificate configuration for a host",
 		Example: `
     # Add CA certificate for a host
-    tanzu config cert add --host test.vmware.com --ca-certificate path/to/ca/ert
+    tanzu config cert add --host test.vmware.com --ca-cert path/to/ca/ert
 
     # Add CA certificate for a host:port
-    tanzu config cert add --host test.vmware.com:8443 --ca-certificate path/to/ca/ert
+    tanzu config cert add --host test.vmware.com:8443 --ca-cert path/to/ca/ert
 
     # Set to skip verifying the certificate while interacting with host
     tanzu config cert add --host test.vmware.com  --skip-cert-verify true
@@ -182,10 +191,10 @@ func newUpdateCertCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Example: `
     # Update CA certificate for a host,
-    tanzu config cert update test.vmware.com --ca-certificate path/to/ca/ert
+    tanzu config cert update test.vmware.com --ca-cert path/to/ca/ert
 
     # Update CA certificate for a host:port,
-    tanzu config cert update test.vmware.com:5443 --ca-certificate path/to/ca/ert
+    tanzu config cert update test.vmware.com:5443 --ca-cert path/to/ca/ert
 
     # Update whether to skip verifying the certificate while interacting with host
     tanzu config cert update test.vmware.com  --skip-cert-verify true

--- a/pkg/command/cert_test.go
+++ b/pkg/command/cert_test.go
@@ -60,7 +60,7 @@ var _ = Describe("config cert command tests", func() {
 			It("should be success and cert list should return the cert successfully", func() {
 				certCmd := newCertCmd()
 				certCmd.SetArgs([]string{
-					"add", "--host", testHost, "--ca-certificate", caCertFile.Name(),
+					"add", "--host", testHost, "--ca-cert", caCertFile.Name(),
 					"--skip-cert-verify", "true", "--insecure", "true"})
 				err = certCmd.Execute()
 				Expect(err).To(BeNil())
@@ -76,13 +76,13 @@ var _ = Describe("config cert command tests", func() {
 			It("should return error if the cert for a host already exists", func() {
 				certCmd := newCertCmd()
 				certCmd.SetArgs([]string{
-					"add", "--host", testHost, "--ca-certificate", caCertFile.Name(),
+					"add", "--host", testHost, "--ca-cert", caCertFile.Name(),
 					"--skip-cert-verify", "true", "--insecure", "true"})
 				err = certCmd.Execute()
 				Expect(err).To(BeNil())
 
 				certCmd.SetArgs([]string{
-					"add", "--host", testHost, "--ca-certificate", caCertFile.Name(),
+					"add", "--host", testHost, "--ca-cert", caCertFile.Name(),
 					"--skip-cert-verify", "true", "--insecure", "false"})
 				err = certCmd.Execute()
 				Expect(err).ToNot(BeNil())
@@ -93,14 +93,14 @@ var _ = Describe("config cert command tests", func() {
 			It("should return error if the arguments for 'skip-cert-verify' and 'insecure' are not boolean", func() {
 				certCmd := newCertCmd()
 				certCmd.SetArgs([]string{
-					"add", "--host", testHost, "--ca-certificate", caCertFile.Name(),
+					"add", "--host", testHost, "--ca-cert", caCertFile.Name(),
 					"--skip-cert-verify", "true", "--insecure", "fakeint"})
 				err = certCmd.Execute()
 				Expect(err).ToNot(BeNil())
 				Expect(err.Error()).To(Equal(`incorrect boolean argument for '--insecure' option : "fakeint"`))
 
 				certCmd.SetArgs([]string{
-					"add", "--host", testHost, "--ca-certificate", caCertFile.Name(),
+					"add", "--host", testHost, "--ca-cert", caCertFile.Name(),
 					"--skip-cert-verify", "fakebool", "--insecure", "false"})
 				err = certCmd.Execute()
 				Expect(err).ToNot(BeNil())
@@ -112,7 +112,7 @@ var _ = Describe("config cert command tests", func() {
 			It("should return success and cert list should return the cert successfully", func() {
 				certCmd := newCertCmd()
 				certCmd.SetArgs([]string{
-					"add", "--host", testHost, "--ca-certificate", caCertFile.Name()})
+					"add", "--host", testHost, "--ca-cert", caCertFile.Name()})
 				err = certCmd.Execute()
 				Expect(err).To(BeNil())
 
@@ -129,7 +129,7 @@ var _ = Describe("config cert command tests", func() {
 			It("should update the host CA cert successfully", func() {
 				certCmd := newCertCmd()
 				certCmd.SetArgs([]string{
-					"add", "--host", testHost, "--ca-certificate", caCertFile.Name()})
+					"add", "--host", testHost, "--ca-cert", caCertFile.Name()})
 				err = certCmd.Execute()
 				Expect(err).To(BeNil())
 
@@ -140,7 +140,7 @@ var _ = Describe("config cert command tests", func() {
 				err = os.WriteFile(caCertFile.Name(), []byte(fakeCACertDataUpdated), 0600)
 				Expect(err).To(BeNil())
 				certCmd.SetArgs([]string{
-					"update", testHost, "--ca-certificate", caCertFile.Name()})
+					"update", testHost, "--ca-cert", caCertFile.Name()})
 				err = certCmd.Execute()
 				Expect(err).To(BeNil())
 
@@ -151,7 +151,7 @@ var _ = Describe("config cert command tests", func() {
 			It("should update the 'skipCertVerify' and 'insecure' config data successfully", func() {
 				certCmd := newCertCmd()
 				certCmd.SetArgs([]string{
-					"add", "--host", testHost, "--ca-certificate", caCertFile.Name(),
+					"add", "--host", testHost, "--ca-cert", caCertFile.Name(),
 					"--skip-cert-verify", "false", "--insecure", "false"})
 				err = certCmd.Execute()
 				Expect(err).To(BeNil())
@@ -181,7 +181,7 @@ var _ = Describe("config cert command tests", func() {
 			It("should delete the cert config successfully if configuration for host exists", func() {
 				certCmd := newCertCmd()
 				certCmd.SetArgs([]string{
-					"add", "--host", testHost, "--ca-certificate", caCertFile.Name(),
+					"add", "--host", testHost, "--ca-cert", caCertFile.Name(),
 					"--skip-cert-verify", "true", "--insecure", "true"})
 				err = certCmd.Execute()
 				Expect(err).To(BeNil())
@@ -318,8 +318,8 @@ func TestCompletionCert(t *testing.T) {
 			expected: "_activeHelp_ Please provide 'host' or 'host:port'\n:4\n",
 		},
 		{
-			test: "completion for the --ca-certificate flag value of the cert add command",
-			args: []string{"__complete", "config", "cert", "add", "--ca-certificate", ""},
+			test: "completion for the --ca-cert flag value of the cert add command",
+			args: []string{"__complete", "config", "cert", "add", "--ca-cert", ""},
 			// ":0" is the value of the ShellCompDirectiveDefault
 			expected: ":0\n",
 		},
@@ -357,8 +357,8 @@ func TestCompletionCert(t *testing.T) {
 			expected: "_activeHelp_ " + compNoMoreArgsMsg + "\n:4\n",
 		},
 		{
-			test: "completion for the --ca-certificate flag value of the cert update command",
-			args: []string{"__complete", "config", "cert", "update", "--ca-certificate", ""},
+			test: "completion for the --ca-cert flag value of the cert update command",
+			args: []string{"__complete", "config", "cert", "update", "--ca-cert", ""},
 			// ":0" is the value of the ShellCompDirectiveDefault
 			expected: ":0\n",
 		},

--- a/test/e2e/framework/framework_constants.go
+++ b/test/e2e/framework/framework_constants.go
@@ -28,7 +28,7 @@ const (
 	ConfigInit         = "%s config init"
 	ConfigServerList   = "%s config server list"
 	ConfigServerDelete = "%s config server delete %s -y"
-	ConfigCertAdd      = "%s config cert add --host %s --ca-certificate %s --skip-cert-verify %s --insecure %s"
+	ConfigCertAdd      = "%s config cert add --host %s --ca-cert %s --skip-cert-verify %s --insecure %s"
 	ConfigCertDelete   = "%s config cert delete %s"
 	ConfigCertList     = "%s config cert list -o json"
 


### PR DESCRIPTION

### What this PR does / why we need it
This PR renames the command option `--ca-certificate ` to `ca-cert` in "tanzu config cert add" and "tanzu config cert update" commands
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
Validated the help and also the functionality for `tanzu config cert add` command with renamed `--ca-cert` options
```
❯ ./bin/tanzu config cert add -h
Add a certificate configuration for a host

Usage:
tanzu config cert add [flags]

Examples:

    # Add CA certificate for a host
    tanzu config cert add --host test.vmware.com --ca-cert path/to/ca/ert

    # Add CA certificate for a host:port
    tanzu config cert add --host test.vmware.com:8443 --ca-cert path/to/ca/ert

    # Set to skip verifying the certificate while interacting with host
    tanzu config cert add --host test.vmware.com  --skip-cert-verify true

    # Set to allow insecure (http) connection while interacting with host
    tanzu config cert add --host test.vmware.com  --insecure true

Flags:
      --ca-cert string            path to the public certificate
  -h, --help                      help for add
      --host string               host or host:port
      --insecure string           allow the use of http when interacting with the host (default "false")
      --skip-cert-verify string   skip server's TLS certificate verification (default "false”)



#### tried shell completion and it shows --ca-cert option instead of --ca-certificate
./bin/tanzu config cert add --host test2.host.com --ca-cert                                                         
--ca-cert           -- path to the public certificate
--help              -- help for add
--insecure          -- allow the use of http when interacting with the host
--skip-cert-verify  -- skip server's TLS certificate verification

#### successful with --ca-cert option
❯ ./bin/tanzu config cert add --host test2.host.com --ca-cert ~/openssl/server.crt
[ok] successfully added certificate data for host test2.host.com
❯ ./bin/tanzu config cert list
  HOST            CA-CERTIFICATE  SKIP-CERT-VERIFICATION  INSECURE
  test1.host.com  Not configured  false                   true
  localhost:9876  <REDACTED>      false                   false
  test2.host.com  <REDACTED>      false                   false

## Also validated the deprecration --ca-certificate option still works with deprecation message
❯  ./bin/tanzu config cert delete test2.host.com 
[ok] deleted certificate data for host test2.host.com
❯ ./bin/tanzu config cert add --host test2.host.com --ca-certificate ~/openssl/server.crt
Flag --ca-certificate has been deprecated, this was done in the v1.1.0 release, it will be removed following the deprecation policy (6 months). Use the --ca-cert flag instead.

[ok] successfully added certificate data for host test2.host.com
```


Validated the help and also the functionality for `tanzu config cert update` command with renamed `--ca-cert` options

```
❯ ./bin/tanzu config cert update -h
Update certificate configuration for a host

Usage:
tanzu config cert update HOST [flags]

Examples:

    # Update CA certificate for a host,
    tanzu config cert update test.vmware.com --ca-cert path/to/ca/ert

    # Update CA certificate for a host:port,
    tanzu config cert update test.vmware.com:5443 --ca-cert path/to/ca/ert

    # Update whether to skip verifying the certificate while interacting with host
    tanzu config cert update test.vmware.com  --skip-cert-verify true

    # Update whether to allow insecure (http) connection while interacting with host
    tanzu config cert update test.vmware.com  --insecure true

Flags:
      --ca-cert string            path to the public certificate
  -h, --help                      help for update
      --insecure string           allow the use of http when interacting with the host (true|false)
      --skip-cert-verify string   skip server's TLS certificate verification (true|false)


./bin/tanzu config cert update test2.host.com --ca-cert                                                           
--ca-cert           -- path to the public certificate
--help              -- help for update
--insecure          -- allow the use of http when interacting with the host (true|false)
--skip-cert-verify  -- skip server's TLS certificate verification (true|false)

## validated the new command option --ca-cert works
❯ ./bin/tanzu config cert update test2.host.com --ca-cert  ~/openssl/server.crt
[ok] updated certificate data for host test2.host.com
❯ ./bin/tanzu config cert list
  HOST            CA-CERTIFICATE  SKIP-CERT-VERIFICATION  INSECURE
  test1.host.com  Not configured  false                   true
  test.host.com   <REDACTED>      false                   false
  test2.host.com  <REDACTED>      false                   false

### validated the deprecated command line option --ca-certificate still works with deprecation message
❯ ./bin/tanzu config cert update test2.host.com --ca-certificate  ~/openssl/server.crt
Flag --ca-certificate has been deprecated, this was done in the v1.1.0 release, it will be removed following the deprecation policy (6 months). Use the --ca-cert flag instead.

[ok] updated certificate data for host test2.host.com
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Rename --ca-certificate option to --ca-cert in "tanzu config cert add" and "tanzu config cert update" commands. The --ca-certificate option is still supported but deprecated in both the commands.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
