### PR TITLE
Use the local "builder" version for the E2E framework tests 

### DIFF
--- a/test/sample-plugin/Makefile
+++ b/test/sample-plugin/Makefile
@@ -37,9 +37,11 @@ $(GOLANGCI_LINT): $(TOOLS_BIN_DIR) ## Install golangci-lint
 
 .PHONY: install-builder
 install-builder: ## Install builder
+	$(MAKE) -C $(ROOT_DIR_RELATIVE)/../.. prepare-builder
+	unset BUILDER_PLUGIN ; \
 	export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="No" ; \
 	export TANZU_CLI_EULA_PROMPT_ANSWER="Yes" ; \
-	tanzu plugin install builder
+	$(MAKE) -C $(ROOT_DIR_RELATIVE)/../.. plugin-build-install-local PLUGIN_NAME=builder
 
 .PHONEY: e2e-tests-simple-plugin ## Run all e2e tests for simple plugin
 e2e-tests-simple-plugin: install-builder plugin-build-local plugin-install-local e2e-tests-sample-plugin-functionality e2e-tests-sample-plugin-e2e-api


### PR DESCRIPTION
### What this PR does / why we need it

When running the tests for the sample-plugin, the `builder` plugin needs to be installed. However, it may happen that there was a change in the sample-plugin Makefile and the `builder` plugin code.  This means we must use the local `builder` version and not the "old" one currently published to the central repository.

This commit does this by:
1. building the `builder` plugin under `bin/`
2. using `bin/builder` to build the `builder` plugin under `artifacts` so it can be installed as a plugin from a local source.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

PR #596 adds a `--debug-symbols` flag to the `builder` plugin and uses it in the `plugin-tooling.mk` file of the sample-plugin.  So I ran with PR #596 (not this PR yet) to confirm the problem:
```
$ cd test/sample-plugin && make e2e-tests-simple-plugin
export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="No" ; \
	export TANZU_CLI_EULA_PROMPT_ANSWER="Yes" ; \
	tanzu plugin install builder
[i] Plugin 'builder:v1.1.0' with target 'global' is already installed. Reinitializing...
[ok] successfully installed 'builder' plugin
tanzu builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/test/sample-plugin/artifacts/plugins \
		--version v1.2.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-06' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=dd08d209c' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev'" \
		--goflags "" \
		--os-arch darwin_arm64 \
		--match "*" \
		--plugin-scope-association-file "" \
		--debug-symbols=false
Error: unknown flag: --debug-symbols
2023-12-05T20:52:46-05:00 [x] : unknown flag: --debug-symbols
make: *** [plugin-build-darwin-arm64] Error 1
```
Then I rebased PR #596 on top of this PR and tried again after doing some cleanup:
```
$ cd test/sample-plugin && make e2e-tests-simple-plugin
/Library/Developer/CommandLineTools/usr/bin/make -C ./../.. prepare-builder
cd cmd/plugin/builder && go build -o /Users/kmarc/git/tanzu-cli/bin/builder .
unset BUILDER_PLUGIN ; \
	export TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="No" ; \
	export TANZU_CLI_EULA_PROMPT_ANSWER="Yes" ; \
	/Library/Developer/CommandLineTools/usr/bin/make -C ./../.. plugin-build-install-local PLUGIN_NAME=builder
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.2.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-06' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=42987257f' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-06' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=42987257f' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev'" \
		--goflags "" \
		--os-arch darwin_arm64 \
		--match "builder" \
		--plugin-scope-association-file "" \
		--debug-symbols=false
2023-12-05T21:14:24-05:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.2.0-dev, [darwin_arm64]
2023-12-05T21:14:24-05:00 [i] 🐮 - building plugin at path "cmd/plugin/builder"
2023-12-05T21:14:26-05:00 [i] 🐮 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/arm64/global/builder/v1.2.0-dev/tanzu-builder-darwin_arm64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-06' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=42987257f' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-06' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=42987257f' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -w -s -tags  ./cmd/plugin/builder
2023-12-05T21:14:28-05:00 [i] ========
2023-12-05T21:14:28-05:00 [i] saving plugin manifest...
2023-12-05T21:14:28-05:00 [ok] successfully built local repository
tanzu plugin install all --local-source /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/arm64
[i] Installing plugin 'builder:v1.2.0-dev' with target 'global'
[ok] successfully installed all plugins
tanzu builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/test/sample-plugin/artifacts/plugins \
		--version v1.2.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-06' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=42987257f' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev'" \
		--goflags "" \
		--os-arch darwin_arm64 \
		--match "*" \
		--plugin-scope-association-file "" \
		--debug-symbols=false
2023-12-05T21:14:30-05:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/test/sample-plugin/artifacts/plugins, v1.2.0-dev, [darwin_arm64]
2023-12-05T21:14:30-05:00 [i] 🐷 - building plugin at path "cmd/plugin/sample-plugin"
2023-12-05T21:14:32-05:00 [i] 🐷 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/tanzu-cli/test/sample-plugin/artifacts/plugins/darwin/arm64/global/sample-plugin/v1.2.0-dev/tanzu-sample-plugin-darwin_arm64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-06' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=42987257f' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -w -s -tags  ./cmd/plugin/sample-plugin
2023-12-05T21:14:33-05:00 [i] 🐷 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/tanzu-cli/test/sample-plugin/artifacts/plugins/darwin/arm64/global/sample-plugin/v1.2.0-dev/test/tanzu-sample-plugin-test-darwin_arm64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-06' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=42987257f' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -w -s -tags  ./cmd/plugin/sample-plugin/test
2023-12-05T21:14:33-05:00 [i] ========
2023-12-05T21:14:33-05:00 [i] saving plugin manifest...
2023-12-05T21:14:33-05:00 [ok] successfully built local repository
tanzu plugin install all --local-source /Users/kmarc/git/tanzu-cli/test/sample-plugin/artifacts/plugins/darwin/arm64
[i] Installing plugin 'sample-plugin:v1.2.0-dev' with target 'global'
[ok] successfully installed all plugins
[...]
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Use the local `builder` version for the E2E framework tests 
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
