### PR TITLE
Add plugin-level remapping support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/vmware-tanzu/carvel-ytt v0.40.0
 	github.com/vmware-tanzu/tanzu-cli/test/e2e/framework v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686
-	github.com/vmware-tanzu/tanzu-plugin-runtime v1.2.0-dev.0.20240222161642-59c7320668fa
+	github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0-dev.0.20240302001423-9b6a526ce007
 	go.pinniped.dev v0.20.0
 	golang.org/x/mod v0.12.0
 	golang.org/x/oauth2 v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -738,8 +738,8 @@ github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502eb
 github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502ebf68/go.mod h1:e1Uef+Ux5BIHpYwqbeP2ZZmOzehBcez2vUEWXHe+xHE=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686 h1:VcuXqUXFxm5WDqWkzAlU/6cJXua0ozELnqD59fy7J6E=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686/go.mod h1:AFGOXZD4tH+KhpmtV0VjWjllXhr8y57MvOsIxTtywc4=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.2.0-dev.0.20240222161642-59c7320668fa h1:153bh9h0EVQHX0EjyiHy+w9KjfLkcN5Z9jITKdKnHpo=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.2.0-dev.0.20240222161642-59c7320668fa/go.mod h1:M7WVZoItdyQp53tEprQIa6PZmhbrLe3CzuyQphWuRyI=
+github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0-dev.0.20240302001423-9b6a526ce007 h1:RtCj2DlulhWMSLE1lqya62ESxML+xaXBQdmyPNuL6ko=
+github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0-dev.0.20240302001423-9b6a526ce007/go.mod h1:M7WVZoItdyQp53tEprQIa6PZmhbrLe3CzuyQphWuRyI=
 github.com/xanzy/go-gitlab v0.83.0 h1:37p0MpTPNbsTMKX/JnmJtY8Ch1sFiJzVF342+RvZEGw=
 github.com/xanzy/go-gitlab v0.83.0/go.mod h1:5ryv+MnpZStBH8I/77HuQBsMbBGANtVpLWC15qOjWAw=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=

--- a/pkg/cli/plugin_cmd.go
+++ b/pkg/cli/plugin_cmd.go
@@ -22,9 +22,9 @@ import (
 // the kubernetes group. Any remap location that points to one should also map
 // to the other to be consistent.
 // This function returns the alternate location, if applicable.
-func alternateRemapLocation(p *PluginInfo, location string) string {
+func alternateRemapLocation(p *PluginInfo, remapLocation string) string {
 	if p.Target == configtypes.TargetK8s {
-		cmdHierarchy := strings.Split(strings.TrimSpace(location), " ")
+		cmdHierarchy := strings.Split(remapLocation, " ")
 		if len(cmdHierarchy) == 1 {
 			return fmt.Sprintf("kubernetes %s", cmdHierarchy[0])
 		}
@@ -39,8 +39,9 @@ func alternateRemapLocation(p *PluginInfo, location string) string {
 func GetCommandMapForPlugin(p *PluginInfo) map[string]*cobra.Command {
 	cmdMap := map[string]*cobra.Command{}
 
-	for _, remapLocation := range p.InvokedAs {
-		cmdHierarchy := strings.Split(strings.TrimSpace(remapLocation), " ")
+	for _, invokedAsItem := range p.InvokedAs {
+		remapLocation := strings.TrimSpace(invokedAsItem)
+		cmdHierarchy := strings.Split(remapLocation, " ")
 
 		if len(cmdHierarchy) > 0 {
 			cmdMap[remapLocation] = getCmdForPluginEx(p, cmdHierarchy[len(cmdHierarchy)-1])

--- a/pkg/cli/plugin_info.go
+++ b/pkg/cli/plugin_info.go
@@ -73,6 +73,14 @@ type PluginInfo struct {
 
 	// DefaultFeatureFlags is default featureflags to be configured if missing when invoking plugin
 	DefaultFeatureFlags map[string]bool `json:"defaultFeatureFlags" yaml:"defaultFeatureFlags"`
+
+	// InvokedAs provides a specific mapping to how any command provided by this plugin should be invoked as.
+	// EXPERIMENTAL: subject to change prior to the next official minor release
+	InvokedAs []string `json:"invokedAs,omitempty" yaml:"invokedAs,omitempty"`
+
+	// SupportedContextType specifies one of more ContextType that this plugin will specifically apply to.
+	// EXPERIMENTAL: subject to change prior to the next official minor release
+	SupportedContextType []configtypes.ContextType `json:"supportedContextType,omitempty" yaml:"supportedContextType,omitempty"`
 }
 
 // PluginInfoSorter sorts PluginInfo objects.

--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -143,6 +143,12 @@ func remapCommandTree(rootCmd *cobra.Command, plugins []cli.PluginInfo) {
 	cmdMap := buildReplacementMap(plugins)
 	for pathKey, cmd := range cmdMap {
 		matchedCmd, parentCmd := findSubCommandByPath(rootCmd, pathKey)
+
+		if parentCmd != nil && parentCmd.Annotations != nil && parentCmd.Annotations["type"] == common.CommandTypePlugin {
+			fmt.Fprintf(os.Stderr, "Remap of plugin into command tree (%s) associated with another plugin is not supported\n", parentCmd.Name())
+			continue
+		}
+
 		if matchedCmd == nil {
 			if parentCmd != nil {
 				parentCmd.AddCommand(cmd)

--- a/pkg/command/root_test.go
+++ b/pkg/command/root_test.go
@@ -1130,9 +1130,7 @@ func TestPluginLevelRemapping(t *testing.T) {
 			unexpected:        []string{"dummy2 commands"},
 		},
 		{
-			test: "deeper mapping is possible",
-			// ... but only in the sense that the plugin's commands are
-			// invocable at the mapped depth
+			test: "nesting plugin within another plugin is not supported",
 			pluginVariants: []fakePluginRemapAttributes{
 				fakePluginRemapAttributes{
 					name:    "dummy",
@@ -1146,7 +1144,7 @@ func TestPluginLevelRemapping(t *testing.T) {
 				},
 			},
 			args:     []string{"kubernetes", "dummy", "deeper", "say", "hello"},
-			expected: []string{"hello"},
+			expected: []string{"Remap of plugin into command tree (dummy) associated with another plugin is not supported"},
 		},
 	}
 


### PR DESCRIPTION
### What this PR does / why we need it

```
    Adds experimental functionality to remap in the CLI command tree
    commands at an entire plugin level.

    The mapping information is currently solely derived from the plugin's
    `info` command output it can extend potentially to mapping metadata 
    specified outside of the plugin binaries.

    Mapping to a nonexistent location should only be possible if the parent
    Command exists AND parent is not one associated another plugin's command
    tree root. (iow where the Command's Annotations indicate it is a wrapper for a
    plugin)

    Any command group that exists in the destination location of the mapping
    is removed from the command tree.

    Mapping is contingent on whether an active CLI context is of a type
    that is one of the supportedContextType list, if the latter is explicitly
    expressed by the plugin.

    An upcoming change will provide more contextual information to the
    plugin on how it's commands are invoked by the Tanzu CLI. Until then
    this remapping functionality is best limited to scenarios of relocating
    without command group renaming, or ones that only involve minor and
    non-surprising renames of the command group for the plugin's commands.
```

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Update unit tests. Additionally

Assuming k8s-targetted plugin `apps` is installed

Build and install additional plugin with different PluginDescriptor ...
1)
```
        p, err := plugin.NewPlugin(&plugin.PluginDescriptor{
                Name:                 "appsv2",
                Description:          "Applicationz2 on Kubernetes",  << for ease of disambuigate of top level help
                SupportedContextType: []string{string(types.ContextTypeTanzu)},
                InvokedAs:            []string{"apps"},
...
        })
```
verified that the apps cmd node (invoked via tanzu apps ... ) is replaced with that for the new plugin. Similarly for `tanzu kubernetes app`, only when an active CLI context is of type tanzu

```
> tanzu

Usage:
  tanzu [command]

Available command groups:

  Admin
    builder                 Build Tanzu components
  Build
    apps                    Applicationz2 on Kubernetes

----

> tanzu kubernetes

Usage:
  tanzu kubernetes [command]

Aliases:
  kubernetes, k8s

Available command groups:

  Build
    apps                    Applicationz2 on Kubernetes
```


2)
```
        p, err := plugin.NewPlugin(&plugin.PluginDescriptor{
                Name:                 "appsv2",
                Description:          "Applicationz2 on Kubernetes",
                InvokedAs:            []string{"apps"},
...
        })
```
verified that the apps cmd node (invoked via tanzu apps ... ) is unconditionally replaced with that for the new plugin. Similarly for `tanzu kubernetes app`

3)
```
        p, err := plugin.NewPlugin(&plugin.PluginDescriptor{
                Name:                 "appsv2",
                Description:          "Applicationz2 on Kubernetes",
                InvokedAs:            []string{"appsalt"},
...
        })
```
verified that the appsalt cmd node (invoked via tanzu appsalt ... ) is introduced. 
This is not a recommended scenario as the presence of the original apps command group could lead to UX artifacts like duplicated aliases warning.


### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
    Adds experimental functionality to remap in the CLI commands at an entire plugin level.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
