### PR TITLE
Fix the tanzu login issue when the "tanzu" context is created with context create command

### DIFF
--- a/pkg/command/login.go
+++ b/pkg/command/login.go
@@ -142,6 +142,9 @@ func getServerTarget(cfg *configtypes.ClientConfig, newServerSelector string) (*
 	promptOpts := getPromptOpts()
 	servers := map[string]*configtypes.Server{} //nolint:staticcheck // Deprecated
 	for _, server := range cfg.KnownServers {   //nolint:staticcheck // Deprecated
+		if server.Type != configtypes.GlobalServerType && server.Type != configtypes.ManagementClusterServerType { //nolint:staticcheck // Deprecated
+			continue
+		}
 		ep, err := config.EndpointFromServer(server) //nolint:staticcheck // Deprecated
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
### What this PR does / why we need it
This PR fixes the `tanzu login` failure issue when the "tanzu" context is created with context create command. This was caused because the login command could not understand the new context type "tanzu" converted to server type during CLI configuratio sync.The fix is for the login command to ignore the server types other than "global" and "managementcluster" server types

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
Verified the `tanzu login` works as expected with "tanzu" contexts already created using `tanzu context create` command

Before the fix:
```
$ tanzu login
Command "login" is deprecated, this was done in the "v0.90.0" release, it will be removed following the deprecation policy (6 months). Use the "context" command instead.

[x] : unknown server type "tanzu"
```

After the fix:
```
//login to new tmc endpoint with server name mytmc12 and it was successful
❯ ./bin/tanzu login --staging
Command "login" is deprecated, this was done in the "v0.90.0" release, it will be removed following the deprecation policy (6 months). Use the "context" command instead.

? Select a server mytmc12             (unstable.tmc-dev.cloud.vmware.com:443)
[i] API token env var is set

[ok] successfully logged into global control plane
[i] Checking for required plugins...
[i] All required plugins are already installed and up-to-date

// tanzu login with out parameters showing only TKG managmentserver and TMC servers and not showing the server of type "tanzu" 
❯ ./bin/tanzu login --staging
Command "login" is deprecated, this was done in the "v0.90.0" release, it will be removed following the deprecation policy (6 months). Use the "context" command instead.

? Select a server  [Use arrows to move, type to filter]
> mytmc               (unstable.tmc-dev.cloud.vmware.com:443)
  mytmc1              (unstable.tmc-dev.cloud.vmware.com:443)
  mytmc12             (unstable.tmc-dev.cloud.vmware.com:443)
  testtmcLogin        (unstable.tmc-dev.cloud.vmware.com:443)
  tkg-mgmt-vc         ()
  tt-test-selfmg      (tmc-sm-main.local-dev.7infra.com:443)
  + new server
[x] : interrupt

❯ ./bin/tanzu context list
  NAME            ISACTIVE  TYPE             ENDPOINT                                                                                           KUBECONFIGPATH                           KUBECONTEXT                    PROJECT  SPACE
  tt-test-selfmg  false     mission-control  tmc-sm-main.local-dev.7infra.com:443                                                               n/a                                      n/a                            n/a      n/a
  tkg-mgmt-vc     false     kubernetes                                                                                                          /Users/pkalle/temp/tkgCluster_admin.kfg  tkg-mgmt-vc-admin@tkg-mgmt-vc  n/a      n/a
  mytmc1          false     mission-control  unstable.tmc-dev.cloud.vmware.com:443                                                              n/a                                      n/a                            n/a      n/a
  mytmc           false     mission-control  unstable.tmc-dev.cloud.vmware.com:443                                                              n/a                                      n/a                            n/a      n/a
  mytmc12         false     mission-control  unstable.tmc-dev.cloud.vmware.com:443                                                              n/a                                      n/a                            n/a      n/a
  mydemotanzu     true      tanzu            https://ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com/org/bc27608b-4809-4cac-9e04-778803963da2  /Users/pkalle/.kube/config               tanzu-cli-mydemotanzu
  testtmcLogin    true      mission-control  unstable.tmc-dev.cloud.vmware.com:443                                                              n/a                                      n/a                            n/a      n/a

```
verified `tanzu context use` works with out any issue. It would show the `tanzu` context along with other context types
```
❯ ./bin/tanzu context use
? Select a context mydemotanzu         (https://ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com/org/bc27608b-4809-4cac-9e04-778803963da2)
[i] Successfully activated context 'mydemotanzu'
[i] Checking for required plugins for context 'mydemotanzu'...
[i] All required plugins are already installed and up-to-date
```
Verified `tanzu context get` works with out any issue. It would show the `tanzu` context with all the details including the additionalMetadata
```
❯ ./bin/tanzu context get
? Select a context mydemotanzu         (https://ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com/org/<REDACTED>)
name: mydemotanzu
target: tanzu
contextType: tanzu
globalOpts:
    endpoint: ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com:443
    auth:
        issuer: https://console-stg.cloud.vmware.com/csp/gateway/am/api
        userName: pkalle
        permissions:
            - <REDACTED>
            - <REDACTED>
            - <REDACTED>
            - <REDACTED>
        accessToken: <REDACTED>
        IDToken: <REDACTED>
        refresh_token: <REDACTED>
        expiration: 2023-10-31T09:39:32.411759-07:00
        type: api-token
clusterOpts:
    endpoint: https://ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com/org/<REDACTED>
    path: /Users/pkalle/.kube/config
    context: tanzu-cli-mydemotanzu
additionalMetadata:
    tanzuOrgID: <REDACTED>
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix the tanzu login issue when the "tanzu" context is created with context create command
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
