### PR TITLE
Update the tanzu context create command help

### DIFF
--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -182,9 +182,15 @@ var createCtxCmd = &cobra.Command{
     and release of new services (and CLI plugins) which extend and combine features provided by
     individual tanzu components.
 
-    Note: To create Mission Control (TMC) or Tanzu contexts, an API Key is required. The API Key
-    value can be provided with the environment variable TANZU_API_TOKEN or can be entered as input
-    while creating the context.
+    Notes: 
+    1. TMC context: To create Mission Control (TMC) context an API Key is required. It can be provided using the 
+       TANZU_API_TOKEN environment variable or entered during context creation.
+    2. Tanzu context: To create Tanzu context an API Key is optional. If provided using the TANZU_API_TOKEN environment
+       variable, it will be used. Otherwise, the CLI will attempt to log in interactively to the user's default Cloud Services
+       organization. You can override or choose a custom organization by setting the TANZU_CLI_CLOUD_SERVICES_ORGANIZATION_ID 
+       environment variable with the custom organization ID value. More information regarding organizations in Cloud Services
+       and how to obtain the organization ID can be found at
+       https://docs.vmware.com/en/VMware-Cloud-services/services/Using-VMware-Cloud-Services/GUID-CF9E9318-B811-48CF-8499-9419997DC1F8.html
 
     [*] : Users have two options to create a kubernetes cluster context. They can choose the control
     plane option by providing 'endpoint', or use the kubeconfig for the cluster by providing


### PR DESCRIPTION
### What this PR does / why we need it
This PR updates tanzu context create command help to include guidance on utilizing TANZU_API_TOKEN and TANZU_CLI_CLOUD_SERVICES_ORGANIZATION_ID environment variables during context creation.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
The tanzu context create command help shows the below help
```
❯ ./bin/tanzu context create -h
Create a Tanzu CLI context

Usage:
  tanzu context create CONTEXT_NAME [flags]

Examples:

    # Create a TKG management cluster context using endpoint and type (--type is optional, if not provided the CLI will infer the type from the endpoint)
    tanzu context create mgmt-cluster --endpoint https://k8s.example.com[:port] --type k8s

    # Create a TKG management cluster context using endpoint
    tanzu context create mgmt-cluster --endpoint https://k8s.example.com[:port]

    # Create a TKG management cluster context using kubeconfig path and context
    tanzu context create mgmt-cluster --kubeconfig path/to/kubeconfig --kubecontext kubecontext

    # Create a TKG management cluster context by using the provided CA Bundle for TLS verification:
    tanzu context create mgmt-cluster --endpoint https://k8s.example.com[:port] --endpoint-ca-certificate /path/to/ca/ca-cert

    # Create a TKG management cluster context by explicit request to skip TLS verification, which is insecure:
    tanzu context create mgmt-cluster --endpoint https://k8s.example.com[:port] --insecure-skip-tls-verify

    # Create a TKG management cluster context using default kubeconfig path and a kubeconfig context
    tanzu context create mgmt-cluster --kubecontext kubecontext

    # Create a TMC(mission-control) context using endpoint and type
    tanzu context create mytmc --endpoint tmc.example.com:443 --type tmc

    # Create an Tanzu context with the default endpoint (--type is not necessary for the default endpoint)
    tanzu context create mytanzu --endpoint https://api.tanzu.cloud.vmware.com

    # Create an Tanzu context (--type is needed for a non-default endpoint)
    tanzu context create mytanzu --endpoint https://non-default.tanzu.endpoint.com --type tanzu

    # Create an Tanzu context by using the provided CA Bundle for TLS verification:
    tanzu context create mytanzu --endpoint https://api.tanzu.cloud.vmware.com  --endpoint-ca-certificate /path/to/ca/ca-cert

    # Create an Tanzu context but skipping TLS verification (this is insecure):
    tanzu context create mytanzu --endpoint https://api.tanzu.cloud.vmware.com --insecure-skip-tls-verify

    Note: The "tanzu" context type is being released to provide advance support for the development
    and release of new services (and CLI plugins) which extend and combine features provided by
    individual tanzu components.

    Notes:
    1. TMC context: To create Mission Control (TMC) context an API Key is required. It can be provided using the
       TANZU_API_TOKEN environment variable or entered during context creation.
    2. Tanzu context: To create Tanzu context an API Key is optional. If provided using the TANZU_API_TOKEN environment
       variable, it will be used. Otherwise, the CLI will attempt to log in interactively to the user's default Cloud Services
       organization. You can override or choose a custom organization by setting the TANZU_CLI_CLOUD_SERVICES_ORGANIZATION_ID
       environment variable with the custom organization ID value. More information regarding organizations in Cloud Services
       and how to obtain the organization ID can be found at
       https://docs.vmware.com/en/VMware-Cloud-services/services/Using-VMware-Cloud-Services/GUID-CF9E9318-B811-48CF-8499-9419997DC1F8.html

    [*] : Users have two options to create a kubernetes cluster context. They can choose the control
    plane option by providing 'endpoint', or use the kubeconfig for the cluster by providing
    'kubeconfig' and 'context'. If only '--context' is set and '--kubeconfig' is not, the
    $KUBECONFIG env variable will be used and, if the $KUBECONFIG env is also not set, the default
    kubeconfig file ($HOME/.kube/config) will be used.

Flags:
      --endpoint string                  endpoint to create a context for
      --endpoint-ca-certificate string   path to the endpoint public certificate
  -h, --help                             help for create
      --insecure-skip-tls-verify         skip endpoint's TLS certificate verification
      --kubeconfig string                path to the kubeconfig file; valid only if user doesn't choose 'endpoint' option.(See [*])
      --kubecontext string               the context in the kubeconfig to use; valid only if user doesn't choose 'endpoint' option.(See [*])
  -t, --type string                      type of context to create (kubernetes[k8s]/mission-control[tmc]/tanzu)
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
