### PR TITLE
Change TANZU_CLI_PLUGIN_DB_CACHE_REFRESH_THRESHOLD to TANZU_CLI_PLUGIN_DB_CACHE_REFRESH_THRESHOLD_SECONDS

### DIFF
--- a/pkg/constants/defaults.go
+++ b/pkg/constants/defaults.go
@@ -3,10 +3,6 @@
 
 package constants
 
-import (
-	"time"
-)
-
 const (
 	// TanzuCLISystemNamespace  is the namespace for tanzu cli resources
 	TanzuCLISystemNamespace = "tanzu-cli-system"
@@ -27,8 +23,13 @@ const (
 	// DefaultCLIEssentialsPluginGroupName  name of the essentials plugin group which is used to install essential plugins
 	DefaultCLIEssentialsPluginGroupName = "vmware-tanzucli/essentials"
 
-	// DefaultPluginDBCacheRefreshThreshold is the default value for db cache refresh
-	DefaultPluginDBCacheRefreshThreshold = 24 * time.Hour
+	// DefaultPluginDBCacheRefreshThresholdSeconds is the default value for db cache refresh
+	// For testing, it can be overridden using the environment variable TANZU_CLI_PLUGIN_DB_CACHE_REFRESH_THRESHOLD_SECONDS.
+	DefaultPluginDBCacheRefreshThresholdSeconds = 24 * 60 * 60 // 24 hours
+
+	// DefaultInventoryRefreshTTLSeconds is the interval in seconds between two checks of the inventory digest.
+	// For testing, it can be overridden using the environment variable TANZU_CLI_PLUGIN_DB_CACHE_TTL_SECONDS.
+	DefaultInventoryRefreshTTLSeconds = 30 * 60 // 30 minutes
 
 	// TanzuContextPluginDiscoveryEndpointPath specifies the default plugin discovery endpoint path
 	// Note: This path value needs to be updated once the Tanzu context backend support the context-scoped

--- a/pkg/constants/env_variables.go
+++ b/pkg/constants/env_variables.go
@@ -44,14 +44,10 @@ const (
 	ConfigVariableActiveHelp = "TANZU_ACTIVE_HELP"
 
 	// Change the default value of the plugin inventory cache TTL
-	ConfigVariablePluginDBCacheTTL = "TANZU_CLI_PLUGIN_DB_CACHE_TTL_SECONDS"
+	ConfigVariablePluginDBCacheTTLSeconds = "TANZU_CLI_PLUGIN_DB_CACHE_TTL_SECONDS"
 
-	// ConfigVariablePluginDBCacheRefreshThreshold Change the default value of db cache refresh threshold
-	// A duration string is a possibly signed sequence of
-	// decimal numbers, each with optional fraction and a unit suffix,
-	// such as "300ms", "-1.5h" or "2h45m".
-	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-	ConfigVariablePluginDBCacheRefreshThreshold = "TANZU_CLI_PLUGIN_DB_CACHE_REFRESH_THRESHOLD"
+	// ConfigVariablePluginDBCacheRefreshThresholdSeconds Change the default value of db cache refresh threshold
+	ConfigVariablePluginDBCacheRefreshThresholdSeconds = "TANZU_CLI_PLUGIN_DB_CACHE_REFRESH_THRESHOLD_SECONDS"
 
 	// CSPLoginOrgID overrides the CSP default OrgID to which the user logs into, using CLI interactive login flow
 	// Note: More information regarding the CSP organizations can be found at

--- a/pkg/discovery/oci_dbbacked.go
+++ b/pkg/discovery/oci_dbbacked.go
@@ -23,10 +23,6 @@ import (
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
 
-// inventoryRefreshTTLInSecs is the interval in seconds between two checks of the inventory digest.
-// For testing, it can be overridden using the environment variable TANZU_CLI_PLUGIN_DB_CACHE_TTL_SECONDS.
-const inventoryRefreshTTLInSecs = 30 * 60 // 30 minutes
-
 // DBBackedOCIDiscovery is an artifact discovery utilizing an OCI image
 // which contains an SQLite database describing the content of the plugin
 // discovery.
@@ -384,8 +380,8 @@ func (od *DBBackedOCIDiscovery) checkDigestFileExistence(hashHexVal, digestPrefi
 }
 
 func getCacheTTLValue() int {
-	cacheTTL := inventoryRefreshTTLInSecs
-	cacheTTLOverride := os.Getenv(constants.ConfigVariablePluginDBCacheTTL)
+	cacheTTL := constants.DefaultInventoryRefreshTTLSeconds
+	cacheTTLOverride := os.Getenv(constants.ConfigVariablePluginDBCacheTTLSeconds)
 	if cacheTTLOverride != "" {
 		cacheTTLOverrideValue, err := strconv.Atoi(cacheTTLOverride)
 		if err == nil && cacheTTLOverrideValue >= 0 {

--- a/pkg/discovery/oci_dbbacked_test.go
+++ b/pkg/discovery/oci_dbbacked_test.go
@@ -490,7 +490,7 @@ var _ = Describe("Unit tests for DB-backed OCI discovery", func() {
 			})
 			AfterEach(func() {
 				os.RemoveAll(dbDir)
-				os.Unsetenv(constants.ConfigVariablePluginDBCacheTTL)
+				os.Unsetenv(constants.ConfigVariablePluginDBCacheTTLSeconds)
 			})
 			It("cacheTTLExpired should return true when TTL is expired", func() {
 				discovery := NewOCIDiscovery("test-expired", "test-expired-image:latest")
@@ -519,7 +519,7 @@ var _ = Describe("Unit tests for DB-backed OCI discovery", func() {
 				Expect(ok).To(BeTrue(), "oci discovery is not of type DBBackedOCIDiscovery")
 
 				// Set the TTL to 1 second, which should expire this digest
-				os.Setenv(constants.ConfigVariablePluginDBCacheTTL, "1")
+				os.Setenv(constants.ConfigVariablePluginDBCacheTTLSeconds, "1")
 				Expect(dbDiscovery.cacheTTLExpired()).To(BeTrue())
 			})
 			It("cacheTTLExpired should return true when there is no DB, even if the TTL has not expired", func() {

--- a/test/e2e/airgapped/airgapped_test.go
+++ b/test/e2e/airgapped/airgapped_test.go
@@ -146,7 +146,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Airgapped-Plugin-Download
 
 		It("validate the plugins from group 'vmware-tmc/tmc-user:v9.9.9' exists", func() {
 			// Temporarily set the TTL to something small
-			os.Setenv(constants.ConfigVariablePluginDBCacheTTL, "3")
+			os.Setenv(constants.ConfigVariablePluginDBCacheTTLSeconds, "3")
 
 			// Wait for the digest TTL to expire so that the DB is refreshed.
 			time.Sleep(time.Second * 5) // Sleep for 5 seconds
@@ -157,7 +157,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Airgapped-Plugin-Download
 			Expect(err).To(BeNil(), framework.NoErrorForPluginGroupSearch)
 
 			// Unset the TTL override now that the DB has been refreshed
-			os.Unsetenv(constants.ConfigVariablePluginDBCacheTTL)
+			os.Unsetenv(constants.ConfigVariablePluginDBCacheTTLSeconds)
 
 			// check all expected plugin groups are available in plugin group search output
 			expectedPluginGroups := []*framework.PluginGroup{

--- a/test/e2e/plugin_lifecycle/plugin_lifecycle_test.go
+++ b/test/e2e/plugin_lifecycle/plugin_lifecycle_test.go
@@ -422,7 +422,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-lifecycle]", func(
 			}
 
 			// Set the TTL to something small: 12 seconds
-			os.Setenv(constants.ConfigVariablePluginDBCacheTTL, "12")
+			os.Setenv(constants.ConfigVariablePluginDBCacheTTLSeconds, "12")
 
 			// Now wait for the TTL to expire so we can start fresh
 			removeDigestFile()
@@ -459,7 +459,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-lifecycle]", func(
 			Expect(err).To(BeNil(), "metadata digest file should have been created")
 
 			// Unset the TTL override
-			os.Unsetenv(constants.ConfigVariablePluginDBCacheTTL)
+			os.Unsetenv(constants.ConfigVariablePluginDBCacheTTLSeconds)
 		})
 		// Run "plugin clean" which also removes the plugin DB and make sure a "plugin search" immediately does a digest check
 		It("clean DB and do a plugin search", func() {
@@ -529,7 +529,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-lifecycle]", func(
 			}
 
 			// Set the TTL to something small: 12 seconds
-			os.Setenv(constants.ConfigVariablePluginDBCacheTTL, "12")
+			os.Setenv(constants.ConfigVariablePluginDBCacheTTLSeconds, "12")
 
 			// Now wait for the TTL to expire so we can start fresh
 			removeDigestFile()
@@ -566,7 +566,7 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-lifecycle]", func(
 			Expect(err).To(BeNil(), "metadata digest file should have been created")
 
 			// Unset the TTL override
-			os.Unsetenv(constants.ConfigVariablePluginDBCacheTTL)
+			os.Unsetenv(constants.ConfigVariablePluginDBCacheTTLSeconds)
 		})
 		// Change the TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY value and make sure
 		// the digest check is done immediately
@@ -644,9 +644,9 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-lifecycle]", func(
 			Expect(err).To(BeNil())
 
 			// Set the TTL to something small: 5 seconds
-			_ = os.Setenv(constants.ConfigVariablePluginDBCacheTTL, "5")
+			_ = os.Setenv(constants.ConfigVariablePluginDBCacheTTLSeconds, "5")
 			// Set the db cache refresh time to 10 seconds
-			_ = os.Setenv(constants.ConfigVariablePluginDBCacheRefreshThreshold, "10s")
+			_ = os.Setenv(constants.ConfigVariablePluginDBCacheRefreshThresholdSeconds, "10")
 
 			// tanzu plugin list should
 			// 1. Read plugin inventory
@@ -681,8 +681,8 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Plugin-lifecycle]", func(
 			Expect(errStream).To(ContainSubstring(refreshPluginInventoryCachePrintout))
 
 			// Unset the TTL override
-			_ = os.Unsetenv(constants.ConfigVariablePluginDBCacheTTL)
-			_ = os.Unsetenv(constants.ConfigVariablePluginDBCacheRefreshThreshold)
+			_ = os.Unsetenv(constants.ConfigVariablePluginDBCacheTTLSeconds)
+			_ = os.Unsetenv(constants.ConfigVariablePluginDBCacheRefreshThresholdSeconds)
 		})
 
 	})


### PR DESCRIPTION
### What this PR does / why we need it

- Change the env variable `TANZU_CLI_PLUGIN_DB_CACHE_REFRESH_THRESHOLD` to `TANZU_CLI_PLUGIN_DB_CACHE_REFRESH_THRESHOLD_SECONDS`

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
- Updated test cases
- Manula testing
```
mpanchajanya@mpanchajanF09MK ~> echo $TANZU_CLI_PLUGIN_DB_CACHE_TTL_SECONDS
5
mpanchajanya@mpanchajanF09MK ~> echo $TANZU_CLI_PLUGIN_DB_CACHE_REFRESH_THRESHOLD_SECONDS
10
mpanchajanya@mpanchajanF09MK ~> tz version
version: v1.2.0-dev
buildDate: 2024-01-30
sha: 741926fe
arch: arm64
mpanchajanya@mpanchajanF09MK ~> tz plugin clean
[ok] successfully cleaned up all plugins
mpanchajanya@mpanchajanF09MK ~> tz plugin list
[i] Refreshing plugin inventory cache for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
[i] The tanzu cli essential plugins have not been installed and are being installed now. The install may take a few seconds.
[i] Installing plugins from plugin group 'vmware-tanzucli/essentials:v1.0.0'
[i] Installed plugin 'telemetry:v1.1.0' with target 'global'

Standalone Plugins
  NAME       DESCRIPTION                                                 TARGET  VERSION  STATUS
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  global  v1.1.0   installed
mpanchajanya@mpanchajanF09MK ~> tz plugin list
[i] Refreshing plugin inventory cache for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
Standalone Plugins
  NAME       DESCRIPTION                                                 TARGET  VERSION  STATUS
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  global  v1.1.0   installed
mpanchajanya@mpanchajanF09MK ~> tz plugin list
Standalone Plugins
  NAME       DESCRIPTION                                                 TARGET  VERSION  STATUS
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  global  v1.1.0   installed
mpanchajanya@mpanchajanF09MK ~> tz plugin list
Standalone Plugins
  NAME       DESCRIPTION                                                 TARGET  VERSION  STATUS
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  global  v1.1.0   installed
mpanchajanya@mpanchajanF09MK ~> tz plugin list
Standalone Plugins
  NAME       DESCRIPTION                                                 TARGET  VERSION  STATUS
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  global  v1.1.0   installed
mpanchajanya@mpanchajanF09MK ~> tz plugin list
Standalone Plugins
  NAME       DESCRIPTION                                                 TARGET  VERSION  STATUS
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  global  v1.1.0   installed
mpanchajanya@mpanchajanF09MK ~> tz plugin list
[i] Refreshing plugin inventory cache for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
Standalone Plugins
  NAME       DESCRIPTION                                                 TARGET  VERSION  STATUS
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  global  v1.1.0   installed
mpanchajanya@mpanchajanF09MK ~>

```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
