### PR TITLE
Allow listing the CLIPlugins resources even if the CRD discovery API returns an error for the kubernetes context

### DIFF
--- a/pkg/discovery/kubernetes.go
+++ b/pkg/discovery/kubernetes.go
@@ -65,6 +65,10 @@ func (k *KubernetesDiscovery) GetDiscoveredPlugins(clusterClient cluster.Client)
 
 	crdExists, errVerifyCRD := clusterClient.VerifyCLIPluginCRD()
 	// If no error and CRD does not exists, return with a log message
+	// If there is an error, wait for the call of ListCLIPluginResources to return
+	// and then decide. As sometimes discovery API can return premature error
+	// if the k8s apiserver is not stable but ListCLIPluginResources might return
+	// correct result. In this case, we will ignore the error we get here.
 	if errVerifyCRD == nil && !crdExists {
 		log.V(4).Info(logMsg)
 		return nil, nil


### PR DESCRIPTION
### What this PR does / why we need it
- Allow the listing of CLIPlugin resources even if the CRD discovery API returns an error for the kubernetes context
- Today, if the ValidateCLIPluginCRD API returns an error, CLI does not try to list CLIPlugin CRs assuming the CRD does not exist.
- However, we have seen in some cases, where the API server is not stable, it does not return to the k8s clients discovery API (`kubectl get customresourcedefinitions.apiextensions.k8s.io cliplugins.cli.tanzu.vmware.com`) but does return the correct result when using the direct client API for the resource (`kubectl get cliplugins`)
- This change is to allow CLI to try and list the CLIPlugin resource if the CRD validation fails.
- If the `ValidateCLIPluginCRD` returns an error but `ListCLIPluginResources` returns correct list, we ignore the first error and continue with the list we got as part of `ListCLIPluginResources`.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

**Setup to reproduce this issue:**
```
## create a kubernetes cluster with k3d which installs a metrics server.
$ k3d cluster create cluster-1 --image rancher/k3s:v1.23.1-k3s1

## Apply CLIPlugins CRD and CLIPlugin Resources
$ kubectl apply -f /Users/anujc/Documents/code/tanzu-cli/apis/config/crd/bases/cli.tanzu.vmware.com_cliplugins.yaml
customresourcedefinition.apiextensions.k8s.io/cliplugins.cli.tanzu.vmware.com created

$ kubectl apply -f /Users/anujc/Desktop/tests/core-cli/0.25-plugin-cr.yaml
cliplugin.cli.tanzu.vmware.com/kubernetes-release created
cliplugin.cli.tanzu.vmware.com/cluster created

## Check the CRD exists
$ kubectl get customresourcedefinitions.apiextensions.k8s.io cliplugins.cli.tanzu.vmware.com
NAME                              CREATED AT
cliplugins.cli.tanzu.vmware.com   2024-01-10T22:20:13Z

## Update the metrics server configuration so that the API server returns an error while querying the CRD
$ kubectl edit endpoints -n kube-system metrics-server

## Try to check the CRD exists, it throws errors
$ kubectl get customresourcedefinitions.apiextensions.k8s.io cliplugins.cli.tanzu.vmware.com
E0110 14:21:11.295027   86872 memcache.go:287] couldn't get resource list for metrics.k8s.io/v1beta1: the server is currently unable to handle the request
E0110 14:21:11.305022   86872 memcache.go:121] couldn't get resource list for metrics.k8s.io/v1beta1: the server is currently unable to handle the request
E0110 14:21:11.329934   86872 memcache.go:121] couldn't get resource list for metrics.k8s.io/v1beta1: the server is currently unable to handle the request
E0110 14:21:11.337124   86872 memcache.go:121] couldn't get resource list for metrics.k8s.io/v1beta1: the server is currently unable to handle the request
NAME                              CREATED AT
cliplugins.cli.tanzu.vmware.com   2024-01-10T22:20:13Z
```

**Before this change:**
```
$ export TANZU_CLI_LOG_LEVEL=9

$ tanzu context create --name k3d-cluster-1 --kubeconfig /Users/anujc/.kube/config --kubecontext k3d-cluster-1
Flag --name has been deprecated, it has been replaced by using an argument to the command
[ok] successfully created a kubernetes context using the kubeconfig /Users/anujc/.kube/config
[i] Checking for required plugins for context 'k3d-cluster-1'...
[i] creating kubernetes client with kubeconfig "/Users/anujc/.kube/config", kubecontext "k3d-cluster-1"
[i] Skipping context-aware plugin discovery because CLIPlugin CRD not present on the logged in cluster. failed to discover unmatched GroupResource: failed to discover server group and resource: unable to retrieve the complete list of server APIs: metrics.k8s.io/v1beta1: the server is currently unable to handle the request

$ tanzu plugin list
[i] creating kubernetes client with kubeconfig "/Users/anujc/.kube/config", kubecontext "k3d-cluster-1"
[i] Skipping context-aware plugin discovery because CLIPlugin CRD not present on the logged in cluster. failed to discover unmatched GroupResource: failed to discover server group and resource: unable to retrieve the complete list of server APIs: metrics.k8s.io/v1beta1: the server is currently unable to handle the request
Standalone Plugins
  NAME                DESCRIPTION                                                        TARGET      VERSION             STATUS
  telemetry           configure cluster-wide settings for vmware tanzu telemetry         global      v1.1.0              installed
```

**After this change:**
```
$ export TANZU_CLI_LOG_LEVEL=9

$ tz context create --name k3d-cluster-1 --kubeconfig /Users/anujc/.kube/config --kubecontext k3d-cluster-1
Flag --name has been deprecated, it has been replaced by using an argument to the command
[ok] successfully created a kubernetes context using the kubeconfig /Users/anujc/.kube/config
[i] Checking for required plugins for context 'k3d-cluster-1'...
[i] creating kubernetes client with kubeconfig "/Users/anujc/.kube/config", kubecontext "k3d-cluster-1"
[i] found 2 CLIPlugin resources.
[i] processing CLIPlugin "kubernetes-release"
[i] processing CLIPlugin "cluster"
[i] The following plugins will be installed for context 'k3d-cluster-1' of contextType 'kubernetes':
  NAME                TARGET      VERSION
  kubernetes-release  kubernetes  v0.30.0
  cluster             kubernetes  v0.30.0
[i] Refreshing plugin inventory cache for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Installing plugin 'kubernetes-release:v0.30.0' with target 'kubernetes'
[i] Installing plugin 'cluster:v0.30.0' with target 'kubernetes' (from cache)
[i] Successfully installed all required plugins

$ tz plugin list
[i] creating kubernetes client with kubeconfig "/Users/anujc/.kube/config", kubecontext "k3d-cluster-1"
[i] found 2 CLIPlugin resources.
[i] processing CLIPlugin "kubernetes-release"
[i] processing CLIPlugin "cluster"
Standalone Plugins
  NAME                DESCRIPTION                                                        TARGET      VERSION             STATUS
  telemetry           configure cluster-wide settings for vmware tanzu telemetry         global      v1.1.0              installed

Plugins from Context:  k3d-cluster-1
  NAME                DESCRIPTION                                 TARGET      VERSION  STATUS
  cluster             KR Plugin For Kubernetes Namespace=default  kubernetes  v0.30.0  installed
  kubernetes-release  KR Plugin For Kubernetes Namespace=default  kubernetes  v0.30.0  installed
```



<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Allow listing the CLIPlugins resources even if the CRD discovery API returns an error for the kubernetes context
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
