### PR TITLE
UX: Sort plugin list and plugin search output by plugin name

### DIFF
--- a/pkg/cli/plugin_info.go
+++ b/pkg/cli/plugin_info.go
@@ -81,8 +81,8 @@ type PluginInfoSorter []PluginInfo
 func (p PluginInfoSorter) Len() int      { return len(p) }
 func (p PluginInfoSorter) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
 func (p PluginInfoSorter) Less(i, j int) bool {
-	if p[i].Target != p[j].Target {
-		return p[i].Target < p[j].Target
+	if p[i].Name != p[j].Name {
+		return p[i].Name < p[j].Name
 	}
-	return p[i].Name < p[j].Name
+	return string(p[i].Target) < string(p[j].Target)
 }

--- a/pkg/discovery/types.go
+++ b/pkg/discovery/types.go
@@ -69,8 +69,8 @@ type DiscoveredSorter []Discovered
 func (d DiscoveredSorter) Len() int      { return len(d) }
 func (d DiscoveredSorter) Swap(i, j int) { d[i], d[j] = d[j], d[i] }
 func (d DiscoveredSorter) Less(i, j int) bool {
-	if d[i].Target != d[j].Target {
-		return d[i].Target < d[j].Target
+	if d[i].Name != d[j].Name {
+		return d[i].Name < d[j].Name
 	}
-	return d[i].Name < d[j].Name
+	return string(d[i].Target) < string(d[j].Target)
 }

--- a/test/e2e/framework/framework_constants.go
+++ b/test/e2e/framework/framework_constants.go
@@ -152,6 +152,7 @@ const (
 	NoErrorForPluginGroupSearch                   = "should not get any error for plugin group search"
 	NoErrorForPluginGroupGet                      = "should not get any error for plugin group get"
 	NoErrorForPluginSearch                        = "should not get any error for plugin search"
+	PluginSearchOutputShouldBeSortedByName        = "plugin search output should be sorted by name"
 	UnableToSync                                  = "unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually"
 	PluginDescribeShouldNotThrowErr               = "should not get any error for plugin describe"
 	PluginDescShouldExist                         = "there should be one plugin description"

--- a/test/e2e/plugin_lifecycle/plugin_lifecycle_helper.go
+++ b/test/e2e/plugin_lifecycle/plugin_lifecycle_helper.go
@@ -26,7 +26,7 @@ func CheckAllLegacyPluginsExists(superList, subList []*framework.PluginInfo) boo
 
 // SearchAllPlugins runs the plugin search command and returns all the plugins from the search output
 func SearchAllPlugins(tf *framework.Framework, opts ...framework.E2EOption) ([]*framework.PluginInfo, error) {
-	pluginsSearchList, err := tf.PluginCmd.SearchPlugins("", opts...)
+	pluginsSearchList, _, _, err := tf.PluginCmd.SearchPlugins("", opts...)
 	return pluginsSearchList, err
 }
 

--- a/test/e2e/plugin_lifecycle/plugin_lifecycle_suite_test.go
+++ b/test/e2e/plugin_lifecycle/plugin_lifecycle_suite_test.go
@@ -111,8 +111,9 @@ func testWithoutPluginDiscoverySources(tf *framework.Framework) {
 	_, err := tf.PluginCmd.DeletePluginDiscoverySource("default")
 	Expect(err).To(BeNil(), "there should not be any error to delete default discovery source")
 
-	_, err = tf.PluginCmd.SearchPlugins("")
+	plugins, _, _, err := tf.PluginCmd.SearchPlugins("")
 	Expect(err.Error()).To(ContainSubstring(errorNoDiscoverySourcesFound))
+	Expect(len(plugins)).Should(BeNumerically("==", 0))
 
 	err = tf.PluginCmd.InstallPlugin("unknowPlugin", "", "")
 	Expect(err.Error()).To(ContainSubstring(errorNoDiscoverySourcesFound))

--- a/test/e2e/plugins_compatibility/plugins_compatibility_helper.go
+++ b/test/e2e/plugins_compatibility/plugins_compatibility_helper.go
@@ -16,7 +16,7 @@ import (
 
 // PluginsForCompatibilityTesting search for test-plugin-'s from the test central repository and returns all test-plugin-'s
 func PluginsForCompatibilityTesting(tf *framework.Framework) []*framework.PluginInfo {
-	list, err := tf.PluginCmd.SearchPlugins("")
+	list, _, _, err := tf.PluginCmd.SearchPlugins("")
 	gomega.Expect(err).To(gomega.BeNil(), "should not occur any error while searching for plugins")
 	testPlugins := make([]*framework.PluginInfo, 0)
 	for _, plugin := range list {


### PR DESCRIPTION
### What this PR does / why we need it
This pull request sorts the plugin list output first by plugin name, and then by plugin target. Sorting the list by name and then target provides a better user experience for the end user by organizing the plugins in a consistent and easy to scan order.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
Before the fix, the `tanzu plugin list` output was not sorted by the plugin's name and then target. After applying the fix, the plugins list output is now sorted by plugin name first, and then by target. 
1. E2E tests are added.
2. Manual testing has done for `tanzu plugin list`, below is the output:
2.a) Before Fix: `tanzu plugin list` output:
![image](https://github.com/vmware-tanzu/tanzu-cli/assets/4702817/2308e122-03ff-48de-b91d-e9f2a93ac637)

2.b) After Fix: `tanzu plugin list` output:
You can see the plugins has been sorted by plugin name's, and the 'cluster' plugin has been sorted by target.
![image](https://github.com/vmware-tanzu/tanzu-cli/assets/4702817/5d4eb88c-9c6c-4e5f-acea-6d0ebf2ae8ad)

3. Manual testing has done for `tanzu plugin search`, below is the output:
3.a) Before fix: `tanzu plugin search` output:
![image](https://github.com/vmware-tanzu/tanzu-cli/assets/4702817/17a0f77c-20c7-4e3d-8f87-9498fab40449)
3.b) After Fix: `tanzu plugin search` output:
![image](https://github.com/vmware-tanzu/tanzu-cli/assets/4702817/d891c63c-f717-4b87-b437-5a43c4b68f65)

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The `tanzu plugin list` and `tanzu plugin search` outputs are now sorted by plugin names instead of by targets.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
