### PR TITLE
Merge plugin-group manifest automatically when building individual plugins with the `builder` plugin

### DIFF
--- a/cmd/plugin/builder/command/cli_compile_test.go
+++ b/cmd/plugin/builder/command/cli_compile_test.go
@@ -94,3 +94,105 @@ func TestMergePluginManifest(t *testing.T) {
 		assert.Equal(foundPlugin.Versions, plugin.Versions)
 	}
 }
+
+func TestMergePluginGroupManifest(t *testing.T) {
+	assert := assert.New(t)
+
+	basePGManifest := cli.PluginGroupManifest{
+		Plugins: []cli.PluginNameTargetScopeVersion{
+			cli.PluginNameTargetScopeVersion{
+				PluginNameTargetScope: cli.PluginNameTargetScope{
+					Name:            "plugin1",
+					Target:          "target-foo",
+					IsContextScoped: true,
+				},
+				Version: "v1.1.1",
+			},
+			cli.PluginNameTargetScopeVersion{
+				PluginNameTargetScope: cli.PluginNameTargetScope{
+					Name:            "plugin2",
+					Target:          "target-foo",
+					IsContextScoped: true,
+				},
+				Version: "v4.0.0",
+			},
+			cli.PluginNameTargetScopeVersion{
+				PluginNameTargetScope: cli.PluginNameTargetScope{
+					Name:            "plugin3",
+					Target:          "target-baz",
+					IsContextScoped: false,
+				},
+				Version: "v3.0.0",
+			},
+		},
+	}
+
+	incomingPGManifest := cli.PluginGroupManifest{
+		Plugins: []cli.PluginNameTargetScopeVersion{
+			cli.PluginNameTargetScopeVersion{
+				PluginNameTargetScope: cli.PluginNameTargetScope{
+					Name:            "plugin1",
+					Target:          "target-foo",
+					IsContextScoped: false,
+				},
+				Version: "v1.0.0",
+			},
+			cli.PluginNameTargetScopeVersion{
+				PluginNameTargetScope: cli.PluginNameTargetScope{
+					Name:            "plugin2",
+					Target:          "target-bar",
+					IsContextScoped: false,
+				},
+				Version: "v2.0.0",
+			},
+		},
+	}
+
+	expectedMergedPGManifest := cli.PluginGroupManifest{
+		Plugins: []cli.PluginNameTargetScopeVersion{
+			cli.PluginNameTargetScopeVersion{
+				PluginNameTargetScope: cli.PluginNameTargetScope{
+					Name:            "plugin1",
+					Target:          "target-foo",
+					IsContextScoped: true,
+				},
+				Version: "v1.1.1",
+			},
+			cli.PluginNameTargetScopeVersion{
+				PluginNameTargetScope: cli.PluginNameTargetScope{
+					Name:            "plugin3",
+					Target:          "target-baz",
+					IsContextScoped: false,
+				},
+				Version: "v3.0.0",
+			},
+			cli.PluginNameTargetScopeVersion{
+				PluginNameTargetScope: cli.PluginNameTargetScope{
+					Name:            "plugin2",
+					Target:          "target-foo",
+					IsContextScoped: true,
+				},
+				Version: "v4.0.0",
+			},
+			cli.PluginNameTargetScopeVersion{
+				PluginNameTargetScope: cli.PluginNameTargetScope{
+					Name:            "plugin2",
+					Target:          "target-bar",
+					IsContextScoped: false,
+				},
+				Version: "v2.0.0",
+			},
+		},
+	}
+
+	mergedManifest := mergePluginGroupManifest(basePGManifest, incomingPGManifest)
+
+	for _, plugin := range expectedMergedPGManifest.Plugins {
+		foundPlugin := findpluginInPluginGroupManifest(mergedManifest, plugin)
+		assert.NotNil(foundPlugin, "expected plugin:%v, target:%v not found", plugin.Name, plugin.Target)
+		assert.Equal(foundPlugin.Name, plugin.Name)
+		assert.Equal(foundPlugin.Target, plugin.Target)
+		assert.Equal(foundPlugin.IsContextScoped, plugin.IsContextScoped)
+		assert.Equal(foundPlugin.Version, plugin.Version)
+	}
+}

--- a/cmd/plugin/builder/command/cli_compile_test.go
+++ b/cmd/plugin/builder/command/cli_compile_test.go
@@ -16,19 +16,19 @@ func TestMergePluginManifest(t *testing.T) {
 
 	baseManifest := cli.Manifest{
 		Plugins: []cli.Plugin{
-			cli.Plugin{
+			{
 				Name:        "plugin1",
 				Target:      "target-foo",
 				Description: "desc-1-foo",
 				Versions:    []string{"v1.1.1"},
 			},
-			cli.Plugin{
+			{
 				Name:        "plugin2",
 				Target:      "target-foo",
 				Description: "desc-2-foo",
 				Versions:    []string{"v4.0.0"},
 			},
-			cli.Plugin{
+			{
 				Name:        "plugin3",
 				Target:      "target-baz",
 				Description: "desc-3",
@@ -39,13 +39,13 @@ func TestMergePluginManifest(t *testing.T) {
 
 	incomingManifest := cli.Manifest{
 		Plugins: []cli.Plugin{
-			cli.Plugin{
+			{
 				Name:        "plugin1",
 				Target:      "target-foo",
 				Description: "desc-1-foo",
 				Versions:    []string{"v1.0.0"},
 			},
-			cli.Plugin{
+			{
 				Name:        "plugin2",
 				Target:      "target-bar",
 				Description: "desc-2",
@@ -56,25 +56,25 @@ func TestMergePluginManifest(t *testing.T) {
 
 	expectedMergedManifest := cli.Manifest{
 		Plugins: []cli.Plugin{
-			cli.Plugin{
+			{
 				Name:        "plugin1",
 				Target:      "target-foo",
 				Description: "desc-1-foo",
 				Versions:    []string{"v1.1.1"},
 			},
-			cli.Plugin{
+			{
 				Name:        "plugin3",
 				Target:      "target-baz",
 				Description: "desc-3",
 				Versions:    []string{"v3.0.0"},
 			},
-			cli.Plugin{
+			{
 				Name:        "plugin2",
 				Target:      "target-foo",
 				Description: "desc-2-foo",
 				Versions:    []string{"v4.0.0"},
 			},
-			cli.Plugin{
+			{
 				Name:        "plugin2",
 				Target:      "target-bar",
 				Description: "desc-2",
@@ -100,7 +100,7 @@ func TestMergePluginGroupManifest(t *testing.T) {
 
 	basePGManifest := cli.PluginGroupManifest{
 		Plugins: []cli.PluginNameTargetScopeVersion{
-			cli.PluginNameTargetScopeVersion{
+			{
 				PluginNameTargetScope: cli.PluginNameTargetScope{
 					Name:            "plugin1",
 					Target:          "target-foo",
@@ -108,7 +108,7 @@ func TestMergePluginGroupManifest(t *testing.T) {
 				},
 				Version: "v1.1.1",
 			},
-			cli.PluginNameTargetScopeVersion{
+			{
 				PluginNameTargetScope: cli.PluginNameTargetScope{
 					Name:            "plugin2",
 					Target:          "target-foo",
@@ -116,7 +116,7 @@ func TestMergePluginGroupManifest(t *testing.T) {
 				},
 				Version: "v4.0.0",
 			},
-			cli.PluginNameTargetScopeVersion{
+			{
 				PluginNameTargetScope: cli.PluginNameTargetScope{
 					Name:            "plugin3",
 					Target:          "target-baz",
@@ -129,7 +129,7 @@ func TestMergePluginGroupManifest(t *testing.T) {
 
 	incomingPGManifest := cli.PluginGroupManifest{
 		Plugins: []cli.PluginNameTargetScopeVersion{
-			cli.PluginNameTargetScopeVersion{
+			{
 				PluginNameTargetScope: cli.PluginNameTargetScope{
 					Name:            "plugin1",
 					Target:          "target-foo",
@@ -137,7 +137,7 @@ func TestMergePluginGroupManifest(t *testing.T) {
 				},
 				Version: "v1.0.0",
 			},
-			cli.PluginNameTargetScopeVersion{
+			{
 				PluginNameTargetScope: cli.PluginNameTargetScope{
 					Name:            "plugin2",
 					Target:          "target-bar",
@@ -150,7 +150,7 @@ func TestMergePluginGroupManifest(t *testing.T) {
 
 	expectedMergedPGManifest := cli.PluginGroupManifest{
 		Plugins: []cli.PluginNameTargetScopeVersion{
-			cli.PluginNameTargetScopeVersion{
+			{
 				PluginNameTargetScope: cli.PluginNameTargetScope{
 					Name:            "plugin1",
 					Target:          "target-foo",
@@ -158,7 +158,7 @@ func TestMergePluginGroupManifest(t *testing.T) {
 				},
 				Version: "v1.1.1",
 			},
-			cli.PluginNameTargetScopeVersion{
+			{
 				PluginNameTargetScope: cli.PluginNameTargetScope{
 					Name:            "plugin3",
 					Target:          "target-baz",
@@ -166,7 +166,7 @@ func TestMergePluginGroupManifest(t *testing.T) {
 				},
 				Version: "v3.0.0",
 			},
-			cli.PluginNameTargetScopeVersion{
+			{
 				PluginNameTargetScope: cli.PluginNameTargetScope{
 					Name:            "plugin2",
 					Target:          "target-foo",
@@ -174,7 +174,7 @@ func TestMergePluginGroupManifest(t *testing.T) {
 				},
 				Version: "v4.0.0",
 			},
-			cli.PluginNameTargetScopeVersion{
+			{
 				PluginNameTargetScope: cli.PluginNameTargetScope{
 					Name:            "plugin2",
 					Target:          "target-bar",


### PR DESCRIPTION
### What this PR does / why we need it

- Before this change, when a user tried to build plugins individually the content of the `plugin_group_manifest.yaml` file was getting overwritten with each plugin build command.

- After this change, if the `plugin_group_manifest.yaml` file already exists under the artifacts directory, building a new plugin will merge the plugin information into the existing `plugin_group_manifest.yaml` file. And if a user is building a plugin that exists in the `plugin_group_manifest.yaml` file with a different version, the content of the `plugin_group_manifest.yaml` will get updated with the newer version of the plugin.

Note: As part of #454, This issue was resolved for plugin_bundle creation along with `plugin_manifest.yaml`. However, that change was not handling the updates to the `plugin_group_manifest.yaml` correctly.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
```
## Try building the builder plugin individually
$ make plugin-build-local PLUGIN_NAME=builder

$ cat artifacts/plugins/plugin_group_manifest.yaml
created: 2024-01-11T12:03:17.663867-08:00
plugins:
    - name: builder
      target: global
      isContextScoped: false
      version: v1.2.0-dev

## Now try building the test plugin individually. The plugin_group_manifest.yaml should be merged containing info of builder and test plugins
$ make plugin-build-local PLUGIN_NAME=test

$ cat artifacts/plugins/plugin_group_manifest.yaml
created: 2024-01-11T12:04:24.036255-08:00
plugins:
    - name: test
      target: global
      isContextScoped: false
      version: v1.2.0-dev
    - name: builder
      target: global
      isContextScoped: false
      version: v1.2.0-dev
```

```
## Set PLUGIN_BUNDLE_OVERWRITE=true to overwrite the plugin bundle and generate a fresh plugin_group_manifest.yaml file
$ make plugin-build-local PLUGIN_NAME=test PLUGIN_BUNDLE_OVERWRITE=true

$ cat artifacts/plugins/plugin_group_manifest.yaml
created: 2024-01-11T12:06:11.563163-08:00
plugins:
    - name: test
      target: global
      isContextScoped: false
      version: v1.2.0-dev
```
```
## Try to build all plugins for all supported architecture and verify that the correct plugin group manifest gets generated
$ make plugin-build

$ cat artifacts/plugins/plugin_group_manifest.yaml
created: 2024-01-11T12:08:48.147526-08:00
plugins:
    - name: builder
      target: global
      isContextScoped: false
      version: v1.2.0-dev
    - name: test
      target: global
      isContextScoped: false
      version: v1.2.0-dev
```


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Merge `plugin_group_manifest.yaml` automatically when building individual plugins with the builder plugin
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
