### PR TITLE
Add empty plugin version validation to PluginGroup Publishing Step

### DIFF
--- a/cmd/plugin/builder/inventory/inventory_plugin_group.go
+++ b/cmd/plugin/builder/inventory/inventory_plugin_group.go
@@ -81,7 +81,7 @@ func (ipuo *InventoryPluginGroupUpdateOptions) getPluginGroupFromManifest() (*pl
 		plugin.Version = strings.TrimSpace(plugin.Version)
 
 		if plugin.Version == "" {
-			return nil, errors.Errorf("invalid plugin version %q for plugin %q, target %q. plugin version cannot be empty for plugin group", plugin.Version, plugin.Name, plugin.Target)
+			return nil, errors.Errorf("invalid version for plugin %q, target %q. plugin version cannot be empty for plugin group", plugin.Name, plugin.Target)
 		}
 		pge := plugininventory.PluginGroupPluginEntry{
 			PluginIdentifier: plugininventory.PluginIdentifier{

--- a/cmd/plugin/builder/inventory/inventory_plugin_group.go
+++ b/cmd/plugin/builder/inventory/inventory_plugin_group.go
@@ -7,6 +7,7 @@ package inventory
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -64,8 +65,8 @@ func (ipuo *InventoryPluginGroupUpdateOptions) getPluginGroupFromManifest() (*pl
 	pg := plugininventory.PluginGroup{
 		Vendor:      ipuo.Vendor,
 		Publisher:   ipuo.Publisher,
-		Name:        ipuo.GroupName,
-		Description: ipuo.Description,
+		Name:        strings.TrimSpace(ipuo.GroupName),
+		Description: strings.TrimSpace(ipuo.Description),
 		Hidden:      ipuo.DeactivatePluginGroup,
 		Versions:    make(map[string][]*plugininventory.PluginGroupPluginEntry, 0),
 	}
@@ -77,9 +78,14 @@ func (ipuo *InventoryPluginGroupUpdateOptions) getPluginGroupFromManifest() (*pl
 
 	var plugins []*plugininventory.PluginGroupPluginEntry
 	for _, plugin := range pluginGroupManifest.Plugins {
+		plugin.Version = strings.TrimSpace(plugin.Version)
+
+		if plugin.Version == "" {
+			return nil, errors.Errorf("invalid plugin version %q for plugin %q, target %q. plugin version cannot be empty for plugin group", plugin.Version, plugin.Name, plugin.Target)
+		}
 		pge := plugininventory.PluginGroupPluginEntry{
 			PluginIdentifier: plugininventory.PluginIdentifier{
-				Name:    plugin.Name,
+				Name:    strings.TrimSpace(plugin.Name),
 				Target:  types.Target(plugin.Target),
 				Version: plugin.Version,
 			},


### PR DESCRIPTION
### What this PR does / why we need it

- Automatically trim any extra leading or trailing space from the plugin-group name and description if specified
- Add validation to make sure plugins with empty plugin versions are not specified in the plugin group.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

- Note that the `builder` plugin will automatically trim any extra space in the plugin group name and description if specified.

```
$ tz plugin search
  NAME     DESCRIPTION             TARGET  LATEST      
  builder  Build Tanzu components  global  v1.3.0-dev  
  test     Test the CLI            global  v1.3.0-dev 
```

- When an empty version is specified for the `builder` plugin.
```
$ make inventory-plugin-group-add PLUGIN_GROUP_NAME_VERSION="  default:v0.0.4  " PLUGIN_GROUP_DESCRIPTION="   THIS IS A Test desc"
/Users/anujc/Documents/code/tanzu-cli/bin/builder inventory plugin-group add \
                --repository localhost:5001/test/v1/tanzu-cli/plugins \
                --plugin-inventory-image-tag latest \
                --publisher tanzucli \
                --vendor vmware \
                --manifest /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins/plugin_group_manifest.yaml \
                --name default \
                --version v0.0.4 \
                --plugin-inventory-db-file "" \
                --description "THIS IS A Test desc" \

2024-02-29T12:28:15-08:00 [i] pulling plugin inventory database from: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
Error: error while reading plugin group: invalid plugin version "" for plugin "builder", target "global". plugin version cannot be empty for plugin group.
2024-02-29T12:28:20-08:00 [x] : error while reading plugin group: invalid plugin version "" for plugin "builder", target "global". plugin version cannot be empty for plugin group.
make: *** [inventory-plugin-group-add] Error 
```

- When an invalid plugin version is specified which is not in the plugin-inventory database (existing)
```
$ make inventory-plugin-group-add PLUGIN_GROUP_NAME_VERSION="  default:v0.0.4  " PLUGIN_GROUP_DESCRIPTION="   THIS IS A Test desc"
/Users/anujc/Documents/code/tanzu-cli/bin/builder inventory plugin-group add \
                --repository localhost:5001/test/v1/tanzu-cli/plugins \
                --plugin-inventory-image-tag latest \
                --publisher tanzucli \
                --vendor vmware \
                --manifest /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins/plugin_group_manifest.yaml \
                --name default \
                --version v0.0.4 \
                --plugin-inventory-db-file "" \
                --description "THIS IS A Test desc" \

2024-02-29T12:28:43-08:00 [i] pulling plugin inventory database from: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
2024-02-29T12:28:43-08:00 [i] updating plugin inventory database with plugin group entry
Error: error while inserting plugin group 'default': specified plugin 'name:test', 'target:global', 'version:v2.3' is not present in the database
2024-02-29T12:28:43-08:00 [x] : error while inserting plugin group 'default': specified plugin 'name:test', 'target:global', 'version:v2.3' is not present in the database
make: *** [inventory-plugin-group-add] Error 1
```

- When correct plugin version are specified in plugin-group.
```
$ make inventory-plugin-group-add PLUGIN_GROUP_NAME_VERSION="  default:v0.0.4  " PLUGIN_GROUP_DESCRIPTION="   THIS IS A Test desc"
/Users/anujc/Documents/code/tanzu-cli/bin/builder inventory plugin-group add \
                --repository localhost:5001/test/v1/tanzu-cli/plugins \
                --plugin-inventory-image-tag latest \
                --publisher tanzucli \
                --vendor vmware \
                --manifest /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins/plugin_group_manifest.yaml \
                --name default \
                --version v0.0.4 \
                --plugin-inventory-db-file "" \
                --description "THIS IS A Test desc" \

2024-02-29T12:29:09-08:00 [i] pulling plugin inventory database from: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
2024-02-29T12:29:09-08:00 [i] updating plugin inventory database with plugin group entry
2024-02-29T12:29:09-08:00 [i] publishing plugin inventory database
2024-02-29T12:29:09-08:00 [i] successfully published plugin inventory database at: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
```
```
$ tz plugin group search
  GROUP                    DESCRIPTION          LATEST  
  vmware-tanzucli/default  THIS IS A Test desc  v0.0.4

$ tz plugin group get vmware-tanzucli/default
Plugins in Group:  vmware-tanzucli/default:v0.0.4
  NAME     TARGET  VERSION  
  builder  global  v1       
  test     global  v1.3 
```


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
`builder` plugin: Add empty plugin version validation to the PluginGroup Publishing step
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
