### PR TITLE
Build a Chocolatey package that supports ARM64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,12 @@ choco-package: ## Build a Chocolatey package
 	fi
 	@# The nuspec file uses a variable but variables don't seem to work anymore
 	@# with chocolatey 2.0.0 so we continue using version 1.4.0
-	docker run --rm -e VERSION=$(BUILD_VERSION) -e SHA_FOR_CHOCO=$(SHA_FOR_CHOCO) -v $(ROOT_DIR):$(ROOT_DIR) $(CHOCO_IMAGE) $(ROOT_DIR)/hack/choco/build_package.sh
+	docker run --rm \
+		-e VERSION=$(BUILD_VERSION) \
+		-e SHA_FOR_CHOCO_AMD64=$(SHA_FOR_CHOCO_AMD64) \
+		-e SHA_FOR_CHOCO_ARM64=$(SHA_FOR_CHOCO_ARM64) \
+		-v $(ROOT_DIR):$(ROOT_DIR) \
+		$(CHOCO_IMAGE) $(ROOT_DIR)/hack/choco/build_package.sh
 
 ## --------------------------------------
 ## Testing

--- a/hack/choco/README.md
+++ b/hack/choco/README.md
@@ -13,20 +13,24 @@ used; a version with a `-` in it is considered a pre-release and will use the
 `tanzu-cli-unstable` package name, while other versions will use the
 official `tanzu-cli` package name.
 
+The package built will automatically handle the installation of either
+`amd64` or `arm64` Windows versions of the CLI based on the architecture
+of the machine on which the package is run.
+
 ## Building the Chocolatey package
 
 Executing the `hack/choco/build_package.sh` script will build the Chocolatey
 package under `hack/choco/_output/choco`.
 
 The `hack/choco/build_package.sh` script is meant to be run on a Linux machine
-that has `choco` installed.  This is most easily done using docker. Note that
-currently, the docker images for Chocolatey only support an `amd64`
-architecture. To facilitate building the package, the new `choco-package`
+that has `choco` installed.  This is most easily done using docker.
+To facilitate building the package, the new `choco-package`
 Makefile target has been added; this Makefile target will first start a docker
 container and then run the `hack/choco/build_package.sh` script.
 
-NOTE: This docker image can ONLY be run on an AMD64 machine (chocolatey crashes
-when running an AMD64 image on an ARM64 arch).
+NOTE: This docker image can ONLY be run on an AMD64 machine (even with emulation
+of AMD64 on Mac, the chocolatey binary crashes when running an AMD64 docker image
+on an ARM64 Mac).
 
 ```bash
 cd tanzu-cli
@@ -34,13 +38,14 @@ make choco-package
 ```
 
 Note that the `hack/choco/build_package.sh` script automatically fetches the
-required SHA for the CLI binary from the appropriate Github release.  If the
+required SHAs for the CLI binaries from the appropriate Github release.  If the
 Github release is not public yet, it is possible to provide the SHA manually
-through the environment variable `SHA_FOR_CHOCO` as shown below:
+through the environment variables `SHA_FOR_CHOCO_AMD64` and `SHA_FOR_CHOCO_ARM64`
+as shown below:
 
 ```bash
 cd tanzu-cli
-SHA_FOR_CHOCO=12345678901234567 make choco-package
+SHA_FOR_CHOCO_AMD64=1234567890 SHA_FOR_CHOCO_ARM64=0987654321 make choco-package
 ```
 
 Note: It is not possible to publish the Chocolatey package before the release

--- a/hack/choco/build_package.sh
+++ b/hack/choco/build_package.sh
@@ -26,19 +26,28 @@ mkdir -p ${OUTPUT_DIR}/
 # Remove the nupkg file made by `choco pack` in the working dir
 rm -f ${OUTPUT_DIR}/*.nupkg
 
-# Obtain SHA if it is not already specified in the variable SHA_FOR_CHOCO
-if [ -z "$SHA_FOR_CHOCO" ]; then
-   SHA_FOR_CHOCO=$(curl -sL https://github.com/vmware-tanzu/tanzu-cli/releases/download/v${VERSION}/tanzu-cli-binaries-checksums.txt | grep tanzu-cli-windows-amd64 |cut -f1 -d" ")
-   if [ -z "$SHA_FOR_CHOCO" ]; then
-      echo "Unable to determine SHA for package of version $VERSION"
+# Obtain SHA if it is not already specified in the variable SHA_FOR_CHOCO_AMD64
+if [ -z "$SHA_FOR_CHOCO_AMD64" ]; then
+   SHA_FOR_CHOCO_AMD64=$(curl -sL https://github.com/vmware-tanzu/tanzu-cli/releases/download/v${VERSION}/tanzu-cli-binaries-checksums.txt | grep tanzu-cli-windows-amd64 |cut -f1 -d" ")
+   if [ -z "$SHA_FOR_CHOCO_AMD64" ]; then
+      echo "Unable to determine SHA_AMD64 for package of version $VERSION"
       exit 1
    fi
 fi
+echo "Using SHA_AMD64: ${SHA_FOR_CHOCO_AMD64}"
 
-echo "Using SHA: ${SHA_FOR_CHOCO}"
+# Obtain SHA if it is not already specified in the variable SHA_FOR_CHOCO_ARM64
+if [ -z "$SHA_FOR_CHOCO_ARM64" ]; then
+   SHA_FOR_CHOCO_ARM64=$(curl -sL https://github.com/vmware-tanzu/tanzu-cli/releases/download/v${VERSION}/tanzu-cli-binaries-checksums.txt | grep tanzu-cli-windows-arm64 |cut -f1 -d" ")
+   if [ -z "$SHA_FOR_CHOCO_ARM64" ]; then
+      echo "Unable to determine SHA_ARM64 for package of version $VERSION"
+      exit 1
+   fi
+fi
+echo "Using SHA_ARM64: ${SHA_FOR_CHOCO_ARM64}"
 
 # Prepare install script
-sed -e s,__CLI_VERSION__,v${VERSION}, -e s,__CLI_SHA__,${SHA_FOR_CHOCO}, \
+sed -e s,__CLI_VERSION__,v${VERSION}, -e s,__CLI_SHA_AMD64__,${SHA_FOR_CHOCO_AMD64}, -e s,__CLI_SHA_ARM64__,${SHA_FOR_CHOCO_ARM64}, \
    ${BASE_DIR}/chocolateyInstall.ps1.tmpl > ${OUTPUT_DIR}/chocolateyInstall.ps1
 chmod a+x ${OUTPUT_DIR}/chocolateyInstall.ps1
 

--- a/hack/choco/chocolateyInstall.ps1.tmpl
+++ b/hack/choco/chocolateyInstall.ps1.tmpl
@@ -6,9 +6,17 @@ $releaseVersion = '__CLI_VERSION__'
 $packageName = 'tanzu-cli'
 $packagePath = "${releaseVersion}"
 $scriptsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url64 = "https://github.com/vmware-tanzu/tanzu-cli/releases/download/${releaseVersion}/tanzu-cli-windows-amd64.zip"
-$checksum64 = '__CLI_SHA__'
 $checksumType64 = 'sha256'
+
+# Check if we are dealing with an ARM64 architecture
+$os = Get-WmiObject -Class Win32_OperatingSystem
+if ($os.OSArchitecture -like "*ARM*") {
+    $url64 = "https://github.com/vmware-tanzu/tanzu-cli/releases/download/${releaseVersion}/tanzu-cli-windows-arm64-windows11.zip"
+    $checksum64 = '__CLI_SHA_ARM64__'
+} else {
+    $url64 = "https://github.com/vmware-tanzu/tanzu-cli/releases/download/${releaseVersion}/tanzu-cli-windows-amd64.zip"
+    $checksum64 = '__CLI_SHA_AMD64__'
+}
 
 $packageArgs = @{
     packageName    = $packageName
@@ -26,7 +34,8 @@ function Install-TanzuEnvironment {
     # Note that we use the scriptsDir path because chocolatey doesn't put
     # binaries on the $PATH until _after_ the install script runs.
     $tanzuExe = "${scriptsDir}\${packagePath}\tanzu.exe"
-    Move-Item "${scriptsDir}\${packagePath}\tanzu-cli-windows_amd64.exe" "${tanzuExe}"
+    # Use a glob pattern since the binary could be for arm64 or amd64
+    Move-Item "${scriptsDir}\${packagePath}\tanzu-cli-windows_*.exe" "${tanzuExe}"
 
     # Setup shell completion
     if (Test-Path -Path $PROFILE) {


### PR DESCRIPTION
### What this PR does / why we need it

This PR updates the Chocolatey package to be able to install a Windows ARM64 CLI build when running on an ARM64 Windows.

To do this, the build script now handles two binaries, the one for AMD64 and the one for ARM64, each one with its own SHA.  Both SHAs are injected in the `chocolateyInstall.ps1.tmpl` template file which is then used as the installation script.  At installation time, this script checks if its running on an ARM64 machine or an AMD64 machine and then downloads the appropriate CLI Windows binary.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Part of #357 

### Describe testing done for PR

This is hard to test directly because there is no Windows ARM64 version currently published on this repo's Github release page.  So what I did was pretend that the `v1.0.0` AMD64 was the ARM64 version, and that the `v1.1.0` AMD64 version was the AMD64 version.  I built the new Chocolatey package with those "hacks" and then ran it on:
1. Windows 11 AMD64 and confirmed the AMD64 CLI was installed (so `v1.1.0`)
2. Windows 11 ARM64 and confirmed the ARM64 CLI was installed (so `v1.0.0`)
3. Windows 10 AMD64 and confirmed the AMD64 CLI was installed (so `v1.1.0`)
 
I also tested building the new Chocolatey package using VMware's internal build system and confirmed the proper installation script was generated using the expected SHAs for AMD64 and ARM64.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add support to install the Windows ARM64 CLI through Chocolatey.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

The script assumes that the Github binary for Windows ARM64 is named `tanzu-cli-windows-arm64-windows11.zip`.
This may need a bit of discussion.

