### PR TITLE
change: UX: Sort context unset and delete output by plugin name

### DIFF
--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -1092,6 +1092,11 @@ func deleteCtx(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	// Sort the installed plugins by name
+	sort.Sort(discovery.DiscoveredSorter(installed))
+
+	// List the plugins that are being deactivated
 	listDeactivatedPlugins(installed, name)
 	deleteKubeconfigContext(ctx)
 
@@ -1259,6 +1264,11 @@ func unsetGivenContext(name string, contextType configtypes.ContextType) error {
 		return err
 	} else if unset {
 		log.Outputf(contextForContextTypeSetInactive, name, contextType)
+
+		// Sort the installed plugins by name
+		sort.Sort(discovery.DiscoveredSorter(installed))
+
+		// List the plugins that are being deactivated
 		listDeactivatedPlugins(installed, name)
 	}
 	return nil


### PR DESCRIPTION
### What this PR does / why we need it
This PR updates the output of `tanzu context unset `and `tanzu context delete` to deactive the required plugins in a sorted order. Sorting the plugins alphabetically by name provides an enhanced user experience by allowing easier visual scanning of the plugins list.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

UX update for `tanzu context unset`:
Before fix: `tanzu context unset`
![image](https://github.com/vmware-tanzu/tanzu-cli/assets/4702817/df6ff625-ce06-4162-915c-1b2c7a4a7c37)

After Fix: `tanzu context unset`
![image](https://github.com/vmware-tanzu/tanzu-cli/assets/4702817/2293de34-10e3-4d1b-937b-731279e982af)

UX update for `tanzu context delete`:

Before Fix:
![image](https://github.com/vmware-tanzu/tanzu-cli/assets/4702817/85014998-e4c1-4a79-a1be-4673b0ee03ad)

After Fix:
![image](https://github.com/vmware-tanzu/tanzu-cli/assets/4702817/a8bad330-741f-4dcb-92a7-935e5bf504f8)

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
