### PR TITLE
Use proper help format for "completion"

### DIFF
--- a/pkg/command/completion.go
+++ b/pkg/command/completion.go
@@ -13,8 +13,13 @@ import (
 	"github.com/lithammer/dedent"
 	"github.com/spf13/cobra"
 
+	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/plugin"
 )
+
+func init() {
+	completionCmd.SetUsageFunc(cli.SubCmdUsageFunc)
+}
 
 const compNoMoreArgsMsg = "This command does not take any more arguments (but may accept flags)."
 
@@ -26,13 +31,12 @@ var (
 		"powershell",
 	}
 
-	completionLongDesc = dedent.Dedent(`
-		Output shell completion code for the specified shell %v.
+	completionLongDesc = `Output shell completion code for the specified shell (%v).
 
-		The shell completion code must be evaluated to provide completion. See Examples
-		for how to perform this for your given shell.
+The shell completion code must be evaluated to provide completion. See Examples
+for how to perform this for your given shell.
 
-		Note for bash users: make sure the bash-completions package has been installed.`)
+Note for bash users: make sure the bash-completions package has been installed.`
 
 	completionExamples = dedent.Dedent(`
 		# Bash instructions:
@@ -91,9 +95,9 @@ var (
 
 // completionCmd represents the completion command
 var completionCmd = &cobra.Command{
-	Use:                   fmt.Sprintf("completion %v", completionShells),
+	Use:                   fmt.Sprintf("completion [%v]", strings.Join(completionShells, "|")),
 	Short:                 "Output shell completion code",
-	Long:                  fmt.Sprintf(completionLongDesc, completionShells),
+	Long:                  fmt.Sprintf(completionLongDesc, strings.Join(completionShells, ", ")),
 	Example:               completionExamples,
 	DisableFlagsInUseLine: true,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -112,7 +116,7 @@ var completionCmd = &cobra.Command{
 
 func runCompletion(out io.Writer, cmd *cobra.Command, args []string) error {
 	if length := len(args); length == 0 {
-		return fmt.Errorf("shell not specified, choose one of: %v", completionShells)
+		return fmt.Errorf("shell not specified, choose one of: %v", strings.Join(completionShells, ", "))
 	} else if length > 1 {
 		return errors.New("too many arguments, expected only the shell type")
 	}

--- a/pkg/command/doc.go
+++ b/pkg/command/doc.go
@@ -67,6 +67,8 @@ func newGenAllDocsCmd() *cobra.Command {
 	// Shell completion for this flag is file completion which is enabled by default
 	genAllDocsCmd.Flags().StringVarP(&docsDir, "docs-dir", "d", DefaultDocsDir, "destination for docs output")
 
+	genAllDocsCmd.SetUsageFunc(cli.SubCmdUsageFunc)
+
 	return genAllDocsCmd
 }
 

--- a/test/e2e/framework/framework_constants.go
+++ b/test/e2e/framework/framework_constants.go
@@ -157,7 +157,7 @@ const (
 	PluginDescShouldExist                         = "there should be one plugin description"
 	PluginNameShouldMatch                         = "plugin name should be same as input value"
 
-	CompletionWithoutShell        = "shell not specified, choose one of: [bash zsh fish powershell]"
+	CompletionWithoutShell        = "shell not specified, choose one of: bash, zsh, fish, powershell"
 	CompletionOutputForBash       = "bash completion V2 for tanzu"
 	CompletionOutputForZsh        = "zsh completion for tanzu"
 	CompletionOutputForFish       = "fish completion for tanzu"


### PR DESCRIPTION
### What this PR does / why we need it

The `completion` and `generate-all-docs` commands' help were using the root command's help format by mistake. This PR fixes that.

Also, this PR improves the output of the list of shells in the help output of the `completion` command.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Before this commit, notice below 
1. the invalid use of `[command]`
2. the invalid use of `Available command groups`
3. the poor formatting of the list `[bash zsh fish powershell]`
```
$ ~/bin/tanzu.v1.0.0 completion -h

Output shell completion code for the specified shell [bash zsh fish powershell].

The shell completion code must be evaluated to provide completion. See Examples
for how to perform this for your given shell.

Note for bash users: make sure the bash-completions package has been installed.

Usage:
  tanzu completion [command]

Examples:

# Bash instructions:

  ## Load only for current session:
  source <(tanzu completion bash)

  ## Load for all new sessions:
  tanzu completion bash >  $HOME/.config/tanzu/completion.bash.inc
  printf "\n# Tanzu shell completion\nsource '$HOME/.config/tanzu/completion.bash.inc'\n" >> $HOME/.bash_profile

  ## NOTE: the bash-completion package must be installed.

# Zsh instructions:

  ## Load only for current session:
  autoload -U compinit; compinit
  source <(tanzu completion zsh)
  compdef _tanzu tanzu

  ## Load for all new sessions:
  echo "autoload -U compinit; compinit" >> ~/.zshrc
  tanzu completion zsh > "${fpath[1]}/_tanzu"

# Fish instructions:

  ## Load only for current session:
  tanzu completion fish | source

  ## Load for all new sessions:
  tanzu completion fish > ~/.config/fish/completions/tanzu.fish

# Powershell instructions:

  ## Load only for current session:
  tanzu completion powershell | Out-String | Invoke-Expression

  ## Load for all new sessions:
  Add the output of the above command to your powershell profile.

Available command groups:


Flags:
  -h, --help   help for completion

Use "tanzu completion [command] --help" for more information about a command.
$ ~/bin/tanzu.v1.0.0 generate-all-docs -h
Generate Cobra CLI docs for all plugins installed

Usage:
  tanzu generate-all-docs [command]

Available command groups:


Flags:
  -d, --docs-dir string   destination for docs output (default "docs/cli/commands")
  -h, --help              help for generate-all-docs

Use "tanzu generate-all-docs [command] --help" for more information about a command.
```

After this commit, notice the help format
1. does not use `[command]` anymore
2. no longer uses `Available command groups`
3. the better formatting of the lists `[bash zsh fish powershell]` 
```
$ tz completion -h
Output shell completion code for the specified shell (bash, zsh, fish, powershell).

The shell completion code must be evaluated to provide completion. See Examples
for how to perform this for your given shell.

Note for bash users: make sure the bash-completions package has been installed.

Usage:
tanzu completion [bash|zsh|fish|powershell]

Examples:

# Bash instructions:

  ## Load only for current session:
  source <(tanzu completion bash)

  ## Load for all new sessions:
  tanzu completion bash > $HOME/.config/tanzu/completion.bash.inc
  printf "\n# Tanzu shell completion\nsource '$HOME/.config/tanzu/completion.bash.inc'\n" >> $HOME/.bashrc

  ## NOTE: the bash-completion OS package must also be installed.

  ## If you invoke the 'tanzu' command using a different name or an alias such as,
  ## for example, 'tz', you must also include the following in your $HOME/.bashrc
  complete -o default -F __start_tanzu tz

# Zsh instructions:

  ## Load only for current session:
  autoload -U compinit; compinit
  source <(tanzu completion zsh)

  ## Load for all new sessions:
  echo "autoload -U compinit; compinit" >> $HOME/.zshrc
  tanzu completion zsh > "${fpath[1]}/_tanzu"

  ## Aliases are handled automatically, but if you have renamed the actual 'tanzu' binary to,
  ## for example, 'tz', you must also include the following in your $HOME/.zshrc
  compdef _tanzu tz

# Fish instructions:

  ## Load only for current session:
  tanzu completion fish | source

  ## Load for all new sessions:
  tanzu completion fish > $HOME/.config/fish/completions/tanzu.fish

  ## Aliases are handled automatically, but if you have renamed the actual 'tanzu' binary to,
  ## for example, 'tz', you must also include the following in your $HOME/.config/fish/config.fish
  complete --command tz --wraps tanzu

# Powershell instructions:

  ## Load only for current session:
  tanzu completion powershell | Out-String | Invoke-Expression

  ## Load for all new sessions:
  printf "\n# Tanzu shell completion\ntanzu completion powershell | Out-String | Invoke-Expression" >> $PROFILE

  ## If you invoke the 'tanzu' command using a different name or an alias such as,
  ## for example, 'tz', you must also include the following in your powershell $PROFILE.
  Register-ArgumentCompleter -CommandName 'tz' -ScriptBlock ${__tanzuCompleterBlock}

Flags:
  -h, --help   help for completion

$ tz completion
[x] : shell not specified, choose one of: bash, zsh, fish, powershell

$ tz generate-all-docs -h
Generate Cobra CLI docs for all plugins installed

Usage:
tanzu generate-all-docs [flags]

Flags:
  -d, --docs-dir string   destination for docs output (default "docs/cli/commands")
  -h, --help              help for generate-all-docs
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Use proper help format for "tanzu completion"
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
