### PR TITLE
E2E: Install tools as part of E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ test-with-summary-report: tools
 	rm ./make_test.output ./test_suite_output.json ./CLI-ginkgo-tests-summary.txt ./CLI-junit-report.xml
 
 .PHONY: e2e-cli-core ## Execute all CLI Core E2E Tests
-e2e-cli-core: start-test-central-repo start-airgapped-local-registry e2e-cli-core-all ## Execute all CLI Core E2E Tests
+e2e-cli-core: tools start-test-central-repo start-airgapped-local-registry e2e-cli-core-all ## Execute all CLI Core E2E Tests
 
 .PHONY: setup-custom-cert-for-test-central-repo
 setup-custom-cert-for-test-central-repo: ## Setup up the custom ca cert for test-central-repo in the config file


### PR DESCRIPTION
This pull request installs all the necessary tools before executing the E2E tests.
When running the CLI core E2E tests (using `make e2e-cli-core`), the process requires tools such as ginkgo, kind, etc. By including the tools target (`make tools`) as part of the E2E tests, it ensures the installation of all the necessary tools for successful execution.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
**Before the fix:**
The make target `make e2e-cli-core` does not install all required tools:
```
❯ make e2e-cli-core
echo "Adding docker test central repo cert to the config file"
Adding docker test central repo cert to the config file
TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER="No" TANZU_CLI_EULA_PROMPT_ANSWER="Yes" /Users/cpamuluri/tkg/tasks/cli_core_main_3/tanzu-cli/bin/tanzu config cert delete localhost:9876 || true
[ok] deleted certificate data for host localhost:9876
/Users/cpamuluri/tkg/tasks/cli_core_main_3/tanzu-cli/bin/tanzu config cert add --host localhost:9876 --ca-cert /Users/cpamuluri/tkg/tasks/cli_core_main_3/tanzu-cli/hack/central-repo/certs/localhost.crt

```
**After the fix:**
The make target `make e2e-cli-core` installs the all required tools.
```
❯ make e2e-cli-core
make -C /Users/cpamuluri/tkg/tasks/cli_core_main_3/tanzu-cli/hack/tools goimports
mkdir -p bin
GOBIN=/Users/cpamuluri/tkg/tasks/cli_core_main_3/tanzu-cli/hack/tools/bin go install golang.org/x/tools/cmd/goimports@v0.13.0
make -C /Users/cpamuluri/tkg/tasks/cli_core_main_3/tanzu-cli/hack/tools golangci-lint
mkdir -p bin
GOBIN=/Users/cpamuluri/tkg/tasks/cli_core_main_3/tanzu-cli/hack/tools/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
# github.com/golangci/golangci-lint/cmd/golangci-lint
ld: warning: -bind_at_load is deprecated on macOS
make -C /Users/cpamuluri/tkg/tasks/cli_core_main_3/tanzu-cli/hack/tools vale
mkdir -p bin
# vale uses 'macOS' for darwin, 'Linux' for linux, '64-bit' for amd64 (yet arm64 remains unchanged)
# for its release asset naming, so manually map them
curl -sfL https://github.com/errata-ai/vale/releases/download/v2.20.1/vale_2.20.1_macOS_64-bit.tar.gz | tar -xz -C /tmp/
mv /tmp/vale bin/vale
chmod a+x bin/vale
make -C /Users/cpamuluri/tkg/tasks/cli_core_main_3/tanzu-cli/hack/tools misspell
mkdir -p bin
GOBIN=/Users/cpamuluri/tkg/tasks/cli_core_main_3/tanzu-cli/hack/tools/bin go install  github.com/client9/misspell/cmd/misspell@v0.3.4
make -C /Users/cpamuluri/tkg/tasks/cli_core_main_3/tanzu-cli/hack/tools controller-gen
mkdir -p bin
#go build -tags=tools -o bin/controller-gen sigs.k8s.io/controller-tools/cmd/controller-gen
GOBIN=/Users/cpamuluri/tkg/tasks/cli_core_main_3/tanzu-cli/hack/tools/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2
make -C /Users/cpamuluri/tkg/tasks/cli_core_main_3/tanzu-cli/hack/tools imgpkg
mkdir -p bin
curl -LO https://github.com/vmware-tanzu/carvel-imgpkg/releases/download/v0.35.0/imgpkg-darwin-amd64
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 17.2M  100 17.2M    0     0  8856k      0  0:00:01  0:00:01 --:--:-- 18.0M
mv imgpkg-darwin-amd64 bin/imgpkg
chmod a+x bin/imgpkg
make -C /Users/cpamuluri/tkg/tasks/cli_core_main_3/tanzu-cli/hack/tools kubectl
mkdir -p bin
curl -LO https://dl.k8s.io/release/v1.26.0/bin/darwin/amd64/kubectl
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   138  100   138    0     0    248      0 --:--:-- --:--:-- --:--:--   251
 97 51.2M   97 49.9M    0     0  1701k      0  0:00:30  0:00:30 --:--:-- 1900k
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
