### PR TITLE
Update TANZU_API_TOKEN help message

### DIFF
--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -183,6 +183,10 @@ var createCtxCmd = &cobra.Command{
     and release of new services (and CLI plugins) which extend and combine features provided by
     individual tanzu components.
 
+    Note: To create Mission Control (TMC) or Tanzu contexts, an API Key is required. The API Key
+    value can be provided with the environment variable TANZU_API_TOKEN or can be entered as input
+    while creating the context.
+
     [*] : Users have two options to create a kubernetes cluster context. They can choose the control
     plane option by providing 'endpoint', or use the kubeconfig for the cluster by providing
     'kubeconfig' and 'context'. If only '--context' is set and '--kubeconfig' is not, the
@@ -632,6 +636,8 @@ func doCSPAuthAndUpdateContext(c *configtypes.Context, endpointType string) (cla
 	if apiTokenExists {
 		log.Info("API token env var is set")
 	} else {
+		fmt.Fprintln(os.Stderr)
+		log.Info("The API key can be provided by setting the TANZU_API_TOKEN environment variable")
 		apiTokenValue, err = promptAPIToken(endpointType)
 		if err != nil {
 			return nil, err

--- a/pkg/command/login.go
+++ b/pkg/command/login.go
@@ -81,6 +81,10 @@ func init() {
     # Login to an existing server
     tanzu login --server mgmt-cluster
 
+    Note: To create Mission Control (TMC) contexts, an API Key is required. The API Key value can
+    be provided with the environment variable TANZU_API_TOKEN or can be entered as input while
+    creating the context.
+
     [*] : Users have two options to login to TKG. They can choose the login endpoint option
     by providing 'endpoint', or can choose to use the kubeconfig for the management cluster by
     providing 'kubeconfig' and 'context'. If only '--context' is set and '--kubeconfig' is not,
@@ -367,6 +371,8 @@ func globalLoginUsingServer(s *configtypes.Server) (err error) { //nolint:static
 	if apiTokenExists {
 		log.Info("API token env var is set")
 	} else {
+		fmt.Fprintln(os.Stderr)
+		log.Info("The API key can be provided by setting the TANZU_API_TOKEN environment variable")
 		apiTokenValue, err = promptAPIToken("TMC")
 		if err != nil {
 			return err

--- a/pkg/constants/env_variables.go
+++ b/pkg/constants/env_variables.go
@@ -20,9 +20,10 @@ const (
 	SuppressSkipSignatureVerificationWarning          = "TANZU_CLI_SUPPRESS_SKIP_SIGNATURE_VERIFICATION_WARNING"
 	CEIPOptInUserPromptAnswer                         = "TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER"
 	EULAPromptAnswer                                  = "TANZU_CLI_EULA_PROMPT_ANSWER"
-	E2ETestEnvironment                                = "TANZU_CLI_E2E_TEST_ENVIRONMENT" // environment variable to indicate that the CLI is running in E2E test environment
-	ShowTelemetryConsoleLogs                          = "TANZU_CLI_SHOW_TELEMETRY_CONSOLE_LOGS"
-	TelemetrySuperColliderEnvironment                 = "TANZU_CLI_SUPERCOLLIDER_ENVIRONMENT"
+	// Environment variable to indicate that the CLI is running in E2E test environment
+	E2ETestEnvironment                = "TANZU_CLI_E2E_TEST_ENVIRONMENT"
+	ShowTelemetryConsoleLogs          = "TANZU_CLI_SHOW_TELEMETRY_CONSOLE_LOGS"
+	TelemetrySuperColliderEnvironment = "TANZU_CLI_SUPERCOLLIDER_ENVIRONMENT"
 
 	// TanzuCLIEssentialsPluginGroupName is used to override and customize the default essentials plugin group name
 	TanzuCLIEssentialsPluginGroupName = "TANZU_CLI_ESSENTIALS_PLUGIN_GROUP_NAME"

--- a/test/e2e/context/tmc/context_tmc_lifecycle_test.go
+++ b/test/e2e/context/tmc/context_tmc_lifecycle_test.go
@@ -12,9 +12,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
+
 	"github.com/vmware-tanzu/tanzu-cli/test/e2e/framework"
 	types "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
-	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
 
 // This test suite includes tests for the TMC context,
@@ -158,6 +159,14 @@ func tmcAndK8sContextTests() bool {
 			var k8sCtx, tmcCtx string
 			k8sCtxs := make([]string, 0)
 			tmcCtxs := make([]string, 0)
+			// Test case: validate help message for --help flag
+			It("validate help message note related to TANZU_API_TOKEN", func() {
+				tmcCtx = prefix + framework.RandomString(4)
+				stdOut, stdErr, err := tf.ContextCmd.CreateContextWithEndPointStaging(tmcCtx, tmcClusterInfo.EndPoint, framework.AddAdditionalFlagAndValue("--help"))
+				Expect(stdErr).To(BeEmpty(), "stdErr should be empty")
+				Expect(err).To(BeNil(), "context should create without any error")
+				Expect(stdOut).To(ContainSubstring("Note: To create Mission Control (TMC) or Tanzu contexts, an API Key is required."))
+			})
 			// Test case: a. create tmc context
 			It("create tmc context with endpoint and check active context", func() {
 				for i := 0; i < 5; i++ {

--- a/test/e2e/context/tmc/context_tmc_suite_test.go
+++ b/test/e2e/context/tmc/context_tmc_suite_test.go
@@ -29,7 +29,7 @@ var (
 
 const prefix = "ctx-tmc-"
 const prefixK8s = "ctx-k8s-"
-const maxCtx = 25
+const maxCtx = 5 // setting few number of context's as TMC context creation is slow and takes time because its dependent on TMC API's
 const ContextShouldNotExists = "the context %s should not exists"
 const ContextShouldExistsAsCreated = "the context %s should exists as its been created"
 

--- a/test/e2e/framework/context_create_operations.go
+++ b/test/e2e/framework/context_create_operations.go
@@ -16,7 +16,7 @@ type ContextCreateOps interface {
 	// CreateContextWithEndPoint creates a context with a given endpoint URL
 	CreateContextWithEndPoint(contextName, endpoint string, opts ...E2EOption) error
 	// CreateContextWithEndPointStaging creates a context with a given endpoint URL for staging, returns stdout, stderr and error
-	CreateContextWithEndPointStaging(contextName, endpoint string, opts ...E2EOption) (string, string, error)
+	CreateContextWithEndPointStaging(contextName, endpoint string, opts ...E2EOption) (stdOut, stdErr string, err error)
 	// CreateContextWithKubeconfig creates a context with the given kubeconfig file path and a context from the kubeconfig file
 	CreateContextWithKubeconfig(contextName, kubeconfigPath, kubeContext string, opts ...E2EOption) error
 	// CreateContextWithDefaultKubeconfig creates a context with the default kubeconfig file and a given input context name if it exists in the default kubeconfig file
@@ -45,15 +45,15 @@ func (cc *contextCreateOps) CreateContextWithEndPoint(contextName, endpoint stri
 	return err
 }
 
-func (cc *contextCreateOps) CreateContextWithEndPointStaging(contextName, endpoint string, opts ...E2EOption) (string, string, error) {
+func (cc *contextCreateOps) CreateContextWithEndPointStaging(contextName, endpoint string, opts ...E2EOption) (stdOut, stdErr string, err error) {
 	createContextCmd := fmt.Sprintf(CreateContextWithEndPointStaging, "%s", endpoint, contextName)
-	out, stdErr, err := cc.cmdExe.TanzuCmdExec(createContextCmd, opts...)
+	out, stdErrBuffer, err := cc.cmdExe.TanzuCmdExec(createContextCmd, opts...)
 	if err != nil {
 		log.Info(fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
-		return out.String(), stdErr.String(), errors.Wrap(err, fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
+		return out.String(), stdErrBuffer.String(), errors.Wrap(err, fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
 	}
 	log.Infof(ContextCreated, contextName)
-	return out.String(), stdErr.String(), err
+	return out.String(), stdErrBuffer.String(), err
 }
 
 func (cc *contextCreateOps) CreateContextWithKubeconfig(contextName, kubeconfigPath, kubeContext string, opts ...E2EOption) error {


### PR DESCRIPTION
### What this PR does / why we need it
This pull request updates the `tanzu context create --help` message regarding the API key, TANZU_API_TOKEN, for creating Mission Control (TMC) or Tanzu contexts. It also updates the same message for `tanzu login --help`. Furthermore, it prints a log message indicating that the API key, TANZU_API_TOKEN, can be set as an environment variable when it is not already set as an environment variable, and users attempt to create a context or log in by providing the API key manually.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
Manual testing:
Use case 1: `tanzu context create --help` output:
```
❯ t context create -h
Create a Tanzu CLI context

Usage:
tanzu context create CONTEXT_NAME [flags]

Examples:
  
    # Create a TKG management cluster context using endpoint and type (--type is optional, if not provided the CLI will infer the type from the endpoint)
    tanzu context create mgmt-cluster --endpoint https://k8s.example.com[:port] --type k8s

    # Create a TKG management cluster context using endpoint
    tanzu context create mgmt-cluster --endpoint https://k8s.example.com[:port]

    # Create a TKG management cluster context using kubeconfig path and context
    tanzu context create mgmt-cluster --kubeconfig path/to/kubeconfig --kubecontext kubecontext

    # Create a TKG management cluster context by using the provided CA Bundle for TLS verification:
    tanzu context create mgmt-cluster --endpoint https://k8s.example.com[:port] --endpoint-ca-certificate /path/to/ca/ca-cert

    # Create a TKG management cluster context by explicit request to skip TLS verification, which is insecure:
    tanzu context create mgmt-cluster --endpoint https://k8s.example.com[:port] --insecure-skip-tls-verify

    # Create a TKG management cluster context using default kubeconfig path and a kubeconfig context
    tanzu context create mgmt-cluster --kubecontext kubecontext

    # Create a TMC(mission-control) context using endpoint and type 
    tanzu context create mytmc --endpoint tmc.example.com:443 --type tmc

    # Create an Tanzu context with the default endpoint (--type is not necessary for the default endpoint)
    tanzu context create mytanzu --endpoint https://api.tanzu.cloud.vmware.com

    # Create an Tanzu context (--type is needed for a non-default endpoint)
    tanzu context create mytanzu --endpoint https://non-default.tanzu.endpoint.com --type tanzu

    # Create an Tanzu context by using the provided CA Bundle for TLS verification:
    tanzu context create mytanzu --endpoint https://api.tanzu.cloud.vmware.com  --endpoint-ca-certificate /path/to/ca/ca-cert

    # Create an Tanzu context but skipping TLS verification (this is insecure):
    tanzu context create mytanzu --endpoint https://api.tanzu.cloud.vmware.com --insecure-skip-tls-verify

    Note: The "tanzu" context type is being released to provide advance support for the development
    and release of new services (and CLI plugins) which extend and combine features provided by
    individual tanzu components.

    Note: To create Mission Control (TMC) or Tanzu contexts, an API Key is required. The API Key
    value can be provided with the environment variable TANZU_API_TOKEN or can be entered as input
    while creating the context.

    [*] : Users have two options to create a kubernetes cluster context. They can choose the control
    plane option by providing 'endpoint', or use the kubeconfig for the cluster by providing
    'kubeconfig' and 'context'. If only '--context' is set and '--kubeconfig' is not, the
    $KUBECONFIG env variable will be used and, if the $KUBECONFIG env is also not set, the default
    kubeconfig file ($HOME/.kube/config) will be used.

Flags:
      --endpoint string                  endpoint to create a context for
      --endpoint-ca-certificate string   path to the endpoint public certificate
  -h, --help                             help for create
      --insecure-skip-tls-verify         skip endpoint's TLS certificate verification
      --kubeconfig string                path to the kubeconfig file; valid only if user doesn't choose 'endpoint' option.(See [*])
      --kubecontext string               the context in the kubeconfig to use; valid only if user doesn't choose 'endpoint' option.(See [*]) 
  -t, --type string                      type of context to create (kubernetes[k8s]/mission-control[tmc]/tanzu)
```
Use case 2: tanzu context create when TANZU_API_TOKEN is not set:
```
❯ t context create   
? Select context creation type Mission Control
? Enter control plane endpoint unstable.tmc-dev.cloud.vmware.com
? Give the context a name tmc55

[i] The API key can be provided by setting the TANZU_API_TOKEN environment variable

[i] If you don't have an API token, visit the VMware Cloud Services console, select your organization, and create an API token with the TMC service roles:
  https://console.cloud.vmware.com/csp/gateway/portal/#/user/tokens

? API Token ****************************************************************
```
Use case 3: tanzu context create when TANZU_API_TOKEN env variable set:
```
❯ t context create                                                                       
? Select context creation type Mission Control
? Enter control plane endpoint unstable.tmc-dev.cloud.vmware.com
? Give the context a name tmc66
[i] API token env var is set
[x] : failed to get token from CSP for TMC: Failed to obtain access token. Please provide valid VMware Cloud Services API-token -- {"metadata":null,"requestId":"69ca682cd3680fbb","statusCode":400,"message":"invalid_grant: Invalid refresh token: xxxx...ATffV","errorCode":null,"moduleCode":540,"traceId":"c536b93cb059e4d0fb404a3f0fa64abe","cspErrorCode":"540.120-340.800"}
```
Use case 4: `tanzu login --help` output:

```
❯ t login -h
Command "login" is deprecated, this was done in the "v0.90.0" release, it will be removed following the deprecation policy (6 months). Use the "context" command instead.

Login to the platform

Usage:
tanzu login [flags]

Aliases:
  login, lo, logins

Examples:
  
    # Login to TKG management cluster using endpoint
    tanzu login --endpoint "https://login.example.com"  --name mgmt-cluster

    #  Login to TKG management cluster by using the provided CA Bundle for TLS verification:
    tanzu login --endpoint https://k8s.example.com[:port] --endpoint-ca-certificate /path/to/ca/ca-cert

    # Login to TKG management cluster by explicit request to skip TLS verification, which is insecure:
    tanzu login --endpoint https://k8s.example.com[:port] --insecure-skip-tls-verify

    # Login to TKG management cluster by using kubeconfig path and context for the management cluster
    tanzu login --kubeconfig path/to/kubeconfig --context path/to/context --name mgmt-cluster

    # Login to TKG management cluster by using default kubeconfig path and context for the management cluster
    tanzu login  --context path/to/context --name mgmt-cluster

    # Login to an existing server
    tanzu login --server mgmt-cluster

    Note: To create Mission Control (TMC) contexts, an API Key is required. The API Key value can
    be provided with the environment variable TANZU_API_TOKEN or can be entered as input while
    creating the context.

    [*] : Users have two options to login to TKG. They can choose the login endpoint option
    by providing 'endpoint', or can choose to use the kubeconfig for the management cluster by
    providing 'kubeconfig' and 'context'. If only '--context' is set and '--kubeconfig' is not,
    the $KUBECONFIG env variable will be used and, if the $KUBECONFIG env is also not set, the
    default kubeconfig file ($HOME/.kube/config) will be used.

Flags:
      --apiToken string                  API token for global login
      --context string                   the context in the kubeconfig to use for management cluster. Valid only if user doesn't choose 'endpoint' option.(See [*]) 
      --endpoint string                  endpoint to login to
      --endpoint-ca-certificate string   path to the endpoint public certificate
  -h, --help                             help for login
      --insecure-skip-tls-verify         skip endpoint's TLS certificate verification
      --kubeconfig string                path to kubeconfig management cluster. Valid only if user doesn't choose 'endpoint' option.(See [*])
      --name string                      name of the server
      --server string                    login to the given server
❯ 
```

Use case 5: tanzu login when TANZU_API_TOKEN not set:
```
❯ t login   
Command "login" is deprecated, this was done in the "v0.90.0" release, it will be removed following the deprecation policy (6 months). Use the "context" command instead.

? Select a server + new server
? Select login type Server endpoint
? Enter server endpoint unstable.tmc-dev.cloud.vmware.com
? Give the server a name server22

[i] The API key can be provided by setting the TANZU_API_TOKEN environment variable

[i] If you don't have an API token, visit the VMware Cloud Services console, select your organization, and create an API token with the TMC service roles:
  https://console.cloud.vmware.com/csp/gateway/portal/#/user/tokens

? API Token *******************************************
```
Use case 6: `tanzu login` when TANZU_API_TOKEN set:
```
❯ tanzu login
Command "login" is deprecated, this was done in the "v0.90.0" release, it will be removed following the deprecation policy (6 months). Use the "context" command instead.

? Select a server + new server
? Select login type Server endpoint
? Enter server endpoint unstable.tmc-dev.cloud.vmware.com
? Give the server a name server88
[i] API token env var is set
[x] : Failed to obtain access token. Please provide valid VMware Cloud Services API-token -- {"errorCode":null,"metadata":null,"requestId":"fe18138309b0d437","statusCode":400,"traceId":"c643954150a58cab62c159c33b84d6bc","message":"invalid_grant: Invalid refresh token: xxxx...ATffV","cspErrorCode":"540.120-340.800","moduleCode":540}
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
