### PR TITLE
[Take2] Support context-scoped plugin discovery for tanzu contexts behind feature-flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 replace cloud.google.com/go => cloud.google.com/go v0.102.1
 
-replace github.com/vmware-tanzu/tanzu-plugin-runtime => github.com/anujc25/tanzu-plugin-runtime v0.0.0-20240119233614-3affdb098903
+replace github.com/vmware-tanzu/tanzu-plugin-runtime => github.com/anujc25/tanzu-plugin-runtime v0.0.0-20240122024954-261ba514ea6a
 
 replace github.com/vmware-tanzu/tanzu-cli/test/e2e/framework => ./test/e2e/framework
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.21
 
 replace cloud.google.com/go => cloud.google.com/go v0.102.1
 
+replace github.com/vmware-tanzu/tanzu-plugin-runtime => github.com/anujc25/tanzu-plugin-runtime v0.0.0-20240118202906-67f297155151
+
 replace github.com/vmware-tanzu/tanzu-cli/test/e2e/framework => ./test/e2e/framework
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 replace cloud.google.com/go => cloud.google.com/go v0.102.1
 
-replace github.com/vmware-tanzu/tanzu-plugin-runtime => github.com/anujc25/tanzu-plugin-runtime v0.0.0-20240118222105-b86ee79b29c4
+replace github.com/vmware-tanzu/tanzu-plugin-runtime => github.com/anujc25/tanzu-plugin-runtime v0.0.0-20240119233614-3affdb098903
 
 replace github.com/vmware-tanzu/tanzu-cli/test/e2e/framework => ./test/e2e/framework
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 replace cloud.google.com/go => cloud.google.com/go v0.102.1
 
-replace github.com/vmware-tanzu/tanzu-plugin-runtime => github.com/anujc25/tanzu-plugin-runtime v0.0.0-20240118202906-67f297155151
+replace github.com/vmware-tanzu/tanzu-plugin-runtime => github.com/anujc25/tanzu-plugin-runtime v0.0.0-20240118222105-b86ee79b29c4
 
 replace github.com/vmware-tanzu/tanzu-cli/test/e2e/framework => ./test/e2e/framework
 

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmx
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
 github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/anujc25/tanzu-plugin-runtime v0.0.0-20240118202906-67f297155151 h1:MSeXae5rWha20DFNJxEhujlKjakoLaB8GKn06auiIG8=
-github.com/anujc25/tanzu-plugin-runtime v0.0.0-20240118202906-67f297155151/go.mod h1:M7WVZoItdyQp53tEprQIa6PZmhbrLe3CzuyQphWuRyI=
+github.com/anujc25/tanzu-plugin-runtime v0.0.0-20240118222105-b86ee79b29c4 h1:grvCB/0+FecHNNDnsqxnk9FFYizVcLobKKgiLD2VJeQ=
+github.com/anujc25/tanzu-plugin-runtime v0.0.0-20240118222105-b86ee79b29c4/go.mod h1:M7WVZoItdyQp53tEprQIa6PZmhbrLe3CzuyQphWuRyI=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmx
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
 github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/anujc25/tanzu-plugin-runtime v0.0.0-20240119233614-3affdb098903 h1:g+TuxfH8z6YHyKAm/s9I8zPixjp9JM9eEvBmtx/JIfI=
-github.com/anujc25/tanzu-plugin-runtime v0.0.0-20240119233614-3affdb098903/go.mod h1:M7WVZoItdyQp53tEprQIa6PZmhbrLe3CzuyQphWuRyI=
+github.com/anujc25/tanzu-plugin-runtime v0.0.0-20240122024954-261ba514ea6a h1:n7K3PZ1Q/pjEeGH6Om0pnWg76TFwTjv2FdbnrSWpYgg=
+github.com/anujc25/tanzu-plugin-runtime v0.0.0-20240122024954-261ba514ea6a/go.mod h1:M7WVZoItdyQp53tEprQIa6PZmhbrLe3CzuyQphWuRyI=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmx
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
 github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/anujc25/tanzu-plugin-runtime v0.0.0-20240118202906-67f297155151 h1:MSeXae5rWha20DFNJxEhujlKjakoLaB8GKn06auiIG8=
+github.com/anujc25/tanzu-plugin-runtime v0.0.0-20240118202906-67f297155151/go.mod h1:M7WVZoItdyQp53tEprQIa6PZmhbrLe3CzuyQphWuRyI=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
@@ -738,8 +740,6 @@ github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502eb
 github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502ebf68/go.mod h1:e1Uef+Ux5BIHpYwqbeP2ZZmOzehBcez2vUEWXHe+xHE=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686 h1:VcuXqUXFxm5WDqWkzAlU/6cJXua0ozELnqD59fy7J6E=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686/go.mod h1:AFGOXZD4tH+KhpmtV0VjWjllXhr8y57MvOsIxTtywc4=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.2.0-dev.0.20240118142028-778d24409033 h1:zd1HXrHCjQyEiqCrVwvl4RFhzpBmnKoAf+Cq5eOcRpk=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.2.0-dev.0.20240118142028-778d24409033/go.mod h1:M7WVZoItdyQp53tEprQIa6PZmhbrLe3CzuyQphWuRyI=
 github.com/xanzy/go-gitlab v0.83.0 h1:37p0MpTPNbsTMKX/JnmJtY8Ch1sFiJzVF342+RvZEGw=
 github.com/xanzy/go-gitlab v0.83.0/go.mod h1:5ryv+MnpZStBH8I/77HuQBsMbBGANtVpLWC15qOjWAw=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmx
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
 github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/anujc25/tanzu-plugin-runtime v0.0.0-20240118222105-b86ee79b29c4 h1:grvCB/0+FecHNNDnsqxnk9FFYizVcLobKKgiLD2VJeQ=
-github.com/anujc25/tanzu-plugin-runtime v0.0.0-20240118222105-b86ee79b29c4/go.mod h1:M7WVZoItdyQp53tEprQIa6PZmhbrLe3CzuyQphWuRyI=
+github.com/anujc25/tanzu-plugin-runtime v0.0.0-20240119233614-3affdb098903 h1:g+TuxfH8z6YHyKAm/s9I8zPixjp9JM9eEvBmtx/JIfI=
+github.com/anujc25/tanzu-plugin-runtime v0.0.0-20240119233614-3affdb098903/go.mod h1:M7WVZoItdyQp53tEprQIa6PZmhbrLe3CzuyQphWuRyI=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=

--- a/pkg/cluster/client.go
+++ b/pkg/cluster/client.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	capdiscovery "github.com/vmware-tanzu/tanzu-framework/capabilities/client/pkg/discovery"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 
 	cliv1alpha1 "github.com/vmware-tanzu/tanzu-cli/apis/cli/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
@@ -97,11 +98,11 @@ type client struct {
 // if kubeconfig path is empty it gets default path
 // if options.poller is nil it creates default poller. You should only pass custom poller for unit testing
 // if options.crtClientFactory is nil it creates default CrtClientFactory
-func NewClient(kubeConfigPath, contextStr string, kubeconfigBytes []byte, options Options) (Client, error) {
+func NewClient(kubeConfigPath, contextStr string, kubeConfigBytes []byte, options Options) (Client, error) {
 	var err error
 	client := &client{}
 
-	if len(kubeconfigBytes) == 0 {
+	if len(kubeConfigBytes) == 0 {
 		var rules *clientcmd.ClientConfigLoadingRules
 		if kubeConfigPath == "" {
 			rules = clientcmd.NewDefaultClientConfigLoadingRules()
@@ -109,8 +110,10 @@ func NewClient(kubeConfigPath, contextStr string, kubeconfigBytes []byte, option
 		}
 		client.kubeConfigPath = kubeConfigPath
 		client.currentContext = contextStr
+		log.V(7).Infof("creating kubernetes client with kubeconfig %q, kubecontext %q", kubeConfigPath, contextStr)
 	} else {
-		client.kubeConfigBytes = kubeconfigBytes
+		client.kubeConfigBytes = kubeConfigBytes
+		log.V(7).Infof("creating kubernetes client with kubeconfigbytes %q", string(kubeConfigBytes))
 	}
 
 	InitializeOptions(&options)

--- a/pkg/cluster/client.go
+++ b/pkg/cluster/client.go
@@ -88,6 +88,7 @@ type client struct {
 	CrtClient       CrtClient
 	DiscoveryClient DiscoveryClient
 	DynamicClient   DynamicClient
+	kubeConfigBytes []byte
 	kubeConfigPath  string
 	currentContext  string
 }
@@ -96,18 +97,23 @@ type client struct {
 // if kubeconfig path is empty it gets default path
 // if options.poller is nil it creates default poller. You should only pass custom poller for unit testing
 // if options.crtClientFactory is nil it creates default CrtClientFactory
-func NewClient(kubeConfigPath, contextStr string, options Options) (Client, error) {
+func NewClient(kubeConfigPath, contextStr string, kubeconfigBytes []byte, options Options) (Client, error) {
 	var err error
-	var rules *clientcmd.ClientConfigLoadingRules
-	if kubeConfigPath == "" {
-		rules = clientcmd.NewDefaultClientConfigLoadingRules()
-		kubeConfigPath = rules.GetDefaultFilename()
+	client := &client{}
+
+	if len(kubeconfigBytes) == 0 {
+		var rules *clientcmd.ClientConfigLoadingRules
+		if kubeConfigPath == "" {
+			rules = clientcmd.NewDefaultClientConfigLoadingRules()
+			kubeConfigPath = rules.GetDefaultFilename()
+		}
+		client.kubeConfigPath = kubeConfigPath
+		client.currentContext = contextStr
+	} else {
+		client.kubeConfigBytes = kubeconfigBytes
 	}
+
 	InitializeOptions(&options)
-	client := &client{
-		kubeConfigPath: kubeConfigPath,
-		currentContext: contextStr,
-	}
 	err = client.getK8sClients(options.CrtClient, options.DiscoveryClientFactory, options.DynamicClientFactory, options.RequestTimeout)
 	if err != nil {
 		return nil, err
@@ -201,19 +207,29 @@ func ConsolidateImageRepoMaps(cmList *corev1.ConfigMapList) (map[string]string, 
 
 func (c *client) getK8sClients(crtClient CrtClient, discoveryClientFactory DiscoveryClientFactory, dynamicClientFactory DynamicClientFactory, timeout time.Duration) error {
 	var discoveryClient discovery.DiscoveryInterface
-	config, err := clientcmd.LoadFromFile(c.kubeConfigPath)
-	if err != nil {
-		return errors.Errorf("Failed to load Kubeconfig file from %q", c.kubeConfigPath)
-	}
-	configOverrides := &clientcmd.ConfigOverrides{}
-	if c.currentContext != "" {
-		configOverrides.CurrentContext = c.currentContext
+	var restConfig *rest.Config
+	var err error
+
+	if len(c.kubeConfigBytes) != 0 {
+		restConfig, err = clientcmd.RESTConfigFromKubeConfig(c.kubeConfigBytes)
+		if err != nil {
+			return errors.Errorf("Unable to set up rest config due to : %v", err)
+		}
+	} else {
+		config, err := clientcmd.LoadFromFile(c.kubeConfigPath)
+		if err != nil {
+			return errors.Errorf("Failed to load Kubeconfig file from %q", c.kubeConfigPath)
+		}
+		configOverrides := &clientcmd.ConfigOverrides{}
+		if c.currentContext != "" {
+			configOverrides.CurrentContext = c.currentContext
+		}
+		restConfig, err = clientcmd.NewDefaultClientConfig(*config, configOverrides).ClientConfig()
+		if err != nil {
+			return errors.Errorf("Unable to set up rest config due to : %v", err)
+		}
 	}
 
-	restConfig, err := clientcmd.NewDefaultClientConfig(*config, configOverrides).ClientConfig()
-	if err != nil {
-		return errors.Errorf("Unable to set up rest config due to : %v", err)
-	}
 	// As there are many registered resources in the cluster, set the values for the maximum number of
 	// queries per second and the maximum burst for throttle to a high value to avoid throttling of messages
 	restConfig.QPS = constants.DefaultQPS
@@ -312,14 +328,14 @@ func NewOptions(crtClient CrtClient, discoveryClientFactory DiscoveryClientFacto
 
 // ClusterClientFactory a factory for creating cluster clients
 type ClusterClientFactory interface {
-	NewClient(kubeConfigPath, context string, options Options) (Client, error)
+	NewClient(kubeConfigPath, contextStr string, kubeConfigBytes []byte, options Options) (Client, error)
 }
 
 type clusterClientFactory struct{}
 
 // NewClient creates new clusterclient
-func (c *clusterClientFactory) NewClient(kubeConfigPath, contextStr string, options Options) (Client, error) {
-	return NewClient(kubeConfigPath, contextStr, options)
+func (c *clusterClientFactory) NewClient(kubeConfigPath, contextStr string, kubeConfigBytes []byte, options Options) (Client, error) {
+	return NewClient(kubeConfigPath, contextStr, kubeConfigBytes, options)
 }
 
 // NewClusterClientFactory creates new clusterclient factory

--- a/pkg/cluster/client_test.go
+++ b/pkg/cluster/client_test.go
@@ -47,7 +47,7 @@ var _ = Describe("New Cluster Client Tests", func() {
 			discoveryClientFactoryFake.ServerVersionReturns(nil, nil)
 		})
 		It("return cluster client", func() {
-			client, err := cluster.NewClient(kubeconfigFile, "foo-context", options)
+			client, err := cluster.NewClient(kubeconfigFile, "foo-context", nil, options)
 			Expect(client).NotTo(BeNil())
 			Expect(err).To(BeNil())
 		})
@@ -61,7 +61,7 @@ var _ = Describe("New Cluster Client Tests", func() {
 			BeforeEach(func() {
 				discoveryClientFactoryFake.NewDiscoveryClientForConfigReturns(&discovery.DiscoveryClient{}, nil)
 				discoveryClientFactoryFake.ServerVersionReturns(nil, nil)
-				clusterClient, _ = cluster.NewClient(kubeconfigFile, "foo-context", options)
+				clusterClient, _ = cluster.NewClient(kubeconfigFile, "foo-context", nil, options)
 				crtClientFake.ListObjectsReturns(nil)
 			})
 			It("return empty plugins and no error", func() {
@@ -74,7 +74,7 @@ var _ = Describe("New Cluster Client Tests", func() {
 			BeforeEach(func() {
 				discoveryClientFactoryFake.NewDiscoveryClientForConfigReturns(&discovery.DiscoveryClient{}, nil)
 				discoveryClientFactoryFake.ServerVersionReturns(nil, nil)
-				clusterClient, _ = cluster.NewClient(kubeconfigFile, "foo-context", options)
+				clusterClient, _ = cluster.NewClient(kubeconfigFile, "foo-context", nil, options)
 				crtClientFake.ListObjectsReturns(nil)
 			})
 			It("return clusterQuery object and no errors", func() {
@@ -87,7 +87,7 @@ var _ = Describe("New Cluster Client Tests", func() {
 			BeforeEach(func() {
 				discoveryClientFactoryFake.NewDiscoveryClientForConfigReturns(&discovery.DiscoveryClient{}, nil)
 				discoveryClientFactoryFake.ServerVersionReturns(nil, nil)
-				clusterClient, _ = cluster.NewClient(kubeconfigFile, "foo-context", options)
+				clusterClient, _ = cluster.NewClient(kubeconfigFile, "foo-context", nil, options)
 				crtClientFake.ListObjectsReturns(nil)
 			})
 			It("return empty map and no error", func() {
@@ -105,7 +105,7 @@ var _ = Describe("New Cluster Client Tests", func() {
 			kubeconfigFile = "invalidkubeconfigfile.yaml"
 		})
 		It("should return error for NewClient()", func() {
-			client, err := cluster.NewClient(kubeconfigFile, "foo-context", options)
+			client, err := cluster.NewClient(kubeconfigFile, "foo-context", nil, options)
 			Expect(client).To(BeNil())
 			Expect(err.Error()).To(ContainSubstring("Failed to load Kubeconfig file from \"invalidkubeconfigfile.yaml\""))
 		})

--- a/pkg/constants/defaults.go
+++ b/pkg/constants/defaults.go
@@ -22,4 +22,11 @@ const (
 
 	// DefaultCLIEssentialsPluginGroupName  name of the essentials plugin group which is used to install essential plugins
 	DefaultCLIEssentialsPluginGroupName = "vmware-tanzucli/essentials"
+
+	// TanzuContextPluginDiscoveryEndpointPath specifies the default plugin discovery endpoint path
+	// Note: This path value needs to be updated once the Tanzu context backend support the context-scoped
+	// plugin discovery and the endpoint value gets finallized
+	// Until then for testing purpose, user can overwrite this path using `TANZU_CLI_TANZU_CONTEXT_PLUGIN_DISCOVERY_PATH`
+	// environment variable
+	TanzuContextPluginDiscoveryEndpointPath = "/discovery"
 )

--- a/pkg/constants/defaults.go
+++ b/pkg/constants/defaults.go
@@ -25,7 +25,7 @@ const (
 
 	// TanzuContextPluginDiscoveryEndpointPath specifies the default plugin discovery endpoint path
 	// Note: This path value needs to be updated once the Tanzu context backend support the context-scoped
-	// plugin discovery and the endpoint value gets finallized
+	// plugin discovery and the endpoint value gets finalized
 	// Until then for testing purpose, user can overwrite this path using `TANZU_CLI_TANZU_CONTEXT_PLUGIN_DISCOVERY_PATH`
 	// environment variable
 	TanzuContextPluginDiscoveryEndpointPath = "/discovery"

--- a/pkg/constants/env_variables.go
+++ b/pkg/constants/env_variables.go
@@ -57,6 +57,6 @@ const (
 	// TanzuContextPluginDiscoveryPath specifies the custom endpoint path to use with the kubeconfig when talking
 	// to the tanzu context to get the recommended plugins by querying CLIPlugin resources
 	// If environment variable 'TANZU_CLI_TANZU_CONTEXT_PLUGIN_DISCOVERY_PATH' is not configured
-	// context-scoped plugin discovery will be disabled for the `tanzu` contexts
+	// default discovery endpoint configured with TanzuContextPluginDiscoveryEndpointPath will be used
 	TanzuContextPluginDiscoveryPath = "TANZU_CLI_TANZU_CONTEXT_PLUGIN_DISCOVERY_PATH"
 )

--- a/pkg/constants/env_variables.go
+++ b/pkg/constants/env_variables.go
@@ -53,4 +53,10 @@ const (
 
 	// TanzuCLIOAuthLocalListenerPort is the port to be used by local listener for OAuth authorization flow
 	TanzuCLIOAuthLocalListenerPort = "TANZU_CLI_OAUTH_LOCAL_LISTENER_PORT"
+
+	// TanzuContextPluginDiscoveryPath specifies the custom endpoint path to use with the kubeconfig when talking
+	// to the tanzu context to get the recommended plugins by querying CLIPlugin resources
+	// If environment variable 'TANZU_CLI_TANZU_CONTEXT_PLUGIN_DISCOVERY_PATH' is not configured
+	// context-scoped plugin discovery will be disabled for the `tanzu` contexts
+	TanzuContextPluginDiscoveryPath = "TANZU_CLI_TANZU_CONTEXT_PLUGIN_DISCOVERY_PATH"
 )

--- a/pkg/constants/featureflags.go
+++ b/pkg/constants/featureflags.go
@@ -7,6 +7,10 @@ package constants
 const (
 	// FeatureContextCommand determines whether to surface the context command. This is disabled by default.
 	FeatureContextCommand = "features.global.context-target-v2"
+
+	// FeatureContextScopedPluginDiscoveryForTanzuContext determines whether to enable context-scoped plugin discovery for Tanzu context.
+	// This is disabled by default
+	FeatureContextScopedPluginDiscoveryForTanzuContext = "features.global.context-plugin-discovery-for-tanzu-context"
 )
 
 // DefaultCliFeatureFlags is used to populate an initially empty config file with default values for feature flags.

--- a/pkg/discovery/interface.go
+++ b/pkg/discovery/interface.go
@@ -119,7 +119,7 @@ func CreateDiscoveryFromV1alpha1(pd configtypes.PluginDiscovery, options ...Disc
 	case pd.Local != nil:
 		return NewLocalDiscovery(pd.Local.Name, pd.Local.Path), nil
 	case pd.Kubernetes != nil:
-		return NewKubernetesDiscovery(pd.Kubernetes.Name, pd.Kubernetes.Path, pd.Kubernetes.Context), nil
+		return NewKubernetesDiscovery(pd.Kubernetes.Name, pd.Kubernetes.Path, pd.Kubernetes.Context, pd.Kubernetes.KubeConfigBytes), nil
 	case pd.REST != nil:
 		return NewRESTDiscovery(pd.REST.Name, pd.REST.Endpoint, pd.REST.BasePath), nil
 	}

--- a/pkg/discovery/interface.go
+++ b/pkg/discovery/interface.go
@@ -119,7 +119,7 @@ func CreateDiscoveryFromV1alpha1(pd configtypes.PluginDiscovery, options ...Disc
 	case pd.Local != nil:
 		return NewLocalDiscovery(pd.Local.Name, pd.Local.Path), nil
 	case pd.Kubernetes != nil:
-		return NewKubernetesDiscovery(pd.Kubernetes.Name, pd.Kubernetes.Path, pd.Kubernetes.Context, pd.Kubernetes.KubeConfigBytes), nil
+		return NewKubernetesDiscovery(pd.Kubernetes.Name, pd.Kubernetes.Path, pd.Kubernetes.Context, nil), nil
 	case pd.REST != nil:
 		return NewRESTDiscovery(pd.REST.Name, pd.REST.Endpoint, pd.REST.BasePath), nil
 	}

--- a/pkg/discovery/kubernetes.go
+++ b/pkg/discovery/kubernetes.go
@@ -48,8 +48,6 @@ func (k *KubernetesDiscovery) Name() string {
 
 // Manifest returns the manifest for a kubernetes repository.
 func (k *KubernetesDiscovery) Manifest() ([]Discovered, error) {
-	log.V(6).Infof("creating kubernetes client with kubeconfig %q, kubecontext %q", k.kubeconfigPath, k.kubecontext)
-
 	// Create cluster client
 	clusterClient, err := cluster.NewClient(k.kubeconfigPath, k.kubecontext, k.kubeconfigBytes, cluster.Options{RequestTimeout: defaultTimeout})
 	if err != nil {

--- a/pkg/discovery/kubernetes.go
+++ b/pkg/discovery/kubernetes.go
@@ -20,17 +20,19 @@ import (
 
 // KubernetesDiscovery is an artifact discovery utilizing CLIPlugin API in kubernetes cluster
 type KubernetesDiscovery struct {
-	name           string
-	kubeconfigPath string
-	kubecontext    string
+	name            string
+	kubeconfigPath  string
+	kubecontext     string
+	kubeconfigBytes []byte
 }
 
 // NewKubernetesDiscovery returns a new kubernetes repository
-func NewKubernetesDiscovery(name, kubeconfigPath, kubecontext string) Discovery {
+func NewKubernetesDiscovery(name, kubeconfigPath, kubecontext string, kubeconfigBytes []byte) Discovery {
 	return &KubernetesDiscovery{
-		name:           name,
-		kubeconfigPath: kubeconfigPath,
-		kubecontext:    kubecontext,
+		name:            name,
+		kubeconfigPath:  kubeconfigPath,
+		kubecontext:     kubecontext,
+		kubeconfigBytes: kubeconfigBytes,
 	}
 }
 
@@ -49,7 +51,7 @@ func (k *KubernetesDiscovery) Manifest() ([]Discovered, error) {
 	log.V(6).Infof("creating kubernetes client with kubeconfig %q, kubecontext %q", k.kubeconfigPath, k.kubecontext)
 
 	// Create cluster client
-	clusterClient, err := cluster.NewClient(k.kubeconfigPath, k.kubecontext, cluster.Options{RequestTimeout: defaultTimeout})
+	clusterClient, err := cluster.NewClient(k.kubeconfigPath, k.kubecontext, k.kubeconfigBytes, cluster.Options{RequestTimeout: defaultTimeout})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/fakes/clusterclientfactory_fake.go
+++ b/pkg/fakes/clusterclientfactory_fake.go
@@ -8,12 +8,13 @@ import (
 )
 
 type ClusterClientFactory struct {
-	NewClientStub        func(string, string, cluster.Options) (cluster.Client, error)
+	NewClientStub        func(string, string, []byte, cluster.Options) (cluster.Client, error)
 	newClientMutex       sync.RWMutex
 	newClientArgsForCall []struct {
 		arg1 string
 		arg2 string
-		arg3 cluster.Options
+		arg3 []byte
+		arg4 cluster.Options
 	}
 	newClientReturns struct {
 		result1 cluster.Client
@@ -27,20 +28,26 @@ type ClusterClientFactory struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *ClusterClientFactory) NewClient(arg1 string, arg2 string, arg3 cluster.Options) (cluster.Client, error) {
+func (fake *ClusterClientFactory) NewClient(arg1 string, arg2 string, arg3 []byte, arg4 cluster.Options) (cluster.Client, error) {
+	var arg3Copy []byte
+	if arg3 != nil {
+		arg3Copy = make([]byte, len(arg3))
+		copy(arg3Copy, arg3)
+	}
 	fake.newClientMutex.Lock()
 	ret, specificReturn := fake.newClientReturnsOnCall[len(fake.newClientArgsForCall)]
 	fake.newClientArgsForCall = append(fake.newClientArgsForCall, struct {
 		arg1 string
 		arg2 string
-		arg3 cluster.Options
-	}{arg1, arg2, arg3})
+		arg3 []byte
+		arg4 cluster.Options
+	}{arg1, arg2, arg3Copy, arg4})
 	stub := fake.NewClientStub
 	fakeReturns := fake.newClientReturns
-	fake.recordInvocation("NewClient", []interface{}{arg1, arg2, arg3})
+	fake.recordInvocation("NewClient", []interface{}{arg1, arg2, arg3Copy, arg4})
 	fake.newClientMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -54,17 +61,17 @@ func (fake *ClusterClientFactory) NewClientCallCount() int {
 	return len(fake.newClientArgsForCall)
 }
 
-func (fake *ClusterClientFactory) NewClientCalls(stub func(string, string, cluster.Options) (cluster.Client, error)) {
+func (fake *ClusterClientFactory) NewClientCalls(stub func(string, string, []byte, cluster.Options) (cluster.Client, error)) {
 	fake.newClientMutex.Lock()
 	defer fake.newClientMutex.Unlock()
 	fake.NewClientStub = stub
 }
 
-func (fake *ClusterClientFactory) NewClientArgsForCall(i int) (string, string, cluster.Options) {
+func (fake *ClusterClientFactory) NewClientArgsForCall(i int) (string, string, []byte, cluster.Options) {
 	fake.newClientMutex.RLock()
 	defer fake.newClientMutex.RUnlock()
 	argsForCall := fake.newClientArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *ClusterClientFactory) NewClientReturns(result1 cluster.Client, result2 error) {

--- a/pkg/pluginmanager/default_discoveries.go
+++ b/pkg/pluginmanager/default_discoveries.go
@@ -6,10 +6,15 @@ package pluginmanager
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
+	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/utils"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
 
 const True = "true"
@@ -38,7 +43,15 @@ func defaultDiscoverySourceBasedOnContext(context *configtypes.Context) []config
 		defaultDiscoveries = append(defaultDiscoveries, defaultDiscoverySourceForK8sTargetedContext(context.Name, context.ClusterOpts.Path, context.ClusterOpts.Context))
 	} else if context.ContextType == configtypes.ContextTypeTMC && context.GlobalOpts != nil {
 		defaultDiscoveries = append(defaultDiscoveries, defaultDiscoverySourceForTMCTargetedContext(context))
+	} else if context.ContextType == configtypes.ContextTypeTanzu && config.IsFeatureActivated(constants.FeatureContextScopedPluginDiscoveryForTanzuContext) {
+		discovery, err := defaultDiscoverySourceForTanzuTargetedContext(context.Name)
+		if err != nil {
+			log.V(6).Infof("error while getting default discovery for context %q, error: %s", context.Name, err.Error())
+		} else {
+			defaultDiscoveries = append(defaultDiscoveries, discovery)
+		}
 	}
+
 	return defaultDiscoveries
 }
 
@@ -60,6 +73,31 @@ func defaultDiscoverySourceForTMCTargetedContext(context *configtypes.Context) c
 			BasePath: "v1alpha1/system/binaries/plugins",
 		},
 	}
+}
+
+func defaultDiscoverySourceForTanzuTargetedContext(context string) (configtypes.PluginDiscovery, error) {
+	tanzuContextDiscoveryEndpointPath := strings.TrimSpace(os.Getenv(constants.TanzuContextPluginDiscoveryPath))
+	if tanzuContextDiscoveryEndpointPath == "" {
+		tanzuContextDiscoveryEndpointPath = constants.TanzuContextPluginDiscoveryEndpointPath
+	}
+
+	kubeconfigBytes, err := config.GetKubeconfigForContext(context, config.ForCustomPath(tanzuContextDiscoveryEndpointPath))
+	if err != nil {
+		return configtypes.PluginDiscovery{}, err
+	}
+	kubeconfigFilePath := filepath.Join(common.DefaultCacheDir, "kubeconfig", "config.yaml")
+	err = utils.SaveFile(kubeconfigFilePath, kubeconfigBytes)
+	if err != nil {
+		return configtypes.PluginDiscovery{}, err
+	}
+
+	return configtypes.PluginDiscovery{
+		Kubernetes: &configtypes.KubernetesDiscovery{
+			Name:    fmt.Sprintf("default-%s", context),
+			Path:    kubeconfigFilePath,
+			Context: "",
+		},
+	}, nil
 }
 
 func appendURLScheme(endpoint string) string {

--- a/pkg/pluginmanager/default_discoveries.go
+++ b/pkg/pluginmanager/default_discoveries.go
@@ -6,12 +6,9 @@ package pluginmanager
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
-	"github.com/vmware-tanzu/tanzu-cli/pkg/utils"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
@@ -85,17 +82,11 @@ func defaultDiscoverySourceForTanzuTargetedContext(context string) (configtypes.
 	if err != nil {
 		return configtypes.PluginDiscovery{}, err
 	}
-	kubeconfigFilePath := filepath.Join(common.DefaultCacheDir, "kubeconfig", "config.yaml")
-	err = utils.SaveFile(kubeconfigFilePath, kubeconfigBytes)
-	if err != nil {
-		return configtypes.PluginDiscovery{}, err
-	}
 
 	return configtypes.PluginDiscovery{
 		Kubernetes: &configtypes.KubernetesDiscovery{
-			Name:    fmt.Sprintf("default-%s", context),
-			Path:    kubeconfigFilePath,
-			Context: "",
+			Name:            fmt.Sprintf("default-%s", context),
+			KubeConfigBytes: kubeconfigBytes,
 		},
 	}, nil
 }

--- a/pkg/pluginmanager/default_discoveries_test.go
+++ b/pkg/pluginmanager/default_discoveries_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 )
@@ -53,11 +54,13 @@ servers:
 
 	server, err := configlib.GetServer("mgmt")
 	assert.Nil(t, err)
-	pds := append(server.DiscoverySources, defaultDiscoverySourceBasedOnServer(server)...)
+	pds := defaultDiscoverySourceBasedOnServer(server)
 	assert.Equal(t, 1, len(pds))
-	assert.Equal(t, pds[0].Kubernetes.Name, "default-mgmt")
-	assert.Equal(t, pds[0].Kubernetes.Path, "config")
-	assert.Equal(t, pds[0].Kubernetes.Context, "mgmt-admin@mgmt")
+	assert.Equal(t, pds[0].Name(), "default-mgmt")
+	assert.Equal(t, pds[0].Type(), common.DiscoveryTypeKubernetes)
+	// assert.Equal(t, pds[0].Kubernetes.Name, "default-mgmt")
+	// assert.Equal(t, pds[0].Kubernetes.Path, "config")
+	// assert.Equal(t, pds[0].Kubernetes.Context, "mgmt-admin@mgmt")
 }
 
 func Test_defaultDiscoverySourceBasedOnContext(t *testing.T) {
@@ -124,24 +127,28 @@ metadata:
 
 	context, err := configlib.GetContext("tmc-test")
 	assert.Nil(t, err)
-	pdsTMC := append(context.DiscoverySources, defaultDiscoverySourceBasedOnContext(context)...)
+	pdsTMC := defaultDiscoverySourceBasedOnContext(context)
 	assert.Equal(t, 1, len(pdsTMC))
-	assert.Equal(t, pdsTMC[0].REST.Endpoint, "https://test.cloud.vmware.com:443")
-	assert.Equal(t, pdsTMC[0].REST.BasePath, "v1alpha1/system/binaries/plugins")
-	assert.Equal(t, pdsTMC[0].REST.Name, "default-tmc-test")
+	assert.Equal(t, pdsTMC[0].Name(), "default-tmc-test")
+	assert.Equal(t, pdsTMC[0].Type(), common.DiscoveryTypeREST)
+	// assert.Equal(t, pdsTMC[0].REST.Endpoint, "https://test.cloud.vmware.com:443")
+	// assert.Equal(t, pdsTMC[0].REST.BasePath, "v1alpha1/system/binaries/plugins")
+	// assert.Equal(t, pdsTMC[0].REST.Name, "default-tmc-test")
 
 	context, err = configlib.GetContext("mgmt")
 	assert.Nil(t, err)
-	pdsK8s := append(context.DiscoverySources, defaultDiscoverySourceBasedOnContext(context)...)
+	pdsK8s := defaultDiscoverySourceBasedOnContext(context)
 	assert.Equal(t, 1, len(pdsK8s))
-	assert.Equal(t, pdsK8s[0].Kubernetes.Name, "default-mgmt")
-	assert.Equal(t, pdsK8s[0].Kubernetes.Path, "config")
-	assert.Equal(t, pdsK8s[0].Kubernetes.Context, "mgmt-admin@mgmt")
+	assert.Equal(t, pdsK8s[0].Name(), "default-mgmt")
+	assert.Equal(t, pdsK8s[0].Type(), common.DiscoveryTypeKubernetes)
+	// assert.Equal(t, pdsK8s[0].Kubernetes.Name, "default-mgmt")
+	// assert.Equal(t, pdsK8s[0].Kubernetes.Path, "config")
+	// assert.Equal(t, pdsK8s[0].Kubernetes.Context, "mgmt-admin@mgmt")
 
 	// Verify that no discovery sources are returned when feature-flag is disabled
 	context, err = configlib.GetContext("tanzu-context-1")
 	assert.Nil(t, err)
-	pdsTanzu := append(context.DiscoverySources, defaultDiscoverySourceBasedOnContext(context)...)
+	pdsTanzu := defaultDiscoverySourceBasedOnContext(context)
 	assert.Equal(t, 0, len(pdsTanzu))
 
 	// Enable feature-flag and verify that one discovery source is returned
@@ -149,10 +156,12 @@ metadata:
 	assert.Nil(t, err)
 	context, err = configlib.GetContext("tanzu-context-1")
 	assert.Nil(t, err)
-	pdsTanzu = append(context.DiscoverySources, defaultDiscoverySourceBasedOnContext(context)...)
+	pdsTanzu = defaultDiscoverySourceBasedOnContext(context)
 	assert.Equal(t, 1, len(pdsTanzu))
-	assert.Equal(t, pdsTanzu[0].Kubernetes.Name, "default-tanzu-context-1")
-	assert.NotEmpty(t, pdsTanzu[0].Kubernetes.KubeConfigBytes)
+	assert.Equal(t, pdsTanzu[0].Name(), "default-tanzu-context-1")
+	assert.Equal(t, pdsTanzu[0].Type(), common.DiscoveryTypeKubernetes)
+	// assert.Equal(t, pdsTanzu[0].Kubernetes.Name, "default-tanzu-context-1")
+	// assert.NotEmpty(t, pdsTanzu[0].Kubernetes.KubeConfigBytes)
 }
 
 func Test_appendURLScheme(t *testing.T) {

--- a/pkg/pluginmanager/default_discoveries_test.go
+++ b/pkg/pluginmanager/default_discoveries_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 )
 
@@ -79,7 +80,26 @@ metadata:
     context: mgmt-admin@mgmt
     path: config
   name: mgmt
-  target: kubernetes`
+  target: kubernetes
+- name: tanzu-context-1
+  target: tanzu
+  contextType: tanzu
+  globalOpts:
+    endpoint: https://localhost:8443
+    auth:
+      issuer: https://console-stg.cloud.vmware.com/csp/gateway/am/api
+      userName: anujc
+      accessToken: eyJ
+      IDToken: eyJ
+      refresh_token: sA4
+      expiration: 2024-01-18T14:56:59.557973-08:00
+      type: id-token
+  clusterOpts:
+    endpoint: https://localhost:8443/org/testorg
+    path: test/kubeconfig.yaml
+    context: tanzu-cli-tanzu-context-1
+  additionalMetadata:
+    tanzuOrgID: testorg`
 	tf, err := os.CreateTemp("", "tanzu_tmc_config")
 	assert.Nil(t, err)
 	err = os.WriteFile(tf.Name(), []byte(tanzuConfigBytes), 0644)
@@ -117,6 +137,22 @@ metadata:
 	assert.Equal(t, pdsK8s[0].Kubernetes.Name, "default-mgmt")
 	assert.Equal(t, pdsK8s[0].Kubernetes.Path, "config")
 	assert.Equal(t, pdsK8s[0].Kubernetes.Context, "mgmt-admin@mgmt")
+
+	// Verify that no discovery sources are returned when feature-flag is disabled
+	context, err = configlib.GetContext("tanzu-context-1")
+	assert.Nil(t, err)
+	pdsTanzu := append(context.DiscoverySources, defaultDiscoverySourceBasedOnContext(context)...)
+	assert.Equal(t, 0, len(pdsTanzu))
+
+	// Enable feature-flag and verify that one discovery source is returned
+	err = configlib.ConfigureFeatureFlags(map[string]bool{constants.FeatureContextScopedPluginDiscoveryForTanzuContext: true})
+	assert.Nil(t, err)
+	context, err = configlib.GetContext("tanzu-context-1")
+	assert.Nil(t, err)
+	pdsTanzu = append(context.DiscoverySources, defaultDiscoverySourceBasedOnContext(context)...)
+	assert.Equal(t, 1, len(pdsTanzu))
+	assert.Equal(t, pdsTanzu[0].Kubernetes.Name, "default-tanzu-context-1")
+	assert.NotEmpty(t, pdsTanzu[0].Kubernetes.KubeConfigBytes)
 }
 
 func Test_appendURLScheme(t *testing.T) {

--- a/pkg/pluginmanager/manager_test.go
+++ b/pkg/pluginmanager/manager_test.go
@@ -1134,7 +1134,7 @@ func TestGetPluginDiscoveries(t *testing.T) {
 	err := os.Setenv(constants.ConfigVariableAdditionalDiscoveryForTesting, "")
 	assertions.Nil(err)
 
-	discoveries, err := getPluginDiscoveries()
+	discoveries, err := getDiscoveries()
 	assertions.Nil(err)
 	assertions.Equal(2, len(discoveries))
 	assertions.Equal("default-local", discoveries[0].Local.Name)
@@ -1145,7 +1145,7 @@ func TestGetPluginDiscoveries(t *testing.T) {
 	err = os.Setenv(constants.ConfigVariableAdditionalDiscoveryForTesting, expectedTestDiscovery)
 	assertions.Nil(err)
 
-	discoveries, err = getPluginDiscoveries()
+	discoveries, err = getDiscoveries()
 	assertions.Nil(err)
 	assertions.Equal(3, len(discoveries))
 	// The test discovery must be last
@@ -1165,7 +1165,7 @@ func TestGetPluginDiscoveries(t *testing.T) {
 		expectedTestDiscoveries[0]+","+expectedTestDiscoveries[1]+"   ,"+expectedTestDiscoveries[2]+"  ,  "+expectedTestDiscoveries[3])
 	assertions.Nil(err)
 
-	discoveries, err = getPluginDiscoveries()
+	discoveries, err = getDiscoveries()
 	assertions.Nil(err)
 	assertions.Equal(len(expectedTestDiscoveries)+2, len(discoveries))
 	// The test discoveries in order but after the configured discoveries

--- a/pkg/pluginmanager/test/kubeconfig.yaml
+++ b/pkg/pluginmanager/test/kubeconfig.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+current-context: tanzu-cli-tanzu-context-1
+clusters:
+  - cluster:
+      insecure-skip-tls-verify: true
+      server: https://tanzu.org:4443
+    name: tanzu-cluster
+contexts:
+  - context:
+      cluster: tanzu-cluster
+      namespace: default
+      user: tanzu-user
+    name: tanzu-cli-tanzu-context-1
+users:
+  - name: tanzu-user
+    user:
+      token: tanzu-user-token


### PR DESCRIPTION
### What this PR does / why we need it
- Support context-scoped plugin discovery for `tanzu` contexts

**Note for reviewers:**
The difference between this PR and #651 is mainly how we are using Discovery Client.
- This PR removes the dependency on PluginRuntime's `PluginDiscovery` (including `KubernetesDiscovery`, and `GenericRESTDiscovery`) resource for Context-Scoped plugin discovery and relies directly on the internal `Discovery` client interface.
    - By doing this, we can avoid adding the `kubeConfigBytes` field to the PluginRuntime's `KubernetesDiscovery` resource.

**Note:** 
- This functionality is by default disabled. To enable this functionality enable the feature flag using
    - `tz config set features.global.context-plugin-discovery-for-tanzu-context true`

- By default, the tanzu context's endpoint implements discovery API at the `/discovery` endpoint. But considering the backend implementation is not done CLI allows configuring this discovery path with the following variable. 
  - `export TANZU_CLI_TANZU_CONTEXT_PLUGIN_DISCOVERY_PATH="/custom-discovery-path"`

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

**Before this change**
```
$ tz context list
  NAME              ISACTIVE  TYPE             PROJECT               SPACE  
  tanzu-demo-1      false     tanzu            padmanabanpr-project         
  tkg-mc-1          false     kubernetes       n/a                   n/a    
  tmc               false     mission-control  n/a                   n/a    
  ucp-local         true      tanzu                                         

[i] Use '--wide' flag to view additional columns.

$ tz plugin list
Standalone Plugins
  NAME       DESCRIPTION                                                 TARGET      VERSION  STATUS     
  builder    Build Tanzu components                                      global      v1.1.0   installed  
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  global      v1.1.0   installed  
  package    Tanzu package management                                    kubernetes  v0.28.0  installed  
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  kubernetes  v0.31.1  installed 
```

**After this change**

* I have configured a local environment where using `<endpoint>/discovery` routes the request to a workspace that has CLIPlugin resources available.
* When `TANZU_CLI_TANZU_CONTEXT_PLUGIN_DISCOVERY_PATH` is configured to point to right endpoint path

```
$ tz config set features.global.context-plugin-discovery-for-tanzu-context true
$ export TANZU_CLI_TANZU_CONTEXT_PLUGIN_DISCOVERY_PATH="/discovery" 

------------------------------------------------
$ tz plugin list
Standalone Plugins
  NAME       DESCRIPTION                                                 TARGET      VERSION  STATUS     
  builder    Build Tanzu components                                      global      v1.1.0   installed  
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  global      v1.1.0   installed  
  package    Tanzu package management                                    kubernetes  v0.28.0  installed  
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  kubernetes  v0.31.1  installed  

Plugins from Context:  ucp-local
  NAME     DESCRIPTION                                             TARGET      VERSION        STATUS         
  project  View, list and use Tanzu Projects                       kubernetes  v0.1.0-beta.1  not installed  
  space    Tanzu space, space profile, and space trait management  kubernetes  v0.1.0-beta.1  not installed  

Note: As shown above, some recommended plugins have not been installed or are outdated. To install them please run 'tanzu plugin sync'.

------------------------------------------------
$ tz plugin sync
[i] Plugin sync will be performed for context: 'ucp-local'
[i] Checking for required plugins for context 'ucp-local'...
[i] The following plugins will be installed for context 'ucp-local' of contextType 'tanzu': 
  NAME     TARGET      VERSION        
  project  kubernetes  v0.1.0-beta.1  
  space    kubernetes  v0.1.0-beta.1  
[i] Installing plugin 'project:v0.1.0-beta.1' with target 'kubernetes' (from cache)
[i] Installing plugin 'space:v0.1.0-beta.1' with target 'kubernetes' (from cache)
[i] Successfully installed all required plugins
[ok] Done

------------------------------------------------
$ tz plugin list
Standalone Plugins
  NAME       DESCRIPTION                                                 TARGET      VERSION  STATUS     
  builder    Build Tanzu components                                      global      v1.1.0   installed  
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  global      v1.1.0   installed  
  package    Tanzu package management                                    kubernetes  v0.28.0  installed  
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  kubernetes  v0.31.1  installed  

Plugins from Context:  ucp-local
  NAME     DESCRIPTION                                             TARGET      VERSION        STATUS     
  project  View, list and use Tanzu Projects                       kubernetes  v0.1.0-beta.1  installed  
  space    Tanzu space, space profile, and space trait management  kubernetes  v0.1.0-beta.1  installed

------------------------------------------------
$ tz project list
Listing projects from b1d48027-bb69-4a56-a5b8-e941ef29fa4b org
NAME      ACTIVE   AGE
default   false    107m

🔎 To set your active project use 'tanzu project use NAME'
```

**Note:**
- Sample kubeconfig that gets used to talk to the tanzu context's discovery endpoint:
```
kind: Config
apiVersion: v1
preferences: {}
clusters:
    - name: tanzu-cli-ucp-local-13/current
      cluster:
        server: https://localhost:8443/discovery
        insecure-skip-tls-verify: true
users:
    - name: tanzu-cli-ucp-local-user
      user:
        exec:
            apiVersion: client.authentication.k8s.io/v1
            args:
                - context
                - get-token
                - ucp-local
            command: tanzu
            env: []
            interactiveMode: Never
            provideClusterInfo: false
contexts:
    - name: tanzu-cli-ucp-local
      context:
        cluster: tanzu-cli-ucp-local/current
        user: tanzu-cli-ucp-local-user
current-context: tanzu-cli-ucp-local
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Support context-scoped plugin discovery for the `tanzu` contexts (This functionality is behind feature-flag and disabled by default)
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
