### PR TITLE
Fix the `tanzu plugin download-bundle` when same plugin is part of multiple plugin-groups

### DIFF
--- a/pkg/airgapped/plugin_bundle_download.go
+++ b/pkg/airgapped/plugin_bundle_download.go
@@ -170,6 +170,11 @@ func (o *DownloadPluginBundleOptions) getSelectedPluginInfo() ([]*plugininventor
 			selectedPluginEntries = append(selectedPluginEntries, pluginEntries...)
 		}
 	}
+
+	// Remove duplicate PluginInventoryEntries and PluginGroups from the selected list
+	selectedPluginEntries = plugininventory.RemoveDuplicatePluginInventoryEntries(selectedPluginEntries)
+	selectedPluginGroups = plugininventory.RemoveDuplicatePluginGroups(selectedPluginGroups)
+
 	return selectedPluginEntries, selectedPluginGroups, nil
 }
 

--- a/pkg/plugininventory/plugin_inventory.go
+++ b/pkg/plugininventory/plugin_inventory.go
@@ -214,3 +214,33 @@ func (p PluginGroupSorter) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
 func (p PluginGroupSorter) Less(i, j int) bool {
 	return PluginGroupToID(p[i]) < PluginGroupToID(p[j])
 }
+
+// RemoveDuplicatePluginInventoryEntries removes the duplicate PluginInventoryEntiries entries
+// based on Name, Target and RecommendedVersion fields.
+func RemoveDuplicatePluginInventoryEntries(entries []*PluginInventoryEntry) []*PluginInventoryEntry {
+	encountered := make(map[string]bool)
+	result := []*PluginInventoryEntry{}
+	for _, entry := range entries {
+		id := fmt.Sprintf("%s-%s-%s", entry.Name, entry.Target, entry.RecommendedVersion)
+		if !encountered[id] {
+			encountered[id] = true
+			result = append(result, entry)
+		}
+	}
+	return result
+}
+
+// RemoveDuplicatePluginGroups removes the duplicate pluginGroups from the list
+// based on Vendor, Publisher, Name and RecommendedVersion fields.
+func RemoveDuplicatePluginGroups(groups []*PluginGroup) []*PluginGroup {
+	encountered := make(map[string]bool)
+	result := []*PluginGroup{}
+	for _, gp := range groups {
+		id := fmt.Sprintf("%s-%s/%s:%s", gp.Vendor, gp.Publisher, gp.Name, gp.RecommendedVersion)
+		if !encountered[id] {
+			encountered[id] = true
+			result = append(result, gp)
+		}
+	}
+	return result
+}

--- a/pkg/plugininventory/plugin_inventory.go
+++ b/pkg/plugininventory/plugin_inventory.go
@@ -215,7 +215,7 @@ func (p PluginGroupSorter) Less(i, j int) bool {
 	return PluginGroupToID(p[i]) < PluginGroupToID(p[j])
 }
 
-// RemoveDuplicatePluginInventoryEntries removes the duplicate PluginInventoryEntiries entries
+// RemoveDuplicatePluginInventoryEntries removes the duplicate PluginInventoryEntries
 // based on Name, Target and RecommendedVersion fields.
 func RemoveDuplicatePluginInventoryEntries(entries []*PluginInventoryEntry) []*PluginInventoryEntry {
 	encountered := make(map[string]bool)

--- a/pkg/plugininventory/plugin_inventory_test.go
+++ b/pkg/plugininventory/plugin_inventory_test.go
@@ -1,0 +1,87 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package plugininventory
+
+import (
+	"reflect"
+	"testing"
+
+	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
+)
+
+func TestRemoveDuplicatePluginInventoryEntries(t *testing.T) {
+	entry1 := &PluginInventoryEntry{Name: "Plugin1", Target: configtypes.TargetK8s, RecommendedVersion: "1.0"}
+	entry2 := &PluginInventoryEntry{Name: "Plugin2", Target: configtypes.TargetK8s, RecommendedVersion: "2.0"}
+	entry3 := &PluginInventoryEntry{Name: "Plugin1", Target: configtypes.TargetK8s, RecommendedVersion: "1.0"} // Duplicate
+	entry4 := &PluginInventoryEntry{Name: "Plugin3", Target: configtypes.TargetK8s, RecommendedVersion: "3.0"}
+
+	tests := []struct {
+		name   string
+		input  []*PluginInventoryEntry
+		output []*PluginInventoryEntry
+	}{
+		{
+			name:   "NoDuplicates",
+			input:  []*PluginInventoryEntry{entry1, entry2, entry4},
+			output: []*PluginInventoryEntry{entry1, entry2, entry4},
+		},
+		{
+			name:   "WithDuplicates",
+			input:  []*PluginInventoryEntry{entry1, entry2, entry3, entry4},
+			output: []*PluginInventoryEntry{entry1, entry2, entry4},
+		},
+		{
+			name:   "EmptyInput",
+			input:  []*PluginInventoryEntry{},
+			output: []*PluginInventoryEntry{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RemoveDuplicatePluginInventoryEntries(tt.input)
+			if !reflect.DeepEqual(got, tt.output) {
+				t.Errorf("TestCase: %v, RemoveDuplicatePluginInventoryEntries() = %v, want %v", tt.name, got, tt.output)
+			}
+		})
+	}
+}
+
+func TestRemoveDuplicatePluginGroups(t *testing.T) {
+	entry1 := &PluginGroup{Vendor: "vmware", Publisher: "tkg", Name: "Plugin1", RecommendedVersion: "v1.0"}
+	entry2 := &PluginGroup{Vendor: "vmware", Publisher: "tkg", Name: "Plugin2", RecommendedVersion: "v2.0"}
+	entry3 := &PluginGroup{Vendor: "vmware", Publisher: "tkg", Name: "Plugin1", RecommendedVersion: "v1.0"} // Duplicate
+	entry4 := &PluginGroup{Vendor: "vmware", Publisher: "tkg", Name: "Plugin1", RecommendedVersion: "v1.1"}
+
+	tests := []struct {
+		name   string
+		input  []*PluginGroup
+		output []*PluginGroup
+	}{
+		{
+			name:   "NoDuplicates",
+			input:  []*PluginGroup{entry1, entry2, entry4},
+			output: []*PluginGroup{entry1, entry2, entry4},
+		},
+		{
+			name:   "WithDuplicates",
+			input:  []*PluginGroup{entry1, entry2, entry3, entry4},
+			output: []*PluginGroup{entry1, entry2, entry4},
+		},
+		{
+			name:   "EmptyInput",
+			input:  []*PluginGroup{},
+			output: []*PluginGroup{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RemoveDuplicatePluginGroups(tt.input)
+			if !reflect.DeepEqual(got, tt.output) {
+				t.Errorf("TestCase: %v, RemoveDuplicatePluginGroups() = %v, want %v", tt.name, got, tt.output)
+			}
+		})
+	}
+}

--- a/test/e2e/airgapped/airgapped_test.go
+++ b/test/e2e/airgapped/airgapped_test.go
@@ -189,10 +189,12 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Airgapped-Plugin-Download
 
 	})
 
-	Context("Download plugin bundle, Upload plugin bundle and plugin lifecycle tests with plugin group 'vmware-tmc/tmc-user:v0.0.1'", func() {
-		// Test case: download plugin bundle for plugin-group vmware-tmc/tmc-user:v0.0.1
+	Context("Download plugin bundle, Upload plugin bundle and plugin lifecycle tests with plugin group 'vmware-tmc/tmc-user:v0.0.1' provided 2 times", func() {
+		// Test case: download plugin bundle for plugin-groups vmware-tmc/tmc-user:v0.0.1 and vmware-tmc/tmc-user:v0.0.1
+		// Note: we are passing same plugin group multiple times to make sure we test the conflicts in the plugin groups
+		// as well as plugins itself are handled properly while downloading and uploading bundle
 		It("download plugin bundle for plugin-group vmware-tmc/tmc-user:v0.0.1", func() {
-			err := tf.PluginCmd.DownloadPluginBundle(e2eTestLocalCentralRepoImage, []string{"vmware-tmc/tmc-user:v0.0.1"}, filepath.Join(tempDir, "plugin_bundle_vmware-tmc-v0.0.1.tar.gz"))
+			err := tf.PluginCmd.DownloadPluginBundle(e2eTestLocalCentralRepoImage, []string{"vmware-tmc/tmc-user:v0.0.1", "vmware-tmc/tmc-user:v0.0.1"}, filepath.Join(tempDir, "plugin_bundle_vmware-tmc-v0.0.1.tar.gz"))
 			Expect(err).To(BeNil(), "should not get any error while downloading plugin bundle with specific group")
 		})
 


### PR DESCRIPTION
### What this PR does / why we need it
- Fix `tanzu plugin download-bundle` when same plugin is part of multiple plugin-groups

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

* We have `vmware-tap/default:v1.7.2` and `vmware-tap/default:v1.7.1` plugin groups with same plugins in both.
```
$ tz plugin group get vmware-tap/default
Plugins in Group:  vmware-tap/default:v1.7.2
  NAME              TARGET      VERSION  
  accelerator       kubernetes  v1.7.0   
  apps              kubernetes  v0.13.0  
  build-service     kubernetes  v1.0.0   
  external-secrets  kubernetes  v0.1.0   
  insight           kubernetes  v1.7.2   
  package           kubernetes  v0.32.1  
  secret            kubernetes  v0.32.0  
  services          kubernetes  v0.8.0   
  
  
$ tz plugin group get vmware-tap/default:v1.7.1
Plugins in Group:  vmware-tap/default:v1.7.1
  NAME              TARGET      VERSION  
  accelerator       kubernetes  v1.7.0   
  apps              kubernetes  v0.13.0  
  build-service     kubernetes  v1.0.0   
  external-secrets  kubernetes  v0.1.0   
  insight           kubernetes  v1.7.0   
  package           kubernetes  v0.32.1  
  secret            kubernetes  v0.32.0  
  services          kubernetes  v0.8.0  
```

* Verify that trying to download plugins using the above plugin groups does not fail. Also it does not download the same plugin images multiple times.
```
$ tz plugin download-bundle --group vmware-tap/default:v1.7.1 --group vmware-tap/default:v1.7.2 --to-tar /tmp/tap-plugins.tar.gz
[i] Getting selected plugin information...
[i] will be downloading the 8 plugins from group: vmware-tap/default:v1.7.1
[i] will be downloading the 8 plugins from group: vmware-tap/default:v1.7.2
[i] will be downloading the one plugin from group: vmware-tanzucli/essentials:v1.0.0
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory@sha256:0678a6f43c468b97f1b81f4251f7012878feeedad6a4209a82b480ceab091917
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory@sha256:371a478ae6c7cc4d8d14b8c41d4ef2eee168427dc58f3d9109caa87e000afd01
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (40.343µs)
[i] copy | done: file 'sha256-05c470412bc4a4e7e8a380e80771e05d7a7963417c911b59c75639444a7f1051.tar.gz' (52.873µs)
[i] copy | done: file 'sha256-8e2625c31de723e294f0d0af6c8ac1f4e697c7a71392b1af2d64ebf1de5e8d9f.tar.gz' (59.068µs)
[i] copy | done: file 'sha256-c1a1ae5e9c77356085c7cd0b97200c2ccdb3d939d8243230dd80473464a25cad.tar.gz' (58.724306ms)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/darwin/amd64/kubernetes/accelerator:v1.7.0"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/darwin/amd64/kubernetes/accelerator@sha256:561ca37652a1daf9a36cdb2fc29763cf7faab9681d32a240f04c6a38bae65252
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/darwin/amd64/kubernetes/accelerator@sha256:5c64085618571b5cedea59880fbc3e695aa68ef6c12a6ee1eaf07ad8e419dbe1
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (21.41µs)
[i] copy | done: file 'sha256-dbc080c48cabfaa48e9cf986a0c261c47fcb884f08d181e584cee715c38fc8c4.tar.gz' (83.458µs)
[i] copy | done: file 'sha256-8114ec6f8cede7f87800a7dbffd90b5f27101b0e447eb8ba474dfd9a8d44fca8.tar.gz' (1.095675933s)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/linux/amd64/kubernetes/accelerator:v1.7.0"
[i] copy | exporting 1 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/linux/amd64/kubernetes/accelerator@sha256:c2e09fd2a3e872078a465e2024f57e4c4c9958e4c32f3e294dd29e31daa2c12b
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (19.903µs)
[i] copy | done: file 'sha256-fe9a870f3bc365703b8d17d0d5adab0df1273f7bb861c49ed0a7c7fa376fe47d.tar.gz' (1.211416377s)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/windows/amd64/kubernetes/accelerator:v1.7.0"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/windows/amd64/kubernetes/accelerator@sha256:2baadb029a94e9d101bcc01b161e8a5ce608ad410ef69049ba68d0f25b2dfee4
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/windows/amd64/kubernetes/accelerator@sha256:676b7877e9599acadabd987442399d8a96f4568caf5d13b51b40c246cd4a5b94
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (16.5µs)
[i] copy | done: file 'sha256-3d7f4c53be4b0a7e36761037c50286eaac4070a8394189fec55a7564b4b020cd.tar.gz' (71.893µs)
[i] copy | done: file 'sha256-ee2766a5a5923a5b236cca2e7de5fab5d4e0fa347e5b72658c7125c0e0f5a2f2.tar.gz' (932.146291ms)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/darwin/amd64/kubernetes/apps:v0.13.0"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/darwin/amd64/kubernetes/apps@sha256:460b350c51a5bd6dfb24936486a3546558cb1231fe1e5485e025694853124c87
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/darwin/amd64/kubernetes/apps@sha256:668e1a53427f88f5803fb654bb177b1089407bf0084f7151376df6703745d4dd
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (18.519µs)
[i] copy | done: file 'sha256-71817621f7760351d74db84143a8ee535e333ce4399ffc6d661659a149c0a302.tar.gz' (60.493µs)
[i] copy | done: file 'sha256-1f7a42eb32461a862965b5f26540ac0cb8f4ba92b6a01158a720e129234dc383.tar.gz' (947.700359ms)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/linux/amd64/kubernetes/apps:v0.13.0"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/linux/amd64/kubernetes/apps@sha256:34c84c86165d8e1fddddca07eb4706d98c763d43a06d89f8a0eb9ff50443ba50
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/linux/amd64/kubernetes/apps@sha256:bc94509f8f2b12927b5ab29214adb5b9b591739da2dab002b499b4d2803486f2
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (25.063µs)
[i] copy | done: file 'sha256-21893e4e692eaef66e054c63ef5c40139c0938b1f45e9b902885b95ac8e5ddb2.tar.gz' (92.824µs)
[i] copy | done: file 'sha256-c7720a460e41b300be1fdd2192de57dfe990f2cadf54dfcf178e0fd12882eb69.tar.gz' (3.600001715s)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/windows/amd64/kubernetes/apps:v0.13.0"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/windows/amd64/kubernetes/apps@sha256:fe87cc6dd8b618524364017cbc7dea9d6536dd13d39cd045a20cd1143f9296ec
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/windows/amd64/kubernetes/apps@sha256:febbab6b84ff0817c7efa97b48880fe76582c23fd2f618b0f4481e74575a09c9
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (16.145µs)
[i] copy | done: file 'sha256-994622b4107eff5e1198fb2fecec56c9c24d92fd61b635eabf3ef50cc81b2c9a.tar.gz' (85.088µs)
[i] copy | done: file 'sha256-102bf849e25d21f38949c5917cc298911285ee3ec3fd10b6f029f08ea5ef8d68.tar.gz' (1.013529406s)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/darwin/amd64/kubernetes/build-service:v1.0.0"
[i] copy | exporting 1 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/darwin/amd64/kubernetes/build-service@sha256:f3ff792f010e77fedbbb722264dab83c59bf9b2c092c06bf457da203ea465429
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (16.329µs)
[i] copy | done: file 'sha256-e5a37febb44c104abbe4899c2d4b96a773c99439b2d5c9ddc5ebfa5150a8ece7.tar.gz' (777.759341ms)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/linux/amd64/kubernetes/build-service:v1.0.0"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/linux/amd64/kubernetes/build-service@sha256:3ce29e9becf192ac601c91e03ab6a14b12f3044c18c4737ceb106defa832436d
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/linux/amd64/kubernetes/build-service@sha256:4d59b1945ad2faf6114904f7a586f6044ba7d52ecc1c04a61bdcdc8294bf4f63
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (13.779µs)
[i] copy | done: file 'sha256-de6a7e33e709eece173ed1a0716a364585df7d04fa48e8bc4726f95082045d8d.tar.gz' (44.781µs)
[i] copy | done: file 'sha256-c6157bab68d42eac4942adfd118057e736a1e64ad28d8ef6deb712d93454af09.tar.gz' (845.236313ms)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/windows/amd64/kubernetes/build-service:v1.0.0"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/windows/amd64/kubernetes/build-service@sha256:cdc808fa25cfb5746a095c9e22998a8d87fb8c9decfa46dab0e3c07e1a058bef
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/windows/amd64/kubernetes/build-service@sha256:eb35a1f0b8310d9b3e194c94705451be8bb9e82f052969d6498f644660433cdd
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (14.518µs)
[i] copy | done: file 'sha256-4229160c562f58f12769d0aa170a899cbba5edfc97e97dadd20ad6330275d603.tar.gz' (74.542µs)
[i] copy | done: file 'sha256-0bed3d4e05b02675bf4869c133b48baf66fd2e544a13bbdd90d18c4921f7ed1e.tar.gz' (4.982013591s)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/darwin/amd64/kubernetes/external-secrets:v0.1.0"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/darwin/amd64/kubernetes/external-secrets@sha256:5e37f82c95c78abef9e8cd414fa27381984d43e0335be0ce4d98b96de5473c8b
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/darwin/amd64/kubernetes/external-secrets@sha256:c4f74c9ccd347a44b88e7c03718787b8da6bcb7063a83a4acb004cda4034d060
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (11.753µs)
[i] copy | done: file 'sha256-9b04929f7f9b81e7645baf982ecc822a99c2de5777995ada5e313e28cd28b103.tar.gz' (42.05µs)
[i] copy | done: file 'sha256-d741056b44485fc6bfd32690fec65f8040ce9f3657ddb67b3e97a95d6c6dcd82.tar.gz' (1.047483042s)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/linux/amd64/kubernetes/external-secrets:v0.1.0"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/linux/amd64/kubernetes/external-secrets@sha256:0b9f200320f782aa13453d5d7d1ad5f559786a96ab5dc4f2de79933858a613b4
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/linux/amd64/kubernetes/external-secrets@sha256:176719520213de90921c03edbff83af12cc565df6d277ce9cef5ed4a245d48f9
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (13.52µs)
[i] copy | done: file 'sha256-ca7533517b3cc2228cacec528bcb7ca3abc3bd12ecb18271b448802d1599dcd6.tar.gz' (43.823µs)
[i] copy | done: file 'sha256-99126d158959c3481bf69b300e9b3a5633be8e24f00335f318fd920837074c6e.tar.gz' (1.186127369s)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/windows/amd64/kubernetes/external-secrets:v0.1.0"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/windows/amd64/kubernetes/external-secrets@sha256:8a72fa5f2e6ef7034173638b6ace24d3949bea37bb6e979839b7fb2af123b183
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/windows/amd64/kubernetes/external-secrets@sha256:ad07bbdfa6d0e2c22bde77bbbe7a06e093f0bee3a58a68083a553e7ab3ef0429
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (10.824µs)
[i] copy | done: file 'sha256-09a7c57c1305489ef0151557d3d4c6964849679ab1904f37baa569c3a1889387.tar.gz' (51.23µs)
[i] copy | done: file 'sha256-aecb0a3115c2e189242ac519d29b50cdb22f1591c377cb6a7a591624d2448751.tar.gz' (1.002126457s)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/darwin/amd64/kubernetes/insight:v1.7.0"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/darwin/amd64/kubernetes/insight@sha256:da9a5b327ee69c130e539d1a6caa0d061f8af18984945560687b2b3b19c5d83a
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/darwin/amd64/kubernetes/insight@sha256:f9335ddce158c5f6308faf0d9fa9e1beab9d34ef5324b199a610feecb4f895f2
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (11.296µs)
[i] copy | done: file 'sha256-267cd264aef2912c797ed7b47534faa574cf7e428fa5097814e2b2bdaab7e2c2.tar.gz' (47.915µs)
[i] copy | done: file 'sha256-77613ad7878d179b3a009816cee6561a49e6cb92e867e640ae1ff7cbea7e3d4e.tar.gz' (434.255539ms)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/linux/amd64/kubernetes/insight:v1.7.0"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/linux/amd64/kubernetes/insight@sha256:1a3d470f97f6ebd8ad33f1a9219e4391ec41024b6c3c9a888e9a4c8a0ee9583a
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/linux/amd64/kubernetes/insight@sha256:926ac3b624ed3482a0c2a4ce19fbb96ad1017a0fe2da6947a6919d2d47b76338
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (12.434µs)
[i] copy | done: file 'sha256-bcb17558210a373ceb2f2ee4d86f5a6e432fee1b6e68d9bdc54f9ea6f1f49686.tar.gz' (29.966µs)
[i] copy | done: file 'sha256-118c7e2738a60c0f1f3a14ef2b2e571d7459d7ddeb5059a7f44919b942402c4b.tar.gz' (406.035389ms)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/windows/amd64/kubernetes/insight:v1.7.0"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/windows/amd64/kubernetes/insight@sha256:0e8f5cca0120d8b78c2d9e8c5f6f3033cc69d662ecc7173dd27d36c69b62c050
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/windows/amd64/kubernetes/insight@sha256:a5882ed5ee32b62ca8ed2c4df54f48f81f0e38ace1f5a4c0c31bad2d639f11d1
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (12.104µs)
[i] copy | done: file 'sha256-88fdcc556255031be31a5e8caaae345fe5debe0c8e0fb2a5f077ba52b6d961d5.tar.gz' (58.585µs)
[i] copy | done: file 'sha256-8ad014e9456ef54325c377041d0d80c828df5e1d2a6ae23eb1e8822455669156.tar.gz' (617.406625ms)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpkgi/darwin/amd64/kubernetes/package:v0.32.1"
[i] copy | exporting 1 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpkgi/darwin/amd64/kubernetes/package@sha256:6cae5bcd06f5c387accebd47944fd59500a489185d3956739e483a7c3c4905f2
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (10.984µs)
[i] copy | done: file 'sha256-4d597e9ebcb165fdbd294c64c5fedb50b1065a2627abef5906ad26e774c4ef86.tar.gz' (869.834711ms)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpkgi/darwin/arm64/kubernetes/package:v0.32.1"
[i] copy | exporting 1 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpkgi/darwin/arm64/kubernetes/package@sha256:36238e3da964707a762ccfcdc34f0e427fdbabe464ff963f03e3041d2067281b
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (17.591µs)
[i] copy | done: file 'sha256-0ab81d20960059a8647de44c1ba2b08125e19cf02eefedbd73694377e871310f.tar.gz' (1.22149995s)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpkgi/linux/amd64/kubernetes/package:v0.32.1"
[i] copy | exporting 1 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpkgi/linux/amd64/kubernetes/package@sha256:0939498e0437f33c0e64414d4956c57084497ceecbc358fbe045692ff75d4b69
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (16.189µs)
[i] copy | done: file 'sha256-6e6654a6fdb36d9f633220a7ec4be0e951f6150caff48fe373e119a54fbb658c.tar.gz' (2.549448472s)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpkgi/linux/arm64/kubernetes/package:v0.32.1"
[i] copy | exporting 1 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpkgi/linux/arm64/kubernetes/package@sha256:651b19bf123adaa7ccd96d60f7e04fbc3983e154574da09f193f35cbda525ea1
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (13.292µs)
[i] copy | done: file 'sha256-000c6800f1cd2435cb651e3d04271ffac26361a0367214f6997e9c46f6c35f6a.tar.gz' (4.213804238s)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpkgi/windows/amd64/kubernetes/package:v0.32.1"
[i] copy | exporting 1 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpkgi/windows/amd64/kubernetes/package@sha256:7420f2c899e0ebae09d47c8af7934f9c2f4b3e77030eaf5cc7baeab087756b05
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (12.434µs)
[i] copy | done: file 'sha256-29d3f4469dfeb23d59750c7884e05d695386d4902b6dc90e9ff2f8c6a29ee529.tar.gz' (1.694344388s)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpkgi/darwin/amd64/kubernetes/secret:v0.32.0"
[i] copy | exporting 1 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpkgi/darwin/amd64/kubernetes/secret@sha256:3cb37e441182a1786d2fe833f397785b973bac8bd19b2ca9d6cd927b93b88398
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (16.823µs)
[i] copy | done: file 'sha256-d761daeee59c55e1e443b2084128b62b03822d187d19502eb59fcc55aa70145e.tar.gz' (822.621207ms)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpkgi/darwin/arm64/kubernetes/secret:v0.32.0"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpkgi/darwin/arm64/kubernetes/secret@sha256:8a62ce52e5ec3b0ebedf032135afa2f9100aeeb1ebbf92856484196f51a868b8
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpkgi/darwin/arm64/kubernetes/secret@sha256:a616c5504e993ba7f3be94653977890e1e2c848e71c44872d13ce4cdda9ee6ea
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (20.315µs)
[i] copy | done: file 'sha256-06935cbbfe6f33141d5cccb51a9dc2bf691806e3354a982f310e22623802e113.tar.gz' (103.498µs)
[i] copy | done: file 'sha256-3cd9a0af964cf9aa62cf030a98a1725a358a929dd1fc87f5058ca1cad2cd41b6.tar.gz' (3.219276116s)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpkgi/linux/amd64/kubernetes/secret:v0.32.0"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpkgi/linux/amd64/kubernetes/secret@sha256:3c067125411623d4948a074e3a3c356a733eebadd0bde9539a6cd3bd61ad8d20
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpkgi/linux/amd64/kubernetes/secret@sha256:88bdfbb89dc38f5250dcca79a4b95bbe56d0301e6fb379fe66b1f42b9cf43caa
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (20.375µs)
[i] copy | done: file 'sha256-df124e1baff8d2c522dca8b8fa826fc5f3c032f2cc5abaddc0e5fc5c55fed974.tar.gz' (64.76µs)
[i] copy | done: file 'sha256-f992d4298cf55ca34319e2f31d3c59a8ee8a4f72ab3d0b068f95372047398eb6.tar.gz' (1.121371481s)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpkgi/linux/arm64/kubernetes/secret:v0.32.0"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpkgi/linux/arm64/kubernetes/secret@sha256:433fe803a43d2b0408899605f92cc8e4d7ddd1e19144e61437c77a4304d0d065
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpkgi/linux/arm64/kubernetes/secret@sha256:c2e2495fead84911d0b47256f3108cfa82d8d6372920cdc1ebcb46d17909aabb
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (13.808µs)
[i] copy | done: file 'sha256-158195ad87ea9e525c3afd9e06c3c4614254f65438f32db385e42b450e8e4273.tar.gz' (79.422µs)
[i] copy | done: file 'sha256-b1b0a265fd0c2106ecbe4ac6c98a8040d7c43dd02f5156714ea9a517bbecbfcc.tar.gz' (756.360745ms)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpkgi/windows/amd64/kubernetes/secret:v0.32.0"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpkgi/windows/amd64/kubernetes/secret@sha256:b977942c84206bcec0559ef031c4f5559e746b463cda52f62e3614a43443bd3a
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpkgi/windows/amd64/kubernetes/secret@sha256:cc5e015cf4f9e5194623ef44cc49c88d6c26a01f6f0f465af0d409fc6fb651ea
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (21.088µs)
[i] copy | done: file 'sha256-088d882c0576440c5cb3afb0bc5cdf9897758be6e181ed3467c60ab4c16b283a.tar.gz' (57.784µs)
[i] copy | done: file 'sha256-aaf03b7be536899a9cbdba20a88c018d7369f542ba70bf066b35384415dcd39f.tar.gz' (1.242097476s)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/darwin/amd64/kubernetes/services:v0.8.0"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/darwin/amd64/kubernetes/services@sha256:4e6fcb10676b5ac9a9f159fcc446eacb9998309fd283519a18e7988a7e34f229
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/darwin/amd64/kubernetes/services@sha256:ef0665e2f548d5dc08d130eaf33b89ff5c9d7f776042283694a1bead965a8893
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (20.988µs)
[i] copy | done: file 'sha256-3a089556c63de4b719ce0d2c66dbde387d30d1dc03b185c2f831c897f29e56c5.tar.gz' (53.183µs)
[i] copy | done: file 'sha256-71122f7987bd20742498d00d8e12f70542e4b08c11fa9f03a60d97d6acd44e39.tar.gz' (890.272761ms)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/linux/amd64/kubernetes/services:v0.8.0"
[i] copy | exporting 1 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/linux/amd64/kubernetes/services@sha256:80ee12ed671e0f5cf3c6b90f3fb066724e0220aa3f16315a719867a4e7e199a7
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (15.972µs)
[i] copy | done: file 'sha256-68d4c186b39a5af53391aac6d94e3c36aa5e4865f4269caf7dd5b41f5e6c1c88.tar.gz' (958.85869ms)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/windows/amd64/kubernetes/services:v0.8.0"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/windows/amd64/kubernetes/services@sha256:a3aed5cde1bdd35601d15e67b6643809099773dbd714b74c73475a4722634450
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/windows/amd64/kubernetes/services@sha256:b9cd644b4dca734f72493c426370639ba87722ff870041f3dc62b85065e659b3
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (16.821µs)
[i] copy | done: file 'sha256-28ac9185292f549132a81f4dec3a4a3eb9d217411ef13817935c24c3abb035d8.tar.gz' (44.524µs)
[i] copy | done: file 'sha256-8ebb6ecdf4072eb48aab3a50562515e638559ce4397932b3bdac2ca323ea079f.tar.gz' (1.166524525s)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/darwin/amd64/kubernetes/insight:v1.7.2"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/darwin/amd64/kubernetes/insight@sha256:cea243976ef1cb73d5ecadde3f51217b706bcb969cd252ad103287b4b8fd26c1
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/darwin/amd64/kubernetes/insight@sha256:f2e1687d33f911964b26184f0399d05957883b7b96584779a6b7d93137a52892
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (13.753µs)
[i] copy | done: file 'sha256-226f019ec0a9172ee41bd9a60d534a15daf7fff12a66ce06adb7546e01b361a9.tar.gz' (58.196µs)
[i] copy | done: file 'sha256-6b30eaa661a932baa3d91c7f231dd4bd30424cc9b96744990b31b58628cbbc87.tar.gz' (404.010842ms)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/linux/amd64/kubernetes/insight:v1.7.2"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/linux/amd64/kubernetes/insight@sha256:2fcd1b6ab9ad941be30475748ed80b21f1e29d3852fd8e5fc034e04aac5a88f1
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/linux/amd64/kubernetes/insight@sha256:dbe9658a0002ff3d80648b30d342797fc656e99847dc9acf3948e05ed2a9af83
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (14.606µs)
[i] copy | done: file 'sha256-3c40e0227c5b2d8f6409178a2588c283e1e6c9c18d9606e541e81e55dba1da8c.tar.gz' (72.988µs)
[i] copy | done: file 'sha256-1cac1fe934f09c0f0d0044636c162377f20bf14ff35295eec5a47d59210dc37c.tar.gz' (524.863647ms)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/windows/amd64/kubernetes/insight:v1.7.2"
[i] copy | exporting 2 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/windows/amd64/kubernetes/insight@sha256:fdb27d5539f10bb305ee6e7d91c9506e3a2949350f592f500fd5c2dea29be088
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tap/windows/amd64/kubernetes/insight@sha256:ff1cf4a63554df632aafb43eb372a632529e501fbcca89c894c58087a50e538f
[i] copy | exported 2 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (15.732µs)
[i] copy | done: file 'sha256-5902c36a1de9de320cadc8b2403926212445239a6d87a6d0a81cd7a70cf1061b.tar.gz' (104.786µs)
[i] copy | done: file 'sha256-e8352fefef026e773b7b13339a9b460492d8bd3e1e6b6db861ac4c73b9fb3585.tar.gz' (470.965268ms)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpi/darwin/amd64/global/telemetry:v1.1.0"
[i] copy | exporting 1 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpi/darwin/amd64/global/telemetry@sha256:4a3b4a73f4530f040da420a11dec75528f1afe6ba20ff799a3f7ebb84ffe4811
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (15.712µs)
[i] copy | done: file 'sha256-ceb1e063221747b6ede202ef5d0272cc0abc5a7d5b57443391dce557f475230e.tar.gz' (697.219766ms)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpi/linux/amd64/global/telemetry:v1.1.0"
[i] copy | exporting 1 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpi/linux/amd64/global/telemetry@sha256:e2204119b6391b750c6a59f1d0c7c668e1e3107c6d0abd3f7e5d9b8676838109
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (19.179µs)
[i] copy | done: file 'sha256-b4d9134b2844f67a980673a5e1f2de2fe6b08466d368f8c35d37061f60af5057.tar.gz' (4.201828541s)
[i] ---------------------------
[i] downloading image "projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpi/windows/amd64/global/telemetry:v1.1.0"
[i] copy | exporting 1 images...
[i] copy | will export projects.registry.vmware.com/tanzu_cli/plugins/vmware/tpi/windows/amd64/global/telemetry@sha256:16ec76e455e7d526c5595a984cd9369e1878b44aaee67d573d0e95d1ab9fac27
[i] copy | exported 1 images
[i] copy | writing layers...
[i] copy | done: file 'manifest.json' (14.615µs)
[i] copy | done: file 'sha256-62fc48abfee0faf165ecf7e831259eaf6d0427294b4594d8394c81ba95a7de46.tar.gz' (790.264419ms)
[i] saving plugin bundle at: /tmp/tap-plugins.tar.gz
```


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fixes `tanzu plugin download-bundle` when the same plugin is part of multiple plugin-groups that the user has requested to download
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
