### PR TITLE
fix: return error if input file for --to-tar exists

### DIFF
--- a/pkg/airgapped/plugin_bundle_download.go
+++ b/pkg/airgapped/plugin_bundle_download.go
@@ -22,6 +22,8 @@ import (
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
 
+const fileExists = "the file '%s' already exists"
+
 // DownloadPluginBundleOptions defines options for downloading plugin bundle
 type DownloadPluginBundleOptions struct {
 	PluginInventoryImage string
@@ -338,6 +340,9 @@ func (o *DownloadPluginBundleOptions) verifyTarFile() error {
 	_, err := os.Stat(dir)
 	if err != nil {
 		return errors.Wrapf(err, "invalid path for %q", dir)
+	}
+	if _, err = os.Stat(o.ToTar); err == nil {
+		return fmt.Errorf(fileExists, o.ToTar)
 	}
 	// Check the input file path for --to-tar is valid
 	var empty []byte

--- a/test/e2e/airgapped/airgapped_test.go
+++ b/test/e2e/airgapped/airgapped_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 const InvalidPath = "invalid path for \"%s\""
+const fileExists = "the file '%s' already exists"
+const showThrowErr = "should throw error for incorrect input path"
 
 var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Airgapped-Plugin-DownloadBundle-UploadBundle-Lifecycle]", func() {
 
@@ -328,20 +330,23 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Airgapped-Plugin-Download
 		// Test case: (negative use case) empty path for --to-tar
 		It("plugin download-bundle when to-tar path is empty", func() {
 			err := tf.PluginCmd.DownloadPluginBundle(e2eTestLocalCentralRepoImage, []string{}, "")
-			Expect(err).NotTo(BeNil(), "should throw error for incorrect input path")
+			Expect(err).NotTo(BeNil(), showThrowErr)
 			Expect(strings.Contains(err.Error(), "flag '--to-tar' is required")).To(BeTrue())
 		})
 		// Test case: (negative use case) directory name only for --to-tar
 		It("plugin download-bundle when to-tar path is a directory", func() {
-			err := tf.PluginCmd.DownloadPluginBundle(e2eTestLocalCentralRepoImage, []string{}, tempDir)
-			Expect(err).NotTo(BeNil(), "should throw error for incorrect input path")
-			Expect(strings.Contains(err.Error(), fmt.Sprintf(InvalidPath, tempDir))).To(BeTrue())
+			// Attempt download bundle specifying directory as output
+			err = tf.PluginCmd.DownloadPluginBundle(e2eTestLocalCentralRepoImage, []string{}, tempDir)
+
+			// Expect error and validate text
+			Expect(err).NotTo(BeNil())
+			Expect(strings.Contains(err.Error(), fmt.Sprintf(fileExists, tempDir))).To(BeTrue())
 		})
 		// Test case: (negative use case) current directory only for --to-tar
 		It("plugin download-bundle when to-tar path is current directory", func() {
 			err := tf.PluginCmd.DownloadPluginBundle(e2eTestLocalCentralRepoImage, []string{}, ".")
-			Expect(err).NotTo(BeNil(), "should throw error for incorrect input path")
-			Expect(strings.Contains(err.Error(), fmt.Sprintf(InvalidPath, "."))).To(BeTrue())
+			Expect(err).NotTo(BeNil(), showThrowErr)
+			Expect(strings.Contains(err.Error(), fmt.Sprintf(fileExists, "."))).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
### What this PR does / why we need it
Previously, the `tanzu plugin download-bundle --to-tar` command would overwrite the output file if an existing file was specified. This PR implements a fix to throw an error if the target file already exists when attempting the bundle download. This change prevents accidentally overriding content in an existing file.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
1)Manual Testing has done.
![image](https://github.com/vmware-tanzu/tanzu-cli/assets/4702817/2617c0b0-b980-4796-996b-6893ecb4fdd3)

2)E2E tests are updated.


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The `tanzu plugin download-bundle --to-tar` command now prevents overwriting an existing output file.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
