### PR TITLE
Build plugins for Windows ARM64

### DIFF
--- a/cmd/plugin/builder/command/cli_compile.go
+++ b/cmd/plugin/builder/command/cli_compile.go
@@ -427,6 +427,17 @@ var archMap = map[cli.Arch]targetBuilder{
 			},
 		}
 	},
+	cli.WinARM64: func(pluginName, outPath string) target {
+		return target{
+			env: []string{
+				"GOARCH=arm64",
+				"GOOS=windows",
+			},
+			args: []string{
+				"-o", filepath.Join(outPath, cli.MakeArtifactName(pluginName, cli.WinARM64)),
+			},
+		}
+	},
 }
 
 func (p *plugin) compile() error {

--- a/cmd/plugin/builder/template/plugintemplates/plugin-tooling.mk.tmpl
+++ b/cmd/plugin/builder/template/plugintemplates/plugin-tooling.mk.tmpl
@@ -36,7 +36,7 @@ PLUGIN_DEBUG=false
 endif
 
 # Add supported OS-ARCHITECTURE combinations here
-PLUGIN_BUILD_OS_ARCH ?= linux-amd64 windows-amd64 darwin-amd64 darwin-arm64 linux-arm64
+PLUGIN_BUILD_OS_ARCH ?= linux-amd64 windows-amd64 darwin-amd64 linux-arm64 darwin-arm64 windows-arm64
 
 # Paths and Directory information
 ROOT_DIR := $(shell git rev-parse --show-toplevel)

--- a/pkg/cli/arch.go
+++ b/pkg/cli/arch.go
@@ -10,13 +10,18 @@ import (
 )
 
 var (
-	// MinOSArch defines minimum OS/ARCH combination for which plugin needs to be built
+	// MinOSArch defines the minimum OS/ARCH combinations for which plugins need to be built
 	MinOSArch = []Arch{LinuxAMD64, DarwinAMD64, WinAMD64}
 
-	// AllOSArch defines all OS/ARCH combination for which plugin can be built
-	AllOSArch = []Arch{LinuxAMD64, DarwinAMD64, WinAMD64, DarwinARM64, LinuxARM64}
+	// AllOSArch defines all OS/ARCH combinations for which plugins can be built
+	AllOSArch = []Arch{LinuxAMD64, DarwinAMD64, WinAMD64, LinuxARM64, DarwinARM64, WinARM64}
 
-	GOOS   = runtime.GOOS
+	// GOOS is the current go os.  Defaults to runtime.GOOS but could be overridden.
+	// The CLI code should always this variable instead of runtime.GOOS.
+	GOOS = runtime.GOOS
+	// GOARCH is the current go architecture.  Defaults to runtime.GOARCH but is overridden
+	// for scenarios like installing AMD64 plugins on an ARM64 machine using emulation.
+	// The CLI code should always this variable instead of runtime.GOARCH.
 	GOARCH = runtime.GOARCH
 )
 
@@ -35,7 +40,7 @@ func SetArch(a Arch) {
 
 // IsWindows tells if an arch is windows.
 func (a Arch) IsWindows() bool {
-	if a == Win386 || a == WinAMD64 {
+	if a == Win386 || a == WinAMD64 || a == WinARM64 {
 		return true
 	}
 	return false
@@ -79,4 +84,6 @@ const (
 	Win386 Arch = "windows_386"
 	// WinAMD64 arch.
 	WinAMD64 Arch = "windows_amd64"
+	// WinARM64 arch.
+	WinARM64 Arch = "windows_arm64"
 )

--- a/plugin-tooling.mk
+++ b/plugin-tooling.mk
@@ -40,7 +40,7 @@ PLUGIN_DEBUG=false
 endif
 
 # Add supported OS-ARCHITECTURE combinations here
-PLUGIN_BUILD_OS_ARCH ?= linux-amd64 windows-amd64 darwin-amd64 darwin-arm64 linux-arm64
+PLUGIN_BUILD_OS_ARCH ?= linux-amd64 windows-amd64 darwin-amd64 linux-arm64 darwin-arm64 windows-arm64  
 
 # Paths and Directory information
 ROOT_DIR := $(shell git rev-parse --show-toplevel)

--- a/test/sample-plugin/plugin-tooling.mk
+++ b/test/sample-plugin/plugin-tooling.mk
@@ -36,7 +36,7 @@ PLUGIN_DEBUG=false
 endif
 
 # Add supported OS-ARCHITECTURE combinations here
-PLUGIN_BUILD_OS_ARCH ?= linux-amd64 windows-amd64 darwin-amd64 darwin-arm64 linux-arm64
+PLUGIN_BUILD_OS_ARCH ?= linux-amd64 windows-amd64 darwin-amd64 linux-arm64 darwin-arm64 windows-arm64
 
 # Paths and Directory information
 SAMPLE_PLUGIN_ROOT_DIR := $(shell pwd)


### PR DESCRIPTION
### What this PR does / why we need it

We start building the 'builder' and 'test' plugins for Windows ARM64.
We also default new plugin projects to also building for Windows ARM64.

The builder plugin will publish the Windows ARM64 binaries and include them in the plugin inventory DB if they are present.  If they are not present, the builder plugin will ignore them with a printout as is done for the other two ARM64 builds.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Part of #357 

### Describe testing done for PR

Building and publish the builder and test plugins for all osarch (including Windows ARM64):
```
$ make cross-build-publish-plugins
cd cmd/plugin/builder && go build -o /Users/kmarc/git/tanzu-cli/bin/builder .
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.2.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-09' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=efe2c930f-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev'" \
		--goflags "" \
		--os-arch linux_amd64 \
		--match "*" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml \
		--debug-symbols=false
[...]
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.2.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-09' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=efe2c930f-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev'" \
		--goflags "" \
		--os-arch windows_arm64 \
		--match "*" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml \
		--debug-symbols=false
2023-12-08T19:12:32-05:00 [i] building local repository at /Users/kmarc/git/tanzu-cli/artifacts/plugins, v1.2.0-dev, [windows_arm64]
2023-12-08T19:12:32-05:00 [i] 🦁 - building plugin at path "cmd/plugin/test"
2023-12-08T19:12:32-05:00 [i] 🦊 - building plugin at path "cmd/plugin/builder"
2023-12-08T19:12:34-05:00 [i] 🦊 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/windows/arm64/global/builder/v1.2.0-dev/tanzu-builder-windows_arm64.exe -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-09' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=efe2c930f-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -w -s -tags  ./cmd/plugin/builder
2023-12-08T19:12:35-05:00 [i] 🦁 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/windows/arm64/global/test/v1.2.0-dev/tanzu-test-windows_arm64.exe -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-09' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=efe2c930f-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -w -s -tags  ./cmd/plugin/test
2023-12-08T19:12:39-05:00 [i] 🦁 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/tanzu-cli/artifacts/plugins/windows/arm64/global/test/v1.2.0-dev/test/tanzu-test-test-windows_arm64.exe -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-09' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=efe2c930f-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev' -w -s -tags  ./cmd/plugin/test/test
2023-12-08T19:12:40-05:00 [i] ========
2023-12-08T19:12:40-05:00 [i] saving plugin manifest...
2023-12-08T19:12:40-05:00 [i] saving plugin group manifest...
2023-12-08T19:12:40-05:00 [ok] successfully built local repository
cd /Users/kmarc/git/tanzu-cli/artifacts/plugins && tar -czvf ../plugin_bundle.tar.gz .
a .
a ./plugin_group_manifest.yaml
a ./plugin_manifest.yaml
a ./linux
a ./darwin
a ./windows
a ./windows/amd64
a ./windows/arm64
a ./windows/arm64/plugin_manifest.yaml
a ./windows/arm64/global
a ./windows/arm64/global/test
a ./windows/arm64/global/builder
a ./windows/arm64/global/builder/v1.2.0-dev
a ./windows/arm64/global/builder/v1.2.0-dev/tanzu-builder-windows_arm64.exe
a ./windows/arm64/global/test/v1.2.0-dev
a ./windows/arm64/global/test/v1.2.0-dev/test
a ./windows/arm64/global/test/v1.2.0-dev/tanzu-test-windows_arm64.exe
a ./windows/arm64/global/test/v1.2.0-dev/test/tanzu-test-test-windows_arm64.exe
a ./windows/amd64/plugin_manifest.yaml
a ./windows/amd64/global
a ./windows/amd64/global/test
a ./windows/amd64/global/builder
a ./windows/amd64/global/builder/v1.2.0-dev
a ./windows/amd64/global/builder/v1.2.0-dev/tanzu-builder-windows_amd64.exe
a ./windows/amd64/global/test/v1.2.0-dev
a ./windows/amd64/global/test/v1.2.0-dev/test
a ./windows/amd64/global/test/v1.2.0-dev/tanzu-test-windows_amd64.exe
a ./windows/amd64/global/test/v1.2.0-dev/test/tanzu-test-test-windows_amd64.exe
a ./darwin/amd64
a ./darwin/arm64
a ./darwin/arm64/plugin_manifest.yaml
a ./darwin/arm64/global
a ./darwin/arm64/global/test
a ./darwin/arm64/global/builder
a ./darwin/arm64/global/builder/v1.2.0-dev
a ./darwin/arm64/global/builder/v1.2.0-dev/tanzu-builder-darwin_arm64
a ./darwin/arm64/global/test/v1.2.0-dev
a ./darwin/arm64/global/test/v1.2.0-dev/test
a ./darwin/arm64/global/test/v1.2.0-dev/tanzu-test-darwin_arm64
a ./darwin/arm64/global/test/v1.2.0-dev/test/tanzu-test-test-darwin_arm64
a ./darwin/amd64/plugin_manifest.yaml
a ./darwin/amd64/global
a ./darwin/amd64/global/test
a ./darwin/amd64/global/builder
a ./darwin/amd64/global/builder/v1.2.0-dev
a ./darwin/amd64/global/builder/v1.2.0-dev/tanzu-builder-darwin_amd64
a ./darwin/amd64/global/test/v1.2.0-dev
a ./darwin/amd64/global/test/v1.2.0-dev/test
a ./darwin/amd64/global/test/v1.2.0-dev/tanzu-test-darwin_amd64
a ./darwin/amd64/global/test/v1.2.0-dev/test/tanzu-test-test-darwin_amd64
a ./linux/amd64
a ./linux/arm64
a ./linux/arm64/plugin_manifest.yaml
a ./linux/arm64/global
a ./linux/arm64/global/test
a ./linux/arm64/global/builder
a ./linux/arm64/global/builder/v1.2.0-dev
a ./linux/arm64/global/builder/v1.2.0-dev/tanzu-builder-linux_arm64
a ./linux/arm64/global/test/v1.2.0-dev
a ./linux/arm64/global/test/v1.2.0-dev/tanzu-test-linux_arm64
a ./linux/arm64/global/test/v1.2.0-dev/test
a ./linux/arm64/global/test/v1.2.0-dev/test/tanzu-test-test-linux_arm64
a ./linux/amd64/plugin_manifest.yaml
a ./linux/amd64/global
a ./linux/amd64/global/test
a ./linux/amd64/global/builder
a ./linux/amd64/global/builder/v1.2.0-dev
a ./linux/amd64/global/builder/v1.2.0-dev/tanzu-builder-linux_amd64
a ./linux/amd64/global/test/v1.2.0-dev
a ./linux/amd64/global/test/v1.2.0-dev/test
a ./linux/amd64/global/test/v1.2.0-dev/tanzu-test-linux_amd64
a ./linux/amd64/global/test/v1.2.0-dev/test/tanzu-test-test-linux_amd64
/Users/kmarc/git/tanzu-cli/bin/builder plugin build-package \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--package-artifacts /Users/kmarc/git/tanzu-cli/artifacts/packages
2023-12-08T19:12:55-05:00 [i] starting local registry server on port 62992, logs available at /var/folders/k0/lwnx9y_n7393cfx7mj7dct580000gq/T/3991448554
2023-12-08T19:12:55-05:00 [i] Using plugin binary artifacts from "/Users/kmarc/git/tanzu-cli/artifacts/plugins"
[...]
2023-12-08T19:13:19-05:00 [i] Saved plugin manifest at "/Users/kmarc/git/tanzu-cli/artifacts/packages/plugin_manifest.yaml"
2023-12-08T19:13:19-05:00 [i] shutting down local registry server...
docker stop temp-package-registry && docker rm -v temp-package-registry || true
temp-package-registry
temp-package-registry
docker run -d -p 5001:5000 --name temp-package-registry library/registry:2
2861db5b02771648f39ef869f05420c8d72e36bd9f185749627f4e6904a13566
/Users/kmarc/git/tanzu-cli/bin/builder plugin publish-package \
		--package-artifacts /Users/kmarc/git/tanzu-cli/artifacts/packages \
		--publisher tanzucli \
		--vendor vmware \
		--repository localhost:5001/test/v1/tanzu-cli/plugins
2023-12-08T19:13:20-05:00 [i] using plugin package artifacts from "/Users/kmarc/git/tanzu-cli/artifacts/packages"
2023-12-08T19:13:20-05:00 [i] 🐯 publishing plugin 'name:test' 'target:global' 'os:darwin' 'arch:amd64' 'version:v1.2.0-dev'
2023-12-08T19:13:20-05:00 [i] 🐰 publishing plugin 'name:builder' 'target:global' 'os:linux' 'arch:arm64' 'version:v1.2.0-dev'
2023-12-08T19:13:20-05:00 [i] 🐱 publishing plugin 'name:builder' 'target:global' 'os:windows' 'arch:arm64' 'version:v1.2.0-dev'
2023-12-08T19:13:20-05:00 [i] 🦁 publishing plugin 'name:test' 'target:global' 'os:linux' 'arch:amd64' 'version:v1.2.0-dev'
2023-12-08T19:13:20-05:00 [i] 🦊 publishing plugin 'name:builder' 'target:global' 'os:darwin' 'arch:arm64' 'version:v1.2.0-dev'
2023-12-08T19:13:20-05:00 [i] 🐼 publishing plugin 'name:builder' 'target:global' 'os:darwin' 'arch:amd64' 'version:v1.2.0-dev'
2023-12-08T19:13:20-05:00 [i] 🐵 publishing plugin 'name:builder' 'target:global' 'os:linux' 'arch:amd64' 'version:v1.2.0-dev'
2023-12-08T19:13:20-05:00 [i] 🐶 publishing plugin 'name:builder' 'target:global' 'os:windows' 'arch:amd64' 'version:v1.2.0-dev'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/amd64/global/builder@sha256:01e5d20d268849b97b63833c02ef23c48d3cb16aafabf3c90d48b99ff1332d24
[...]
2023-12-08T19:13:35-05:00 [i] 🐨 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/arm64/global/test:v1.2.0-dev'
/Users/kmarc/git/tanzu-cli/bin/builder inventory init \
		--repository localhost:5001/test/v1/tanzu-cli/plugins \
		--plugin-inventory-image-tag latest \

2023-12-08T19:13:35-05:00 [i] created database locally at: "/var/folders/k0/lwnx9y_n7393cfx7mj7dct580000gq/T/plugin_inventory.db"
2023-12-08T19:13:35-05:00 [i] publishing database at: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
2023-12-08T19:13:37-05:00 [i] successfully published plugin inventory database
/Users/kmarc/git/tanzu-cli/bin/builder inventory plugin add \
		--repository localhost:5001/test/v1/tanzu-cli/plugins \
		--plugin-inventory-image-tag latest \
		--publisher tanzucli \
		--vendor vmware \
		--manifest /Users/kmarc/git/tanzu-cli/artifacts/packages/plugin_manifest.yaml \
		--plugin-inventory-db-file ""
2023-12-08T19:13:37-05:00 [i] pulling plugin inventory database from: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
2023-12-08T19:13:37-05:00 [i] 🐯 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/amd64/global/test:v1.2.0-dev'
2023-12-08T19:13:37-05:00 [i] 🐵 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/amd64/global/builder:v1.2.0-dev'
2023-12-08T19:13:37-05:00 [i] 🦊 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/arm64/global/builder:v1.2.0-dev'
2023-12-08T19:13:37-05:00 [i] 🐼 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/amd64/global/builder:v1.2.0-dev'
2023-12-08T19:13:37-05:00 [i] 🐰 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/arm64/global/builder:v1.2.0-dev'
2023-12-08T19:13:37-05:00 [i] 🦁 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/amd64/global/test:v1.2.0-dev'
2023-12-08T19:13:37-05:00 [i] 🐱 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/arm64/global/builder:v1.2.0-dev'
2023-12-08T19:13:37-05:00 [i] 🐶 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/amd64/global/builder:v1.2.0-dev'
2023-12-08T19:13:37-05:00 [i] 🐮 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/amd64/global/test:v1.2.0-dev'
2023-12-08T19:13:37-05:00 [i] 🐷 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/arm64/global/test:v1.2.0-dev'
2023-12-08T19:13:37-05:00 [i] 🐭 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/arm64/global/test:v1.2.0-dev'
2023-12-08T19:13:37-05:00 [i] 🐨 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/arm64/global/test:v1.2.0-dev'
2023-12-08T19:13:38-05:00 [i] publishing plugin inventory database
2023-12-08T19:13:40-05:00 [i] successfully published plugin inventory database at: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"

$ tz config set env.TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest
$ tz plugin source update default -u localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest
[i] Reading plugin inventory for "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest", this will take a few seconds.
[!] Skipping the plugins discovery image signature verification for "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"

[ok] updated discovery source default

# Search the DB to see all the different architectures and notice windows/arm64 is present
$ echo "select distinct PluginName,Target,Version,OS,Architecture from PluginBinaries;" | sqlite3 ~/.cache/tanzu/plugin_inventory/default/plugin_inventory.db

builder|global|v1.2.0-dev|darwin|amd64
builder|global|v1.2.0-dev|darwin|arm64
builder|global|v1.2.0-dev|linux|amd64
builder|global|v1.2.0-dev|linux|arm64
builder|global|v1.2.0-dev|windows|amd64
builder|global|v1.2.0-dev|windows|arm64
test|global|v1.2.0-dev|darwin|amd64
test|global|v1.2.0-dev|darwin|arm64
test|global|v1.2.0-dev|linux|amd64
test|global|v1.2.0-dev|linux|arm64
test|global|v1.2.0-dev|windows|amd64
test|global|v1.2.0-dev|windows|arm64
```

Making sure a plugin can build and publish WITHOUT the new Windows ARM64.
I removed the string `windows-arm64` from the plugin-tooling.mk file.
```
$ \rm -rf artifacts
$ make cross-build-publish-plugins
[...]
cd /Users/kmarc/git/tanzu-cli/artifacts/plugins && tar -czvf ../plugin_bundle.tar.gz .
a .
a ./plugin_group_manifest.yaml
a ./plugin_manifest.yaml
a ./linux
a ./darwin
a ./windows
a ./windows/amd64
a ./windows/amd64/plugin_manifest.yaml
a ./windows/amd64/global
a ./windows/amd64/global/test
a ./windows/amd64/global/builder
a ./windows/amd64/global/builder/v1.2.0-dev
a ./windows/amd64/global/builder/v1.2.0-dev/tanzu-builder-windows_amd64.exe
a ./windows/amd64/global/test/v1.2.0-dev
a ./windows/amd64/global/test/v1.2.0-dev/test
a ./windows/amd64/global/test/v1.2.0-dev/tanzu-test-windows_amd64.exe
a ./windows/amd64/global/test/v1.2.0-dev/test/tanzu-test-test-windows_amd64.exe
a ./darwin/amd64
a ./darwin/arm64
a ./darwin/arm64/plugin_manifest.yaml
a ./darwin/arm64/global
a ./darwin/arm64/global/test
a ./darwin/arm64/global/builder
a ./darwin/arm64/global/builder/v1.2.0-dev
a ./darwin/arm64/global/builder/v1.2.0-dev/tanzu-builder-darwin_arm64
a ./darwin/arm64/global/test/v1.2.0-dev
a ./darwin/arm64/global/test/v1.2.0-dev/test
a ./darwin/arm64/global/test/v1.2.0-dev/tanzu-test-darwin_arm64
a ./darwin/arm64/global/test/v1.2.0-dev/test/tanzu-test-test-darwin_arm64
a ./darwin/amd64/plugin_manifest.yaml
a ./darwin/amd64/global
a ./darwin/amd64/global/test
a ./darwin/amd64/global/builder
a ./darwin/amd64/global/builder/v1.2.0-dev
a ./darwin/amd64/global/builder/v1.2.0-dev/tanzu-builder-darwin_amd64
a ./darwin/amd64/global/test/v1.2.0-dev
a ./darwin/amd64/global/test/v1.2.0-dev/test
a ./darwin/amd64/global/test/v1.2.0-dev/tanzu-test-darwin_amd64
a ./darwin/amd64/global/test/v1.2.0-dev/test/tanzu-test-test-darwin_amd64
a ./linux/amd64
a ./linux/arm64
a ./linux/arm64/plugin_manifest.yaml
a ./linux/arm64/global
a ./linux/arm64/global/test
a ./linux/arm64/global/builder
a ./linux/arm64/global/builder/v1.2.0-dev
a ./linux/arm64/global/builder/v1.2.0-dev/tanzu-builder-linux_arm64
a ./linux/arm64/global/test/v1.2.0-dev
a ./linux/arm64/global/test/v1.2.0-dev/tanzu-test-linux_arm64
a ./linux/arm64/global/test/v1.2.0-dev/test
a ./linux/arm64/global/test/v1.2.0-dev/test/tanzu-test-test-linux_arm64
a ./linux/amd64/plugin_manifest.yaml
a ./linux/amd64/global
a ./linux/amd64/global/test
a ./linux/amd64/global/builder
a ./linux/amd64/global/builder/v1.2.0-dev
a ./linux/amd64/global/builder/v1.2.0-dev/tanzu-builder-linux_amd64
a ./linux/amd64/global/test/v1.2.0-dev
a ./linux/amd64/global/test/v1.2.0-dev/test
a ./linux/amd64/global/test/v1.2.0-dev/tanzu-test-linux_amd64
a ./linux/amd64/global/test/v1.2.0-dev/test/tanzu-test-test-linux_amd64
[...]
/Users/kmarc/git/tanzu-cli/bin/builder inventory plugin add \
		--repository localhost:5001/test/v1/tanzu-cli/plugins \
		--plugin-inventory-image-tag latest \
		--publisher tanzucli \
		--vendor vmware \
		--manifest /Users/kmarc/git/tanzu-cli/artifacts/packages/plugin_manifest.yaml \
		--plugin-inventory-db-file ""
2023-12-08T19:24:44-05:00 [i] pulling plugin inventory database from: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
2023-12-08T19:24:44-05:00 [i] 🐯 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/amd64/global/test:v1.2.0-dev'
2023-12-08T19:24:44-05:00 [i] 🐱 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/arm64/global/builder:v1.2.0-dev'
2023-12-08T19:24:44-05:00 [i] 🐰 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/arm64/global/builder:v1.2.0-dev'
2023-12-08T19:24:44-05:00 [i] 🐼 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/amd64/global/builder:v1.2.0-dev'
2023-12-08T19:24:44-05:00 [i] 🐶 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/amd64/global/builder:v1.2.0-dev'
2023-12-08T19:24:44-05:00 [i] 🦊 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/arm64/global/builder:v1.2.0-dev'
2023-12-08T19:24:44-05:00 [i] 🐵 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/amd64/global/builder:v1.2.0-dev'
2023-12-08T19:24:44-05:00 [i] 🦁 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/amd64/global/test:v1.2.0-dev'
2023-12-08T19:24:44-05:00 [i] 🐱 ignoring unavailable plugin for optional os/arch: windows_arm64
2023-12-08T19:24:44-05:00 [i] 🐮 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/amd64/global/test:v1.2.0-dev'
2023-12-08T19:24:45-05:00 [i] 🐷 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/arm64/global/test:v1.2.0-dev'
2023-12-08T19:24:45-05:00 [i] 🐭 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/arm64/global/test:v1.2.0-dev'
2023-12-08T19:24:45-05:00 [i] 🐨 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/arm64/global/test:v1.2.0-dev'
2023-12-08T19:24:45-05:00 [i] 🐨 ignoring unavailable plugin for optional os/arch: windows_arm64
2023-12-08T19:24:45-05:00 [i] publishing plugin inventory database
2023-12-08T19:24:46-05:00 [i] successfully published plugin inventory database at: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"

$ tz config set env.TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest
$ tz plugin source update default -u localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest
[i] Reading plugin inventory for "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest", this will take a few seconds.
[!] Skipping the plugins discovery image signature verification for "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"

[ok] updated discovery source default

# Notice there is no windows/arm64 as expected
$ echo "select distinct PluginName,Target,Version,OS,Architecture from PluginBinaries;" | sqlite3 ~/.cache/tanzu/plugin_inventory/default/plugin_inventory.db
builder|global|v1.2.0-dev|darwin|amd64
builder|global|v1.2.0-dev|darwin|arm64
builder|global|v1.2.0-dev|linux|amd64
builder|global|v1.2.0-dev|linux|arm64
builder|global|v1.2.0-dev|windows|amd64
test|global|v1.2.0-dev|darwin|amd64
test|global|v1.2.0-dev|darwin|arm64
test|global|v1.2.0-dev|linux|amd64
test|global|v1.2.0-dev|linux|arm64
test|global|v1.2.0-dev|windows|amd64
```
Notice above the message `ignoring unavailable plugin for optional os/arch: windows_arm64` which is expected since we did not build the plugin for that OS/ARCH.


Check when just doing validation after building all osarch, including Windows ARM64:
```
$ \rm -rf artifacts
$ make plugin-build-and-publish-packages
/Users/kmarc/git/tanzu-cli/bin/builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/tanzu-cli/artifacts/plugins \
		--version v1.2.0-dev \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-09' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=efe2c930f-dirty' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v1.2.0-dev'" \
		--goflags "" \
		--os-arch linux_amd64 \
		--match "*" \
		--plugin-scope-association-file ./cmd/plugin/plugin-scope-association.yaml \
		--debug-symbols=false
[...]

$ make inventory-init
/Users/kmarc/git/tanzu-cli/bin/builder inventory init \
		--repository localhost:5001/test/v1/tanzu-cli/plugins \
		--plugin-inventory-image-tag latest \

2023-12-08T19:32:39-05:00 [i] created database locally at: "/var/folders/k0/lwnx9y_n7393cfx7mj7dct580000gq/T/plugin_inventory.db"
2023-12-08T19:32:39-05:00 [i] publishing database at: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
2023-12-08T19:32:40-05:00 [i] successfully published plugin inventory database

$ bin/builder inventory plugin add \
                --repository localhost:5001/test/v1/tanzu-cli/plugins \
                --plugin-inventory-image-tag latest \
                --publisher tzcli \
                --vendor vmware \
                --manifest ./artifacts/packages/plugin_manifest.yaml --validate
2023-12-08T19:32:56-05:00 [i] pulling plugin inventory database from: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
2023-12-08T19:32:56-05:00 [i] validation successful
```

I also checked when just doing validation after building as above but WITHOUT the new Windows ARM64.
I first removed the string `windows-arm64` from the `plugin-tooling.mk` file.
I confirm it works.


Test creating a new plugin to see that Windows ARM64 is built by default:
```
# Install the new builder
$ tanzu plugin install all --local-source /Users/kmarc/git/tanzu-cli/artifacts/plugins/darwin/arm64
[i] Installing plugin 'builder:v1.2.0-dev' with target 'global'
[i] Installing plugin 'test:v1.2.0-dev' with target 'global'
[ok] successfully installed all plugins
# Confirm it is the right SHA
$ tz builder info
{"name":"builder","description":"Build Tanzu components","target":"global","version":"v1.2.0-dev","buildSHA":"a172fbf77","digest":"","group":"Admin","docURL":"","completionType":0,"pluginRuntimeVersion":"v1.1.0","binaryArch":"arm64"}
$ g log | head -1
commit a172fbf777badd485c32acf72419b7aa0b5c107e

$ cd $git
$ tz builder init plugin-arm64
? choose a repository type GitHub
2023-12-08T21:04:49-05:00 [ok] successfully created repository
$ cd plugin-arm64
# I unfortunately named the plugin `arm64` which is a bit confusing below, sorry.
$ tz builder cli add-plugin arm64
? provide a description windows arm64 test
2023-12-08T21:05:14-05:00 [ok] successfully created plugin
$ g add .
$ g cam initial
[main (root-commit) 98eedec] initial
 12 files changed, 578 insertions(+)
 create mode 100644 .github/workflows/build.yaml
 create mode 100644 .gitignore
 create mode 100644 .golangci.yaml
 create mode 100644 CODEOWNERS
 create mode 100644 Makefile
 create mode 100644 README.md
 create mode 100644 cmd/plugin/arm64/README.md
 create mode 100644 cmd/plugin/arm64/main.go
 create mode 100644 cmd/plugin/arm64/test/main.go
 create mode 100644 common.mk
 create mode 100644 go.mod
 create mode 100644 plugin-tooling.mk

$ sed s,types.TargetUnknown,types.TargetGlobal, cmd/plugin/arm64/main.go > tmp && mv tmp cmd/plugin/arm64/main.go
overwrite cmd/plugin/arm64/main.go? (y/n [n]) y
$ git commit -a -m global
[main a97cee0] global
 1 file changed, 1 insertion(+), 1 deletion(-)
$ git tag v0.0.1
$ make gomod
go mod tidy
go: finding module for package github.com/vmware-tanzu/tanzu-plugin-runtime/config/types
go: finding module for package github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo
go: finding module for package github.com/spf13/cobra
go: finding module for package github.com/vmware-tanzu/tanzu-plugin-runtime/log
go: finding module for package github.com/vmware-tanzu/tanzu-plugin-runtime/plugin
go: finding module for package github.com/vmware-tanzu/tanzu-plugin-runtime/test/framework
go: found github.com/vmware-tanzu/tanzu-plugin-runtime/config/types in github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0
go: found github.com/vmware-tanzu/tanzu-plugin-runtime/log in github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0
go: found github.com/vmware-tanzu/tanzu-plugin-runtime/plugin in github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0
go: found github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo in github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0
go: found github.com/spf13/cobra in github.com/spf13/cobra v1.8.0
go: found github.com/vmware-tanzu/tanzu-plugin-runtime/test/framework in github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0
$ git add -A
git commit -m "Configure go.mod and go.sum"
[main 8e679ba] Configure go.mod and go.sum
 2 files changed, 122 insertions(+)
 create mode 100644 go.sum


$ make plugin-build-and-publish-packages
tanzu builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/plugin-arm64/artifacts/plugins \
		--version v0.0.1 \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-09' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=8e679ba' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1'" \
		--goflags "" \
		--os-arch linux_amd64 \
		--match "*" \
		--plugin-scope-association-file "" \
		--debug-symbols=false
2023-12-08T21:09:00-05:00 [i] building local repository at /Users/kmarc/git/plugin-arm64/artifacts/plugins, v0.0.1, [linux_amd64]
2023-12-08T21:09:00-05:00 [i] 🦁 - building plugin at path "cmd/plugin/arm64"
2023-12-08T21:09:02-05:00 [i] 🦁 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/plugin-arm64/artifacts/plugins/linux/amd64/global/arm64/v0.0.1/tanzu-arm64-linux_amd64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-09' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=8e679ba' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1' -w -s -tags  ./cmd/plugin/arm64
2023-12-08T21:09:03-05:00 [i] 🦁 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/plugin-arm64/artifacts/plugins/linux/amd64/global/arm64/v0.0.1/test/tanzu-arm64-test-linux_amd64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-09' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=8e679ba' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1' -w -s -tags  ./cmd/plugin/arm64/test
2023-12-08T21:09:04-05:00 [i] ========
2023-12-08T21:09:04-05:00 [i] saving plugin manifest...
2023-12-08T21:09:04-05:00 [ok] successfully built local repository
tanzu builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/plugin-arm64/artifacts/plugins \
		--version v0.0.1 \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-09' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=8e679ba' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1'" \
		--goflags "" \
		--os-arch windows_amd64 \
		--match "*" \
		--plugin-scope-association-file "" \
		--debug-symbols=false
2023-12-08T21:09:05-05:00 [i] building local repository at /Users/kmarc/git/plugin-arm64/artifacts/plugins, v0.0.1, [windows_amd64]
2023-12-08T21:09:05-05:00 [i] 🐰 - building plugin at path "cmd/plugin/arm64"
2023-12-08T21:09:06-05:00 [i] 🐰 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/plugin-arm64/artifacts/plugins/windows/amd64/global/arm64/v0.0.1/tanzu-arm64-windows_amd64.exe -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-09' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=8e679ba' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1' -w -s -tags  ./cmd/plugin/arm64
2023-12-08T21:09:07-05:00 [i] 🐰 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/plugin-arm64/artifacts/plugins/windows/amd64/global/arm64/v0.0.1/test/tanzu-arm64-test-windows_amd64.exe -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-09' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=8e679ba' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1' -w -s -tags  ./cmd/plugin/arm64/test
2023-12-08T21:09:09-05:00 [i] ========
2023-12-08T21:09:09-05:00 [i] saving plugin manifest...
2023-12-08T21:09:09-05:00 [ok] successfully built local repository
tanzu builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/plugin-arm64/artifacts/plugins \
		--version v0.0.1 \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-09' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=8e679ba' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1'" \
		--goflags "" \
		--os-arch darwin_amd64 \
		--match "*" \
		--plugin-scope-association-file "" \
		--debug-symbols=false
2023-12-08T21:09:10-05:00 [i] building local repository at /Users/kmarc/git/plugin-arm64/artifacts/plugins, v0.0.1, [darwin_amd64]
2023-12-08T21:09:10-05:00 [i] 🐵 - building plugin at path "cmd/plugin/arm64"
2023-12-08T21:09:11-05:00 [i] 🐵 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/plugin-arm64/artifacts/plugins/darwin/amd64/global/arm64/v0.0.1/tanzu-arm64-darwin_amd64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-09' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=8e679ba' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1' -w -s -tags  ./cmd/plugin/arm64
2023-12-08T21:09:12-05:00 [i] 🐵 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/plugin-arm64/artifacts/plugins/darwin/amd64/global/arm64/v0.0.1/test/tanzu-arm64-test-darwin_amd64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-09' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=8e679ba' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1' -w -s -tags  ./cmd/plugin/arm64/test
2023-12-08T21:09:13-05:00 [i] ========
2023-12-08T21:09:13-05:00 [i] saving plugin manifest...
2023-12-08T21:09:13-05:00 [ok] successfully built local repository
tanzu builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/plugin-arm64/artifacts/plugins \
		--version v0.0.1 \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-09' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=8e679ba' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1'" \
		--goflags "" \
		--os-arch linux_arm64 \
		--match "*" \
		--plugin-scope-association-file "" \
		--debug-symbols=false
2023-12-08T21:09:14-05:00 [i] building local repository at /Users/kmarc/git/plugin-arm64/artifacts/plugins, v0.0.1, [linux_arm64]
2023-12-08T21:09:14-05:00 [i] 🐵 - building plugin at path "cmd/plugin/arm64"
2023-12-08T21:09:15-05:00 [i] 🐵 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/plugin-arm64/artifacts/plugins/linux/arm64/global/arm64/v0.0.1/tanzu-arm64-linux_arm64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-09' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=8e679ba' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1' -w -s -tags  ./cmd/plugin/arm64
2023-12-08T21:09:16-05:00 [i] 🐵 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/plugin-arm64/artifacts/plugins/linux/arm64/global/arm64/v0.0.1/test/tanzu-arm64-test-linux_arm64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-09' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=8e679ba' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1' -w -s -tags  ./cmd/plugin/arm64/test
2023-12-08T21:09:17-05:00 [i] ========
2023-12-08T21:09:17-05:00 [i] saving plugin manifest...
2023-12-08T21:09:17-05:00 [ok] successfully built local repository
tanzu builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/plugin-arm64/artifacts/plugins \
		--version v0.0.1 \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-09' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=8e679ba' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1'" \
		--goflags "" \
		--os-arch darwin_arm64 \
		--match "*" \
		--plugin-scope-association-file "" \
		--debug-symbols=false
2023-12-08T21:09:18-05:00 [i] building local repository at /Users/kmarc/git/plugin-arm64/artifacts/plugins, v0.0.1, [darwin_arm64]
2023-12-08T21:09:18-05:00 [i] 🐶 - building plugin at path "cmd/plugin/arm64"
2023-12-08T21:09:19-05:00 [i] 🐶 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/plugin-arm64/artifacts/plugins/darwin/arm64/global/arm64/v0.0.1/tanzu-arm64-darwin_arm64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-09' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=8e679ba' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1' -w -s -tags  ./cmd/plugin/arm64
2023-12-08T21:09:20-05:00 [i] 🐶 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/plugin-arm64/artifacts/plugins/darwin/arm64/global/arm64/v0.0.1/test/tanzu-arm64-test-darwin_arm64 -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-09' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=8e679ba' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1' -w -s -tags  ./cmd/plugin/arm64/test
2023-12-08T21:09:21-05:00 [i] ========
2023-12-08T21:09:21-05:00 [i] saving plugin manifest...
2023-12-08T21:09:21-05:00 [ok] successfully built local repository
tanzu builder plugin build \
		--path ./cmd/plugin \
		--binary-artifacts /Users/kmarc/git/plugin-arm64/artifacts/plugins \
		--version v0.0.1 \
		--ldflags "-X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-09' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=8e679ba' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1'" \
		--goflags "" \
		--os-arch windows_arm64 \
		--match "*" \
		--plugin-scope-association-file "" \
		--debug-symbols=false
2023-12-08T21:09:23-05:00 [i] building local repository at /Users/kmarc/git/plugin-arm64/artifacts/plugins, v0.0.1, [windows_arm64]
2023-12-08T21:09:23-05:00 [i] 🐯 - building plugin at path "cmd/plugin/arm64"
2023-12-08T21:09:24-05:00 [i] 🐯 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/plugin-arm64/artifacts/plugins/windows/arm64/global/arm64/v0.0.1/tanzu-arm64-windows_arm64.exe -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-09' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=8e679ba' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1' -w -s -tags  ./cmd/plugin/arm64
2023-12-08T21:09:25-05:00 [i] 🐯 - $ /Users/kmarc/.asdf/shims/go build -gcflags=all=-l -o /Users/kmarc/git/plugin-arm64/artifacts/plugins/windows/arm64/global/arm64/v0.0.1/test/tanzu-arm64-test-windows_arm64.exe -ldflags -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Date=2023-12-09' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.SHA=8e679ba' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1' -X 'github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo.Version=v0.0.1' -w -s -tags  ./cmd/plugin/arm64/test
2023-12-08T21:09:26-05:00 [i] ========
2023-12-08T21:09:26-05:00 [i] saving plugin manifest...
2023-12-08T21:09:26-05:00 [ok] successfully built local repository
cd /Users/kmarc/git/plugin-arm64/artifacts/plugins && tar -czvf ../plugin_bundle.tar.gz .
a .
a ./plugin_manifest.yaml
a ./linux
a ./darwin
a ./windows
a ./windows/amd64
a ./windows/arm64
a ./windows/arm64/plugin_manifest.yaml
a ./windows/arm64/global
a ./windows/arm64/global/arm64
a ./windows/arm64/global/arm64/v0.0.1
a ./windows/arm64/global/arm64/v0.0.1/test
a ./windows/arm64/global/arm64/v0.0.1/tanzu-arm64-windows_arm64.exe
a ./windows/arm64/global/arm64/v0.0.1/test/tanzu-arm64-test-windows_arm64.exe
a ./windows/amd64/plugin_manifest.yaml
a ./windows/amd64/global
a ./windows/amd64/global/arm64
a ./windows/amd64/global/arm64/v0.0.1
a ./windows/amd64/global/arm64/v0.0.1/test
a ./windows/amd64/global/arm64/v0.0.1/tanzu-arm64-windows_amd64.exe
a ./windows/amd64/global/arm64/v0.0.1/test/tanzu-arm64-test-windows_amd64.exe
a ./darwin/amd64
a ./darwin/arm64
a ./darwin/arm64/plugin_manifest.yaml
a ./darwin/arm64/global
a ./darwin/arm64/global/arm64
a ./darwin/arm64/global/arm64/v0.0.1
a ./darwin/arm64/global/arm64/v0.0.1/test
a ./darwin/arm64/global/arm64/v0.0.1/tanzu-arm64-darwin_arm64
a ./darwin/arm64/global/arm64/v0.0.1/test/tanzu-arm64-test-darwin_arm64
a ./darwin/amd64/plugin_manifest.yaml
a ./darwin/amd64/global
a ./darwin/amd64/global/arm64
a ./darwin/amd64/global/arm64/v0.0.1
a ./darwin/amd64/global/arm64/v0.0.1/test
a ./darwin/amd64/global/arm64/v0.0.1/tanzu-arm64-darwin_amd64
a ./darwin/amd64/global/arm64/v0.0.1/test/tanzu-arm64-test-darwin_amd64
a ./linux/amd64
a ./linux/arm64
a ./linux/arm64/plugin_manifest.yaml
a ./linux/arm64/global
a ./linux/arm64/global/arm64
a ./linux/arm64/global/arm64/v0.0.1
a ./linux/arm64/global/arm64/v0.0.1/test
a ./linux/arm64/global/arm64/v0.0.1/tanzu-arm64-linux_arm64
a ./linux/arm64/global/arm64/v0.0.1/test/tanzu-arm64-test-linux_arm64
a ./linux/amd64/plugin_manifest.yaml
a ./linux/amd64/global
a ./linux/amd64/global/arm64
a ./linux/amd64/global/arm64/v0.0.1
a ./linux/amd64/global/arm64/v0.0.1/tanzu-arm64-linux_amd64
a ./linux/amd64/global/arm64/v0.0.1/test
a ./linux/amd64/global/arm64/v0.0.1/test/tanzu-arm64-test-linux_amd64
tanzu builder plugin build-package \
		--binary-artifacts /Users/kmarc/git/plugin-arm64/artifacts/plugins \
		--package-artifacts /Users/kmarc/git/plugin-arm64/artifacts/packages
2023-12-08T21:09:31-05:00 [i] starting local registry server on port 49889, logs available at /var/folders/k0/lwnx9y_n7393cfx7mj7dct580000gq/T/105701323
2023-12-08T21:09:31-05:00 [i] Using plugin binary artifacts from "/Users/kmarc/git/plugin-arm64/artifacts/plugins"
2023-12-08T21:09:31-05:00 [i] 🐱 Validating Plugin Binary file: /Users/kmarc/git/plugin-arm64/artifacts/plugins/windows/arm64/global/arm64/v0.0.1/tanzu-arm64-windows_arm64.exe
2023-12-08T21:09:31-05:00 [i] 🐶 Validating Plugin Binary file: /Users/kmarc/git/plugin-arm64/artifacts/plugins/windows/amd64/global/arm64/v0.0.1/tanzu-arm64-windows_amd64.exe
2023-12-08T21:09:31-05:00 [i] 🐱 Generating plugin package for 'plugin:arm64' 'target:global' 'os:windows' 'arch:arm64' 'version:v0.0.1'
2023-12-08T21:09:31-05:00 [i] 🐶 Generating plugin package for 'plugin:arm64' 'target:global' 'os:windows' 'arch:amd64' 'version:v0.0.1'
2023-12-08T21:09:31-05:00 [i] 🐰 Validating Plugin Binary file: /Users/kmarc/git/plugin-arm64/artifacts/plugins/linux/arm64/global/arm64/v0.0.1/tanzu-arm64-linux_arm64
2023-12-08T21:09:31-05:00 [i] 🐰 Generating plugin package for 'plugin:arm64' 'target:global' 'os:linux' 'arch:arm64' 'version:v0.0.1'
2023-12-08T21:09:31-05:00 [i] 🐵 Validating Plugin Binary file: /Users/kmarc/git/plugin-arm64/artifacts/plugins/linux/amd64/global/arm64/v0.0.1/tanzu-arm64-linux_amd64
2023-12-08T21:09:31-05:00 [i] 🐵 Generating plugin package for 'plugin:arm64' 'target:global' 'os:linux' 'arch:amd64' 'version:v0.0.1'
2023-12-08T21:09:31-05:00 [i] 🦊 Validating Plugin Binary file: /Users/kmarc/git/plugin-arm64/artifacts/plugins/darwin/arm64/global/arm64/v0.0.1/tanzu-arm64-darwin_arm64
2023-12-08T21:09:31-05:00 [i] 🐼 Validating Plugin Binary file: /Users/kmarc/git/plugin-arm64/artifacts/plugins/darwin/amd64/global/arm64/v0.0.1/tanzu-arm64-darwin_amd64
2023-12-08T21:09:31-05:00 [i] 🦊 Generating plugin package for 'plugin:arm64' 'target:global' 'os:darwin' 'arch:arm64' 'version:v0.0.1'
2023-12-08T21:09:31-05:00 [i] 🐼 Generating plugin package for 'plugin:arm64' 'target:global' 'os:darwin' 'arch:amd64' 'version:v0.0.1'
2023-12-08T21:09:38-05:00 [i] 🐱 Generated plugin package at "/Users/kmarc/git/plugin-arm64/artifacts/packages/windows/arm64/global/arm64/v0.0.1/arm64-windows_arm64.tar"
2023-12-08T21:09:39-05:00 [i] 🐶 Generated plugin package at "/Users/kmarc/git/plugin-arm64/artifacts/packages/windows/amd64/global/arm64/v0.0.1/arm64-windows_amd64.tar"
2023-12-08T21:09:41-05:00 [i] 🦊 Generated plugin package at "/Users/kmarc/git/plugin-arm64/artifacts/packages/darwin/arm64/global/arm64/v0.0.1/arm64-darwin_arm64.tar"
2023-12-08T21:09:42-05:00 [i] 🐼 Generated plugin package at "/Users/kmarc/git/plugin-arm64/artifacts/packages/darwin/amd64/global/arm64/v0.0.1/arm64-darwin_amd64.tar"
2023-12-08T21:09:42-05:00 [i] 🐰 Generated plugin package at "/Users/kmarc/git/plugin-arm64/artifacts/packages/linux/arm64/global/arm64/v0.0.1/arm64-linux_arm64.tar"
2023-12-08T21:09:43-05:00 [i] 🐵 Generated plugin package at "/Users/kmarc/git/plugin-arm64/artifacts/packages/linux/amd64/global/arm64/v0.0.1/arm64-linux_amd64.tar"
2023-12-08T21:09:43-05:00 [i] Saved plugin manifest at "/Users/kmarc/git/plugin-arm64/artifacts/packages/plugin_manifest.yaml"
2023-12-08T21:09:43-05:00 [i] shutting down local registry server...
docker stop temp-package-registry && docker rm -v temp-package-registry || true
temp-package-registry
temp-package-registry
docker run -d -p 5001:5000 --name temp-package-registry library/registry:2
db3e1f6fb1732ef98c6d6a57e1e88bad67ffce9895990858a41e8abfe506f2da
tanzu builder plugin publish-package \
		--package-artifacts /Users/kmarc/git/plugin-arm64/artifacts/packages \
		--publisher tanzucli \
		--vendor vmware \
		--repository localhost:5001/test/v1/tanzu-cli/plugins
2023-12-08T21:09:48-05:00 [i] using plugin package artifacts from "/Users/kmarc/git/plugin-arm64/artifacts/packages"
2023-12-08T21:09:48-05:00 [i] 🐱 publishing plugin 'name:arm64' 'target:global' 'os:windows' 'arch:arm64' 'version:v0.0.1'
2023-12-08T21:09:48-05:00 [i] 🐶 publishing plugin 'name:arm64' 'target:global' 'os:windows' 'arch:amd64' 'version:v0.0.1'
2023-12-08T21:09:48-05:00 [i] 🐰 publishing plugin 'name:arm64' 'target:global' 'os:linux' 'arch:arm64' 'version:v0.0.1'
2023-12-08T21:09:48-05:00 [i] 🦊 publishing plugin 'name:arm64' 'target:global' 'os:darwin' 'arch:arm64' 'version:v0.0.1'
2023-12-08T21:09:48-05:00 [i] 🐵 publishing plugin 'name:arm64' 'target:global' 'os:linux' 'arch:amd64' 'version:v0.0.1'
2023-12-08T21:09:48-05:00 [i] 🐼 publishing plugin 'name:arm64' 'target:global' 'os:darwin' 'arch:amd64' 'version:v0.0.1'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/arm64/global/arm64@sha256:feda28b744fd5ae9ed7d999a6e16d981ce2660f7134483e397cbbdb62949f833
2023-12-08T21:09:49-05:00 [i] 🐰 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/arm64/global/arm64:v0.0.1'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/amd64/global/arm64@sha256:f72e9e4ac1c681e68f978525d435a4e2a90c67ec1b3d7d0c5d649a1c23bf8564
2023-12-08T21:09:49-05:00 [i] 🐵 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/amd64/global/arm64:v0.0.1'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/amd64/global/arm64@sha256:66391dfc73245e2c73acc0f45f9f9301204104d2592252429cd9e661c7cd9960
2023-12-08T21:09:50-05:00 [i] 🐶 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/amd64/global/arm64:v0.0.1'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/arm64/global/arm64@sha256:ce6d534ea340c207a25b31e2f157ce664ade7dea3853bf24d77ade505335b75c
2023-12-08T21:09:51-05:00 [i] 🦊 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/arm64/global/arm64:v0.0.1'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/amd64/global/arm64@sha256:dd68d010ef7bd2fedaf1a95d3a3083fddc0f879b64002b57aa7babb218d12fc8
2023-12-08T21:09:52-05:00 [i] 🐼 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/amd64/global/arm64:v0.0.1'
localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/arm64/global/arm64@sha256:064a3c2fd90ccdd589d096f3b9ffbe6127f5688b9be1a76aaba0291f33379d0b
2023-12-08T21:09:53-05:00 [i] 🐱 published plugin at 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/arm64/global/arm64:v0.0.1'

$ make inventory-init
tanzu builder inventory init \
		--repository localhost:5001/test/v1/tanzu-cli/plugins \
		--plugin-inventory-image-tag latest \

2023-12-08T21:10:00-05:00 [i] created database locally at: "/var/folders/k0/lwnx9y_n7393cfx7mj7dct580000gq/T/plugin_inventory.db"
2023-12-08T21:10:00-05:00 [i] publishing database at: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
2023-12-08T21:10:01-05:00 [i] successfully published plugin inventory database

$ make inventory-plugin-add
tanzu builder inventory plugin add \
		--repository localhost:5001/test/v1/tanzu-cli/plugins \
		--plugin-inventory-image-tag latest \
		--publisher tanzucli \
		--vendor vmware \
		--manifest /Users/kmarc/git/plugin-arm64/artifacts/packages/plugin_manifest.yaml
2023-12-08T21:10:08-05:00 [i] pulling plugin inventory database from: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
2023-12-08T21:10:08-05:00 [i] 🐱 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/arm64/global/arm64:v0.0.1'
2023-12-08T21:10:08-05:00 [i] 🐼 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/amd64/global/arm64:v0.0.1'
2023-12-08T21:10:08-05:00 [i] 🐵 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/amd64/global/arm64:v0.0.1'
2023-12-08T21:10:08-05:00 [i] 🐶 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/windows/amd64/global/arm64:v0.0.1'
2023-12-08T21:10:08-05:00 [i] 🐰 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/linux/arm64/global/arm64:v0.0.1'
2023-12-08T21:10:08-05:00 [i] 🦊 getting plugin digest from image: 'localhost:5001/test/v1/tanzu-cli/plugins/vmware/tanzucli/darwin/arm64/global/arm64:v0.0.1'
2023-12-08T21:10:09-05:00 [i] publishing plugin inventory database
2023-12-08T21:10:11-05:00 [i] successfully published plugin inventory database at: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"

$ tz config set env.TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest
$ tz plugin source update default -u localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest
[i] Reading plugin inventory for "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest", this will take a few seconds.
[!] Skipping the plugins discovery image signature verification for "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"

[ok] updated discovery source default

# Notice there is a Windows ARM64 plugin in the DB
$ echo "select distinct PluginName,Target,Version,OS,Architecture from PluginBinaries;" | sqlite3 ~/.cache/tanzu/plugin_inventory/default/plugin_inventory.db
arm64|global|v0.0.1|darwin|amd64
arm64|global|v0.0.1|darwin|arm64
arm64|global|v0.0.1|linux|amd64
arm64|global|v0.0.1|linux|arm64
arm64|global|v0.0.1|windows|amd64
arm64|global|v0.0.1|windows|arm64
```

And finally, I uploaded the Windows ARM64 CLI binary and the `artifacts/plugins/windows/arm64` directory to an ARM64 Windows machine on Azure and was able to install and run both the `builder` and `test` plugins.





### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The `builder` plugin can now build for Windows ARM64.  The `builder` and `test` plugins are themselves built for Windows ARM64.  New plugin projects will default to including a build for Windows ARM64.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
