### PR TITLE
Refresh the plugin DB on `plugin source init`

### DIFF
--- a/pkg/command/discovery_source.go
+++ b/pkg/command/discovery_source.go
@@ -165,6 +165,14 @@ func newInitDiscoverySourceCmd() *cobra.Command {
 				return err
 			}
 
+			// Refresh the inventory DB
+			if discoverySource, err := configlib.GetCLIDiscoverySource(config.DefaultStandaloneDiscoveryName); err == nil {
+				// Ignore any failures since the real operation
+				// the user is trying to do is set the config
+				// to the central repo, which was done above
+				_ = checkDiscoverySource(*discoverySource)
+			}
+
 			log.Successf("successfully initialized discovery source")
 			return nil
 		},

--- a/pkg/command/discovery_source_test.go
+++ b/pkg/command/discovery_source_test.go
@@ -7,11 +7,13 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/config"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
@@ -139,6 +141,12 @@ func Test_initDiscoverySources(t *testing.T) {
 	os.Setenv(configlib.EnvConfigNextGenKey, configFileNG.Name())
 	defer os.RemoveAll(configFileNG.Name())
 
+	dir, err := os.MkdirTemp("", "test-source")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	common.DefaultCacheDir = dir
+
 	os.Setenv(constants.CEIPOptInUserPromptAnswer, "No")
 	os.Setenv(constants.EULAPromptAnswer, "Yes")
 
@@ -182,11 +190,15 @@ func Test_initDiscoverySources(t *testing.T) {
 					assert.Nil(err)
 					assert.Equal(1, len(discoverySources))
 
-					for _, ds := range discoverySources {
-						assert.NotNil(ds.OCI)
-						assert.Equal(config.DefaultStandaloneDiscoveryName, ds.OCI.Name)
-						assert.Equal(constants.TanzuCLIDefaultCentralPluginDiscoveryImage, ds.OCI.Image)
-					}
+					ds := discoverySources[0]
+					assert.NotNil(ds.OCI)
+					assert.Equal(config.DefaultStandaloneDiscoveryName, ds.OCI.Name)
+					assert.Equal(constants.TanzuCLIDefaultCentralPluginDiscoveryImage, ds.OCI.Image)
+
+					// Check that the digest file was immediately created
+					pluginDataDir := filepath.Join(common.DefaultCacheDir, common.PluginInventoryDirName, ds.OCI.Name)
+					matches, _ := filepath.Glob(filepath.Join(pluginDataDir, "digest.*"))
+					assert.Equal(1, len(matches))
 				}
 			}
 		})
@@ -244,6 +256,12 @@ func Test_updateDiscoverySources(t *testing.T) {
 	os.Setenv(configlib.EnvConfigNextGenKey, configFileNG.Name())
 	defer os.RemoveAll(configFileNG.Name())
 
+	dir, err := os.MkdirTemp("", "test-source")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	common.DefaultCacheDir = dir
+
 	os.Setenv(constants.CEIPOptInUserPromptAnswer, "No")
 	os.Setenv(constants.EULAPromptAnswer, "Yes")
 
@@ -287,11 +305,15 @@ func Test_updateDiscoverySources(t *testing.T) {
 					assert.Nil(err)
 					assert.Equal(1, len(discoverySources))
 
-					for _, ds := range discoverySources {
-						assert.NotNil(ds.OCI)
-						assert.Equal(config.DefaultStandaloneDiscoveryName, ds.OCI.Name)
-						assert.Equal(constants.TanzuCLIDefaultCentralPluginDiscoveryImage, ds.OCI.Image)
-					}
+					ds := discoverySources[0]
+					assert.NotNil(ds.OCI)
+					assert.Equal(config.DefaultStandaloneDiscoveryName, ds.OCI.Name)
+					assert.Equal(constants.TanzuCLIDefaultCentralPluginDiscoveryImage, ds.OCI.Image)
+
+					// Check that the digest file was immediately created
+					pluginDataDir := filepath.Join(common.DefaultCacheDir, common.PluginInventoryDirName, ds.OCI.Name)
+					matches, _ := filepath.Glob(filepath.Join(pluginDataDir, "digest.*"))
+					assert.Equal(1, len(matches))
 				}
 			}
 		})


### PR DESCRIPTION
### What this PR does / why we need it

This PR forces a refresh of the plugin inventory DB on a `tanzu plugin source init`.

Not refreshing the plugin inventory DB on `plugin source init` can cause confusion for some situations.  For example, shell completion, which only uses the inventory cache, would continue using the old cache after a `plugin source init`; similarly, the installation of the essential plugins would not get updated until the DB was refreshed through another command.

Furthermore, this becomes even more important as we plan to improve the DB cache to not check the digest for a certain period of time; in such a case, after running a `plugin source init`, the DB could be stale for all commands.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

```
# Set the plugin source to something else than the central repo
$ make start-test-central-repo
[...]
$ tz config set env.TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST localhost:9876/tanzu-cli/plugins/central:small
$ tz plugin source update default --uri localhost:9876/tanzu-cli/plugins/central:small
[i] Reading plugin inventory for "localhost:9876/tanzu-cli/plugins/central:small", this will take a few seconds.
[!] Skipping the plugins discovery image signature verification for "localhost:9876/tanzu-cli/plugins/central:small"

[ok] updated discovery source default

# Notice that shell completion does not find any "cost" plugin since there is none in this repo
# We do this so that we can check later that shell completion does find it.
$ tz __complete plugin install ''|grep cost
Completion ended with directive: ShellCompDirectiveNoFileComp

# Check the digest of this plugin source
$ ls -l /Users/kmarc/.cache/tanzu/plugin_inventory/default/digest.*
-rw-r--r--  1 kmarc  staff     0B  2 Dec 15:04 /Users/kmarc/.cache/tanzu/plugin_inventory/default/digest.793fbad3e13912b6d1432f3383d7bd2de6ebdbf793706e4dc3dd45bb35df5239

# Notice that the new DB is being read right way
$ tz plugin source init
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
[ok] successfully initialized discovery source

# Notice the new digest
$ ls -l /Users/kmarc/.cache/tanzu/plugin_inventory/default/digest.*
-rw-r--r--  1 kmarc  staff     0B  2 Dec 15:05 /Users/kmarc/.cache/tanzu/plugin_inventory/default/digest.3bda1cf622a73873e51804cefdc6a246ad955de079ccfb7c49016418fe65be12

# Notice that shell completion immediately know about the new content of the DB
$ tz __complete plugin install ''|grep cost
Completion ended with directive: ShellCompDirectiveNoFileComp
cost	A cost object for cluster and clustergroup
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Update the plugin inventory DB on a `tanzu plugin source init`
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
