### PR TITLE
Disable installing essential plugins for tanzu plugin source commands

### DIFF
--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -247,6 +247,8 @@ func InstallEssentialPlugins(cmd *cobra.Command) {
 		"tanzu pinniped-auth",
 		// Avoid trying to install essential plugins when user want to remove all plugins using tanzu plugin clean
 		"tanzu plugin clean",
+		// Avoid trying to install essential plugins when users initializes or update the plugin source information
+		"tanzu plugin source",
 	}
 	skipEssentials := false
 	for _, cmdPath := range skipCommandsForEssentials {


### PR DESCRIPTION
### What this PR does / why we need it
- Add `tanzu plugin source` command to skipCommands list for essentials plugins i.e. Tanzu CLi will not attempt to install essential plugins when tanzu plugin source and its sub commands are triggered.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR


**Before this change**

```
> tz plugin source
Manage plugin discovery sources. Discovery source provides metadata about the list of available plugins, their supported versions and how to download them.

Usage:
  tanzu plugin source [command]

Available Commands:
  init        Initialize the discovery source to its default value
  list        List available discovery sources
  update      Update a discovery source configuration

Flags:
  -h, --help   help for source

Use "tanzu plugin source [command] --help" for more information about a command.
> tz plugin source list
[i] Refreshing plugin inventory cache for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
[i] The tanzu cli essential plugins have not been installed and are being installed now. The install may take a few seconds.
[i] Installing plugins from plugin group 'vmware-tanzucli/essentials:v1.0.0'
[i] Installed plugin 'telemetry:v1.1.0' with target 'global' 

  NAME     IMAGE                                                                   
  default  projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest  
```

**After this change**

```
> tz plugin source
Manage plugin discovery sources. Discovery source provides metadata about the list of available plugins, their supported versions and how to download them.

Usage:
  tanzu plugin source [command]

Available Commands:
  init        Initialize the discovery source to its default value
  list        List available discovery sources
  update      Update a discovery source configuration

Flags:
  -h, --help   help for source

Use "tanzu plugin source [command] --help" for more information about a command.
> tz plugin source list
  NAME     IMAGE                                                                   
  default  projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest  
> tz plugin list
[i] Refreshing plugin inventory cache for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
[i] The tanzu cli essential plugins have not been installed and are being installed now. The install may take a few seconds.
[i] Installing plugins from plugin group 'vmware-tanzucli/essentials:v1.0.0'
[i] Installed plugin 'telemetry:v1.1.0' with target 'global' 

Standalone Plugins
  NAME       DESCRIPTION                                                 TARGET  VERSION  STATUS     
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  global  v1.1.0   installed  


```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Tanzu CLI doesn't attempt to install Essential plugins for tanzu plugin source commands
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
