### PR TITLE
Add support for interactive login on terminal based hosts(without browser) for tanzu context

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	golang.org/x/mod v0.12.0
 	golang.org/x/oauth2 v0.8.0
 	golang.org/x/sync v0.3.0
+	golang.org/x/term v0.15.0
 	google.golang.org/grpc v1.56.3
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -218,7 +219,6 @@ require (
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
-	golang.org/x/term v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.12.0 // indirect

--- a/pkg/auth/csp/tanzu_test.go
+++ b/pkg/auth/csp/tanzu_test.go
@@ -4,14 +4,20 @@
 package csp
 
 import (
+	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2"
 )
+
+const fakeIssuerURL = "https://fake.issuer.com"
 
 func TestHandleTokenRefresh(t *testing.T) {
 	// Mock HTTP server for token refresh
@@ -81,7 +87,6 @@ func TestGetOrgNameFromOrgID(t *testing.T) {
 func TestGetAuthCodeURL_validResponse(t *testing.T) {
 	assert := assert.New(t)
 	var err error
-	fakeIssuerURL := "https://fake.issuer.com"
 	h := &cspLoginHandler{
 		oauthConfig: &oauth2.Config{
 			RedirectURL: fakeIssuerURL,
@@ -117,4 +122,126 @@ func TestGetAuthCodeURL_validResponse(t *testing.T) {
 	assert.Equal(u.Query().Get("client_id"), tanzuCLIClientID)
 	assert.Equal(u.Query().Get("orgId"), "fake-org-id")
 	assert.Equal(u.Query().Get("code_challenge_method"), "S256")
+}
+
+func TestGetTokenUsingAuthCode(t *testing.T) {
+	// Mock HTTP server for token refresh
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		body, _ := io.ReadAll(r.Body)
+		if strings.Contains(string(body), "code=valid_auth_code") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token": "fake-access-token", "refresh_token": "fake-refresh-token", "expires_in": 3600, "id_token": "fake-id-token"}`))
+			return
+		}
+		http.Error(w, "invalid_auth_code_fake_error", http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	// Mock the necessary components
+	h := &cspLoginHandler{
+		oauthConfig: &oauth2.Config{
+			RedirectURL: fakeIssuerURL,
+			ClientID:    tanzuCLIClientID,
+			Endpoint: oauth2.Endpoint{
+				TokenURL: server.URL,
+			},
+		},
+	}
+
+	// Test with a valid auth code
+	token, err := h.getTokenUsingAuthCode(context.TODO(), "valid_auth_code")
+	if err != nil {
+		t.Errorf("getTokenUsingAuthCode returned an unexpected error: %v", err)
+	}
+
+	if token == nil || token.Extra("id_token").(string) == "" {
+		t.Error("getTokenUsingAuthCode did not return the expected token")
+	}
+	// Test with an invalid auth code
+	_, err = h.getTokenUsingAuthCode(context.TODO(), "invalid_auth_code")
+	if err == nil || !strings.Contains(err.Error(), "invalid_auth_code_fake_error") {
+		t.Error("getTokenUsingAuthCode did not return an error for an invalid auth code")
+	}
+}
+
+func TestPromptAndLoginWithAuthCode(t *testing.T) {
+	// Mock HTTP server for token refresh
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		body, _ := io.ReadAll(r.Body)
+		if strings.Contains(string(body), "code=valid_auth_code") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token": "fake-access-token", "refresh_token": "fake-refresh-token", "expires_in": 3600, "id_token": "fake-id-token"}`))
+			return
+		}
+		http.Error(w, "invalid_auth_code_fake_error", http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	// Mock the necessary components
+	h := &cspLoginHandler{
+		tokenExchange:         context.TODO(),
+		tokenExchangeComplete: func() {},
+		oauthConfig: &oauth2.Config{
+			RedirectURL: fakeIssuerURL,
+			ClientID:    tanzuCLIClientID,
+			Endpoint: oauth2.Endpoint{
+				TokenURL: server.URL,
+			},
+		},
+		promptForValue: func(ctx context.Context, promptLabel string, out io.Writer) (string, error) {
+			return "valid_auth_code", nil
+		},
+		isTTY: func(_ int) bool {
+			return true
+		},
+	}
+
+	// Test user providing valid auth code
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	wg := h.promptAndLoginWithAuthCode(ctx, "http://example.com/auth")
+	// Wait for the prompt to finish
+	wg()
+
+	if h.token == nil || h.token.Extra("id_token").(string) == "" {
+		t.Error("promptAndLoginWithAuthCode did not set the token")
+	}
+
+	// Test user providing invalid auth code
+	h.token = nil
+	h.promptForValue = func(ctx context.Context, promptLabel string, out io.Writer) (string, error) {
+		return "invalid_auth_code", nil
+	}
+	wg = h.promptAndLoginWithAuthCode(ctx, "http://example.com/auth")
+	wg()
+
+	if h.token != nil {
+		t.Error("promptAndLoginWithAuthCode set the token using invalid auth code")
+	}
+
+	// Test without a TTY
+	h.token = nil
+	wg = h.promptAndLoginWithAuthCode(ctx, "http://example.com/auth")
+	wg()
+
+	if h.token != nil {
+		t.Error("promptAndLoginWithAuthCode set the token without a TTY")
+	}
+
+	// Test with context canceled while waiting for user input
+	h.token = nil
+	h.promptForValue = func(ctx context.Context, promptLabel string, out io.Writer) (string, error) {
+		time.Sleep(10 * time.Second)
+		return "should_not_reach_here", nil
+	}
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	_ = h.promptAndLoginWithAuthCode(ctx, "http://example.com/auth")
+	ctxCancel()
+
+	if h.token != nil {
+		t.Error("promptAndLoginWithAuthCode set the token with context canceled while waiting for user input")
+	}
 }

--- a/pkg/auth/csp/token.go
+++ b/pkg/auth/csp/token.go
@@ -19,6 +19,7 @@ import (
 
 	configapi "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/interfaces"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
@@ -213,7 +214,8 @@ func GetToken(g *configapi.GlobalServerAuth) (*oauth2.Token, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get the CSP OrgID from the existing access token")
 		}
-		token, err = TanzuLogin(g.Issuer, WithRefreshToken(g.RefreshToken), WithOrgID(orgID))
+		loginOptions := []LoginOption{WithRefreshToken(g.RefreshToken), WithOrgID(orgID), WithListenerPortFromEnv(constants.TanzuCLIOAuthLocalListenerPort)}
+		token, err = TanzuLogin(g.Issuer, loginOptions...)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/auth/tanzu/kubeconfig.go
+++ b/pkg/auth/tanzu/kubeconfig.go
@@ -82,7 +82,7 @@ func getExecConfig(c *configtypes.Context) *clientcmdapi.ExecConfig {
 		APIVersion:      clientauthenticationv1.SchemeGroupVersion.String(),
 		Args:            []string{},
 		Env:             []clientcmdapi.ExecEnvVar{},
-		InteractiveMode: clientcmdapi.NeverExecInteractiveMode,
+		InteractiveMode: clientcmdapi.IfAvailableExecInteractiveMode,
 	}
 
 	execConfig.Command = "tanzu"

--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -167,16 +167,16 @@ var createCtxCmd = &cobra.Command{
     # Create a TMC(mission-control) context using endpoint and type 
     tanzu context create mytmc --endpoint tmc.example.com:443 --type tmc
 
-    # Create an Tanzu context with the default endpoint (--type is not necessary for the default endpoint)
+    # Create a Tanzu context with the default endpoint (--type is not necessary for the default endpoint)
     tanzu context create mytanzu --endpoint https://api.tanzu.cloud.vmware.com
 
-    # Create an Tanzu context (--type is needed for a non-default endpoint)
+    # Create a Tanzu context (--type is needed for a non-default endpoint)
     tanzu context create mytanzu --endpoint https://non-default.tanzu.endpoint.com --type tanzu
 
-    # Create an Tanzu context by using the provided CA Bundle for TLS verification:
+    # Create a Tanzu context by using the provided CA Bundle for TLS verification:
     tanzu context create mytanzu --endpoint https://api.tanzu.cloud.vmware.com  --endpoint-ca-certificate /path/to/ca/ca-cert
 
-    # Create an Tanzu context but skipping TLS verification (this is insecure):
+    # Create a Tanzu context but skip TLS verification (this is insecure):
     tanzu context create mytanzu --endpoint https://api.tanzu.cloud.vmware.com --insecure-skip-tls-verify
 
     Note: The "tanzu" context type is being released to provide advance support for the development
@@ -184,11 +184,11 @@ var createCtxCmd = &cobra.Command{
     individual tanzu components.
 
     Notes: 
-    1. TMC context: To create Mission Control (TMC) context an API Key is required. It can be provided using the 
+    1. TMC context: To create Mission Control (TMC) context an API Key is required. It can be provided using the
        TANZU_API_TOKEN environment variable or entered during context creation.
     2. Tanzu context: To create Tanzu context an API Key is optional. If provided using the TANZU_API_TOKEN environment
        variable, it will be used. Otherwise, the CLI will attempt to log in interactively to the user's default Cloud Services
-       organization. You can override or choose a custom organization by setting the TANZU_CLI_CLOUD_SERVICES_ORGANIZATION_ID 
+       organization. You can override or choose a custom organization by setting the TANZU_CLI_CLOUD_SERVICES_ORGANIZATION_ID
        environment variable with the custom organization ID value. More information regarding organizations in Cloud Services
        and how to obtain the organization ID can be found at
        https://docs.vmware.com/en/VMware-Cloud-services/services/Using-VMware-Cloud-Services/GUID-CF9E9318-B811-48CF-8499-9419997DC1F8.html
@@ -678,11 +678,13 @@ func doCSPInteractiveLoginAndUpdateContext(c *configtypes.Context) (claims *csp.
 		issuer = csp.StgIssuer
 	}
 	cspOrgIDValue, cspOrgIDExists := os.LookupEnv(constants.CSPLoginOrgID)
-	var options []csp.LoginOption
+	var loginOptions []csp.LoginOption
 	if cspOrgIDExists && cspOrgIDValue != "" {
-		options = append(options, csp.WithOrgID(cspOrgIDValue))
+		loginOptions = append(loginOptions, csp.WithOrgID(cspOrgIDValue))
 	}
-	token, err := csp.TanzuLogin(issuer, options...)
+	// If user chooses to use a specific local listener port, use it
+	loginOptions = append(loginOptions, csp.WithListenerPortFromEnv(constants.TanzuCLIOAuthLocalListenerPort))
+	token, err := csp.TanzuLogin(issuer, loginOptions...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get the token from CSP")
 	}

--- a/pkg/constants/env_variables.go
+++ b/pkg/constants/env_variables.go
@@ -50,4 +50,7 @@ const (
 	// Note: More information regarding the CSP organizations can be found at
 	// https://docs.vmware.com/en/VMware-Cloud-services/services/Using-VMware-Cloud-Services/GUID-CF9E9318-B811-48CF-8499-9419997DC1F8.html
 	CSPLoginOrgID = "TANZU_CLI_CLOUD_SERVICES_ORGANIZATION_ID"
+
+	// TanzuCLIOAuthLocalListenerPort is the port to be used by local listener for OAuth authorization flow
+	TanzuCLIOAuthLocalListenerPort = "TANZU_CLI_OAUTH_LOCAL_LISTENER_PORT"
 )


### PR DESCRIPTION
### What this PR does / why we need it

This PR adds support for interactive login on terminal based hosts for tanzu context

Changes summary:
- Add support for interactive login on terminal based hosts for tanzu context. CLI would prompt the authorization URL so that user can open the URL in the host having browser and then copy the authcode manually to complete the login.
- User can choose the local listener port for callback URLs during OAuth authorization flow by setting the TANZU_CLI_OAUTH_LOCAL_LISTENER_PORT environment variable with port number user want to use on the local host.


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Copied the tanzu binary to terminal based host and created tanzu context successfully( opened the auth URL posted on the terminal on the local machine browser and copied the auth code from the browser URL)
```
kubo@xGgQ2fHmfJ4uz:~$ export HOME=/tmp/Prem-CLIHome/
kubo@xGgQ2fHmfJ4uz:/home/kubo$ /tmp/tanzu-cli-linux_amd64 context create prem-ucp-intg-ctx5 --type tanzu --endpoint https://api.tanzu-dev.cloud.vmware.com --staging
[i] Opening the browser window to complete the login
[!] failed to open the browser for login:exec: "xdg-open,x-www-browser,www-browser": executable file not found in $PATH
Log in by visiting this link:

    https://console-stg.cloud.vmware.com/csp/gateway/discovery?client_id=tanzu-cli-client-id&code_challenge=G2cpk7jR0snIb1drJ9VX_4skPAss81ySQQ1LuiorFFc&code_challenge_method=S256&redirect_uri=http%3A%2F%2F127.0.0.1%3A40391%2Fcallback&response_type=code&state=c8f2497ed53e91def558490211a85d24

    Optionally, paste your authorization code: b2tRay1HN0RvNXFpWFc4Zlduc1RyRmZ0ZzRUTU8taHM6dXMtd2VzdC0y


[ok] Successfully logged into 'One Tanzu Integration' organization and created a tanzu context
[i] Checking for required plugins for context 'prem-ucp-intg-ctx5'...
[i] All required plugins are already installed and up-to-date
```
Tested copying invlaid auth code , and CLI errors ourt as expected.

```
kubo@xGgQ2fHmfJ4uz:/home/kubo$ /tmp/tanzu-cli-linux_amd64 context create prem-ucp-intg-ctx6 --type tanzu --endpoint https://api.tanzu-dev.cloud.vmware.com --staging
[i] Opening the browser window to complete the login
[!] failed to open the browser for login:exec: "xdg-open,x-www-browser,www-browser": executable file not found in $PATH
Log in by visiting this link:

    https://console-stg.cloud.vmware.com/csp/gateway/discovery?client_id=tanzu-cli-client-id&code_challenge=yROGaa0RWBgLzqTCvN7dtyonnnEVmH9EvsJjyL7NiQ8&code_challenge_method=S256&redirect_uri=http%3A%2F%2F127.0.0.1%3A46859%2Fcallback&response_type=code&state=873ccb739415f510a235c19e7f787489

    Optionally, paste your authorization code: b2tRay1HN0RvNXFpWFc4Zlduc1RyRmZ0ZzRUTU8taHM6dXMtd2VzdC0yInvalid
[i] failed to exchange auth code for oauth tokens, err=oauth2: cannot fetch token: 400 Bad Request
Response: {"requestId":"c2a540ca88556f42","errorCode":null,"statusCode":400,"traceId":"8c06b00497f68403","cspErrorCode":"540.324-340.800","metadata":null,"moduleCode":540,"message":"invalid_grant: Invalid authorization code"}

[x] : failed to get the token from CSP: token issuer https://console-stg.cloud.vmware.com/csp/gateway/am/api did not return expected tokens
```
Verified the kubectl  triggers the interactive login and allows user to copy the auth code, and once the auth code is pasted the login flow was successful.

```
kubo@xGgQ2fHmfJ4uz:/home/kubo$ kubectl get projects
[i] Opening the browser window to complete the login
[!] failed to open the browser for login:exec: "xdg-open,x-www-browser,www-browser": executable file not found in $PATH
Log in by visiting this link:

    https://console-stg.cloud.vmware.com/csp/gateway/discovery?client_id=tanzu-cli-client-id&code_challenge=PLG3eZM6MfByUJnucuZDvHAEM32tRPTFt0IKlOPVT8M&code_challenge_method=S256&orgId=b1d48027-bb69-4a56-a5b8-e941ef29fa4b&redirect_uri=http%3A%2F%2F127.0.0.1%3A44705%2Fcallback&response_type=code&state=23bf9d874597ccbf11ae01b80d494a72

    Optionally, paste your authorization code: dmFNR1JLMWR0cmc4QmpIWUdvbmpVU09FY0EyR1YxbEI6dXMtd2VzdC0y

NAME
abhisheks-project
adib-project
aditya-project
...
yuva-project
kubo@xGgQ2fHmfJ4uz:/home/kubo$
```


create a tanzu context on my mac (with browser) without setting the environment variable for local host listener port and it was successful( CLI opens a random port)
```
❯ ./bin/tanzu context create prem-ucp-intg-ctx6 --type tanzu --endpoint https://api.tanzu-dev.cloud.vmware.com --staging
[i] Opening the browser window to complete the login
Log in by visiting this link:

    https://console-stg.cloud.vmware.com/csp/gateway/discovery?client_id=tanzu-cli-client-id&code_challenge=tRabEloiPE3bj65VM9Q-rQE3Yy-PfIHqXNEybwkTGgc&code_challenge_method=S256&redirect_uri=http%3A%2F%2F127.0.0.1%3A54215%2Fcallback&response_type=code&state=ccf5af586459e0b4ddb5e27923346cb7

    Optionally, paste your authorization code: [...]


[ok] Successfully logged into 'One Tanzu Integration' organization and created a tanzu context
[i] Checking for required plugins for context 'prem-ucp-intg-ctx6'...
[i] All required plugins are already installed and up-to-date
```

created tanzu context successfully with local listener port set using the environment variable `TANZU_CLI_OAUTH_LOCAL_LISTENER_PORT` with 8645
```
❯ export TANZU_CLI_OAUTH_LOCAL_LISTENER_PORT=8645
❯ ./bin/tanzu context create prem-ucp-intg-ctx6 --type tanzu --endpoint https://api.tanzu-dev.cloud.vmware.com --staging
[i] Opening the browser window to complete the login
Log in by visiting this link:

    https://console-stg.cloud.vmware.com/csp/gateway/discovery?client_id=tanzu-cli-client-id&code_challenge=FjTuhkeY1bN4AgHWUPD7L06FGefFgDDdQWCrK7ptCcM&code_challenge_method=S256&redirect_uri=http%3A%2F%2F127.0.0.1%3A8645%2Fcallback&response_type=code&state=c7cb77f60a0c4953f3253950e62e0fd5

    Optionally, paste your authorization code: [...]

        context: tanzu-cli-one-tanzu-demo-ctx2

[ok] Successfully logged into 'One Tanzu Integration' organization and created a tanzu context
[i] Checking for required plugins for context 'prem-ucp-intg-ctx6'...
[i] All required plugins are already installed and up-to-date
```

Tested with invalid port and CLI errors out as expected.
```
❯ export TANZU_CLI_OAUTH_LOCAL_LISTENER_PORT=8645777
❯ ./bin/tanzu context create prem-ucp-intg-ctx6 --type tanzu --endpoint https://api.tanzu-dev.cloud.vmware.com --staging
[x] : failed to get the token from CSP: failed to parse TANZU_CLI_OAUTH_LOCAL_LISTENER_PORT as uint16: strconv.ParseUint: parsing "8645777": value out of range
```



<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add support for interactive login on terminal based hosts for creating 'tanzu' context. User can choose the local listener port for callback URL during OAuth authorization flow by setting the TANZU_CLI_OAUTH_LOCAL_LISTENER_PORT environment variable.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
