### PR TITLE
UX: Sort context create and context use output by context name

### DIFF
--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -287,6 +287,9 @@ func syncContextPlugins(cmd *cobra.Command, contextType configtypes.ContextType,
 	// update plugins installation status
 	pluginmanager.UpdatePluginsInstallationStatus(plugins)
 
+	// sort the plugins based on the plugin name
+	sort.Sort(discovery.DiscoveredSorter(plugins))
+
 	// list plugins only if listPlugins is true and there are plugins to be installed
 	if listPlugins {
 		pluginsNeedstoBeInstalled := 0

--- a/test/e2e/context/k8s/context_k8s_lifecycle_test.go
+++ b/test/e2e/context/k8s/context_k8s_lifecycle_test.go
@@ -46,7 +46,7 @@ func k8sContextLifeCycleTests() bool {
 		It("create context with kubeconfig and context", func() {
 			By("create context with kubeconfig and context")
 			ctxName := ContextNameConfigPrefix + framework.RandomString(4)
-			err := tf.ContextCmd.CreateContextWithKubeconfig(ctxName, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
+			_, _, err := tf.ContextCmd.CreateContextWithKubeconfig(ctxName, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
 			Expect(err).To(BeNil(), "context should create without any error")
 			log.Infof("context: %s added", ctxName)
 			Expect(framework.IsContextExists(tf, ctxName)).To(BeTrue(), fmt.Sprintf(framework.ContextShouldExistsAsCreated, ctxName))
@@ -57,7 +57,7 @@ func k8sContextLifeCycleTests() bool {
 		It("create context with incorrect kubeconfig and context", func() {
 			By("create context with incorrect kubeconfig and context")
 			ctxName := ContextNameConfigPrefix + framework.RandomString(4)
-			err := tf.ContextCmd.CreateContextWithKubeconfig(ctxName, framework.RandomString(4), clusterInfo.ClusterKubeContext)
+			_, _, err := tf.ContextCmd.CreateContextWithKubeconfig(ctxName, framework.RandomString(4), clusterInfo.ClusterKubeContext)
 			Expect(err).ToNot(BeNil())
 			Expect(strings.Contains(err.Error(), framework.FailedToCreateContext)).To(BeTrue())
 			Expect(framework.IsContextExists(tf, ctxName)).To(BeFalse(), fmt.Sprintf(framework.ContextShouldNotExists, ctxName))
@@ -66,7 +66,7 @@ func k8sContextLifeCycleTests() bool {
 		It("create context with kubeconfig and incorrect context", func() {
 			By("create context with kubeconfig and incorrect context")
 			ctxName := ContextNameConfigPrefix + framework.RandomString(4)
-			err := tf.ContextCmd.CreateContextWithKubeconfig(ctxName, clusterInfo.KubeConfigPath, framework.RandomString(4))
+			_, _, err := tf.ContextCmd.CreateContextWithKubeconfig(ctxName, clusterInfo.KubeConfigPath, framework.RandomString(4))
 			Expect(err).ToNot(BeNil())
 			Expect(strings.Contains(err.Error(), framework.FailedToCreateContext)).To(BeTrue())
 			Expect(framework.IsContextExists(tf, ctxName)).To(BeFalse(), fmt.Sprintf(framework.ContextShouldNotExists, ctxName))
@@ -222,7 +222,7 @@ func k8sContextStressTests() bool {
 			By("create multiple contexts with kubeconfig and context")
 			for i := 0; i < ContextCreateLimit; i++ {
 				ctxName := ContextNameConfigPrefix + framework.RandomString(4)
-				err = tf.ContextCmd.CreateContextWithKubeconfig(ctxName, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
+				_, _, err = tf.ContextCmd.CreateContextWithKubeconfig(ctxName, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
 				Expect(err).To(BeNil(), "context should create without any error")
 				log.Info("context: " + ctxName + " added")
 				Expect(framework.IsContextExists(tf, ctxName)).To(BeTrue(), fmt.Sprintf(framework.ContextShouldExistsAsCreated, ctxName))

--- a/test/e2e/context/tmc/context_tmc_lifecycle_test.go
+++ b/test/e2e/context/tmc/context_tmc_lifecycle_test.go
@@ -127,7 +127,7 @@ func tmcAndK8sContextTests() bool {
 			// Test case: b. create k8s context, make sure its active
 			It("create k8s context", func() {
 				k8sCtx = prefixK8s + framework.RandomString(4)
-				err := tf.ContextCmd.CreateContextWithKubeconfig(k8sCtx, k8sClusterInfo.KubeConfigPath, k8sClusterInfo.ClusterKubeContext)
+				_, _, err := tf.ContextCmd.CreateContextWithKubeconfig(k8sCtx, k8sClusterInfo.KubeConfigPath, k8sClusterInfo.ClusterKubeContext)
 				Expect(err).To(BeNil(), "context should create without any error")
 				Expect(framework.IsContextExists(tf, k8sCtx)).To(BeTrue(), fmt.Sprintf(framework.ContextShouldExistsAsCreated, k8sCtx))
 
@@ -195,7 +195,7 @@ func tmcAndK8sContextTests() bool {
 			It("create k8s context", func() {
 				for i := 0; i < 5; i++ {
 					k8sCtx = prefixK8s + framework.RandomString(4)
-					err := tf.ContextCmd.CreateContextWithKubeconfig(k8sCtx, k8sClusterInfo.KubeConfigPath, k8sClusterInfo.ClusterKubeContext)
+					_, _, err := tf.ContextCmd.CreateContextWithKubeconfig(k8sCtx, k8sClusterInfo.KubeConfigPath, k8sClusterInfo.ClusterKubeContext)
 					Expect(err).To(BeNil(), "context should create without any error")
 					Expect(framework.IsContextExists(tf, k8sCtx)).To(BeTrue(), fmt.Sprintf(framework.ContextShouldExistsAsCreated, k8sCtx))
 

--- a/test/e2e/framework/context_create_operations.go
+++ b/test/e2e/framework/context_create_operations.go
@@ -18,7 +18,7 @@ type ContextCreateOps interface {
 	// CreateContextWithEndPointStaging creates a context with a given endpoint URL for staging, returns stdout, stderr and error
 	CreateContextWithEndPointStaging(contextName, endpoint string, opts ...E2EOption) (stdOut, stdErr string, err error)
 	// CreateContextWithKubeconfig creates a context with the given kubeconfig file path and a context from the kubeconfig file
-	CreateContextWithKubeconfig(contextName, kubeconfigPath, kubeContext string, opts ...E2EOption) error
+	CreateContextWithKubeconfig(contextName, kubeconfigPath, kubeContext string, opts ...E2EOption) (stdOut, stdErr string, err error)
 	// CreateContextWithDefaultKubeconfig creates a context with the default kubeconfig file and a given input context name if it exists in the default kubeconfig file
 	CreateContextWithDefaultKubeconfig(contextName, kubeContext string, opts ...E2EOption) error
 }
@@ -56,15 +56,15 @@ func (cc *contextCreateOps) CreateContextWithEndPointStaging(contextName, endpoi
 	return out.String(), stdErrBuffer.String(), err
 }
 
-func (cc *contextCreateOps) CreateContextWithKubeconfig(contextName, kubeconfigPath, kubeContext string, opts ...E2EOption) error {
+func (cc *contextCreateOps) CreateContextWithKubeconfig(contextName, kubeconfigPath, kubeContext string, opts ...E2EOption) (stdOut, stdErr string, err error) {
 	createContextCmd := fmt.Sprintf(CreateContextWithKubeconfigFile, "%s", kubeconfigPath, kubeContext, contextName)
-	out, _, err := cc.cmdExe.TanzuCmdExec(createContextCmd, opts...)
+	stdOutBuff, stdErrBuff, err := cc.cmdExe.TanzuCmdExec(createContextCmd, opts...)
 	if err != nil {
-		log.Info(fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
-		return errors.Wrap(err, fmt.Sprintf(FailedToCreateContextWithStdout, out.String()))
+		log.Info(fmt.Sprintf(FailedToCreateContextWithStdout, stdOutBuff.String()))
+		return stdOutBuff.String(), stdErrBuff.String(), err
 	}
 	log.Infof(ContextCreated, contextName)
-	return err
+	return stdOutBuff.String(), stdErrBuff.String(), err
 }
 
 func (cc *contextCreateOps) CreateContextWithDefaultKubeconfig(contextName, kubeContext string, opts ...E2EOption) error {

--- a/test/e2e/plugin_sync/k8s/plugin_sync_k8s_lifecycle_test.go
+++ b/test/e2e/plugin_sync/k8s/plugin_sync_k8s_lifecycle_test.go
@@ -64,7 +64,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 		It("create context with kubeconfig and context", func() {
 			By("create context with kubeconfig and context")
 			contextName = f.ContextPrefixK8s + f.RandomString(4)
-			err := tf.ContextCmd.CreateContextWithKubeconfig(contextName, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
+			_, _, err := tf.ContextCmd.CreateContextWithKubeconfig(contextName, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
 			Expect(err).To(BeNil(), "context should create without any error")
 			active, err := tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
 			Expect(err).To(BeNil(), "there should be a active context")
@@ -126,7 +126,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 		// Test case: c. create context and make sure context has created
 		It("create context with kubeconfig and context", func() {
 			contextName = f.ContextPrefixK8s + f.RandomString(4)
-			err = tf.ContextCmd.CreateContextWithKubeconfig(contextName, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
+			_, _, err = tf.ContextCmd.CreateContextWithKubeconfig(contextName, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
 			Expect(err).To(BeNil(), "context should create without any error")
 			active, err := tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
 			Expect(err).To(BeNil(), "there should be a active context")
@@ -264,7 +264,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 		It("create context with kubeconfig and context", func() {
 			By("create context with kubeconfig and context")
 			contextName = f.ContextPrefixK8s + f.RandomString(4)
-			err = tf.ContextCmd.CreateContextWithKubeconfig(contextName, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
+			_, _, err = tf.ContextCmd.CreateContextWithKubeconfig(contextName, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
 			Expect(err).To(BeNil(), "context should create without any error")
 			active, err := tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
 			Expect(err).To(BeNil(), "there should be a active context")
@@ -366,7 +366,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 		It("create context and validate installed plugins list, should installed all plugins for which CRs has applied in KIND cluster", func() {
 			By("create context with kubeconfig and context")
 			contextName = f.ContextPrefixK8s + f.RandomString(4)
-			err = tf.ContextCmd.CreateContextWithKubeconfig(contextName, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
+			_, _, err = tf.ContextCmd.CreateContextWithKubeconfig(contextName, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
 			Expect(err).To(BeNil(), "context should create without any error")
 			pluginsList, err = tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
@@ -440,7 +440,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 		It("create context and validate installed plugins list, should installed all plugins for which CRs has applied in KIND cluster", func() {
 			By("create context with kubeconfig and context")
 			contextNameClusterOne = f.ContextPrefixK8s + f.RandomString(4)
-			err = tf.ContextCmd.CreateContextWithKubeconfig(contextNameClusterOne, clusterOne.KubeConfigPath, clusterOne.ClusterKubeContext)
+			_, _, err = tf.ContextCmd.CreateContextWithKubeconfig(contextNameClusterOne, clusterOne.KubeConfigPath, clusterOne.ClusterKubeContext)
 			Expect(err).To(BeNil(), "context should create without any error")
 			pluginsListClusterOne, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameClusterOne, true)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
@@ -452,7 +452,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 		It("create context and validate installed plugins list, should installed all plugins for which CRs has applied in KIND cluster", func() {
 			By("create context with kubeconfig and context")
 			contextNameClusterTwo = f.ContextPrefixK8s + f.RandomString(4)
-			err = tf.ContextCmd.CreateContextWithKubeconfig(contextNameClusterTwo, clusterTwo.KubeConfigPath, clusterTwo.ClusterKubeContext)
+			_, _, err = tf.ContextCmd.CreateContextWithKubeconfig(contextNameClusterTwo, clusterTwo.KubeConfigPath, clusterTwo.ClusterKubeContext)
 			Expect(err).To(BeNil(), "context should create without any error")
 			pluginsListClusterTwo, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameClusterTwo, true)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
@@ -519,7 +519,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 		It("create context with kubeconfig and context", func() {
 			By("create context with kubeconfig and context")
 			contextName = f.ContextPrefixK8s + f.RandomString(4)
-			err = tf.ContextCmd.CreateContextWithKubeconfig(contextName, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
+			_, _, err = tf.ContextCmd.CreateContextWithKubeconfig(contextName, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
 			Expect(err).To(BeNil(), "context should create without any error")
 			active, err := tf.ContextCmd.GetActiveContext(string(types.TargetK8s))
 			Expect(err).To(BeNil(), "there should be a active context")

--- a/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_test.go
+++ b/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_test.go
@@ -545,7 +545,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		It("create context with kubeconfig and context", func() {
 			By("create context with kubeconfig and context")
 			contextNameK8s = f.ContextPrefixK8s + f.RandomString(4)
-			err := tf.ContextCmd.CreateContextWithKubeconfig(contextNameK8s, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
+			_, _, err := tf.ContextCmd.CreateContextWithKubeconfig(contextNameK8s, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
 			Expect(err).To(BeNil(), "context should create without any error")
 			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeK8s))
 			Expect(err).To(BeNil(), "there should be a active context")
@@ -721,7 +721,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		It("create context with kubeconfig and context", func() {
 			By("create context with kubeconfig and context")
 			contextNameK8s = f.ContextPrefixK8s + f.RandomString(4)
-			err = tf.ContextCmd.CreateContextWithKubeconfig(contextNameK8s, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
+			_, _, err = tf.ContextCmd.CreateContextWithKubeconfig(contextNameK8s, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
 			Expect(err).To(BeNil(), "context should create without any error")
 			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeK8s))
 			Expect(err).To(BeNil(), thereShouldNotBeError+" while getting active context")
@@ -1020,7 +1020,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		It("create context with kubeconfig and context", func() {
 			By("create context with kubeconfig and context")
 			contextNameK8s = f.ContextPrefixK8s + f.RandomString(4)
-			err := tf.ContextCmd.CreateContextWithKubeconfig(contextNameK8s, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
+			_, _, err := tf.ContextCmd.CreateContextWithKubeconfig(contextNameK8s, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
 			Expect(err).To(BeNil(), "context should create without any error")
 			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeK8s))
 			Expect(err).To(BeNil(), "there should be a active context")

--- a/test/sample-plugin/cmd/plugin/sample-plugin/test/e2e/framework_functionality/plugin_functionality_test.go
+++ b/test/sample-plugin/cmd/plugin/sample-plugin/test/e2e/framework_functionality/plugin_functionality_test.go
@@ -58,7 +58,7 @@ var _ = framework.CLICoreDescribe("[Tests:Sample-Plugin-E2E][Feature:plugin-spec
 		It("create context with kubeconfig and context", func() {
 			By("create context with kubeconfig and context")
 			contextName = "k8s-context-" + framework.RandomString(4)
-			err := tf.ContextCmd.CreateContextWithKubeconfig(contextName, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
+			_, _, err := tf.ContextCmd.CreateContextWithKubeconfig(contextName, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
 			Expect(err).To(BeNil(), "context should create without any error")
 			log.Infof("context: %s added", contextName)
 			Expect(framework.IsContextExists(tf, contextName)).To(BeTrue(), fmt.Sprintf(framework.ContextShouldExistsAsCreated, contextName))


### PR DESCRIPTION
### What this PR does / why we need it
This PR updates the output of `tanzu context create` and `tanzu context use` to list and install the required plugins in a sorted order. Sorting the plugins alphabetically by name provides an enhanced user experience by allowing easier visual scanning of the plugins list.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
1. E2E tests are updated
2. Manual testing has done, below is the output:
2.a) tanzu context use output:
Before fix: Contexts are not sorted by context name:
<img width="1283" alt="image" src="https://github.com/vmware-tanzu/tanzu-cli/assets/4702817/908833da-ff19-42fe-b1d3-7f180c9193f0">
After fix: Contexts are sorted by context name:
<img width="1169" alt="image" src="https://github.com/vmware-tanzu/tanzu-cli/assets/4702817/6abaf510-5a70-429e-9d49-0d570cd83547">
2.b) tanxu context create output:
Before fix: Contexts are not sorted by context name:
<img width="1109" alt="image" src="https://github.com/vmware-tanzu/tanzu-cli/assets/4702817/30fd5579-a3f9-4c4a-8c61-86903067e887">

After fix: Contexts are sorted by context name:
<img width="1502" alt="image" src="https://github.com/vmware-tanzu/tanzu-cli/assets/4702817/469b21a8-cbc4-44c8-9e2f-3a93b238fc2e">

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
