### PR TITLE
Update `tanzu context update  tanzu-active-resource` to support `--clustergroup` flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ replace cloud.google.com/go => cloud.google.com/go v0.102.1
 
 replace github.com/vmware-tanzu/tanzu-cli/test/e2e/framework => ./test/e2e/framework
 
+replace github.com/vmware-tanzu/tanzu-plugin-runtime => github.com/anujc25/tanzu-plugin-runtime v0.0.0-20231215153217-450decceb82b
+
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/Masterminds/semver v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ replace cloud.google.com/go => cloud.google.com/go v0.102.1
 
 replace github.com/vmware-tanzu/tanzu-cli/test/e2e/framework => ./test/e2e/framework
 
-replace github.com/vmware-tanzu/tanzu-plugin-runtime => github.com/anujc25/tanzu-plugin-runtime v0.0.0-20231215153217-450decceb82b
+replace github.com/vmware-tanzu/tanzu-plugin-runtime => github.com/anujc25/tanzu-plugin-runtime v0.0.0-20231226212532-363c7ea75e7b
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,6 @@ replace cloud.google.com/go => cloud.google.com/go v0.102.1
 
 replace github.com/vmware-tanzu/tanzu-cli/test/e2e/framework => ./test/e2e/framework
 
-replace github.com/vmware-tanzu/tanzu-plugin-runtime => github.com/anujc25/tanzu-plugin-runtime v0.0.0-20231226212532-363c7ea75e7b
-
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/Masterminds/semver v1.5.0
@@ -44,7 +42,7 @@ require (
 	github.com/vmware-tanzu/carvel-ytt v0.40.0
 	github.com/vmware-tanzu/tanzu-cli/test/e2e/framework v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686
-	github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0
+	github.com/vmware-tanzu/tanzu-plugin-runtime v1.2.0-dev.0.20231226233521-ad86606a9e90
 	go.pinniped.dev v0.20.0
 	golang.org/x/mod v0.12.0
 	golang.org/x/oauth2 v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,6 @@ github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmx
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
 github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/anujc25/tanzu-plugin-runtime v0.0.0-20231226212532-363c7ea75e7b h1:/n/Uzfs1xUrF9kvV09twRqhWMpYt5onmaMHi+bJuSaw=
-github.com/anujc25/tanzu-plugin-runtime v0.0.0-20231226212532-363c7ea75e7b/go.mod h1:M7WVZoItdyQp53tEprQIa6PZmhbrLe3CzuyQphWuRyI=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
@@ -738,6 +736,8 @@ github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502eb
 github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502ebf68/go.mod h1:e1Uef+Ux5BIHpYwqbeP2ZZmOzehBcez2vUEWXHe+xHE=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686 h1:VcuXqUXFxm5WDqWkzAlU/6cJXua0ozELnqD59fy7J6E=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686/go.mod h1:AFGOXZD4tH+KhpmtV0VjWjllXhr8y57MvOsIxTtywc4=
+github.com/vmware-tanzu/tanzu-plugin-runtime v1.2.0-dev.0.20231226233521-ad86606a9e90 h1:JqF2XLGmzHo7sNaOfZ17YTu6ZJR3SogiWjYQ8UWRVdI=
+github.com/vmware-tanzu/tanzu-plugin-runtime v1.2.0-dev.0.20231226233521-ad86606a9e90/go.mod h1:M7WVZoItdyQp53tEprQIa6PZmhbrLe3CzuyQphWuRyI=
 github.com/xanzy/go-gitlab v0.83.0 h1:37p0MpTPNbsTMKX/JnmJtY8Ch1sFiJzVF342+RvZEGw=
 github.com/xanzy/go-gitlab v0.83.0/go.mod h1:5ryv+MnpZStBH8I/77HuQBsMbBGANtVpLWC15qOjWAw=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmx
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
 github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/anujc25/tanzu-plugin-runtime v0.0.0-20231215153217-450decceb82b h1:TD/9A+n/UYO2UD7OWbDQ8m3PQ6I5ICYfB0t8+lYRVnQ=
+github.com/anujc25/tanzu-plugin-runtime v0.0.0-20231215153217-450decceb82b/go.mod h1:M7WVZoItdyQp53tEprQIa6PZmhbrLe3CzuyQphWuRyI=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
@@ -736,8 +738,6 @@ github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502eb
 github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502ebf68/go.mod h1:e1Uef+Ux5BIHpYwqbeP2ZZmOzehBcez2vUEWXHe+xHE=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686 h1:VcuXqUXFxm5WDqWkzAlU/6cJXua0ozELnqD59fy7J6E=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686/go.mod h1:AFGOXZD4tH+KhpmtV0VjWjllXhr8y57MvOsIxTtywc4=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0 h1:HtlrUyddxVzn4rZBtW6kQM4v2I6bgI0C/k9wJzGrbjE=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0/go.mod h1:M7WVZoItdyQp53tEprQIa6PZmhbrLe3CzuyQphWuRyI=
 github.com/xanzy/go-gitlab v0.83.0 h1:37p0MpTPNbsTMKX/JnmJtY8Ch1sFiJzVF342+RvZEGw=
 github.com/xanzy/go-gitlab v0.83.0/go.mod h1:5ryv+MnpZStBH8I/77HuQBsMbBGANtVpLWC15qOjWAw=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmx
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
 github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/anujc25/tanzu-plugin-runtime v0.0.0-20231215153217-450decceb82b h1:TD/9A+n/UYO2UD7OWbDQ8m3PQ6I5ICYfB0t8+lYRVnQ=
-github.com/anujc25/tanzu-plugin-runtime v0.0.0-20231215153217-450decceb82b/go.mod h1:M7WVZoItdyQp53tEprQIa6PZmhbrLe3CzuyQphWuRyI=
+github.com/anujc25/tanzu-plugin-runtime v0.0.0-20231226212532-363c7ea75e7b h1:/n/Uzfs1xUrF9kvV09twRqhWMpYt5onmaMHi+bJuSaw=
+github.com/anujc25/tanzu-plugin-runtime v0.0.0-20231226212532-363c7ea75e7b/go.mod h1:M7WVZoItdyQp53tEprQIa6PZmhbrLe3CzuyQphWuRyI=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=

--- a/go.work.sum
+++ b/go.work.sum
@@ -301,6 +301,8 @@ github.com/aliyun/credentials-go v1.2.3/go.mod h1:/KowD1cfGSLrLsH28Jr8W+xwoId0yw
 github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
 github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 h1:yL7+Jz0jTC6yykIK/Wh74gnTJnrGr5AyrNMXuA0gves=
 github.com/antlr/antlr4/runtime/Go/antlr v1.4.10/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
+github.com/anujc25/tanzu-plugin-runtime v0.0.0-20231215153217-450decceb82b h1:TD/9A+n/UYO2UD7OWbDQ8m3PQ6I5ICYfB0t8+lYRVnQ=
+github.com/anujc25/tanzu-plugin-runtime v0.0.0-20231215153217-450decceb82b/go.mod h1:M7WVZoItdyQp53tEprQIa6PZmhbrLe3CzuyQphWuRyI=
 github.com/apache/beam/sdks/v2 v2.47.0-RC3 h1:Y/FmwSp2FfVwbfM81Ix+LPENDurLIbIwkz35tXu8CIQ=
 github.com/apache/beam/sdks/v2 v2.47.0-RC3/go.mod h1:n8ybxT4OltLeoykTV8CGg/xQ1yrUJw13aJRkQY36lE8=
 github.com/armon/go-metrics v0.4.0 h1:yCQqn7dwca4ITXb+CbubHmedzaQYHhNhrEXLYUeEe8Q=
@@ -425,7 +427,6 @@ github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d h1:105gxyaGwC
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
-github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flatcar/container-linux-config-transpiler v0.9.4 h1:yXQ0NB8PeNrKJPrZvbv5/DV63PNhTqt8vaf8YxmX/RA=
@@ -819,8 +820,6 @@ go.opentelemetry.io/proto/otlp v0.19.0 h1:IVN6GR+mhC4s5yfcTbmzHYODqvWAp3ZedA2SJP
 go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
 go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 h1:+FNtrFTmVw0YZGpBGX56XDee331t6JAXeK2bcyhLOOc=
 go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5/go.mod h1:nmDLcffg48OtT/PSW0Hg7FvpRQsQh5OSqIylirxKC7o=
-go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
-go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
 go4.org v0.0.0-20201209231011-d4a079459e60 h1:iqAGo78tVOJXELHQFRjR6TMwItrvXH4hrGJ32I/NFF8=
 go4.org v0.0.0-20201209231011-d4a079459e60/go.mod h1:CIiUVy99QCPfoE13bO4EZaz5GZMZXMSBGhxRdsvzbkg=
 gocloud.dev v0.29.0 h1:fBy0jwJSmxs0IjT0fE32MO+Mj+307VZQwyHaTyFZbC4=

--- a/go.work.sum
+++ b/go.work.sum
@@ -301,8 +301,6 @@ github.com/aliyun/credentials-go v1.2.3/go.mod h1:/KowD1cfGSLrLsH28Jr8W+xwoId0yw
 github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
 github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 h1:yL7+Jz0jTC6yykIK/Wh74gnTJnrGr5AyrNMXuA0gves=
 github.com/antlr/antlr4/runtime/Go/antlr v1.4.10/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
-github.com/anujc25/tanzu-plugin-runtime v0.0.0-20231226212532-363c7ea75e7b h1:/n/Uzfs1xUrF9kvV09twRqhWMpYt5onmaMHi+bJuSaw=
-github.com/anujc25/tanzu-plugin-runtime v0.0.0-20231226212532-363c7ea75e7b/go.mod h1:M7WVZoItdyQp53tEprQIa6PZmhbrLe3CzuyQphWuRyI=
 github.com/apache/beam/sdks/v2 v2.47.0-RC3 h1:Y/FmwSp2FfVwbfM81Ix+LPENDurLIbIwkz35tXu8CIQ=
 github.com/apache/beam/sdks/v2 v2.47.0-RC3/go.mod h1:n8ybxT4OltLeoykTV8CGg/xQ1yrUJw13aJRkQY36lE8=
 github.com/armon/go-metrics v0.4.0 h1:yCQqn7dwca4ITXb+CbubHmedzaQYHhNhrEXLYUeEe8Q=

--- a/go.work.sum
+++ b/go.work.sum
@@ -301,8 +301,8 @@ github.com/aliyun/credentials-go v1.2.3/go.mod h1:/KowD1cfGSLrLsH28Jr8W+xwoId0yw
 github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
 github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 h1:yL7+Jz0jTC6yykIK/Wh74gnTJnrGr5AyrNMXuA0gves=
 github.com/antlr/antlr4/runtime/Go/antlr v1.4.10/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
-github.com/anujc25/tanzu-plugin-runtime v0.0.0-20231215153217-450decceb82b h1:TD/9A+n/UYO2UD7OWbDQ8m3PQ6I5ICYfB0t8+lYRVnQ=
-github.com/anujc25/tanzu-plugin-runtime v0.0.0-20231215153217-450decceb82b/go.mod h1:M7WVZoItdyQp53tEprQIa6PZmhbrLe3CzuyQphWuRyI=
+github.com/anujc25/tanzu-plugin-runtime v0.0.0-20231226212532-363c7ea75e7b h1:/n/Uzfs1xUrF9kvV09twRqhWMpYt5onmaMHi+bJuSaw=
+github.com/anujc25/tanzu-plugin-runtime v0.0.0-20231226212532-363c7ea75e7b/go.mod h1:M7WVZoItdyQp53tEprQIa6PZmhbrLe3CzuyQphWuRyI=
 github.com/apache/beam/sdks/v2 v2.47.0-RC3 h1:Y/FmwSp2FfVwbfM81Ix+LPENDurLIbIwkz35tXu8CIQ=
 github.com/apache/beam/sdks/v2 v2.47.0-RC3/go.mod h1:n8ybxT4OltLeoykTV8CGg/xQ1yrUJw13aJRkQY36lE8=
 github.com/armon/go-metrics v0.4.0 h1:yCQqn7dwca4ITXb+CbubHmedzaQYHhNhrEXLYUeEe8Q=

--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -1260,6 +1260,7 @@ type ContextListOutputRow struct {
 	KubeContext    string
 	Project        string
 	Space          string
+	ClusterGroup   string
 }
 
 func displayContextListOutputWithDynamicColumns(cfg *configtypes.ClientConfig, writer io.Writer) {
@@ -1274,6 +1275,7 @@ func displayContextListOutputWithDynamicColumns(cfg *configtypes.ClientConfig, w
 		context := NA
 		project := NA
 		space := NA
+		clustergroup := NA
 
 		isCurrent := ctx.Name == cfg.CurrentContext[ctx.ContextType]
 
@@ -1285,6 +1287,7 @@ func displayContextListOutputWithDynamicColumns(cfg *configtypes.ClientConfig, w
 		case configtypes.ContextTypeTanzu:
 			project = ""
 			space = ""
+			clustergroup = ""
 			ep = ""
 			path = ""
 			context = ""
@@ -1299,6 +1302,9 @@ func displayContextListOutputWithDynamicColumns(cfg *configtypes.ClientConfig, w
 			if ctx.AdditionalMetadata[config.SpaceNameKey] != nil {
 				space = ctx.AdditionalMetadata[config.SpaceNameKey].(string)
 			}
+			if ctx.AdditionalMetadata[config.ClusterGroupNameKey] != nil {
+				clustergroup = ctx.AdditionalMetadata[config.ClusterGroupNameKey].(string)
+			}
 		default:
 			if ctx.ClusterOpts != nil {
 				ep = ctx.ClusterOpts.Endpoint
@@ -1306,7 +1312,7 @@ func displayContextListOutputWithDynamicColumns(cfg *configtypes.ClientConfig, w
 				context = ctx.ClusterOpts.Context
 			}
 		}
-		row := ContextListOutputRow{ctx.Name, strconv.FormatBool(isCurrent), string(ctx.ContextType), ep, path, context, project, space}
+		row := ContextListOutputRow{ctx.Name, strconv.FormatBool(isCurrent), string(ctx.ContextType), ep, path, context, project, space, clustergroup}
 		rows = append(rows, row)
 	}
 

--- a/pkg/command/context_test.go
+++ b/pkg/command/context_test.go
@@ -199,7 +199,7 @@ var _ = Describe("Test tanzu context command", func() {
 			columnsString := strings.Join(strings.Fields(lines[0]), " ")
 
 			Expect(err).To(BeNil())
-			Expect(columnsString).To(Equal("NAME ISACTIVE TYPE ENDPOINT KUBECONFIGPATH KUBECONTEXT PROJECT SPACE"))
+			Expect(columnsString).To(Equal("NAME ISACTIVE TYPE ENDPOINT KUBECONFIGPATH KUBECONTEXT PROJECT SPACE CLUSTERGROUP"))
 		})
 
 		It("should return with tanzu related columns when listing all contexts", func() {
@@ -210,7 +210,7 @@ var _ = Describe("Test tanzu context command", func() {
 			columnsString := strings.Join(strings.Fields(lines[0]), " ")
 
 			Expect(err).To(BeNil())
-			Expect(columnsString).To(Equal("NAME ISACTIVE TYPE ENDPOINT KUBECONFIGPATH KUBECONTEXT PROJECT SPACE"))
+			Expect(columnsString).To(Equal("NAME ISACTIVE TYPE ENDPOINT KUBECONFIGPATH KUBECONTEXT PROJECT SPACE CLUSTERGROUP"))
 		})
 
 		It("should not return tanzu related columns when not listing tanzu contexts", func() {

--- a/pkg/telemetry/metrics_helper.go
+++ b/pkg/telemetry/metrics_helper.go
@@ -62,7 +62,8 @@ func computeEndpointSHAForTanzuContext(ctx *configtypes.Context) string {
 	return hashString(ctx.GlobalOpts.Endpoint +
 		stringValue(ctx.AdditionalMetadata[configlib.OrgIDKey]) +
 		stringValue(ctx.AdditionalMetadata[configlib.ProjectNameKey]) +
-		stringValue(ctx.AdditionalMetadata[configlib.SpaceNameKey]))
+		stringValue(ctx.AdditionalMetadata[configlib.SpaceNameKey]) +
+		stringValue(ctx.AdditionalMetadata[configlib.ClusterGroupNameKey]))
 }
 
 func computeEndpointSHAForTMCContext(ctx *configtypes.Context) string {

--- a/pkg/telemetry/metrics_helper_test.go
+++ b/pkg/telemetry/metrics_helper_test.go
@@ -24,8 +24,9 @@ var _ = Describe("metrics helper tests", func() {
 		err          error
 	)
 	const (
-		testProjectName = "project-A"
-		testSpaceName   = "space-A"
+		testProjectName      = "project-A"
+		testSpaceName        = "space-A"
+		testClusterGroupName = "clustergroup-A"
 	)
 	BeforeEach(func() {
 		configFile, err = os.CreateTemp("", "config")
@@ -74,6 +75,7 @@ var _ = Describe("metrics helper tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			ctx.AdditionalMetadata[configlib.ProjectNameKey] = ""
 			ctx.AdditionalMetadata[configlib.SpaceNameKey] = ""
+			// Also when the ClusterGroupNameKey is not configured under AdditionalMetadata
 			err = configlib.SetContext(ctx, true)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -84,6 +86,7 @@ var _ = Describe("metrics helper tests", func() {
 			// when tanzu context has active project
 			ctx.AdditionalMetadata[configlib.ProjectNameKey] = testProjectName
 			ctx.AdditionalMetadata[configlib.SpaceNameKey] = ""
+			ctx.AdditionalMetadata[configlib.ClusterGroupNameKey] = ""
 			err = configlib.SetContext(ctx, true)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -94,6 +97,14 @@ var _ = Describe("metrics helper tests", func() {
 			// when tanzu context has active space
 			ctx.AdditionalMetadata[configlib.ProjectNameKey] = testProjectName
 			ctx.AdditionalMetadata[configlib.SpaceNameKey] = testSpaceName
+			ctx.AdditionalMetadata[configlib.ClusterGroupNameKey] = ""
+			err = configlib.SetContext(ctx, true)
+			Expect(err).ToNot(HaveOccurred())
+
+			// when tanzu context has active clustergroup
+			ctx.AdditionalMetadata[configlib.ProjectNameKey] = testProjectName
+			ctx.AdditionalMetadata[configlib.SpaceNameKey] = ""
+			ctx.AdditionalMetadata[configlib.ClusterGroupNameKey] = testClusterGroupName
 			err = configlib.SetContext(ctx, true)
 			Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
### What this PR does / why we need it
- Update `tanzu context update  tanzu-active-resource` to support `--clustergroup` flag
- As part of this change, the context object within the `config-ng.yaml` file also saves `tanzuClusterGroupName` under the `additionalMetadata` section.
```
      additionalMetadata:
        tanzuClusterGroupName: clustergroupA
        tanzuOrgID: b1d48027-bb69-4a56-a5b8-e941ef29fa4b
        tanzuProjectName: projectA
        tanzuSpaceName: ""
```

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR


```
## Set project as active
$ tz context update tanzu-active-resource one-tanzu-demo-1 --project "projectA"
$ tz context list
  NAME              ISACTIVE  TYPE        ENDPOINT                                                                         KUBECONFIGPATH             KUBECONTEXT                 PROJECT   SPACE  CLUSTERGROUP  
  one-tanzu-demo-1  false     tanzu       https://api.tanzu-dev.cloud.vmware.com/org/b1d48027-bb69-4a56-a5b8-e941ef29fa4b  /Users/anujc/.kube/config  tanzu-cli-one-tanzu-demo-1  projectA                       
  tkg-mc-1          true      kubernetes                                                                                   /Users/anujc/.kube/config  kind-mc-1                   n/a       n/a    n/a           
```
```
## Set space within a project as active
$ tz context update tanzu-active-resource one-tanzu-demo-1 --project "projectA" --space "spaceA"
$ tz context list
  NAME              ISACTIVE  TYPE        ENDPOINT                                                                         KUBECONFIGPATH             KUBECONTEXT                 PROJECT   SPACE   CLUSTERGROUP  
  one-tanzu-demo-1  false     tanzu       https://api.tanzu-dev.cloud.vmware.com/org/b1d48027-bb69-4a56-a5b8-e941ef29fa4b  /Users/anujc/.kube/config  tanzu-cli-one-tanzu-demo-1  projectA  spaceA                
  tkg-mc-1          true      kubernetes                                                                                   /Users/anujc/.kube/config  kind-mc-1                   n/a       n/a     n/a           
```
```
## Set clustergroup within a project as active
$ tz context update tanzu-active-resource one-tanzu-demo-1 --project "projectA" --clustergroup "clustergroupA"
$ tz context list
  NAME              ISACTIVE  TYPE        ENDPOINT                                                                         KUBECONFIGPATH             KUBECONTEXT                 PROJECT   SPACE  CLUSTERGROUP   
  one-tanzu-demo-1  false     tanzu       https://api.tanzu-dev.cloud.vmware.com/org/b1d48027-bb69-4a56-a5b8-e941ef29fa4b  /Users/anujc/.kube/config  tanzu-cli-one-tanzu-demo-1  projectA         clustergroupA  
  tkg-mc-1          true      kubernetes                                                                                   /Users/anujc/.kube/config  kind-mc-1                   n/a       n/a    n/a            
```

- Incorrect input tests:
```
## Try to set space and clustergroup both within a project as active
$ tz context update tanzu-active-resource one-tanzu-demo-1 --project "projectA" --space "spaceA"  --clustergroup "clustergroupA"
[x] : either space or clustergroup can be set as active resource. Please provide either --space or --clustergroup option

## Try to set clustergroup without a project
$ tz context update tanzu-active-resource one-tanzu-demo-1 --clustergroup "clustergroupA"
[x] : clustergroup cannot be set without project name. Please provide project name also using --project option

## Try to set space without a project
$ tz context update tanzu-active-resource one-tanzu-demo-1 --space "spaceA"
[x] : space cannot be set without project name. Please provide project name also using --project option
```


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Support configuring ClusterGroup with the `tanzu context update  tanzu-active-resource` command using `--clustergroup` flag
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
