### PR TITLE
Adjust empty line delimiter for essential plugins

### DIFF
--- a/docs/quickstart/install.md
+++ b/docs/quickstart/install.md
@@ -287,6 +287,8 @@ Do you agree to the VMware General Terms?
  > Yes
 
 [i] The tanzu cli essential plugins have not been installed and are being installed now. The install may take a few seconds.
+[i] Installing plugins from plugin group 'vmware-tanzucli/essentials:v1.0.0'
+[i] Installing plugin 'telemetry:v1.1.0' with target 'global'
 
 Standalone Plugins
   NAME       DESCRIPTION              TARGET  VERSION  STATUS
@@ -303,6 +305,8 @@ Essentials plugins being updated when a new version of plugin is available
 
 > tanzu plugin list
 [i] The tanzu cli essential plugins are outdated and are being updated now. The update may take a few seconds.
+[i] Installing plugins from plugin group 'vmware-tanzucli/essentials:v1.0.0'
+[i] Installing plugin 'telemetry:v1.1.0' with target 'global'
 
 Standalone Plugins
   NAME       DESCRIPTION              TARGET  VERSION  STATUS

--- a/pkg/pluginmanager/essentials.go
+++ b/pkg/pluginmanager/essentials.go
@@ -5,6 +5,7 @@ package pluginmanager
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/essentials"
@@ -37,11 +38,11 @@ func InstallPluginsFromEssentialPluginGroup() (string, error) {
 
 	log.Info(actionMessage)
 
-	// Print an empty line
-	fmt.Println()
-
 	// Attempt to install or upgrade the essential plugin group.
 	_, err = installPluginsFromEssentialPluginGroup(name, version)
+
+	// Print an empty line to delimit the essential plugins output with any actual command output
+	fmt.Fprintln(os.Stderr)
 
 	// If there's an error during installation or upgrade, return it with additional context.
 	if err != nil {


### PR DESCRIPTION
### What this PR does / why we need it

Move the empty line delimiter to after all the essential plugins printouts
In the v1.0.0 release of the CLI, the only essential plugins printout was:
`[i] The tanzu cli essential plugins have not been installed and are being installed now. The install may take a few seconds.
`
but now the CLI prints the plugin group name and the plugin(s) being installed:
```
[i] The tanzu cli essential plugins have not been installed and are being installed now. The install may take a few seconds.

[i] Installing plugins from plugin group 'vmware-tanzucli/essentials:v1.0.0'
[i] Installing plugin 'telemetry:v1.1.0' with target 'global' (from cache)
```

The empty line meant to separate the essential plugins printouts from the real command output was not in the correct place.  This PR moves it to after the new printouts.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

```
$ tz plugin uninstall telemetry
Uninstalling plugin 'telemetry' for target 'global'. Are you sure? [y/N]: y
[i] Uninstalling plugin 'telemetry' for target 'global'
[ok] successfully uninstalled plugin 'telemetry'

# Notice the empty line is now after all the essential plugins printouts
$ tz context list
[i] The tanzu cli essential plugins have not been installed and are being installed now. The install may take a few seconds.
[i] Installing plugins from plugin group 'vmware-tanzucli/essentials:v1.0.0'
[i] Installing plugin 'telemetry:v1.1.0' with target 'global' (from cache)

  NAME   ISACTIVE  TYPE             ENDPOINT                                                                         KUBECONFIGPATH                          KUBECONTEXT      PROJECT  SPACE
  tanzu  false     tanzu            https://api.tanzu-dev.cloud.vmware.com/org/ee04bfae-a665-4f20-a5b9-d8b043180252  /Users/kmarc/.k3d/kubeconfig-tkg1.yaml  tanzu-cli-tanzu
  tkg1   true      kubernetes                                                                                        /Users/kmarc/.k3d/kubeconfig-tkg1.yaml  k3d-tkg1         n/a      n/a
  tmc    false     mission-control  unstable.tmc-dev.cloud.vmware.com:443                                            n/a                                     n/a              n/a      n/a
  tmc2   false     mission-control  unstable.tmc-dev.cloud.vmware.com:443                                            n/a                                     n/a              n/a      n/a


$ tz plugin uninstall telemetry
Uninstalling plugin 'telemetry' for target 'global'. Are you sure? [y/N]: y
[i] Uninstalling plugin 'telemetry' for target 'global'
[ok] successfully uninstalled plugin 'telemetry'

# Notice the empty line is now on stderr like the other essential plugins printouts

$ tz context list >tt
[i] The tanzu cli essential plugins have not been installed and are being installed now. The install may take a few seconds.
[i] Installing plugins from plugin group 'vmware-tanzucli/essentials:v1.0.0'
[i] Installing plugin 'telemetry:v1.1.0' with target 'global' (from cache)

$ cat tt
  NAME   ISACTIVE  TYPE             ENDPOINT                                                                         KUBECONFIGPATH                          KUBECONTEXT      PROJECT  SPACE
  tanzu  false     tanzu            https://api.tanzu-dev.cloud.vmware.com/org/ee04bfae-a665-4f20-a5b9-d8b043180252  /Users/kmarc/.k3d/kubeconfig-tkg1.yaml  tanzu-cli-tanzu
  tkg1   true      kubernetes                                                                                        /Users/kmarc/.k3d/kubeconfig-tkg1.yaml  k3d-tkg1         n/a      n/a
  tmc    false     mission-control  unstable.tmc-dev.cloud.vmware.com:443                                            n/a                                     n/a              n/a      n/a
  tmc2   false     mission-control  unstable.tmc-dev.cloud.vmware.com:443                                            n/a                                     n/a              n/a      n/a

```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
