### PR TITLE
Don't use logging for user output

### DIFF
--- a/pkg/command/plugin.go
+++ b/pkg/command/plugin.go
@@ -577,7 +577,7 @@ func displayInstalledAndMissingSplitView(installedStandalonePlugins []cli.Plugin
 	if pluginSyncRequired {
 		// Print a warning to the user that some context plugins are not installed or outdated and plugin sync is required to install them
 		fmt.Println("")
-		log.Warningf("As shown above, some recommended plugins have not been installed or are outdated. To install them please run 'tanzu plugin sync'.")
+		fmt.Println("Note: As shown above, some recommended plugins have not been installed or are outdated. To install them please run 'tanzu plugin sync'.")
 	}
 }
 

--- a/pkg/command/plugin_group.go
+++ b/pkg/command/plugin_group.go
@@ -234,11 +234,8 @@ func displayGroupContentAsTable(group *plugininventory.PluginGroup, specifiedVer
 	outputStandalone.Render()
 
 	if showNonMandatory {
-		log.SetStdout(writer)
-		log.SetStderr(writer)
-
 		fmt.Fprintln(writer)
-		log.Infof("The standalone plugins in this plugin group are installed when the 'tanzu plugin install --group %s%s' command is invoked.\n", gID, specifiedVersion)
+		fmt.Fprintf(writer, "Note: The standalone plugins in this plugin group are installed when the 'tanzu plugin install --group %s%s' command is invoked.\n", gID, specifiedVersion)
 
 		fmt.Fprintln(writer)
 		outputContext := component.NewOutputWriterWithOptions(writer, outputFormat, []component.OutputWriterOption{}, "Name", "Target", "Version")
@@ -251,7 +248,7 @@ func displayGroupContentAsTable(group *plugininventory.PluginGroup, specifiedVer
 		outputContext.Render()
 
 		fmt.Fprintln(writer)
-		log.Info("The contextual plugins in this plugin group are automatically installed, and only available for use, when a Tanzu context which supports them is created or activated/used.\n")
+		fmt.Fprintln(writer, "Note: The contextual plugins in this plugin group are automatically installed, and only available for use, when a Tanzu context which supports them is created or activated/used.")
 	}
 }
 

--- a/pkg/command/plugin_group_test.go
+++ b/pkg/command/plugin_group_test.go
@@ -139,13 +139,13 @@ func TestPluginGroupGet(t *testing.T) {
 			test:            "get a plugin group with --all with no context-scoped",
 			args:            []string{"plugin", "group", "get", "vmware-tkg/default", "--all"},
 			expectedFailure: false,
-			expected:        "Plugins in Group: vmware-tkg/default:v2.2.2 Standalone Plugins NAME TARGET VERSION isolated-cluster global v1.3 [i] The standalone plugins in this plugin group are installed when the 'tanzu plugin install --group vmware-tkg/default' command is invoked. Contextual Plugins NAME TARGET VERSION [i] The contextual plugins in this plugin group are automatically installed, and only available for use, when a Tanzu context which supports them is created or activated/used.",
+			expected:        "Plugins in Group: vmware-tkg/default:v2.2.2 Standalone Plugins NAME TARGET VERSION isolated-cluster global v1.3 Note: The standalone plugins in this plugin group are installed when the 'tanzu plugin install --group vmware-tkg/default' command is invoked. Contextual Plugins NAME TARGET VERSION Note: The contextual plugins in this plugin group are automatically installed, and only available for use, when a Tanzu context which supports them is created or activated/used.",
 		},
 		{
 			test:            "get a plugin group with --all with context-scoped",
 			args:            []string{"plugin", "group", "get", "vmware-tkg/default:v1.1.1", "--all"},
 			expectedFailure: false,
-			expected:        "Plugins in Group: vmware-tkg/default:v1.1.1 Standalone Plugins NAME TARGET VERSION isolated-cluster global v1.2.3 login global v1.2.0 management-cluster kubernetes v0.1.0 package kubernetes v0.2.0 secret kubernetes v0.3.0 [i] The standalone plugins in this plugin group are installed when the 'tanzu plugin install --group vmware-tkg/default:v1.1.1' command is invoked. Contextual Plugins NAME TARGET VERSION cluster kubernetes v1.1.1 [i] The contextual plugins in this plugin group are automatically installed, and only available for use, when a Tanzu context which supports them is created or activated/used.",
+			expected:        "Plugins in Group: vmware-tkg/default:v1.1.1 Standalone Plugins NAME TARGET VERSION isolated-cluster global v1.2.3 login global v1.2.0 management-cluster kubernetes v0.1.0 package kubernetes v0.2.0 secret kubernetes v0.3.0 Note: The standalone plugins in this plugin group are installed when the 'tanzu plugin install --group vmware-tkg/default:v1.1.1' command is invoked. Contextual Plugins NAME TARGET VERSION cluster kubernetes v1.1.1 Note: The contextual plugins in this plugin group are automatically installed, and only available for use, when a Tanzu context which supports them is created or activated/used.",
 		},
 		{
 			test:            "get a plugin group in json with --all with no context-scoped",


### PR DESCRIPTION
### What this PR does / why we need it

The logging library was being used for normal user output.
This PR removes those instances and handles the user output directly.
It also adds a `Note:` prefix, instead of the `[i]` that was printed by the logging library.


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

```
# Notice the new "Note:" prefixes
$ tz plugin group get vmware-tkg/default --all
Plugins in Group:  vmware-tkg/default:v2.4.0

Standalone Plugins
  NAME                TARGET      VERSION
  isolated-cluster    global      v0.31.0
  management-cluster  kubernetes  v0.31.0
  package             kubernetes  v0.31.0
  pinniped-auth       global      v0.31.0
  secret              kubernetes  v0.31.0
  telemetry           kubernetes  v0.31.0

Note: The standalone plugins in this plugin group are installed when the 'tanzu plugin install --group vmware-tkg/default' command is invoked.

Contextual Plugins
  NAME                TARGET      VERSION
  cluster             kubernetes  v0.31.0
  feature             kubernetes  v0.31.0
  kubernetes-release  kubernetes  v0.31.0

Note: The contextual plugins in this plugin group are automatically installed, and only available for use, when a Tanzu context which supports them is created or activated/used.

# Confirm that all printouts are on stdout
$ tz plugin group get vmware-tkg/default --all >tt

# Notice the "Note:" prefix instead of "[!]"
$ tz plugin list
Standalone Plugins
  NAME              DESCRIPTION                                                                       TARGET           VERSION         STATUS
  builder           Build Tanzu components                                                            global           v1.1.0-dev      installed
  imgpkg            imgpkg allows to store configuration and image references as oci artifacts        global           v0.1.0          installed
                    (copy, describe, pull, push, tag, version)
  isolated-cluster  Prepopulating images/bundle for internet-restricted environments                  global           v0.31.0         installed
  telemetry         configure cluster-wide settings for vmware tanzu telemetry                        global           v1.1.0          installed
  test              Test the CLI                                                                      global           v1.1.0-rc.0     installed
  project           View, list and use Tanzu Projects.                                                kubernetes       v0.1.0-build.4  installed
  space             Tanzu space, space profile, and space trait management                            kubernetes       v0.1.0-build.5  installed
  context           Management for TMC contexts                                                       mission-control  v0.1.7          installed

Plugins from Context:  tkg1
  NAME                DESCRIPTION                           TARGET      VERSION  STATUS
  cluster             Kubernetes cluster operations         kubernetes  v0.30.1  not installed
  feature             Operate on features and featuregates  kubernetes  v0.31.0  installed
  kubernetes-release  Kubernetes release operations         kubernetes  v0.30.1  installed

Note: As shown above, some recommended plugins have not been installed or are outdated. To install them please run 'tanzu plugin sync'.

# Notice that all the output goes to stdout
$ tz plugin list >tt
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Prefer "Note:" prefixes in user output.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
