### PR TITLE
Add show details reminder in group search output

### DIFF
--- a/pkg/command/plugin_group.go
+++ b/pkg/command/plugin_group.go
@@ -28,6 +28,8 @@ var (
 	showNonMandatory bool
 )
 
+const groupSearchShowDetailsMsg = "Note: To view all plugin group versions available, use 'tanzu plugin group search --show-details'."
+
 func newPluginGroupCmd() *cobra.Command {
 	var pluginGroupCmd = &cobra.Command{
 		Use:   "group",
@@ -158,6 +160,11 @@ func displayGroupsFound(groups []*plugininventory.PluginGroup, writer io.Writer)
 		output.AddRow(id, pg.Description, pg.RecommendedVersion)
 	}
 	output.Render()
+
+	if outputFormat == "" || outputFormat == string(component.TableOutputType) {
+		fmt.Fprintln(writer)
+		fmt.Fprintln(writer, groupSearchShowDetailsMsg)
+	}
 }
 
 func displayGroupDetails(groups []*plugininventory.PluginGroup, writer io.Writer) {

--- a/pkg/command/plugin_group_test.go
+++ b/pkg/command/plugin_group_test.go
@@ -23,13 +23,13 @@ func TestPluginGroupSearch(t *testing.T) {
 			test:            "search for all groups",
 			args:            []string{"plugin", "group", "search"},
 			expectedFailure: false,
-			expected:        "GROUP DESCRIPTION LATEST vmware-tap/default Plugins for TAP v3.3.3 vmware-tkg/default Plugins for TKG v2.2.2",
+			expected:        "GROUP DESCRIPTION LATEST vmware-tap/default Plugins for TAP v3.3.3 vmware-tkg/default Plugins for TKG v2.2.2 " + groupSearchShowDetailsMsg,
 		},
 		{
 			test:            "search for group with --name",
 			args:            []string{"plugin", "group", "search", "--name", "vmware-tap/default"},
 			expectedFailure: false,
-			expected:        "GROUP DESCRIPTION LATEST vmware-tap/default Plugins for TAP v3.3.3",
+			expected:        "GROUP DESCRIPTION LATEST vmware-tap/default Plugins for TAP v3.3.3 " + groupSearchShowDetailsMsg,
 		},
 		{
 			test:            "search for invalid group with --name",


### PR DESCRIPTION
### What this PR does / why we need it

Shows a notes at the bottom of the group search tabular output about using the --show-details flag to see all versions of the groups.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Added unit tests.

Output changes are as follows:
```
> tanzu plugin group search
  GROUP                       DESCRIPTION                          LATEST
  vmware-tanzucli/essentials  Essential plugins for the Tanzu CLI  v1.0.0
  vmware-tap/default          Plugins for TAP                      v1.7.3
  vmware-tkg/default          Plugins for TKG                      v2.4.1
  vmware-tmc/default          Plugins for TMC                      v1.0.0

Note: to view all plugin group versions available, use 'tanzu plugin group search --show-details'
>
```


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Added note in "tanzu plugin group search" about using --show-details to see all versions of groups 
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
