### PR TITLE
TMC E2E tests fix - ignore endpoint validation

### DIFF
--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -482,7 +482,7 @@ func createContextWithTMCEndpoint() (context *configtypes.Context, err error) {
 		return
 	}
 
-	if strings.HasPrefix(endpoint, "https:") || strings.HasPrefix(endpoint, "http:") {
+	if os.Getenv(constants.E2ETestEnvironment) != "true" && (strings.HasPrefix(endpoint, "https:") || strings.HasPrefix(endpoint, "http:")) {
 		return nil, errors.Errorf("TMC endpoint URL %s should not contain http or https scheme. It should be of the format host[:port]", endpoint)
 	}
 

--- a/pkg/command/context_test.go
+++ b/pkg/command/context_test.go
@@ -800,19 +800,33 @@ var _ = Describe("create new context", func() {
 			})
 		})
 		Context("with endpoint URL having https/http scheme", func() {
+			const httpsURL = "https://cloud.vmware.com"
+			const httpURL = "http://cloud.vmware.com"
 			It("should return error", func() {
-				endpoint = "https://cloud.vmware.com"
+				endpoint = httpsURL
 				ctxName = testContextName
 				ctx, err = createNewContext()
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("TMC endpoint URL https://cloud.vmware.com should not contain http or https scheme. It should be of the format host[:port]"))
 
-				endpoint = "http://cloud.vmware.com"
+				endpoint = httpURL
 				ctxName = testContextName
 				ctx, err = createNewContext()
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("TMC endpoint URL http://cloud.vmware.com should not contain http or https scheme. It should be of the format host[:port]"))
+			})
+			It("should not return error when E2E test environment variable is set true", func() {
+				endpoint = httpsURL
+				os.Setenv(constants.E2ETestEnvironment, "true")
+				defer os.Unsetenv(constants.E2ETestEnvironment)
+				ctxName = testContextName
+				ctx, err = createNewContext()
+				Expect(err).ToNot(HaveOccurred())
 
+				endpoint = httpURL
+				ctxName = testContextName
+				ctx, err = createNewContext()
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 		Context("context name already exists", func() {

--- a/pkg/constants/env_variables.go
+++ b/pkg/constants/env_variables.go
@@ -20,7 +20,7 @@ const (
 	SuppressSkipSignatureVerificationWarning          = "TANZU_CLI_SUPPRESS_SKIP_SIGNATURE_VERIFICATION_WARNING"
 	CEIPOptInUserPromptAnswer                         = "TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER"
 	EULAPromptAnswer                                  = "TANZU_CLI_EULA_PROMPT_ANSWER"
-	E2ETestEnvironment                                = "TANZU_CLI_E2E_TEST_ENVIRONMENT"
+	E2ETestEnvironment                                = "TANZU_CLI_E2E_TEST_ENVIRONMENT" // environment variable to indicate that the CLI is running in E2E test environment
 	ShowTelemetryConsoleLogs                          = "TANZU_CLI_SHOW_TELEMETRY_CONSOLE_LOGS"
 	TelemetrySuperColliderEnvironment                 = "TANZU_CLI_SUPERCOLLIDER_ENVIRONMENT"
 


### PR DESCRIPTION
### What this PR does / why we need it
This pull request addresses the issues in the TMC-Sync E2E tests. Prior to this fix, in the TMC context creation process, the TMC endpoint was validated, causing context creation to fail if the endpoint was HTTP. This pull request updates the TMC context creation flow to bypass the endpoint validation when executed in an E2E test environment.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
E2E tests and Unit tests are updated.
Manual testing has done
```
❯ t context create tmc345 --endpoint http://unstable.tmc-dev.cloud.vmware.com --type tmc --staging 
[x] : TMC endpoint URL http://unstable.tmc-dev.cloud.vmware.com should not contain http or https scheme. It should be of the format host[:port]
❯ t context create tmc345 --endpoint https://unstable.tmc-dev.cloud.vmware.com --type tmc --staging
[x] : TMC endpoint URL https://unstable.tmc-dev.cloud.vmware.com should not contain http or https scheme. It should be of the format host[:port]
❯
❯ t context create mytmc12 --endpoint unstable.tmc-dev.cloud.vmware.com --type tmc --staging
[i] API token env var is set

[ok] successfully created a TMC context
[i] Checking for required plugins for context 'mytmc12'...
[i] The following plugins will be installed for context 'mytmc12' of contextType 'mission-control': 
  NAME                  TARGET           VERSION  
  events                mission-control  v0.1.13  
  secret                mission-control  v0.1.14  
  setting               mission-control  v0.2.11  
  audit                 mission-control  v0.1.13  
  tanzupackage          mission-control  v0.3.0   
  integration           mission-control  v0.1.13  
  continuousdelivery    mission-control  v0.1.13  
  apply                 mission-control  v0.3.10  
  aks-cluster           mission-control  v0.2.3   
  iam                   mission-control  v0.1.13  
  account               mission-control  v0.1.16  
  cluster               mission-control  v0.2.8   
  data-protection       mission-control  v0.1.13  
  helm                  mission-control  v0.1.13  
  agentartifacts        mission-control  v0.1.13  
  ekscluster            mission-control  v0.1.13  
  inspection            mission-control  v0.1.13  
  policy                mission-control  v0.1.13  
  provider-eks-cluster  mission-control  v0.1.13  
  workspace             mission-control  v0.1.15  
  clustergroup          mission-control  v0.1.13  
  provider-aks-cluster  mission-control  v0.1.14  
  management-cluster    mission-control  v0.2.13  
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Installing plugin 'events:v0.1.13' with target 'mission-control' (from cache)
[i] Installing plugin 'secret:v0.1.14' with target 'mission-control' 
[i] Installing plugin 'setting:v0.2.11' with target 'mission-control' (from cache)
[i] Installing plugin 'audit:v0.1.13' with target 'mission-control' (from cache)
[i] Installing plugin 'tanzupackage:v0.3.0' with target 'mission-control' 
 

```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
