### PR TITLE
Add boolean validation for tanzu config set feature flags

### DIFF
--- a/pkg/command/config.go
+++ b/pkg/command/config.go
@@ -145,6 +145,9 @@ func setConfiguration(pathParam, value string) error {
 		if len(paramArray) != 3 {
 			return errors.New("unable to parse config path parameter into three parts [" + strings.Join(paramArray, ".") + "]  (was expecting 'features.<plugin>.<feature>'")
 		}
+		if value != "true" && value != "false" { //nolint:goconst
+			return errors.New("invalid value provided only boolean true or false are accepted")
+		}
 		return configlib.SetFeature(paramArray[1], paramArray[2], value)
 	case ConfigLiteralEnv:
 		if len(paramArray) != 2 {

--- a/pkg/command/config_test.go
+++ b/pkg/command/config_test.go
@@ -69,6 +69,62 @@ func TestConfigEnv(t *testing.T) {
 	}
 }
 
+// TestConfigFeatureFlags validates functionality when normal env path argument is provided.
+func TestConfigFeatureFlags(t *testing.T) {
+	tests := []struct {
+		name   string
+		key    string
+		value  string
+		errStr string
+	}{
+		{
+			name:  "should set valid feature flag",
+			key:   "features.global.foo",
+			value: "true",
+		},
+		{
+			name:   "should not set invalid feature flag value",
+			key:    "features.global.foo",
+			value:  "bar",
+			errStr: "invalid value provided only boolean true or false are accepted",
+		},
+		{
+			name:   "should not set invalid feature flag key 1",
+			key:    "features.global",
+			value:  "false",
+			errStr: "unable to parse config path parameter into three parts [features.global]  (was expecting 'features.<plugin>.<feature>'",
+		},
+		{
+			name:   "should not set invalid feature flag key 2",
+			key:    "features",
+			value:  "false",
+			errStr: "unable to parse config path parameter into parts [features]  (was expecting 'features.<plugin>.<feature>' or 'env.<env_variable>')",
+		},
+		{
+			name:   "should not set invalid feature flag key 3",
+			key:    "feature",
+			value:  "false",
+			errStr: "unable to parse config path parameter into parts [feature]  (was expecting 'features.<plugin>.<feature>' or 'env.<env_variable>')",
+		},
+		{
+			name:   "should not set invalid key anv value",
+			key:    "",
+			value:  "",
+			errStr: "unable to parse config path parameter into parts []  (was expecting 'features.<plugin>.<feature>' or 'env.<env_variable>')",
+		},
+	}
+	for _, spec := range tests {
+		t.Run(spec.name, func(t *testing.T) {
+			err := setConfiguration(spec.key, spec.value)
+			if spec.errStr != "" {
+				assert.Equal(t, spec.errStr, err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestCompletionConfig(t *testing.T) {
 	// Setup a temporary configuration
 	configFile, err := os.CreateTemp("", "config")


### PR DESCRIPTION
### What this PR does / why we need it
- Add validation for tanzu config set feature flag value to restrict to boolean true or false values.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
- Added unit tests
- Manual testing

```
> tz config get | grep foo
> tz config set features.global.foo bar
[x] : invalid value provided only boolean true or false are accepted
> tz config set features.global.foo true
> tz config set features.global.foo false
> tz config set features.global.foo bar
[x] : invalid value provided only boolean true or false are accepted
> tz config set features.global.foo ""
[x] : invalid value provided only boolean true or false are accepted
> tz config set features.global.foo true
> tz config get | grep foo
            foo: "true"
> 

```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Tanzu CLI will only allow boolean true or false feature flag values
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
