### PR TITLE
fix: update chocolatey installer

### DIFF
--- a/hack/choco/chocolateyInstall.ps1.tmpl
+++ b/hack/choco/chocolateyInstall.ps1.tmpl
@@ -7,15 +7,18 @@ $packageName = 'tanzu-cli'
 $packagePath = "${releaseVersion}"
 $scriptsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $checksumType64 = 'sha256'
+$tanzuExeName = ''
 
 # Check if we are dealing with an ARM64 architecture
 $os = Get-WmiObject -Class Win32_OperatingSystem
 if ($os.OSArchitecture -like "*ARM*") {
     $url64 = "https://github.com/vmware-tanzu/tanzu-cli/releases/download/${releaseVersion}/tanzu-cli-windows-arm64-windows11.zip"
     $checksum64 = '__CLI_SHA_ARM64__'
+    $tanzuExeName = 'tanzu-cli-windows_arm64.exe'
 } else {
     $url64 = "https://github.com/vmware-tanzu/tanzu-cli/releases/download/${releaseVersion}/tanzu-cli-windows-amd64.zip"
     $checksum64 = '__CLI_SHA_AMD64__'
+    $tanzuExeName = 'tanzu-cli-windows_amd64.exe'
 }
 
 $packageArgs = @{
@@ -30,12 +33,19 @@ $packageArgs = @{
 }
 
 function Install-TanzuEnvironment {
-    # Rename CLI
-    # Note that we use the scriptsDir path because chocolatey doesn't put
-    # binaries on the $PATH until _after_ the install script runs.
-    $tanzuExe = "${scriptsDir}\${packagePath}\tanzu.exe"
-    # Use a glob pattern since the binary could be for arm64 or amd64
-    Move-Item "${scriptsDir}\${packagePath}\tanzu-cli-windows_*.exe" "${tanzuExe}"
+    # The default shim normally created by Chocolatey in the bin directory does not forward interrupts to the CLI
+    # Since the CLI needs to catch interrupts we prevent chocolatey from creating the shim, and instead
+    # we copy the full CLI binary to the bin directory
+
+    $binDirectory = Join-Path $env:ChocolateyInstall 'bin'
+    $tanzuExePath = Join-Path $(Join-Path ${scriptsDir} ${packagePath}) $tanzuExeName
+
+    $tanzuExe = Join-Path ${binDirectory} tanzu.exe
+
+    Copy-Item "${tanzuExePath}" "${tanzuExe}"
+
+    #Create .ignore file so chocolatey does not shim the Exe
+    New-Item "${tanzuExePath}.ignore" -type file -force | Out-Null
 
     # Setup shell completion
     if (Test-Path -Path $PROFILE) {


### PR DESCRIPTION
### What this PR does / why we need it

When installing the latest CLI version v1.2.0-rc.0 using Chocolatey, there is an issue with the spinner when installing plugins. If Ctrl+C is pressed while the spinner is running, it does not properly handle the interrupt and terminate the spinner. Instead, the CLI hangs without returning an error.

The root cause is the Windows Chocolatey install wrapper or shim that gets created for the tanzu executable. This wrapper kills the CLI process on Ctrl+C without allowing the CLI to catch the interrupt itself. There is a long-standing open issue on this behavior: https://github.com/chocolatey/home/issues/134

This PR fixes the issue by avoiding the Chocolatey-generated wrapper or shim for the tanzu executable. Instead, it directly uses the tanzu CLI release executable tanzu-cli-windows-*.exe or tanzu command, and updates the install script to ignore creating a wrapper.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
1) The choco pack built in Mac:
```
cpamuluri@cpamuluriGMD6R tanzu-cli % make choco-package BUILD_VERSION=v1.2.0-rc.0  
docker run --rm \
                -e VERSION=v1.2.0-rc.0 \
                -e SHA_FOR_CHOCO_AMD64= \
                -e SHA_FOR_CHOCO_ARM64= \
                -v /Users/cpamuluri/tkg/tasks/cli_core_main/tanzu-cli:/Users/cpamuluri/tkg/tasks/cli_core_main/tanzu-cli \
                chocolatey/choco:v1.4.0 /Users/cpamuluri/tkg/tasks/cli_core_main/tanzu-cli/hack/choco/build_package.sh
Using SHA_AMD64: d4a715501a10382e903dbb38d18200ca483cf2c32b6bc66c83b49a5e18501e8a
Using SHA_ARM64: ebc49a47dc162d6c1ed1c91db183f8958def7638822e38f4296efdd84ae84b0a
Chocolatey v1.4.0
Attempting to build package from 'tanzu-cli-unstable.nuspec'.
Successfully created package '/Users/cpamuluri/tkg/tasks/cli_core_main/tanzu-cli/hack/choco/_output/choco/tanzu-cli-unstable.1.2.0-rc0.nupkg'

Are you ready for the ultimate experience? Check out Pro / Business!
 https://chocolatey.org/compare
```
2)Installation after the fix:
After the above build, the files from the `tanzu-cli/hack/choco/_output/choco/` (`chocolateyInstall.ps1 and tanzu-cli-unstable.1.2.0-rc0.nupkg`) copied to windows AMD system, then installed the choco package:
`choco install -s=/Users/chan/Downloads tanzu-cli-unstabl --pre --force`
![image](https://github.com/vmware-tanzu/tanzu-cli/assets/4702817/ee3d6564-e25b-499a-a0a4-0a19bdf0ec32)

3)The spinner issue is tested in Power shell and Command prompt, its working fine:
![image](https://github.com/vmware-tanzu/tanzu-cli/assets/4702817/37719df8-1bcb-45ef-945b-3e692cb424c5)
![image](https://github.com/vmware-tanzu/tanzu-cli/assets/4702817/906c120d-fc9e-46c7-b2a3-982f1e706da5)

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The plugin installation spinner termination issue on Windows has been fixed.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
