### PR TITLE
Warn user of shadowed variables on "config get"

### DIFF
--- a/test/e2e/config/config_suite_test.go
+++ b/test/e2e/config/config_suite_test.go
@@ -30,7 +30,7 @@ const (
 	featureFlagPrefix          = "features.global.e2e-test-"
 	numberOfFlagsForStressTest = 100
 	noErrorForFeatureFlagSet   = "there should not be any error for global feature flag set operation"
-	noErrorForFeatureFlagGet   = "there should not be any error for global feature flag set operation"
+	noErrorForFeatureFlagGet   = "there should not be any error for global feature flag get operation"
 	noErrorForConfigInit       = "there should not be any error for config init operation"
 )
 

--- a/test/e2e/framework/framework_constants.go
+++ b/test/e2e/framework/framework_constants.go
@@ -23,7 +23,7 @@ const (
 	// Config commands
 	ConfigCmd          = "%s config"
 	ConfigSet          = "%s config set "
-	ConfigGet          = "%s config get "
+	ConfigGet          = "%s config get"
 	ConfigUnset        = "%s config unset "
 	ConfigInit         = "%s config init"
 	ConfigServerList   = "%s config server list"


### PR DESCRIPTION
### What this PR does / why we need it

When running `tanzu config get` the user will now get a warning if some configured variables are shadowed by the same variable set in the shell. This aims to make it easier to understand the behaviour of the CLI when a variable value set in its config is not the one used.

Also this commit removes the extra empty line at the end of the output of `tanzu config get`.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

```
$ # Plain config get
$ tz config get
clientOptions:
    cli:
        edition: tkg
        bomRepo: projects.registry.vmware.com/tkg
        compatibilityFilePath: tkg-compatibility
    features:
        global:
            context-target-v2: "true"
cli:
    ceipOptIn: "false"
    eulaStatus: accepted
    discoverySources:
        - oci:
            name: default
            image: projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest
    cliId: 7ad8775d-fef6-40d6-ac78-d8d273c2b557
    telemetry:
        source: /Users/kmarc/.config/tanzu-cli-telemetry/cli_metrics.db
$
$ # Add some variables
$ tz config set env.TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST localhost:9876/tanzu-cli/plugins/central:small
$ tz config set env.TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY localhost:9876/tanzu-cli/plugins/central:small
$ tz config set env.TEST hello
$
# Plain config get (with variables in the config only)
$ tz config get
clientOptions:
    cli:
        edition: tkg
        bomRepo: projects.registry.vmware.com/tkg
        compatibilityFilePath: tkg-compatibility
    features:
        global:
            context-target-v2: "true"
    env:
        TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY: localhost:9876/tanzu-cli/plugins/central:small
        TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST: localhost:9876/tanzu-cli/plugins/central:small
        TEST: hello
cli:
    ceipOptIn: "false"
    eulaStatus: accepted
    discoverySources:
        - oci:
            name: default
            image: projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest
    cliId: 7ad8775d-fef6-40d6-ac78-d8d273c2b557
    telemetry:
$
$ # Set a shell variable directly on the command line and check the warning at the end of "config get"
$ TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY=some.other.url tz config get
clientOptions:
    cli:
        edition: tkg
        bomRepo: projects.registry.vmware.com/tkg
        compatibilityFilePath: tkg-compatibility
    features:
        global:
            context-target-v2: "true"
    env:
        TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY: localhost:9876/tanzu-cli/plugins/central:small
        TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST: localhost:9876/tanzu-cli/plugins/central:small
        TEST: hello
cli:
    ceipOptIn: "false"
    eulaStatus: accepted
    discoverySources:
        - oci:
            name: default
            image: projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest
    cliId: 7ad8775d-fef6-40d6-ac78-d8d273c2b557
    telemetry:
        source: /Users/kmarc/.config/tanzu-cli-telemetry/cli_metrics.db

Note: The following variables set in the current shell take precedence over the ones of the same name set in the tanzu config:
    - TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY: some.other.url
$
$ # Export a shell variable set to an EMPTY value and check the warning at the end of "config get"
$ export TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST=
$ tz config get
clientOptions:
    cli:
        edition: tkg
        bomRepo: projects.registry.vmware.com/tkg
        compatibilityFilePath: tkg-compatibility
    features:
        global:
            context-target-v2: "true"
    env:
        TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY: localhost:9876/tanzu-cli/plugins/central:small
        TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST: localhost:9876/tanzu-cli/plugins/central:small
        TEST: hello
cli:
    ceipOptIn: "false"
    eulaStatus: accepted
    discoverySources:
        - oci:
            name: default
            image: projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest
    cliId: 7ad8775d-fef6-40d6-ac78-d8d273c2b557
    telemetry:
        source: /Users/kmarc/.config/tanzu-cli-telemetry/cli_metrics.db

Note: The following variables set in the current shell take precedence over the ones of the same name set in the tanzu config:
    - TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST: ''
$
$ # Export a second shell variable and check the warning
$ export TEST=other
$ tz config get
clientOptions:
    cli:
        edition: tkg
        bomRepo: projects.registry.vmware.com/tkg
        compatibilityFilePath: tkg-compatibility
    features:
        global:
            context-target-v2: "true"
    env:
        TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY: localhost:9876/tanzu-cli/plugins/central:small
        TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST: localhost:9876/tanzu-cli/plugins/central:small
        TEST: hello
cli:
    ceipOptIn: "false"
    eulaStatus: accepted
    discoverySources:
        - oci:
            name: default
            image: projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest
    cliId: 7ad8775d-fef6-40d6-ac78-d8d273c2b557
    telemetry:
        source: /Users/kmarc/.config/tanzu-cli-telemetry/cli_metrics.db

Note: The following variables set in the current shell take precedence over the ones of the same name set in the tanzu config:
    - TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST: ''
    - TEST: other
$
$ # Unset a variable and check the warning
$ unset TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST
$ tz config get
clientOptions:
    cli:
        edition: tkg
        bomRepo: projects.registry.vmware.com/tkg
        compatibilityFilePath: tkg-compatibility
    features:
        global:
            context-target-v2: "true"
    env:
        TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY: localhost:9876/tanzu-cli/plugins/central:small
        TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST: localhost:9876/tanzu-cli/plugins/central:small
        TEST: hello
cli:
    ceipOptIn: "false"
    eulaStatus: accepted
    discoverySources:
        - oci:
            name: default
            image: projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest
    cliId: 7ad8775d-fef6-40d6-ac78-d8d273c2b557
    telemetry:
        source: /Users/kmarc/.config/tanzu-cli-telemetry/cli_metrics.db

Note: The following variables set in the current shell take precedence over the ones of the same name set in the tanzu config:
    - TEST: other
$
$ # Unset the second variable and check no more warning
$ unset TEST
$ tz config get
clientOptions:
    cli:
        edition: tkg
        bomRepo: projects.registry.vmware.com/tkg
        compatibilityFilePath: tkg-compatibility
    features:
        global:
            context-target-v2: "true"
    env:
        TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY: localhost:9876/tanzu-cli/plugins/central:small
        TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST: localhost:9876/tanzu-cli/plugins/central:small
        TEST: hello
cli:
    ceipOptIn: "false"
    eulaStatus: accepted
    discoverySources:
        - oci:
            name: default
            image: projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest
    cliId: 7ad8775d-fef6-40d6-ac78-d8d273c2b557
    telemetry:
        source: /Users/kmarc/.config/tanzu-cli-telemetry/cli_metrics.db
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The `tanzu config get` command now prints a note to the user if environment variables from the tanzu config are being shadowed by environment variables set in the current shell.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
