### PR TITLE
Don't disable flag parsing on the root command

### DIFF
--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -136,8 +136,6 @@ func newRootCmd() *cobra.Command {
 		SilenceErrors: true,
 		// silencing usage for now as we are getting double usage from plugins on errors
 		SilenceUsage: true,
-		// Flag parsing must be deactivated because the root plugin won't know about all flags.
-		DisableFlagParsing: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// Ensure mutual exclusion in current contexts just in case if any plugins with old
 			// plugin-runtime sets k8s context as current when tanzu context is already set as current


### PR DESCRIPTION
The first commit of this PR is #594 for cobra 1.8.0

### What this PR does / why we need it

This PR stops disabling flag parsing on the root CLI command to fix a small bug when updating to cobra 1.8.0.

I purposely kept this PR separate from #594 because even if we don't move to cobra 1.8.0, there is no reason for the CLI to disable flag parsing on its root command, as is explained below.

By disabling flag parsing on the root command, we tell Cobra not to parse flags when running the root command.  Since there are are currently no flags on the root command this is not a problem. Furthermore, even with say, a global flag on the root command, this situation would still not be a problem because the root command is not actually runnable itself (no `Run` function), so flags would not be executed on the root command itself, but instead the `DisableFlagParsing` field would be read from the executable sub-command used.

However, there is an issue with not parsing flags on the root which is that it prevents Cobra's shell completion logic to complete the `--help/-h` flags on the root command.  This is because all flag name completion becomes the responsibility of the program itself, and the program did not itself define `--help/-h`.  This happens starting with Cobra v1.8.0.

We can see this by running `tanzu __complete -` and noticing the `--help/-h` flags are not suggested when using cobra 1.8.0.

The reason flag parsing was disabled on the root seems to be to allow plugins to handle their own flags.  However, this is already done by each individual plugin sub-command created by `GetCmdForPlugin()` which does disable flag parsing already.  There is therefore no reason to disable flag parsing on the root command.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

```
# Current behaviour of shell completion for the help flag on the root command
# This is correct, since the --help/-h flag is valid on the root command
$ git checkout main
$ make build
build darwin-arm64 CLI with version: v1.2.0-dev
mkdir -p bin
cp /Users/kmarc/git/tanzu-cli/artifacts/darwin/arm64/cli/core/v1.2.0-dev/tanzu-cli-darwin_arm64 ./bin/tanzu
$ tz __complete -
--help	help for tanzu
-h	help for tanzu
:4
Completion ended with directive: ShellCompDirectiveNoFileComp

# New behaviour of shell completion once we move to cobra 1.8.0
# This is now wrong as the --help/-h are not longer completed
$ git checkout feat/cobra1.8.0
Switched to branch 'feat/cobra1.8.0'
$ make build
build darwin-arm64 CLI with version: v1.2.0-dev
mkdir -p bin
cp /Users/kmarc/git/tanzu-cli/artifacts/darwin/arm64/cli/core/v1.2.0-dev/tanzu-cli-darwin_arm64 ./bin/tanzu
$ tz __complete -
:4
Completion ended with directive: ShellCompDirectiveNoFileComp

# Fix for this issue
$ git checkout fix/compDoubleHelpFlagForPlugins
Switched to branch 'fix/compDoubleHelpFlagForPlugins'
$ make build
build darwin-arm64 CLI with version: v1.2.0-dev
mkdir -p bin
cp /Users/kmarc/git/tanzu-cli/artifacts/darwin/arm64/cli/core/v1.2.0-dev/tanzu-cli-darwin_arm64 ./bin/tanzu
$ tz __complete -
--help	help for tanzu
-h	help for tanzu
:4
Completion ended with directive: ShellCompDirectiveNoFileComp
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Don't disable flag parsing on the root command.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
