### PR TITLE
Allow for shell vars set to an empty value

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -76,7 +76,7 @@ func ConfigureEnvVariables() {
 	for variable, value := range envMap {
 		// If environment variable is not already set
 		// set the environment variable
-		if os.Getenv(variable) == "" {
+		if _, isSet := os.LookupEnv(variable); !isSet {
 			os.Setenv(variable, value)
 		}
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -32,6 +32,20 @@ var _ = Describe("config env variables", func() {
 			Expect(os.Getenv(envVar)).To(Equal(envVar))
 			os.Setenv(envVar, prevValue)
 		})
+		It("env variable should not be changed if it already exists", func() {
+			existingVal := "existing"
+			os.Setenv(envVar, existingVal)
+			ConfigureEnvVariables()
+			Expect(os.Getenv(envVar)).To(Equal(existingVal))
+			os.Setenv(envVar, prevValue)
+		})
+		It("env variable should not be changed if it already exists even if it is set to an empty value", func() {
+			emptyVal := ""
+			os.Setenv(envVar, emptyVal)
+			ConfigureEnvVariables()
+			Expect(os.Getenv(envVar)).To(Equal(emptyVal))
+			os.Setenv(envVar, prevValue)
+		})
 	})
 	Context("config return nil map", func() {
 		BeforeEach(func() {


### PR DESCRIPTION
### What this PR does / why we need it

If an shell variable is set it takes precedence over the same variable set in the tanzu config.  However, if a shell variable was set to an empty value it was ignored.

With this commit, an empty value is no longer ignored as it is a valid value for a shell variable.

See #623 for an example.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #623

### Describe testing done for PR

```
# Clean the plugin DB
$ rm ~/.cache/tanzu/plugin_inventory/default/

# Set a signature skip value for a test repo
$ tz config set env.TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST localhost:9876/tanzu-cli/plugins/central:small

# Set a shell variable that should take precedence that says "do not SKIP anything" in this shell
$ export TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST=''

# Confirm that the signature verification is performed, which means the shell variable is read
# and takes precedence over the one in the tanzu config 
$ tz plugin source update default -u localhost:9876/tanzu-cli/plugins/central:small
[i] Reading plugin inventory for "localhost:9876/tanzu-cli/plugins/central:small", this will take a few seconds.
[!] Unable to verify the plugins discovery image signature: failed validating the signature of the image localhost:9876/tanzu-cli/plugins/central:small :no matching signatures:
invalid signature when validating ASN.1 encoded signature
[x] Fatal, plugins discovery image signature verification failed. The `tanzu` CLI can not ensure the integrity of the plugins to be installed. To ignore this validation please append "localhost:9876/tanzu-cli/plugins/central:small" to the comma-separated list in the environment variable "TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST".  This is NOT RECOMMENDED and could put your environment at risk!

# Unset the shell variable and see that the one from the tanzu config is then read and that a skip is done
$ unset TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST
$ tz plugin source update default -u localhost:9876/tanzu-cli/plugins/central:small
[i] Reading plugin inventory for "localhost:9876/tanzu-cli/plugins/central:small", this will take a few seconds.
[!] Skipping the plugins discovery image signature verification for "localhost:9876/tanzu-cli/plugins/central:small"

[ok] updated discovery source default
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
A shell variable set to an empty value is no longer ignored by the CLI and takes precedence over a similar variable present in the tanzu config, as expected.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
