### PR TITLE
Note about advance support for the 'tanzu' context

### DIFF
--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -176,6 +176,10 @@ var createCtxCmd = &cobra.Command{
     # Create an Tanzu context but skipping TLS verification (this is insecure):
     tanzu context create mytanzu --endpoint https://api.tanzu.cloud.vmware.com --insecure-skip-tls-verify
 
+    Note: The "tanzu" context type is being released to provide advance support for the development
+    and release of new services (and CLI plugins) which extend and combine features provided by
+    individual tanzu components.
+
     [*] : Users have two options to create a kubernetes cluster context. They can choose the control
     plane option by providing 'endpoint', or use the kubeconfig for the cluster by providing
     'kubeconfig' and 'context'. If only '--context' is set and '--kubeconfig' is not, the
@@ -654,6 +658,14 @@ func doCSPAuthAndUpdateContext(c *configtypes.Context, endpointType string) (cla
 func promptContextType() (ctxCreationType ContextCreationType, err error) {
 	ctxCreationTypeStr := ""
 	promptOpts := getPromptOpts()
+
+	fmt.Print(`
+Note: The "tanzu" context type is being released to provide advance support for the development
+and release of new services (and CLI plugins) which extend and combine features provided by
+individual tanzu components.
+
+`)
+
 	err = component.Prompt(
 		&component.PromptConfig{
 			Message: "Select context creation type",


### PR DESCRIPTION
### What this PR does / why we need it

Add a couple of notes explaining the new context type `tanzu`

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

```
$ tz context create -h
Create a Tanzu CLI context

Usage:
tanzu context create CONTEXT_NAME [flags]

Examples:

    # Create a TKG management cluster context using endpoint and type (--type is optional, if not provided the CLI will infer the type from the endpoint)
    tanzu context create mgmt-cluster --endpoint https://k8s.example.com[:port] --type k8s

    # Create a TKG management cluster context using endpoint
    tanzu context create mgmt-cluster --endpoint https://k8s.example.com[:port]

    # Create a TKG management cluster context using kubeconfig path and context
    tanzu context create mgmt-cluster --kubeconfig path/to/kubeconfig --kubecontext kubecontext

    # Create a TKG management cluster context by using the provided CA Bundle for TLS verification:
    tanzu context create mgmt-cluster --endpoint https://k8s.example.com[:port] --endpoint-ca-certificate /path/to/ca/ca-cert

    # Create a TKG management cluster context by explicit request to skip TLS verification, which is insecure:
    tanzu context create mgmt-cluster --endpoint https://k8s.example.com[:port] --insecure-skip-tls-verify

    # Create a TKG management cluster context using default kubeconfig path and a kubeconfig context
    tanzu context create mgmt-cluster --kubecontext kubecontext

    # Create an Tanzu context with the default endpoint (--type is not necessary for the default endpoint)
    tanzu context create mytanzu --endpoint https://api.tanzu.cloud.vmware.com

    # Create an Tanzu context (--type is needed for a non-default endpoint)
    tanzu context create mytanzu --endpoint https://non-default.tanzu.endpoint.com --type tanzu

    # Create an Tanzu context by using the provided CA Bundle for TLS verification:
    tanzu context create mytanzu --endpoint https://api.tanzu.cloud.vmware.com  --endpoint-ca-certificate /path/to/ca/ca-cert

    # Create an Tanzu context but skipping TLS verification (this is insecure):
    tanzu context create mytanzu --endpoint https://api.tanzu.cloud.vmware.com --insecure-skip-tls-verify

    Note: The "tanzu" context type is being released to provide advance support for the development
    and release of new services (and CLI plugins) which extend and combine features provided by
    individual tanzu components.

    [*] : Users have two options to create a kubernetes cluster context. They can choose the control
    plane option by providing 'endpoint', or use the kubeconfig for the cluster by providing
    'kubeconfig' and 'context'. If only '--context' is set and '--kubeconfig' is not, the
    $KUBECONFIG env variable will be used and, if the $KUBECONFIG env is also not set, the default
    kubeconfig file ($HOME/.kube/config) will be used.

Flags:
      --endpoint string                  endpoint to create a context for
      --endpoint-ca-certificate string   path to the endpoint public certificate
  -h, --help                             help for create
      --insecure-skip-tls-verify         skip endpoint's TLS certificate verification
      --kubeconfig string                path to the kubeconfig file; valid only if user doesn't choose 'endpoint' option.(See [*])
      --kubecontext string               the context in the kubeconfig to use; valid only if user doesn't choose 'endpoint' option.(See [*])
  -t, --type string                      type of context to create (kubernetes[k8s]/mission-control[tmc]/tanzu)


$ tz context create

Note: The "tanzu" context type is being released to provide advance support for the development
and release of new services (and CLI plugins) which extend and combine features provided by
individual tanzu components.

? Select context creation type Tanzu
? Enter control plane endpoint (https://api.tanzu.cloud.vmware.com)
[x] : interrupt

# Just check a case where we don't prompt for the context type
$ tz context create tkg3 --kubecontext k3d-tkg1
[ok] successfully created a kubernetes context using the kubeconfig /Users/kmarc/.k3d/kubeconfig-tkg1.yaml
[i] Checking for required plugins for context 'tkg3'...
[i] The following plugins will be installed for context 'tkg3' of contextType 'kubernetes':
  NAME                TARGET      VERSION
  cluster             kubernetes  v0.30.1
  kubernetes-release  kubernetes  v0.30.1
  feature             kubernetes  v0.31.0
^C

$ tz context create tkg3 --kubeconfig ~/allo

Note: The "tanzu" context type is being released to provide advance support for the development
and release of new services (and CLI plugins) which extend and combine features provided by
individual tanzu components.

? Select context creation type  [Use arrows to move, type to filter]
> Tanzu
  Mission Control
  Kubernetes (Cluster Endpoint)
  Kubernetes (Local Kubeconfig)
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The "tanzu" context type is being released to provide advance support for the development and release of new services (and CLI plugins) which extend and combine features provided by individual tanzu components.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
