### PR TITLE
Clear all the local metrics data when user opt out of CEIP

### DIFF
--- a/pkg/telemetry/client.go
+++ b/pkg/telemetry/client.go
@@ -139,6 +139,16 @@ func (tc *telemetryClient) SaveMetrics() error {
 		return errors.Wrap(err, "unable to create the telemetry schema")
 	}
 
+	// If user opts-out from CEIP, clear the metrics data from the local database
+	// TODO(prkalle): Once the DB is emptied, the subsequent calls will keep trying to delete the rows from the empty DB.
+	// So this need to be optimized. One possible future enhancement/optimization could be to let the telemetry plugin to empty
+	// the DB as soon as the user updates the opt-out choice and CLI would just ignore saving the metrics if user opts-out.
+	ceipOptInConfigVal, _ := configlib.GetCEIPOptIn()
+	optIn, _ := strconv.ParseBool(ceipOptInConfigVal)
+	if !optIn {
+		return tc.metricsDB.ClearMetricData()
+	}
+
 	return tc.metricsDB.SaveOperationMetric(tc.currentOperationMetrics)
 }
 

--- a/pkg/telemetry/metric_db.go
+++ b/pkg/telemetry/metric_db.go
@@ -13,4 +13,7 @@ type MetricsDB interface {
 
 	// GetRowCount gets metrics table current row count
 	GetRowCount() (int, error)
+
+	// ClearMetricData clears all the CLI operation metrics collected in the database
+	ClearMetricData() error
 }


### PR DESCRIPTION
### What this PR does / why we need it
This PR  add changes to clear all the local metrics data when user opt out of CEIP and CLI will ignore (not store) the metrics.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Initially opted-in for the telemetry and later opted-out and verified the local metrics DB data is cleared.

```
❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db "select count(*) from tanzu_cli_operations;"
count(*)
0
❯ ./bin/tanzu telemetry cli-usage-analytics update --opt-in
I0118 16:12:52.175949   92176 update.go:70] "successfully opted into CEIP"
I0118 16:12:52.189164   92176 update.go:95] "successfully set CLI telemetry options"
❯ ./bin/tanzu context list --current
  NAME                ISACTIVE  TYPE   PROJECT  SPACE
  prem-ucp-intg-ctx7  true      tanzu

[i] Use '--wide' flag to view additional columns.
❯ ./bin/tanzu context list --current
  NAME                ISACTIVE  TYPE   PROJECT  SPACE
  prem-ucp-intg-ctx7  true      tanzu

[i] Use '--wide' flag to view additional columns.
❯ ./bin/tanzu context list --current
  NAME                ISACTIVE  TYPE   PROJECT  SPACE
  prem-ucp-intg-ctx7  true      tanzu

[i] Use '--wide' flag to view additional columns.
❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db "select count(*) from tanzu_cli_operations;"
count(*)
3
❯ ./bin/tanzu telemetry cli-usage-analytics update --opt-out
I0118 16:13:31.126997   92246 update.go:77] "successfully opted out of CEIP"
I0118 16:13:31.138951   92246 update.go:95] "successfully set CLI telemetry options"
❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db "select count(*) from tanzu_cli_operations;"
count(*)
3
❯ ./bin/tanzu context list --current
  NAME                ISACTIVE  TYPE   PROJECT  SPACE
  prem-ucp-intg-ctx7  true      tanzu

[i] Use '--wide' flag to view additional columns.
❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db "select count(*) from tanzu_cli_operations;"
count(*)
0
```

Some latency numbers with 6000 rows of metric data existing in local DB and if user opt-out, the metric data is deleted. Also captured the time taken when there are 0 rows in the DB. The latency numbers are in acceptable range.

```
❯ cp /tmp/test.db $HOME/.config/tanzu-cli-telemetry/cli_metrics.db
❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db "select count(*) from tanzu_cli_operations;"
count(*)
6000

❯ time ./bin/tanzu context list --current
  NAME                ISACTIVE  TYPE   PROJECT  SPACE
  prem-ucp-intg-ctx7  true      tanzu

[i] Use '--wide' flag to view additional columns.
./bin/tanzu context list --current  0.34s user 0.08s system 71% cpu 0.582 total

❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db "select count(*) from tanzu_cli_operations;"
count(*)
0
❯ time ./bin/tanzu context list --current
  NAME                ISACTIVE  TYPE   PROJECT  SPACE
  prem-ucp-intg-ctx7  true      tanzu

[i] Use '--wide' flag to view additional columns.
./bin/tanzu context list --current  0.33s user 0.08s system 70% cpu 0.586 total

```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Clear all the local metrics data when user opt out of CEIP
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
