### PR TITLE
Hide a target command that has no plugins

### DIFF
--- a/docs/full/README.md
+++ b/docs/full/README.md
@@ -58,9 +58,9 @@ cluster endpoint type and Tanzu Mission Control endpoint type respectively. A
 context is associated with one of the two supported targets. Plugins are
 generally associated with one of the above mentioned targets but if a plugin
 doesn't fall into any of the above categories a developer can create a plugin
-with the 'global' target. A plugin using the `global` target is available as a
-root Tanzu CLI command. To see plugins that only apply the `kubernetes` Target
-or only to the `mission-control` Target, run the command `tanzu <target>'.
+with the `global` target. A plugin using the `global` target is available as a
+root Tanzu CLI sub-command. To see plugins that only apply to the `kubernetes` target
+or only to the `mission-control` target, run the command `tanzu <target>'.
 
 Similarly, commands from plugins that are associated with a target are
 unambiguously invoked by prefixing the command group with the target, like so:
@@ -72,10 +72,15 @@ tanzu k8s management-cluster ...
 ```
 
 Note that today, the CLI supports omitting the target for historical reasons,
-but this omission only applies to commands for the k8s target.
+but this omission only applies to commands for the `k8s` target.
 (So `tanzu management-cluster ...` is a valid variant of the above example, but not
 `tanzu data-protection ...`). The CLI team is exploring making the 'assumed target'
 configurable.
+
+Note also that until a plugin associated with a target is installed, the target in
+question will be hidden from the user.  For example, if no `tmc`/`mission-control`
+plugins are installed, the `tanzu tmc`/`tanzu mission-control` sub-command will not
+be shown to the user in the help.
 
 ## Interaction between CLI and its plugins
 

--- a/pkg/cli/usage.go
+++ b/pkg/cli/usage.go
@@ -78,13 +78,12 @@ func (u *MainUsage) Template() string {
   {{.NameAndAliases}}{{end}}{{if .HasExample}}
 
 {{ bold "Examples:" }}
-  {{.Example}}{{end}}
+  {{.Example}}{{end}}{{if gt (len .CmdMap) 0}}
 
 {{ bold "Available command groups:" }}
 {{ range $group, $cmds := .CmdMap}}
   {{ bold $group }}{{ range $cmd := $cmds }}
-    {{rpad $cmd.Name 24}}{{$cmd.Short}} {{end}}
-	{{end}}
+    {{rpad $cmd.Name 24}}{{$cmd.Short}} {{end}}{{end}}{{end}}
 
 {{ bold "Flags:" }}
 {{.LocalFlags.FlagUsages  | trimTrailingWhitespaces}}


### PR DESCRIPTION
### What this PR does / why we need it

When a target (`k8s` or `tmc`) has no plugins, this PR hides the command for that target.  The target may never be applicable to some users, so we try to avoid complicating things by hiding it.  Note that we don't completely remove the command for such a target because it is possible that savvy users expect it to be there even before they've installed plugins.

Further, when no plugins are installed for a target:
- `tanzu <target>` will now print the help **including a note**
- `tanzu <target> invalid` will now print the help **including a note**
- `tanzu <target> -h` will now print the help

Previously, the above cases would only print, e.g., for TMC: "Tanzu CLI plugins that target a Tanzu Mission Control endpoint"

The PR also removes the "Available command groups:" section of the help of a target if no plugins are available for that target.

Finally, there was an extra empty line between the end of the "Available command groups:" and the "Flags:" section, which is removed by this PR.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #625 

### Describe testing done for PR

Unit tests have been added to cover each case.

Before this PR:
```
$ tz plugin clean
[ok] successfully cleaned up all plugins

$ tz tmc
Tanzu CLI plugins that target a Tanzu Mission Control endpoint
$ tz tmc -h
Tanzu CLI plugins that target a Tanzu Mission Control endpoint
$ tz mission-control invalidplugin
Tanzu CLI plugins that target a Tanzu Mission Control endpoint

$ tz k8s
Tanzu CLI plugins that target a Kubernetes cluster
$ tz k8s -h
Tanzu CLI plugins that target a Kubernetes cluster
$ tz k8s invalidplugin
Tanzu CLI plugins that target a Kubernetes cluster

# Note that the help shows these empty target sub-commands
$ tz -h
Usage:
  tanzu [command]

Available command groups:

  System
    completion              Output shell completion code
    config                  Configuration for the CLI
    context                 Configure and manage contexts for the Tanzu CLI
    init                    Initialize the CLI
    plugin                  Manage CLI plugins
    version                 Version information

  Target
    kubernetes              Tanzu CLI plugins that target a Kubernetes cluster
    mission-control         Tanzu CLI plugins that target a Tanzu Mission Control endpoint


Flags:
  -h, --help   help for tanzu

Use "tanzu [command] --help" for more information about a command.
```

With this PR:
```
# Start with not plugins for both targets
$ tz plugin list
Standalone Plugins
  NAME       DESCRIPTION                                                 TARGET  VERSION  STATUS
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  global  v1.1.0   installed

# Notice the "Note" and that the help is printed and that "Available command groups" is not shown
$ tz k8s
Note: No plugins are currently installed for the "kubernetes" target.
      Such plugins will be accessible when a "kubernetes" context is created/activated or a "kubernetes" plugin is explicitly installed.

Tanzu CLI plugins that target a Kubernetes cluster

Usage:
  tanzu kubernetes [command]

Aliases:
  kubernetes, k8s

Flags:
  -h, --help   help for kubernetes

Use "tanzu kubernetes [command] --help" for more information about a command.

$ tz tmc
Note: No plugins are currently installed for the "mission-control" target.
      Such plugins will be accessible when a "mission-control" context is created/activated or a "mission-control" plugin is explicitly installed.

Tanzu CLI plugins that target a Tanzu Mission Control endpoint

Usage:
  tanzu mission-control [command]

Aliases:
  mission-control, tmc

Flags:
  -h, --help   help for mission-control

Use "tanzu mission-control [command] --help" for more information about a command.

# There is no "Note" when explicitly calling the help (because cobra does this automatically)
# "Available command groups" is not shown
$ tz k8s -h
Tanzu CLI plugins that target a Kubernetes cluster

Usage:
  tanzu kubernetes [command]

Aliases:
  kubernetes, k8s

Flags:
  -h, --help   help for kubernetes

Use "tanzu kubernetes [command] --help" for more information about a command.

$ tz tmc -h
Tanzu CLI plugins that target a Tanzu Mission Control endpoint

Usage:
  tanzu mission-control [command]

Aliases:
  mission-control, tmc

Flags:
  -h, --help   help for mission-control

Use "tanzu mission-control [command] --help" for more information about a command.

# Notice the "Note" and that the help is printed and that "Available command groups" is not shown
$ tz k8s invalid
Note: No plugins are currently installed for the "kubernetes" target.
      Such plugins will be accessible when a "kubernetes" context is created/activated or a "kubernetes" plugin is explicitly installed.

Tanzu CLI plugins that target a Kubernetes cluster

Usage:
  tanzu kubernetes [command]

Aliases:
  kubernetes, k8s

Flags:
  -h, --help   help for kubernetes

Use "tanzu kubernetes [command] --help" for more information about a command.

$ tz tmc invalid
Note: No plugins are currently installed for the "mission-control" target.
      Such plugins will be accessible when a "mission-control" context is created/activated or a "mission-control" plugin is explicitly installed.

Tanzu CLI plugins that target a Tanzu Mission Control endpoint

Usage:
  tanzu mission-control [command]

Aliases:
  mission-control, tmc

Flags:
  -h, --help   help for mission-control

Use "tanzu mission-control [command] --help" for more information about a command.


# Add a k8s plugin
$ tz plugin install space
[i] Refreshing plugin inventory cache for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Installing plugin 'space:v0.1.0-beta.1' with target 'kubernetes' (from cache)
[ok] successfully installed 'space' plugin

# Notice no more "note"and that "Available command groups" is properly shown

$ tz k8s
Tanzu CLI plugins that target a Kubernetes cluster

Usage:
  tanzu kubernetes [command]

Aliases:
  kubernetes, k8s

Available command groups:

  Build
    space                   Tanzu space, space profile, and space trait management

Flags:
  -h, --help   help for kubernetes

Use "tanzu kubernetes [command] --help" for more information about a command.
$ tz k8s -h
Tanzu CLI plugins that target a Kubernetes cluster

Usage:
  tanzu kubernetes [command]

Aliases:
  kubernetes, k8s

Available command groups:

  Build
    space                   Tanzu space, space profile, and space trait management

Flags:
  -h, --help   help for kubernetes

Use "tanzu kubernetes [command] --help" for more information about a command.

$ tz k8s invalid
Tanzu CLI plugins that target a Kubernetes cluster

Usage:
  tanzu kubernetes [command]

Aliases:
  kubernetes, k8s

Available command groups:

  Build
    space                   Tanzu space, space profile, and space trait management

Flags:
  -h, --help   help for kubernetes

Use "tanzu kubernetes [command] --help" for more information about a command.

# The "note" is still printed for TMC and "Available command groups" is not shown
$ tz tmc
Note: No plugins are currently installed for the "mission-control" target.
      Such plugins will be accessible when a "mission-control" context is created/activated or a "mission-control" plugin is explicitly installed.

Tanzu CLI plugins that target a Tanzu Mission Control endpoint

Usage:
  tanzu mission-control [command]

Aliases:
  mission-control, tmc

Flags:
  -h, --help   help for mission-control

Use "tanzu mission-control [command] --help" for more information about a command.
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Provide proper help for `tanzu k8s` and `tanzu tmc` commands when no plugins are installed for such a target.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
