### PR TITLE
Add doc to use package managers to upgrade the CLI

### DIFF
--- a/docs/quickstart/install.md
+++ b/docs/quickstart/install.md
@@ -42,6 +42,8 @@ brew update
 brew install vmware-tanzu/tanzu/tanzu-cli
 ```
 
+To upgrade to a new release: `brew update && brew upgrade tanzu-cli`
+
 To uninstall: `brew uninstall tanzu-cli`
 
 #### Installing a Specific Version
@@ -52,11 +54,11 @@ a specific version by first extracting it to a local tap:
 
 ```console
 brew tap-new local/tap
-brew extract --version=0.90.1 vmware-tanzu/tanzu/tanzu-cli local/tap
-brew install tanzu-cli@0.90.1
+brew extract --version=1.0.0 vmware-tanzu/tanzu/tanzu-cli local/tap
+brew install tanzu-cli@1.0.0
 
 # To uninstall such an installation
-brew uninstall tanzu-cli@0.90.1
+brew uninstall tanzu-cli@1.0.0
 ```
 
 #### Installing a Pre-Release
@@ -91,8 +93,10 @@ you can explicitly specify the version you want to install using the `--version`
 
 ```console
 choco install tanzu-cli --version <version>
-# example: choco install tanzu-cli --version 0.90.0
+# example: choco install tanzu-cli --version 1.0.0
 ```
+
+To upgrade to a new release: `choco upgrade tanzu-cli`
 
 To uninstall: `choco uninstall tanzu-cli`
 
@@ -133,6 +137,8 @@ echo "deb [signed-by=/etc/apt/keyrings/tanzu-archive-keyring.gpg] https://storag
 sudo apt update
 sudo apt install -y tanzu-cli
 ```
+
+To upgrade to a new release: `sudo apt update && sudo apt upgrade -y tanzu-cli`
 
 To uninstall: `sudo apt remove tanzu-cli`
 
@@ -185,6 +191,8 @@ EOF
 
 sudo yum install -y tanzu-cli # dnf install can also be used
 ```
+
+To upgrade to a new release: `sudo yum update -y tanzu-cli`
 
 To uninstall: `sudo yum remove tanzu-cli`
 


### PR DESCRIPTION
### What this PR does / why we need it

When using package managers, the instructions to upgrade the CLI when it is already installed are very slightly different than for a fresh install.  This PR adds a bit of info about that in the documentation.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Let CI run

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add documentation on how to use package managers to upgrade the CLI
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

I took advantage of this PR to change references to `v0.90.*` to use `v1.0.0` as it felt more appropriate.