### PR TITLE
Fix log message on activating context when project/space/clustergroup keys not exists in config

### DIFF
--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -1161,14 +1161,14 @@ func useCtx(cmd *cobra.Command, args []string) error {
 
 	suffixString := ""
 	if ctx.ContextType == configtypes.ContextTypeTanzu {
-		if ctx.AdditionalMetadata[config.ProjectNameKey] != "" {
-			suffixString += fmt.Sprintf("Project: %s", ctx.AdditionalMetadata[config.ProjectNameKey])
+		if project, exists := ctx.AdditionalMetadata[config.ProjectNameKey]; exists && project != "" {
+			suffixString += fmt.Sprintf("Project: %s", project)
 		}
-		if ctx.AdditionalMetadata[config.SpaceNameKey] != "" {
-			suffixString += fmt.Sprintf(", Space: %s", ctx.AdditionalMetadata[config.SpaceNameKey])
+		if space, exists := ctx.AdditionalMetadata[config.SpaceNameKey]; exists && space != "" {
+			suffixString += fmt.Sprintf(", Space: %s", space)
 		}
-		if ctx.AdditionalMetadata[config.ClusterGroupNameKey] != "" {
-			suffixString += fmt.Sprintf(", ClusterGroup: %s", ctx.AdditionalMetadata[config.ClusterGroupNameKey])
+		if clustergroup, exists := ctx.AdditionalMetadata[config.ClusterGroupNameKey]; exists && clustergroup != "" {
+			suffixString += fmt.Sprintf(", ClusterGroup: %s", clustergroup)
 		}
 	}
 	if suffixString != "" {


### PR DESCRIPTION
### What this PR does / why we need it
- Fix log message on activating context when project/space/clustergroup keys not exists in config

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

- When configuration `config-ng.yaml` for additionalMetadata is missing `tanzuProjectName`, `tanzuSpaceName` and `tanzuClusterGroupName` keys
```
      additionalMetadata:
        tanzuOrgID: b1d48027-bb69-4a56-a5b8-e941ef29fa4b
```

**Before the fix:**
```
[i] Successfully activated context 'ucp-local-2' of type 'tanzu' (Project: %!s(<nil>), Space: %!s(<nil>), ClusterGroup: %!s(<nil>)).
```
**After the fix:**
```
$ tz context use ucp-local-2
[i] Successfully activated context 'ucp-local-2' of type 'tanzu'.
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
None
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
