### PR TITLE
Fix indentation in usage line of help of leaf commands

### DIFF
--- a/pkg/cli/usage.go
+++ b/pkg/cli/usage.go
@@ -66,7 +66,10 @@ func (u *MainUsage) GenerateDescriptor(c *cobra.Command, w io.Writer) error {
 	return nil
 }
 
-// Template returns the template for the main usage.
+// Template returns the template for the root cmd help as well
+// as for the two target commands ('kubernetes' and 'mission-control').
+// Those three commands use this template because they use command groups
+// for their help text.
 func (u *MainUsage) Template() string {
 	return `{{ bold "Usage:" }}
   {{.Command.CommandPath}} [command]{{if gt (len .Aliases) 0}}
@@ -90,7 +93,7 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.
 `
 }
 
-// SubCmdUsageFunc is the usage func for a plugin.
+// SubCmdUsageFunc is the usage func for all core sub-commands.
 var SubCmdUsageFunc = func(c *cobra.Command) error {
 	t, err := template.New("usage").Funcs(TemplateFuncs).Parse(SubCmdTemplate)
 	if err != nil {
@@ -99,9 +102,9 @@ var SubCmdUsageFunc = func(c *cobra.Command) error {
 	return t.Execute(os.Stdout, c)
 }
 
-// SubCmdTemplate is the template for plugin commands.
+// SubCmdTemplate is the template for all core sub-commands.
 const SubCmdTemplate = `{{ bold "Usage:" }}{{if .Runnable}}
-{{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
   {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
 
 {{ bold "Aliases:" }}


### PR DESCRIPTION
### What this PR does / why we need it

In the help output, the usage line of leaf commands was not indented as it is for non-leaf commands.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Before this commit:
```
~/bin/tanzu.v1.0.0 context list -h
List contexts

Usage:
tanzu context list [flags]
[...]
```

After the commit:
```
$  tz context list -h
List contexts

Usage:
  tanzu context list [flags]
[...]
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix indentation in usage line of help text of leaf commands
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
