### PR TITLE
Move plugin installation spinner signal code to runtime

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ replace cloud.google.com/go => cloud.google.com/go v0.102.1
 
 replace github.com/vmware-tanzu/tanzu-cli/test/e2e/framework => ./test/e2e/framework
 
+replace github.com/vmware-tanzu/tanzu-plugin-runtime => ../../runtime-code/tanzu-plugin-runtime
+
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/Masterminds/semver v1.5.0
@@ -42,7 +44,7 @@ require (
 	github.com/vmware-tanzu/carvel-ytt v0.40.0
 	github.com/vmware-tanzu/tanzu-cli/test/e2e/framework v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686
-	github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0-dev.0.20240302001423-9b6a526ce007
+	// github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0-dev.0.20240302001423-9b6a526ce007
 	go.pinniped.dev v0.20.0
 	golang.org/x/mod v0.12.0
 	golang.org/x/oauth2 v0.8.0
@@ -57,6 +59,8 @@ require (
 	modernc.org/sqlite v1.21.1
 	sigs.k8s.io/controller-runtime v0.14.5
 )
+
+require github.com/vmware-tanzu/tanzu-plugin-runtime v1.1.0
 
 require (
 	cloud.google.com/go/compute v1.19.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -738,8 +738,6 @@ github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502eb
 github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502ebf68/go.mod h1:e1Uef+Ux5BIHpYwqbeP2ZZmOzehBcez2vUEWXHe+xHE=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686 h1:VcuXqUXFxm5WDqWkzAlU/6cJXua0ozELnqD59fy7J6E=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686/go.mod h1:AFGOXZD4tH+KhpmtV0VjWjllXhr8y57MvOsIxTtywc4=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0-dev.0.20240302001423-9b6a526ce007 h1:RtCj2DlulhWMSLE1lqya62ESxML+xaXBQdmyPNuL6ko=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0-dev.0.20240302001423-9b6a526ce007/go.mod h1:M7WVZoItdyQp53tEprQIa6PZmhbrLe3CzuyQphWuRyI=
 github.com/xanzy/go-gitlab v0.83.0 h1:37p0MpTPNbsTMKX/JnmJtY8Ch1sFiJzVF342+RvZEGw=
 github.com/xanzy/go-gitlab v0.83.0/go.mod h1:5ryv+MnpZStBH8I/77HuQBsMbBGANtVpLWC15qOjWAw=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=

--- a/pkg/pluginmanager/manager.go
+++ b/pkg/pluginmanager/manager.go
@@ -10,10 +10,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"os/signal"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"github.com/Masterminds/semver"
 	"github.com/pkg/errors"
@@ -750,34 +748,13 @@ func installOrUpgradePlugin(p *discovery.Discovered, version string, installTest
 
 	// Initialize the spinner if the spinner is allowed
 	if component.IsTTYEnabled() {
-		// Create a channel to receive OS signals
-		signalChannel := make(chan os.Signal, 1)
-		// Register the channel to receive interrupt signals (e.g., Ctrl+C)
-		signal.Notify(signalChannel, syscall.SIGINT, syscall.SIGTERM)
-		defer func() {
-			signal.Stop(signalChannel)
-			close(signalChannel)
-		}()
-
 		// Initialize the spinner
 		spinner = component.NewOutputWriterSpinner(component.WithOutputStream(os.Stderr),
 			component.WithSpinnerText(installingMsg),
 			component.WithSpinnerStarted(),
-			component.WithSpinnerFinalText(installedMsg, log.LogTypeINFO))
-
+			component.WithSpinnerFinalText(installedMsg, log.LogTypeINFO),
+			component.WithSpinnerErrorText(errMsg))
 		defer spinner.StopSpinner()
-
-		// Start a goroutine that listens for interrupt signals
-		go func(s component.OutputWriterSpinner) {
-			sig := <-signalChannel
-			if sig != nil {
-				if s != nil {
-					s.SetFinalText(errMsg, log.LogTypeERROR)
-					s.StopSpinner()
-				}
-				os.Exit(128 + int(sig.(syscall.Signal)))
-			}
-		}(spinner)
 	} else {
 		log.Info(installingMsg)
 	}


### PR DESCRIPTION
### What this PR does / why we need it
This PR updates the plugin installation code to move the spinner OS interruption handlers to the runtime API. This ensures that OS signal handling is part of the spinner API itself, eliminating the need to handle it separately every time the spinner API is used.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
