### PR TITLE
Fix the security issue reported on code scan

### DIFF
--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -221,9 +221,9 @@ func setLoggerVerbosity() {
 	// Configure the log level if env variable TANZU_CLI_LOG_LEVEL is set
 	logLevel := os.Getenv(log.EnvTanzuCLILogLevel)
 	if logLevel != "" {
-		logValue, err := strconv.Atoi(logLevel)
+		logValue, err := strconv.ParseInt(logLevel, 10, 32)
 		if err == nil {
-			log.SetVerbosity(int32(logValue)) //nolint:gosec
+			log.SetVerbosity(int32(logValue))
 		}
 	}
 }


### PR DESCRIPTION
### What this PR does / why we need it

- Fix the security issue reported by code scan https://github.com/vmware-tanzu/tanzu-cli/security/code-scanning/2


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

```

mpanchajanya@mpanchajanF09MK ~> tz version
version: v1.2.0-dev
buildDate: 2024-02-07
sha: 3197c652-dirty
arch: arm64
mpanchajanya@mpanchajanF09MK ~> tz config get
clientOptions:
    features:
        global:
            context-target-v2: "true"
cli:
    ceipOptIn: "true"
    eulaStatus: accepted
    discoverySources:
        - oci:
            name: default
            image: projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest
    cliId: 736bddac-be88-4084-a00d-137a4972b487
    telemetry:
        source: /Users/mpanchajanya/.config/tanzu-cli-telemetry/cli_metrics.db
mpanchajanya@mpanchajanF09MK ~> tz config set env.TANZU_CLI_LOG_LEVEL 9
mpanchajanya@mpanchajanF09MK ~> tz config get
[i] testing logger with 6
clientOptions:
    features:
        global:
            context-target-v2: "true"
    env:
        TANZU_CLI_LOG_LEVEL: "9"
cli:
    ceipOptIn: "true"
    eulaStatus: accepted
    discoverySources:
        - oci:
            name: default
            image: projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest
    cliId: 736bddac-be88-4084-a00d-137a4972b487
    telemetry:
        source: /Users/mpanchajanya/.config/tanzu-cli-telemetry/cli_metrics.db
mpanchajanya@mpanchajanF09MK ~> tz version
[i] testing logger with 6
version: v1.2.0-dev
buildDate: 2024-02-07
sha: 3197c652-dirty
arch: arm64
mpanchajanya@mpanchajanF09MK ~> tz config set env.TANZU_CLI_LOG_LEVEL 5
[i] testing logger with 6
mpanchajanya@mpanchajanF09MK ~> tz config get
clientOptions:
    features:
        global:
            context-target-v2: "true"
    env:
        TANZU_CLI_LOG_LEVEL: "5"
cli:
    ceipOptIn: "true"
    eulaStatus: accepted
    discoverySources:
        - oci:
            name: default
            image: projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest
    cliId: 736bddac-be88-4084-a00d-137a4972b487
    telemetry:
        source: /Users/mpanchajanya/.config/tanzu-cli-telemetry/cli_metrics.db
mpanchajanya@mpanchajanF09MK ~> tz version
version: v1.2.0-dev
buildDate: 2024-02-07
sha: 3197c652-dirty
arch: arm64
mpanchajanya@mpanchajanF09MK ~>

```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
