### PR TITLE
Add confirmation to "tanzu plugin clean"

### DIFF
--- a/test/e2e/framework/framework_constants.go
+++ b/test/e2e/framework/framework_constants.go
@@ -44,7 +44,7 @@ const (
 	InstallAllPluginsFromGroupCmd       = "%s plugin install --group %s"
 	DescribePluginCmd                   = "%s plugin describe %s"
 	UninstallPLuginCmd                  = "%s plugin uninstall %s --yes"
-	CleanPluginsCmd                     = "%s plugin clean"
+	CleanPluginsCmd                     = "%s plugin clean --yes"
 	pluginSyncCmd                       = "%s plugin sync"
 	PluginDownloadBundleCmd             = "%s plugin download-bundle"
 	PluginUploadBundleCmd               = "%s plugin upload-bundle"

--- a/test/e2e/framework/plugin_lifecycle_operations.go
+++ b/test/e2e/framework/plugin_lifecycle_operations.go
@@ -306,7 +306,7 @@ func (po *pluginCmdOps) RunPluginCmd(options string, opts ...E2EOption) (string,
 	}
 	stdOut, stdErr, err := po.cmdExe.TanzuCmdExec(cmd, opts...)
 	if err != nil {
-		log.Errorf(ErrorLogForCommandWithErrStdErrAndStdOut, CleanPluginsCmd, err.Error(), stdErr.String(), stdOut.String())
+		log.Errorf(ErrorLogForCommandWithErrStdErrAndStdOut, cmd, err.Error(), stdErr.String(), stdOut.String())
 		return stdOut.String(), stdErr.String(), nil
 	}
 	return stdOut.String(), stdErr.String(), nil


### PR DESCRIPTION
### What this PR does / why we need it

Adds a prompt before accepting `tanzu plugin clean`:
```
tz plugin clean
This command will delete all plugin binaries from your machine. You will need to re-download any plugins you wish to use. Are you sure you want to continue? [y/N]:
```
A new `--yes/-y` flag is added to `tanzu plugin clean` allowing to by-pass the prompt.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

```
# Notice the new prompt and that by just pressing ENTER, it means NO
$ tz plugin clean
This command will delete all plugin binaries from your machine. You will need to re-download any plugins you wish to use. Are you sure you want to continue? [y/N]:
$ ls /Users/kmarc/Library/Application\ Support/tanzu-cli
accelerator          audit                continuousdelivery   feature              isolated-cluster     provider-aks-cluster supplychain
account              build-service        cost                 helm                 kubernetes-release   provider-eks-cluster tanzupackage
agentartifacts       builder              data-protection      iam                  management-cluster   sample-plugin        telemetry
aks-cluster          cartographer         diagnostics          imgpkg               package              secret               test
allo                 cluster              ekscluster           insight              pinniped-auth        services             workload
apply                clustergroup         events               inspection           policy               setting              workspace
apps                 context              external-secrets     integration          project              space

# Now we say yes to the prompt
$ tz plugin clean
This command will delete all plugin binaries from your machine. You will need to re-download any plugins you wish to use. Are you sure you want to continue? [y/N]: y
[ok] successfully cleaned up all plugins
$ ls /Users/kmarc/Library/Application\ Support/tanzu-cli
ls: /Users/kmarc/Library/Application Support/tanzu-cli: No such file or directory

# Re-install a plugin
$ tz plugin install builder
[i] Refreshing plugin inventory cache for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
[i] The tanzu cli essential plugins have not been installed and are being installed now. The install may take a few seconds.
[i] Installing plugins from plugin group 'vmware-tanzucli/essentials:v1.0.0'
[i] Installed plugin 'telemetry:v1.1.0' with target 'global'

[i] Installed plugin 'builder:v1.1.0' with target 'global'
[ok] successfully installed 'builder' plugin
$ ls /Users/kmarc/Library/Application\ Support/tanzu-cli
builder   telemetry test

# Test the new -y flag
$ tz plugin clean -y
[ok] successfully cleaned up all plugins
$ ls /Users/kmarc/Library/Application\ Support/tanzu-cli
ls: /Users/kmarc/Library/Application Support/tanzu-cli: No such file or directory
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add a user confirmation before accepting `tanzu plugin clean`
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

This breaks backwards-compatibility because any user or more importantly, pipeline/script, that currently does a `tanzu plugin clean` will now block on the prompt.
