### PR TITLE
Strip CLI and plugin binaries to reduce their size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,12 @@ LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-cli/pkg/buildinfo.Date=$(BUILD_DAT
 LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-cli/pkg/buildinfo.SHA=$(BUILD_SHA)'
 LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-cli/pkg/buildinfo.Version=$(BUILD_VERSION)'
 
+# Remove debug symbols to reduce binary size
+# To build with debug symbols: TANZU_CLI_ENABLE_DEBUG=1
+ifneq ($(strip $(TANZU_CLI_ENABLE_DEBUG)),1)
+LD_FLAGS += -w -s
+endif
+
 APT_IMAGE=ubuntu
 ifdef APT_BUILDER_IMAGE
 APT_IMAGE=$(APT_BUILDER_IMAGE)
@@ -133,9 +139,9 @@ build-cli-%: ##Build the Tanzu Core CLI for a platform
 	fi
 
 	@if [ "$(OS)" = "windows" ]; then \
-		GOOS=$(OS) GOARCH=$(ARCH) $(GO) build --ldflags "$(LD_FLAGS)"  -o "$(ARTIFACTS_DIR)/$(OS)/$(ARCH)/cli/core/$(BUILD_VERSION)/tanzu-cli-$(OS)_$(ARCH).exe" ./cmd/tanzu/main.go;\
+		GOOS=$(OS) GOARCH=$(ARCH) $(GO) build -gcflags=all="-l" --ldflags "$(LD_FLAGS)" -o "$(ARTIFACTS_DIR)/$(OS)/$(ARCH)/cli/core/$(BUILD_VERSION)/tanzu-cli-$(OS)_$(ARCH).exe" ./cmd/tanzu/main.go;\
 	else \
-		GOOS=$(OS) GOARCH=$(ARCH) $(GO) build --ldflags "$(LD_FLAGS)"  -o "$(ARTIFACTS_DIR)/$(OS)/$(ARCH)/cli/core/$(BUILD_VERSION)/tanzu-cli-$(OS)_$(ARCH)" ./cmd/tanzu/main.go;\
+		GOOS=$(OS) GOARCH=$(ARCH) $(GO) build -gcflags=all="-l" --ldflags "$(LD_FLAGS)" -o "$(ARTIFACTS_DIR)/$(OS)/$(ARCH)/cli/core/$(BUILD_VERSION)/tanzu-cli-$(OS)_$(ARCH)" ./cmd/tanzu/main.go;\
 	fi
 
 ## --------------------------------------

--- a/cmd/plugin/builder/plugin.go
+++ b/cmd/plugin/builder/plugin.go
@@ -39,6 +39,7 @@ type pluginBuildFlags struct {
 	Match                      string
 	PluginScopeAssociationFile string
 	GoFlags                    string
+	DebugSymbols               bool
 }
 
 type pluginBuildPackageFlags struct {
@@ -82,6 +83,7 @@ func newPluginBuildCmd() *cobra.Command {
 				PluginScopeAssociationFile: pbFlags.PluginScopeAssociationFile,
 				GroupByOSArch:              true,
 				GoFlags:                    pbFlags.GoFlags,
+				DebugSymbols:               pbFlags.DebugSymbols,
 			}
 
 			return command.Compile(compileArgs)
@@ -96,6 +98,7 @@ func newPluginBuildCmd() *cobra.Command {
 	pluginBuildCmd.Flags().StringVarP(&pbFlags.Match, "match", "", "*", "match a plugin name to build, supports globbing")
 	pluginBuildCmd.Flags().StringVarP(&pbFlags.PluginScopeAssociationFile, "plugin-scope-association-file", "", "", "file specifying plugin scope association")
 	pluginBuildCmd.Flags().StringVarP(&pbFlags.GoFlags, "goflags", "", "", "goflags to set on build")
+	pluginBuildCmd.Flags().BoolVarP(&pbFlags.DebugSymbols, "debug-symbols", "", false, "include debug symbols in the build")
 
 	_ = pluginBuildCmd.MarkFlagRequired("version")
 

--- a/cmd/plugin/builder/template/plugintemplates/plugin-tooling.mk.tmpl
+++ b/cmd/plugin/builder/template/plugintemplates/plugin-tooling.mk.tmpl
@@ -20,7 +20,20 @@ endif
 PLUGIN_LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=$(PLUGIN_BUILD_DATE)'
 PLUGIN_LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=$(PLUGIN_BUILD_SHA)'
 PLUGIN_LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=$(PLUGIN_BUILD_VERSION)'
+
+# This variable can be used to pass additional go flags to the build command.
+# Note that the builder plugin already implicitly sets the go flags "-gcflags=all=-l"
+# which disable function inlining to reduce binary size.  If you want to prevent the
+# use of this flag, you can set PLUGIN_GO_FLAGS to "-gcflags=all=" which will replace
+# the default value.
 PLUGIN_GO_FLAGS ?=
+
+# To build with debug symbols use PLUGIN_ENABLE_DEBUG=1
+ifeq ($(strip $(PLUGIN_ENABLE_DEBUG)),1)
+PLUGIN_DEBUG=true
+else
+PLUGIN_DEBUG=false
+endif
 
 # Add supported OS-ARCHITECTURE combinations here
 PLUGIN_BUILD_OS_ARCH ?= linux-amd64 windows-amd64 darwin-amd64 darwin-arm64 linux-arm64
@@ -102,7 +115,8 @@ plugin-build-%:
 		--goflags "$(PLUGIN_GO_FLAGS)" \
 		--os-arch $(OS)_$(ARCH) \
 		--match "$(PLUGIN_NAME)" \
-		--plugin-scope-association-file $(PLUGIN_SCOPE_ASSOCIATION_FILE)
+		--plugin-scope-association-file $(PLUGIN_SCOPE_ASSOCIATION_FILE) \
+		--debug-symbols=$(PLUGIN_DEBUG)
 
 .PHONY: plugin-build-packages
 plugin-build-packages: ## Build plugin packages

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -54,6 +54,17 @@ To run e2e tests for the repository:
 make e2e-cli-core
 ```
 
+### Debugging
+
+By default the CLI is built without debug symbols to reduce its binary size;
+this has the side-effect of preventing the use of a debugger towards the built
+binary.  However, when using an IDE, a different binary is used, one built by
+the IDE, and therefore the debugger can be used directly from the IDE.
+
+If you require using a debugger directly on a CLI binary, you have to build
+a binary that includes the debug symbols.  You can build such a binary by using
+`TANZU_CLI_ENABLE_DEBUG=1` along with your build command.
+
 ## Centralized Discovery of Plugins
 
 The Tanzu CLI uses a system of plugins to provide functionality to interact

--- a/docs/plugindev/README.md
+++ b/docs/plugindev/README.md
@@ -231,6 +231,30 @@ well.
 
 Edit the file as appropriate.
 
+#### Optimizations, debugging and build flags
+
+By default the `builder` plugin `v1.2.0` or later optimizes build flags to
+reduce the binary size of the plugin being built.  Two optimizations are done:
+building without debug symbols (which reduces the binary size by up to 30%),
+and deactivating function inlining (which reduces the binary size by about 6%).
+
+Building without debug symbols has the side-effect of preventing the use of a
+debugger towards the built binary.  However, when using an IDE, a different
+binary is used, one built by the IDE, and therefore the debugger can be used
+directly from the IDE.
+
+If you require using a debugger directly on a plugin binary, you have to build
+a binary that includes the debug symbols.  You can build such a binary by using
+`PLUGIN_ENABLE_DEBUG=1` along with your `make` command.
+
+The `builder` plugin deactivates function inlining by implicitly injecting
+the `-gcflags=all=-l` go flags.  Be aware that if you use the `PLUGIN_GO_FLAGS`
+variable to inject other `-gcflags`, you should pay attention to also include
+the `all=-l` to keep the optimization. If for some reason you need to activate
+function inlining (at the cost of a larger binary), you can do so by
+using `PLUGIN_GO_FLAGS=-gcflags=all=` (without the `-l` specified), which will
+have the effect of replacing the go flags specified by the `builder` plugin.
+
 ### Publishing a plugin
 
 To publish one or more built plugins to a target repository, one would need to

--- a/plugin-tooling.mk
+++ b/plugin-tooling.mk
@@ -24,7 +24,20 @@ endif
 PLUGIN_LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=$(PLUGIN_BUILD_DATE)'
 PLUGIN_LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=$(PLUGIN_BUILD_SHA)'
 PLUGIN_LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=$(PLUGIN_BUILD_VERSION)'
+
+# This variable can be used to pass additional go flags to the build command.
+# Note that the builder plugin already implicitly sets the go flags "-gcflags=all=-l"
+# which disable function inlining to reduce binary size.  If you want to prevent the
+# use of this flag, you can set PLUGIN_GO_FLAGS to "-gcflags=all=" which will replace
+# the default value.
 PLUGIN_GO_FLAGS ?=
+
+# To build with debug symbols use PLUGIN_ENABLE_DEBUG=1
+ifeq ($(strip $(PLUGIN_ENABLE_DEBUG)),1)
+PLUGIN_DEBUG=true
+else
+PLUGIN_DEBUG=false
+endif
 
 # Add supported OS-ARCHITECTURE combinations here
 PLUGIN_BUILD_OS_ARCH ?= linux-amd64 windows-amd64 darwin-amd64 darwin-arm64 linux-arm64
@@ -106,7 +119,8 @@ plugin-build-%:
 		--goflags "$(PLUGIN_GO_FLAGS)" \
 		--os-arch $(OS)_$(ARCH) \
 		--match "$(PLUGIN_NAME)" \
-		--plugin-scope-association-file $(PLUGIN_SCOPE_ASSOCIATION_FILE)
+		--plugin-scope-association-file $(PLUGIN_SCOPE_ASSOCIATION_FILE) \
+		--debug-symbols=$(PLUGIN_DEBUG)
 
 .PHONY: plugin-build-packages
 plugin-build-packages:  ## Build plugin packages

--- a/test/sample-plugin/Makefile
+++ b/test/sample-plugin/Makefile
@@ -37,9 +37,11 @@ $(GOLANGCI_LINT): $(TOOLS_BIN_DIR) ## Install golangci-lint
 
 .PHONY: install-builder
 install-builder: ## Install builder
+	$(MAKE) -C $(ROOT_DIR_RELATIVE)/../.. prepare-builder
+	unset BUILDER_PLUGIN ; \
 	export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="No" ; \
 	export TANZU_CLI_EULA_PROMPT_ANSWER="Yes" ; \
-	tanzu plugin install builder
+	$(MAKE) -C $(ROOT_DIR_RELATIVE)/../.. plugin-build-install-local PLUGIN_NAME=builder
 
 .PHONEY: e2e-tests-simple-plugin ## Run all e2e tests for simple plugin
 e2e-tests-simple-plugin: install-builder plugin-build-local plugin-install-local e2e-tests-sample-plugin-functionality e2e-tests-sample-plugin-e2e-api

--- a/test/sample-plugin/plugin-tooling.mk
+++ b/test/sample-plugin/plugin-tooling.mk
@@ -20,7 +20,20 @@ endif
 PLUGIN_LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=$(PLUGIN_BUILD_DATE)'
 PLUGIN_LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=$(PLUGIN_BUILD_SHA)'
 PLUGIN_LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=$(PLUGIN_BUILD_VERSION)'
+
+# This variable can be used to pass additional go flags to the build command.
+# Note that the builder plugin already implicitly sets the go flags "-gcflags=all=-l"
+# which disable function inlining to reduce binary size.  If you want to prevent the
+# use of this flag, you can set PLUGIN_GO_FLAGS to "-gcflags=all=" which will replace
+# the default value.
 PLUGIN_GO_FLAGS ?=
+
+# To build with debug symbols use PLUGIN_ENABLE_DEBUG=1
+ifeq ($(strip $(PLUGIN_ENABLE_DEBUG)),1)
+PLUGIN_DEBUG=true
+else
+PLUGIN_DEBUG=false
+endif
 
 # Add supported OS-ARCHITECTURE combinations here
 PLUGIN_BUILD_OS_ARCH ?= linux-amd64 windows-amd64 darwin-amd64 darwin-arm64 linux-arm64
@@ -88,8 +101,9 @@ plugin-install-local:
 .PHONY: plugin-build
 plugin-build: $(PLUGIN_BUILD_TARGETS) generate-plugin-bundle ## Build all plugin binaries for all supported os-arch
 
+.PHONY: plugin-build-local
 plugin-build-local: plugin-build-$(GOHOSTOS)-$(GOHOSTARCH) ## Build all plugin binaries for local platform
-	
+
 plugin-build-%:
 	$(eval ARCH = $(word 2,$(subst -, ,$*)))
 	$(eval OS = $(word 1,$(subst -, ,$*)))
@@ -101,7 +115,8 @@ plugin-build-%:
 		--goflags "$(PLUGIN_GO_FLAGS)" \
 		--os-arch $(OS)_$(ARCH) \
 		--match "$(PLUGIN_NAME)" \
-		--plugin-scope-association-file $(PLUGIN_SCOPE_ASSOCIATION_FILE)
+		--plugin-scope-association-file $(PLUGIN_SCOPE_ASSOCIATION_FILE) \
+		--debug-symbols=$(PLUGIN_DEBUG)
 
 .PHONY: plugin-build-packages
 plugin-build-packages: ## Build plugin packages


### PR DESCRIPTION
This PR is on top of #606 which is needed to make CI pass.

### What this PR does / why we need it

This PR changes the compilation for the CLI and plugins to string debug symbols, so as to reduce the binary sizes.

Overall binary reduction achieved by this commit:
- 28% decrease for Darwin
- 36% decrease for Linux and Windows

This commit does two optimizations:

1. Remove symbol tables (reduce about 30% for Linux/Windows, 22% for Mac) 
--
When compiling the CLI and plugins, this commit adds the "-s" and "-w" flags.  The "-s" flag omits the symbol table and debug information while "-w" omits the DWARF symbol table.  These symbol tables are used by debuggers.  The impact in removing them will be that it will not be possible to use a debugger on a production binary; this is acceptable and it is actually a standard approach to ship production binaries without debug symbols.  If a debugger needs to be used, a binary can built with the symbol tables.

Note that the removal of debug symbols does not prevent proper traces from being shown in a go "panic".

2. Disable function inlining (reduce about 6% on every OS) 
--
Adding the flag "-gcflags=all=-l" removes function inlining.  This normally reduces performance a little but saves space.  Considering we are dealing with a CLI tool which does not perform CPU intensive operations, the slight possible performance degradation is not of concern.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Test CLI build
```
# Check the size before this PR
$ ll bin/tanzu
-rwxr-xr-x  1 kmarc  staff    82M 15 Nov 17:15 bin/tanzu

# Check the size with this PR
$ g co -
Switched to branch 'test/binarySize'
$ make build
build darwin-arm64 CLI with version: v1.2.0-dev
mkdir -p bin
cp /Users/kmarc/git/tanzu-cli/artifacts/darwin/arm64/cli/core/v1.1.0-dev/tanzu-cli-darwin_arm64 ./bin/tanzu
$ ll bin/tanzu
-rwxr-xr-x  1 kmarc  staff    60M  5 Dec 17:16 bin/tanzu

# Debugging should not work
$ dlv exec bin/tanzu
could not launch process: decoding dwarf section info at offset 0x0: too short - debuggee must not be built with 'go run' or -ldflags='-s -w', which strip debug info

# Build to enable debugging
$ make build TANZU_CLI_ENABLE_DEBUG=1
build darwin-arm64 CLI with version: v1.2.0-dev
mkdir -p bin
cp /Users/kmarc/git/tanzu-cli/artifacts/darwin/arm64/cli/core/v1.1.0-dev/tanzu-cli-darwin_arm64 ./bin/tanzu
# Check the larger size
$ ll bin/tanzu
-rwxr-xr-x  1 kmarc  staff    73M  5 Dec 21:36 bin/tanzu

# Check debugging works
$ dlv exec bin/tanzu
Type 'help' for list of commands.
(dlv) break main.main
Breakpoint 1 set at 0x103fd46cc for main.main() ./cmd/tanzu/main.go:14
(dlv) continue
> main.main() ./cmd/tanzu/main.go:14 (hits goroutine(1):1 total:1) (PC: 0x103fd46cc)
Warning: debugging optimized function
     9:
    10:		"github.com/vmware-tanzu/tanzu-cli/pkg/command"
    11:		"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
    12:	)
    13:
=>  14:	func main() {
    15:		if err := command.Execute(); err != nil {
    16:			if errStr, ok := err.(*exec.ExitError); ok {
    17:				// If a plugin exited with an error, we don't want to print its
    18:				// exit status as a string, but want to use it as our own exit code.
    19:				os.Exit(errStr.ExitCode())
(dlv) exit
```
Testing with plugins
```
# Check the sizes before this PR
$ ll artifacts/plugins/darwin/arm64/global/builder/v1.2.0-dev/tanzu-builder-darwin_arm64 artifacts/plugins/darwin/arm64/global/test/v1.2.0-dev/tanzu-test-darwin_arm64
-rwxr-xr-x  1 kmarc  staff    34M  5 Dec 21:42 artifacts/plugins/darwin/arm64/global/builder/v1.2.0-dev/tanzu-builder-darwin_arm64
-rwxr-xr-x  1 kmarc  staff    81M  5 Dec 21:42 artifacts/plugins/darwin/arm64/global/test/v1.2.0-dev/tanzu-test-darwin_arm64

# Check the sizes with this PR
$ g co -
Switched to branch 'test/binarySize'

$ make plugin-build-local
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.2.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-06' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=42987257f' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev'" \
		--goflags "" \
		--os-arch darwin_arm64 \
		--match "*" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml \
		--debug-symbols=false
2023-12-05T21:44:15-05:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.2.0-dev, [darwin_arm64]
2023-12-05T21:44:15-05:00 [i] 🐰 - building plugin at path "cmd/plugin/test"
2023-12-05T21:44:15-05:00 [i] 🐼 - building plugin at path "cmd/plugin/builder"
2023-12-05T21:44:17-05:00 [i] 🐼 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/arm64/global/builder/v1.2.0-dev/tanzu-builder-darwin_arm64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-06' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=42987257f' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -w -s -tags  ./cmd/plugin/builder
2023-12-05T21:44:18-05:00 [i] 🐰 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/arm64/global/test/v1.2.0-dev/tanzu-test-darwin_arm64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-06' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=42987257f' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -w -s -tags  ./cmd/plugin/test
2023-12-05T21:44:22-05:00 [i] 🐰 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/arm64/global/test/v1.2.0-dev/test/tanzu-test-test-darwin_arm64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-06' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=42987257f' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -w -s -tags  ./cmd/plugin/test/test
2023-12-05T21:44:23-05:00 [i] ========
2023-12-05T21:44:23-05:00 [i] saving plugin manifest...
2023-12-05T21:44:23-05:00 [i] saving plugin group manifest...
2023-12-05T21:44:23-05:00 [ok] successfully built local repository

$ ll artifacts/plugins/darwin/arm64/global/builder/v1.2.0-dev/tanzu-builder-darwin_arm64 artifacts/plugins/darwin/arm64/global/test/v1.2.0-dev/tanzu-test-darwin_arm64
-rwxr-xr-x  1 kmarc  staff    24M  5 Dec 21:44 artifacts/plugins/darwin/arm64/global/builder/v1.2.0-dev/tanzu-builder-darwin_arm64
-rwxr-xr-x  1 kmarc  staff    59M  5 Dec 21:44 artifacts/plugins/darwin/arm64/global/test/v1.2.0-dev/tanzu-test-darwin_arm64

# Try debugging which should fail
$ dlv exec artifacts/plugins/darwin/arm64/global/builder/v1.2.0-dev/tanzu-builder-darwin_arm64
could not launch process: decoding dwarf section info at offset 0x0: too short - debuggee must not be built with 'go run' or -ldflags='-s -w', which strip debug info

# Build to allow debugging
$ make plugin-build-local PLUGIN_ENABLE_DEBUG=1
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.2.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-06' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=42987257f' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev'" \
		--goflags "" \
		--os-arch darwin_arm64 \
		--match "*" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml \
		--debug-symbols=true
2023-12-05T21:46:29-05:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.2.0-dev, [darwin_arm64]
2023-12-05T21:46:29-05:00 [i] 🐨 - building plugin at path "cmd/plugin/test"
2023-12-05T21:46:29-05:00 [i] 🐷 - building plugin at path "cmd/plugin/builder"
2023-12-05T21:46:31-05:00 [i] 🐷 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/arm64/global/builder/v1.2.0-dev/tanzu-builder-darwin_arm64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-06' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=42987257f' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -tags  ./cmd/plugin/builder
2023-12-05T21:46:32-05:00 [i] 🐨 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/arm64/global/test/v1.2.0-dev/tanzu-test-darwin_arm64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-06' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=42987257f' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -tags  ./cmd/plugin/test
2023-12-05T21:46:36-05:00 [i] 🐨 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/arm64/global/test/v1.2.0-dev/test/tanzu-test-test-darwin_arm64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-06' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=42987257f' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -tags  ./cmd/plugin/test/test
2023-12-05T21:46:37-05:00 [i] ========
2023-12-05T21:46:37-05:00 [i] saving plugin manifest...
2023-12-05T21:46:37-05:00 [i] saving plugin group manifest...
2023-12-05T21:46:37-05:00 [ok] successfully built local repository

# Check the larger sizes
$ ll artifacts/plugins/darwin/arm64/global/builder/v1.2.0-dev/tanzu-builder-darwin_arm64 artifacts/plugins/darwin/arm64/global/test/v1.2.0-dev/tanzu-test-darwin_arm64
-rwxr-xr-x  1 kmarc  staff    30M  5 Dec 21:46 artifacts/plugins/darwin/arm64/global/builder/v1.2.0-dev/tanzu-builder-darwin_arm64
-rwxr-xr-x  1 kmarc  staff    72M  5 Dec 21:46 artifacts/plugins/darwin/arm64/global/test/v1.2.0-dev/tanzu-test-darwin_arm64

# Check debugging works
$ dlv exec artifacts/plugins/darwin/arm64/global/builder/v1.2.0-dev/tanzu-builder-darwin_arm64
Type 'help' for list of commands.
(dlv) b main.main
Breakpoint 1 set at 0x101601b80 for main.main() ./cmd/plugin/builder/main.go:22
(dlv) continue
> main.main() ./cmd/plugin/builder/main.go:22 (hits goroutine(1):1 total:1) (PC: 0x101601b80)
Warning: debugging optimized function
    17:		Group:       plugin.AdminCmdGroup,
    18:		Version:     buildinfo.Version,
    19:		BuildSHA:    buildinfo.SHA,
    20:	}
    21:
=>  22:	func main() {
    23:		p, err := plugin.NewPlugin(&descriptor)
    24:		if err != nil {
    25:			log.Fatal(err, "")
    26:		}
    27:
(dlv) exit
```
Test activating function inlining:
```
$ make plugin-build-local PLUGIN_GO_FLAGS=-gcflags=all=
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.2.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-06' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=42987257f' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev'" \
		--goflags "-gcflags=all=" \
		--os-arch darwin_arm64 \
		--match "*" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml \
		--debug-symbols=false
2023-12-05T21:49:14-05:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.2.0-dev, [darwin_arm64]
2023-12-05T21:49:14-05:00 [i] 🐮 - building plugin at path "cmd/plugin/test"
2023-12-05T21:49:14-05:00 [i] 🦁 - building plugin at path "cmd/plugin/builder"
2023-12-05T21:49:16-05:00 [i] 🦁 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -gcflags=all= -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/arm64/global/builder/v1.2.0-dev/tanzu-builder-darwin_arm64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-06' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=42987257f' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -w -s -tags  ./cmd/plugin/builder
2023-12-05T21:49:18-05:00 [i] 🐮 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -gcflags=all= -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/arm64/global/test/v1.2.0-dev/tanzu-test-darwin_arm64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-06' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=42987257f' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -w -s -tags  ./cmd/plugin/test
2023-12-05T21:49:21-05:00 [i] 🐮 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -gcflags=all= -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/arm64/global/test/v1.2.0-dev/test/tanzu-test-test-darwin_arm64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-06' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=42987257f' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -w -s -tags  ./cmd/plugin/test/test
2023-12-05T21:49:21-05:00 [i] ========
2023-12-05T21:49:21-05:00 [i] saving plugin manifest...
2023-12-05T21:49:21-05:00 [i] saving plugin group manifest...
2023-12-05T21:49:21-05:00 [ok] successfully built local repository
$ ll artifacts/plugins/darwin/arm64/global/builder/v1.2.0-dev/tanzu-builder-darwin_arm64 artifacts/plugins/darwin/arm64/global/test/v1.2.0-dev/tanzu-test-darwin_arm64
-rwxr-xr-x  1 kmarc  staff    26M  5 Dec 21:49 artifacts/plugins/darwin/arm64/global/builder/v1.2.0-dev/tanzu-builder-darwin_arm64
-rwxr-xr-x  1 kmarc  staff    64M  5 Dec 21:49 artifacts/plugins/darwin/arm64/global/test/v1.2.0-dev/tanzu-test-darwin_arm64
```
Test building a plugin with an old plugin-tooling.mk file but the new builder.
```
$ g co main
Switched to branch 'main'
Your branch is up to date with 'upstream/main'.
$ make plugin-build-local PLUGIN_NAME=builder
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.2.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-06' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=d5ab70c0b' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev'" \
		--goflags "" \
		--os-arch darwin_arm64 \
		--match "builder" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml
2023-12-05T22:04:29-05:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.2.0-dev, [darwin_arm64]
2023-12-05T22:04:29-05:00 [i] 🐰 - building plugin at path "cmd/plugin/builder"
2023-12-05T22:04:31-05:00 [i] 🐰 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/arm64/global/builder/v1.2.0-dev/tanzu-builder-darwin_arm64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-06' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=d5ab70c0b' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -w -s -tags  ./cmd/plugin/builder
2023-12-05T22:04:33-05:00 [i] ========
2023-12-05T22:04:33-05:00 [i] saving plugin manifest...
2023-12-05T22:04:33-05:00 [i] saving plugin group manifest...
2023-12-05T22:04:33-05:00 [ok] successfully built local repository

# The size is still reduced
$ ll artifacts/plugins/darwin/arm64/global/builder/v1.2.0-dev/tanzu-builder-darwin_arm64
-rwxr-xr-x  1 kmarc  staff    24M  5 Dec 22:04 artifacts/plugins/darwin/arm64/global/builder/v1.2.0-dev/tanzu-builder-darwin_arm64
```

Test creating a new plugin
```
# Install the builder plugin using this PR
$ tz plugin install builder --local-source $git/tanzu-cli/artifacts/plugins/darwin/arm64
[i] Installing plugin 'builder:v1.2.0-dev' with target 'global'
[ok] successfully installed 'builder' plugin

$ cd git
~git
$ tz builder init plugin-december
? choose a repository type GitHub
2023-12-05T21:52:52-05:00 [ok] successfully created repository
$ cd plugin-december
$ tz builder cli add-plugin december
? provide a description december description
2023-12-05T21:53:25-05:00 [ok] successfully created plugin
$ git add .
$ git commit -m initial
[main (root-commit) 5db6204] initial
 12 files changed, 578 insertions(+)
 create mode 100644 .github/workflows/build.yaml
 create mode 100644 .gitignore
 create mode 100644 .golangci.yaml
 create mode 100644 CODEOWNERS
 create mode 100644 Makefile
 create mode 100644 README.md
 create mode 100644 cmd/plugin/december/README.md
 create mode 100644 cmd/plugin/december/main.go
 create mode 100644 cmd/plugin/december/test/main.go
 create mode 100644 common.mk
 create mode 100644 go.mod
 create mode 100644 plugin-tooling.mk
$ make gomod
go mod tidy
go: finding module for package github.com/vmware-tanzu/tanzu-plugin-runtime/config/types
go: finding module for package github.com/spf13/cobra
go: finding module for package github.com/vmware-tanzu/tanzu-plugin-runtime/log
go: finding module for package github.com/vmware-tanzu/tanzu-plugin-runtime/test/framework
go: finding module for package github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo
go: finding module for package github.com/vmware-tanzu/tanzu-plugin-runtime/plugin
go: found github.com/vmware-tanzu/tanzu-plugin-runtime/config/types in github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0
go: found github.com/vmware-tanzu/tanzu-plugin-runtime/log in github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0
go: found github.com/vmware-tanzu/tanzu-plugin-runtime/plugin in github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0
go: found github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo in github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0
go: found github.com/spf13/cobra in github.com/spf13/cobra v1.8.0
go: found github.com/vmware-tanzu/tanzu-plugin-runtime/test/framework in github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0

# Set the target
$ sed s,types.TargetUnknown,types.TargetGlobal, cmd/plugin/december/main.go > tmp && mv tmp cmd/plugin/december/main.go
overwrite cmd/plugin/december/main.go? (y/n [n]) y

# Check the plugin builds and that the new flags are seen in the command below
$ make plugin-build-local
tanzu builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/plugin-december/artifacts/plugins \
		--version v0.0.0 \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-06' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=5db6204-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.0'" \
		--goflags "" \
		--os-arch darwin_arm64 \
		--match "*" \
		--plugin-scope-association-file "" \
		--debug-symbols=false
2023-12-05T21:55:13-05:00 [i] building local repository at /Users/kmarc/git/plugin-december/artifacts/plugins, v0.0.0, [darwin_arm64]
2023-12-05T21:55:13-05:00 [i] 🐶 - building plugin at path "cmd/plugin/december"
2023-12-05T21:55:15-05:00 [i] 🐶 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/plugin-december/artifacts/plugins/darwin/arm64/global/december/v0.0.0/tanzu-december-darwin_arm64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-06' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=5db6204-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.0' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.0' -w -s -tags  ./cmd/plugin/december
2023-12-05T21:55:16-05:00 [i] 🐶 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/plugin-december/artifacts/plugins/darwin/arm64/global/december/v0.0.0/test/tanzu-december-test-darwin_arm64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-06' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=5db6204-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.0' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.0' -w -s -tags  ./cmd/plugin/december/test
2023-12-05T21:55:17-05:00 [i] ========
2023-12-05T21:55:17-05:00 [i] saving plugin manifest...
2023-12-05T21:55:17-05:00 [ok] successfully built local repository

# Check the plugin can be run
$ artifacts/plugins/darwin/arm64/global/december/v0.0.0/tanzu-december-darwin_arm64 version
v0.0.0
$ artifacts/plugins/darwin/arm64/global/december/v0.0.0/tanzu-december-darwin_arm64 info
{"name":"december","description":"december description","target":"global","version":"v0.0.0","buildSHA":"5db6204-dirty","digest":"","group":"Manage","docURL":"","completionType":0,"pluginRuntimeVersion":"v1.1.0","binaryArch":"arm64"}
$ artifacts/plugins/darwin/arm64/global/december/v0.0.0/tanzu-december-darwin_arm64 -h
december description

Usage:

Flags:
  -h, --help   help for december

# Check that we can build this plugin with debugging enabled
$ make plugin-build-local PLUGIN_ENABLE_DEBUG=1
$ dlv exec artifacts/plugins/darwin/arm64/global/december/v0.0.0/tanzu-december-darwin_arm64
Type 'help' for list of commands.
(dlv) b main.main
Breakpoint 1 set at 0x10485703c for main.main() ./cmd/plugin/december/main.go:21
(dlv) continue
> main.main() ./cmd/plugin/december/main.go:21 (hits goroutine(1):1 total:1) (PC: 0x10485703c)
Warning: debugging optimized function
    16:		Version:     buildinfo.Version,
    17:		BuildSHA:    buildinfo.SHA,
    18:		Group:       plugin.ManageCmdGroup, // set group
    19:	}
    20:
=>  21:	func main() {
    22:		p, err := plugin.NewPlugin(&descriptor)
    23:		if err != nil {
    24:			log.Fatal(err, "")
    25:		}
    26:		p.AddCommands(
(dlv) exit
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Reduce binary size by around 30% by building CLI and plugins without debug symbols.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
