### PR TITLE
Unify the plugin installation for standalone and context-scoped plugins and use context as recommendation

### DIFF
--- a/cmd/plugin/test/main.go
+++ b/cmd/plugin/test/main.go
@@ -45,7 +45,7 @@ func main() {
 		pluginsCmd,
 	)
 
-	installedPlugins, err := pluginsupplier.GetInstalledStandalonePlugins()
+	installedPlugins, err := pluginsupplier.GetInstalledPlugins()
 	if err != nil {
 		log.Fatal(err, "")
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ replace cloud.google.com/go => cloud.google.com/go v0.102.1
 
 replace github.com/vmware-tanzu/tanzu-cli/test/e2e/framework => ./test/e2e/framework
 
+replace github.com/vmware-tanzu/tanzu-plugin-runtime => github.com/anujc25/tanzu-plugin-runtime v0.0.0-20240307195649-fc031588c721
+
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/Masterminds/semver v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmx
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
 github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/anujc25/tanzu-plugin-runtime v0.0.0-20240307195649-fc031588c721 h1:rjyjWyAVhzC7d075MrM630ZXJxB7bcI2uKDyzhMHL08=
+github.com/anujc25/tanzu-plugin-runtime v0.0.0-20240307195649-fc031588c721/go.mod h1:5m73y796B4EoeXZtvkq8jbQPPQXeYkLPLS2BBbxZp7o=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
@@ -738,8 +740,6 @@ github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502eb
 github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502ebf68/go.mod h1:e1Uef+Ux5BIHpYwqbeP2ZZmOzehBcez2vUEWXHe+xHE=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686 h1:VcuXqUXFxm5WDqWkzAlU/6cJXua0ozELnqD59fy7J6E=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686/go.mod h1:AFGOXZD4tH+KhpmtV0VjWjllXhr8y57MvOsIxTtywc4=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0-dev.0.20240302001423-9b6a526ce007 h1:RtCj2DlulhWMSLE1lqya62ESxML+xaXBQdmyPNuL6ko=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0-dev.0.20240302001423-9b6a526ce007/go.mod h1:M7WVZoItdyQp53tEprQIa6PZmhbrLe3CzuyQphWuRyI=
 github.com/xanzy/go-gitlab v0.83.0 h1:37p0MpTPNbsTMKX/JnmJtY8Ch1sFiJzVF342+RvZEGw=
 github.com/xanzy/go-gitlab v0.83.0/go.mod h1:5ryv+MnpZStBH8I/77HuQBsMbBGANtVpLWC15qOjWAw=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=

--- a/pkg/command/context_tkg_helper.go
+++ b/pkg/command/context_tkg_helper.go
@@ -94,7 +94,7 @@ func (tkfo *TKGKubeconfigFetcherOptions) getKubeconfigUsingPinnipedAuthPlugin() 
 }
 
 func (tkfo *TKGKubeconfigFetcherOptions) isPinnipedPluginInstalled() (bool, error) {
-	standalonePlugins, err := pluginsupplier.GetInstalledStandalonePlugins()
+	standalonePlugins, err := pluginsupplier.GetInstalledPlugins()
 	if err != nil {
 		return false, err
 	}

--- a/pkg/command/plugin.go
+++ b/pkg/command/plugin.go
@@ -520,7 +520,7 @@ func displayInstalledPlugins(installedPlugins []cli.PluginInfo, recommendedConte
 				target:      string(recommendedContextPlugins[index].Target),
 				installed:   "",
 				recommended: recommendedContextPlugins[index].RecommendedVersion,
-				status:      common.PluginStatusNotInstalled,
+				status:      common.PluginStatusRecommendInstall,
 				active:      false,
 			}
 			plugins = append(plugins, p)

--- a/pkg/command/plugin.go
+++ b/pkg/command/plugin.go
@@ -10,7 +10,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -42,7 +41,7 @@ var (
 const (
 	invalidTargetMsg                = "invalid target specified. Please specify a correct value for the `--target` flag from '" + common.TargetList + "'"
 	errorWhileDiscoveringPlugins    = "there was an error while discovering plugins, error information: '%v'"
-	errorWhileGettingContextPlugins = "there was an error while getting installed context plugins, error information: '%v'"
+	errorWhileGettingContextPlugins = "there was an error while discovering context plugins, error information: '%v'"
 	pluginNameCaps                  = "PLUGIN_NAME"
 )
 
@@ -69,6 +68,7 @@ func newPluginCmd() *cobra.Command {
 
 	listPluginCmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format (yaml|json|table)")
 	utils.PanicOnErr(listPluginCmd.RegisterFlagCompletionFunc("output", completionGetOutputFormats))
+	listPluginCmd.Flags().BoolVar(&showAllColumns, "wide", false, "display additional columns for plugins")
 
 	describePluginCmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format (yaml|json|table)")
 	utils.PanicOnErr(describePluginCmd.RegisterFlagCompletionFunc("output", completionGetOutputFormats))
@@ -132,31 +132,25 @@ func newListPluginCmd() *cobra.Command {
 	var listCmd = &cobra.Command{
 		Use:               "list",
 		Short:             "List installed plugins",
-		Long:              "List installed standalone plugins or plugins recommended by the contexts being used",
+		Long:              "List installed plugins and plugins recommended by the active contexts",
 		ValidArgsFunction: noMoreCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			errorList := make([]error, 0)
-			// List installed standalone plugins
-			standalonePlugins, err := pluginsupplier.GetInstalledStandalonePlugins()
+			// List installed plugins
+			installedPlugins, err := pluginsupplier.GetInstalledPlugins()
 			if err != nil {
 				errorList = append(errorList, err)
-				log.Warningf("there was an error while getting installed standalone plugins, error information: '%v'", err.Error())
+				log.Warningf("there was an error while getting installed plugins, error information: '%v'", err.Error())
 			}
 
-			// List installed context plugins and also missing context plugins.
-			// Showing missing ones guides the user to know some plugins are recommended for the
-			// active contexts, but are not installed.
-			installedContextPlugins, missingContextPlugins, pluginSyncRequired, err := getInstalledAndMissingContextPlugins()
+			// Get List of discovered Server Plugins
+			discoveredServerPlugins, err := pluginmanager.DiscoverServerPlugins()
 			if err != nil {
 				errorList = append(errorList, err)
 				log.Warningf(errorWhileGettingContextPlugins, err.Error())
 			}
 
-			if outputFormat == "" || outputFormat == string(component.TableOutputType) {
-				displayInstalledAndMissingSplitView(standalonePlugins, installedContextPlugins, missingContextPlugins, pluginSyncRequired, cmd.OutOrStdout())
-			} else {
-				displayInstalledAndMissingListView(standalonePlugins, installedContextPlugins, missingContextPlugins, cmd.OutOrStdout())
-			}
+			displayInstalledPlugins(installedPlugins, discoveredServerPlugins, cmd.OutOrStdout())
 
 			return kerrors.NewAggregate(errorList)
 		},
@@ -172,6 +166,11 @@ func newDescribePluginCmd() *cobra.Command {
 		Long:              "Displays detailed information for a plugin",
 		ValidArgsFunction: completeInstalledPlugins,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			if outputFormat == "" {
+				outputFormat = string(component.ListTableOutputType)
+				fmt.Fprintln(cmd.OutOrStdout())
+				defer fmt.Fprintln(cmd.OutOrStdout())
+			}
 			output := component.NewOutputWriterWithOptions(cmd.OutOrStdout(), outputFormat, []component.OutputWriterOption{}, "name", "version", "status", "target", "description", "installationPath")
 			if len(args) != 1 {
 				return fmt.Errorf("must provide one plugin name as a positional argument")
@@ -427,7 +426,6 @@ Plugins installed with this command will only be available while the context rem
 			if err != nil {
 				return err
 			}
-			log.Success("Done")
 			return nil
 		},
 	}
@@ -441,25 +439,19 @@ func syncPlugins(cmd *cobra.Command) error {
 		return err
 	}
 	errList := make([]error, 0)
-	contextNames := ""
 	count := 0
 	for _, context := range contextMap {
-		if contextNames != "" {
-			contextNames += ", "
+		if strings.TrimSpace(context.Name) != "" {
+			count++
 		}
-		contextNames += fmt.Sprintf("'%s'", context.Name)
-		count++
 	}
 	if count == 0 {
 		log.Warning("No active contexts available to perform plugin sync")
 		return nil
-	} else if count == 1 {
-		log.Infof("Plugin sync will be performed for context: %s", contextNames)
-	} else if count > 1 {
-		log.Infof("Plugin sync will be performed for contexts: %s", contextNames)
 	}
+
 	for contextType, context := range contextMap {
-		err = syncContextPlugins(cmd, contextType, context.Name, true)
+		err = syncContextPlugins(cmd, contextType, context.Name)
 		if err != nil {
 			errList = append(errList, err)
 		}
@@ -467,161 +459,102 @@ func syncPlugins(cmd *cobra.Command) error {
 	return kerrors.NewAggregate(errList)
 }
 
-// getInstalledAndMissingContextPlugins returns any context plugins that are not installed
-func getInstalledAndMissingContextPlugins() (installed, missing []discovery.Discovered, pluginSyncRequired bool, err error) {
-	errorList := make([]error, 0)
-	serverPlugins, err := pluginmanager.DiscoverServerPlugins()
-	if err != nil {
-		errorList = append(errorList, err)
-		log.Warningf(errorWhileDiscoveringPlugins, err.Error())
+type pluginListInfo struct {
+	name        string
+	description string
+	target      string
+	installed   string
+	recommended string
+	status      string
+	active      bool
+}
+
+// pluginListInfoSorter sorts pluginListInfo objects.
+type pluginListInfoSorter []pluginListInfo
+
+func (d pluginListInfoSorter) Len() int      { return len(d) }
+func (d pluginListInfoSorter) Swap(i, j int) { d[i], d[j] = d[j], d[i] }
+func (d pluginListInfoSorter) Less(i, j int) bool {
+	if d[i].name != d[j].name {
+		return d[i].name < d[j].name
 	}
+	return d[i].target < d[j].target
+}
 
-	// Note that the plugins we get here don't know from which context they were installed.
-	// We need to cross-reference them with the discovered plugins.
-	installedPlugins, err := pluginsupplier.GetInstalledServerPlugins()
-	if err != nil {
-		errorList = append(errorList, err)
-		log.Warningf(errorWhileGettingContextPlugins, err.Error())
-	}
+func displayInstalledPlugins(installedPlugins []cli.PluginInfo, recommendedContextPlugins []discovery.Discovered, writer io.Writer) {
+	pluginSyncRequired := false
 
-	for i := range serverPlugins {
-		found := false
-		for j := range installedPlugins {
-			if serverPlugins[i].Name != installedPlugins[j].Name || serverPlugins[i].Target != installedPlugins[j].Target {
-				continue
+	getRecommendedPluginVersion := func(installedPlugin cli.PluginInfo) string {
+		for index := range recommendedContextPlugins {
+			if installedPlugin.Name == recommendedContextPlugins[index].Name && installedPlugin.Target == recommendedContextPlugins[index].Target {
+				recommendedContextPlugins[index].Status = common.PluginStatusInstalled
+				return recommendedContextPlugins[index].RecommendedVersion
 			}
-
-			// Store the installed plugin, which includes the context from which it was installed
-			found = true
-			if serverPlugins[i].RecommendedVersion != installedPlugins[j].Version {
-				serverPlugins[i].Status = common.PluginStatusUpdateAvailable
-				pluginSyncRequired = true
-			} else {
-				serverPlugins[i].Status = common.PluginStatusInstalled
-			}
-			serverPlugins[i].InstalledVersion = installedPlugins[j].Version
-			installed = append(installed, serverPlugins[i])
-			break
 		}
-		if !found {
-			// We have a server plugin that is not installed, include it in the list
-			serverPlugins[i].Status = common.PluginStatusNotInstalled
-			missing = append(missing, serverPlugins[i])
+		return ""
+	}
+
+	plugins := []pluginListInfo{}
+
+	for index := range installedPlugins {
+		p := pluginListInfo{
+			name:        installedPlugins[index].Name,
+			description: installedPlugins[index].Description,
+			target:      string(installedPlugins[index].Target),
+			installed:   installedPlugins[index].Version,
+			recommended: getRecommendedPluginVersion(installedPlugins[index]),
+			status:      common.PluginStatusInstalled,
+			active:      pluginsupplier.IsPluginActive(&installedPlugins[index]),
+		}
+		if p.recommended != "" && p.installed != p.recommended {
+			p.status = common.PluginStatusRecommendUpdate
+			pluginSyncRequired = true
+		}
+		plugins = append(plugins, p)
+	}
+	for index := range recommendedContextPlugins {
+		if recommendedContextPlugins[index].Status != common.PluginStatusInstalled {
+			p := pluginListInfo{
+				name:        recommendedContextPlugins[index].Name,
+				description: recommendedContextPlugins[index].Description,
+				target:      string(recommendedContextPlugins[index].Target),
+				installed:   "",
+				recommended: recommendedContextPlugins[index].RecommendedVersion,
+				status:      common.PluginStatusNotInstalled,
+				active:      false,
+			}
+			plugins = append(plugins, p)
 			pluginSyncRequired = true
 		}
 	}
-	return installed, missing, pluginSyncRequired, kerrors.NewAggregate(errorList)
-}
 
-func displayInstalledAndMissingSplitView(installedStandalonePlugins []cli.PluginInfo, installedContextPlugins, missingContextPlugins []discovery.Discovered, pluginSyncRequired bool, writer io.Writer) {
-	// List installed standalone plugins
-	cyanBold := color.New(color.FgCyan).Add(color.Bold)
-	_, _ = cyanBold.Println("Standalone Plugins")
+	sort.Sort(pluginListInfoSorter(plugins))
 
-	sort.Sort(cli.PluginInfoSorter(installedStandalonePlugins))
-	outputStandalone := component.NewOutputWriterWithOptions(writer, outputFormat, []component.OutputWriterOption{}, "Name", "Description", "Target", "Version", "Status")
-	for index := range installedStandalonePlugins {
-		outputStandalone.AddRow(
-			installedStandalonePlugins[index].Name,
-			installedStandalonePlugins[index].Description,
-			string(installedStandalonePlugins[index].Target),
-			installedStandalonePlugins[index].Version,
-			common.PluginStatusInstalled,
-		)
-	}
-	outputStandalone.Render()
-
-	// List installed and missing context plugins in one list.
-	// First group them by context.
-	contextPlugins := installedContextPlugins
-	contextPlugins = append(contextPlugins, missingContextPlugins...)
-
-	ctxPluginsByContext := make(map[string][]discovery.Discovered)
-	for index := range contextPlugins {
-		ctx := contextPlugins[index].ContextName
-		ctxPluginsByContext[ctx] = append(ctxPluginsByContext[ctx], contextPlugins[index])
-	}
-
-	cyanBoldItalic := color.New(color.FgCyan).Add(color.Bold, color.Italic)
-
-	// sort contexts to maintain consistency in the plugin list output
-	contexts := make([]string, 0, len(ctxPluginsByContext))
-	for context := range ctxPluginsByContext {
-		contexts = append(contexts, context)
-	}
-	sort.Strings(contexts)
-	for _, context := range contexts {
-		outputWriter := component.NewOutputWriterWithOptions(writer, outputFormat, []component.OutputWriterOption{}, "Name", "Description", "Target", "Version", "Status")
-
-		ctxSpecificPlugins := ctxPluginsByContext[context]
-		// sort plugins to maintain consistency in the plugin list output
-		sort.Sort(discovery.DiscoveredSorter(ctxSpecificPlugins))
-		fmt.Println("")
-		_, _ = cyanBold.Println("Plugins from Context: ", cyanBoldItalic.Sprintf(context))
-		for i := range ctxSpecificPlugins {
-			v := ctxSpecificPlugins[i].InstalledVersion
-			if ctxSpecificPlugins[i].Status == common.PluginStatusNotInstalled {
-				v = ctxSpecificPlugins[i].RecommendedVersion
-			}
-			outputWriter.AddRow(
-				ctxSpecificPlugins[i].Name,
-				ctxSpecificPlugins[i].Description,
-				string(ctxSpecificPlugins[i].Target),
-				v,
-				ctxSpecificPlugins[i].Status,
-			)
+	outputPluginWriter := component.NewOutputWriterWithOptions(writer, outputFormat, []component.OutputWriterOption{})
+	if isTableOutputFormat() {
+		columnsNames := []string{"Name", "Description", "Target", "Installed", "Recommended", "Status"}
+		if showAllColumns {
+			columnsNames = append(columnsNames, "Active")
 		}
-		outputWriter.Render()
+		outputPluginWriter.SetKeys(columnsNames...)
+		outputPluginWriter.MarkDynamicKeys("Recommended") // Marking this column as dynamic so that it will only be shown if at least one row is non-empty
+		for index := range plugins {
+			outputPluginWriter.AddRow(plugins[index].name, plugins[index].description, plugins[index].target, plugins[index].installed, plugins[index].recommended, plugins[index].status, plugins[index].active)
+		}
+	} else {
+		outputPluginWriter.SetKeys("Name", "Description", "Target", "Installed", "Recommended", "Status", "Active", "Context", "Version") // Add 'Context' and 'Version' fields for backwards compatibility
+		for index := range plugins {
+			outputPluginWriter.AddRow(plugins[index].name, plugins[index].description, plugins[index].target, plugins[index].installed, plugins[index].recommended, plugins[index].status, plugins[index].active, "", plugins[index].installed)
+		}
 	}
 
-	if pluginSyncRequired {
+	outputPluginWriter.Render()
+
+	if pluginSyncRequired && isTableOutputFormat() {
 		// Print a warning to the user that some context plugins are not installed or outdated and plugin sync is required to install them
 		fmt.Println("")
-		fmt.Println("Note: As shown above, some recommended plugins have not been installed or are outdated. To install them please run 'tanzu plugin sync'.")
+		fmt.Printf("Note: As shown above, some recommended plugins have not been installed or are outdated. To install them please run %s.\n", "'tanzu plugin sync'")
 	}
-}
-
-func displayInstalledAndMissingListView(installedStandalonePlugins []cli.PluginInfo, installedContextPlugins, missingContextPlugins []discovery.Discovered, writer io.Writer) {
-	// List installed standalone plugins
-	outputWriter := component.NewOutputWriterWithOptions(writer, outputFormat, []component.OutputWriterOption{}, "Name", "Description", "Target", "Version", "Status", "Context")
-	sort.Sort(cli.PluginInfoSorter(installedStandalonePlugins))
-	for index := range installedStandalonePlugins {
-		outputWriter.AddRow(
-			installedStandalonePlugins[index].Name,
-			installedStandalonePlugins[index].Description,
-			string(installedStandalonePlugins[index].Target),
-			installedStandalonePlugins[index].Version,
-			installedStandalonePlugins[index].Status,
-			"", // No context
-		)
-	}
-
-	// List context plugins that are installed
-	sort.Sort(discovery.DiscoveredSorter(installedContextPlugins))
-	for i := range installedContextPlugins {
-		outputWriter.AddRow(
-			installedContextPlugins[i].Name,
-			installedContextPlugins[i].Description,
-			string(installedContextPlugins[i].Target),
-			installedContextPlugins[i].InstalledVersion,
-			installedContextPlugins[i].Status,
-			installedContextPlugins[i].ContextName,
-		)
-	}
-
-	// List context plugins that are not installed
-	sort.Sort(discovery.DiscoveredSorter(missingContextPlugins))
-	for i := range missingContextPlugins {
-		outputWriter.AddRow(
-			missingContextPlugins[i].Name,
-			missingContextPlugins[i].Description,
-			string(missingContextPlugins[i].Target),
-			missingContextPlugins[i].RecommendedVersion,
-			common.PluginStatusNotInstalled,
-			missingContextPlugins[i].ContextName,
-		)
-	}
-	outputWriter.Render()
 }
 
 func getTarget() configtypes.Target {

--- a/pkg/command/plugin_group.go
+++ b/pkg/command/plugin_group.go
@@ -134,7 +134,7 @@ func newGetCmd() *cobra.Command {
 				log.Warningf("unexpectedly found %d entries for group %q. Using the first one", len(groups), gID)
 			}
 
-			if outputFormat == "" || outputFormat == string(component.TableOutputType) {
+			if isTableOutputFormat() {
 				displayGroupContentAsTable(groups[0], specifiedVersion, outputFormat, true, showNonMandatory, cmd.OutOrStdout())
 			} else {
 				displayGroupContentAsList(groups[0], cmd.OutOrStdout())
@@ -161,7 +161,7 @@ func displayGroupsFound(groups []*plugininventory.PluginGroup, writer io.Writer)
 	}
 	output.Render()
 
-	if outputFormat == "" || outputFormat == string(component.TableOutputType) {
+	if isTableOutputFormat() {
 		fmt.Fprintln(writer)
 		fmt.Fprintln(writer, groupSearchShowDetailsMsg)
 	}
@@ -177,7 +177,7 @@ func displayGroupDetails(groups []*plugininventory.PluginGroup, writer io.Writer
 	}
 
 	// For the table format, we will use individual yaml output for each group
-	if outputFormat == "" || outputFormat == string(component.TableOutputType) {
+	if isTableOutputFormat() {
 		first := true
 		for _, pg := range groups {
 			if !first {

--- a/pkg/command/plugin_helper_test.go
+++ b/pkg/command/plugin_helper_test.go
@@ -48,18 +48,11 @@ var availablePlugins = []plugininventory.PluginIdentifier{
 var installedStandalonePlugins = []plugininventory.PluginIdentifier{
 	{Name: "management-cluster", Target: configtypes.TargetK8s, Version: "v0.1.0"},
 	{Name: "secret", Target: configtypes.TargetK8s, Version: "v0.3.0"},
+	{Name: "cluster", Target: configtypes.TargetK8s, Version: "v0.0.1"},
+	{Name: "feature", Target: configtypes.TargetK8s, Version: "v0.0.2"},
 
 	{Name: "management-cluster", Target: configtypes.TargetTMC, Version: "v0.0.1"},
-}
-
-var installedContextPlugins = map[string][]plugininventory.PluginIdentifier{
-	"myK8sCtx": {
-		{Name: "cluster", Target: configtypes.TargetK8s, Version: "v0.0.1"},
-		{Name: "feature", Target: configtypes.TargetK8s, Version: "v0.0.2"},
-	},
-	"myTMCCtx": {
-		{Name: "cluster", Target: configtypes.TargetTMC, Version: "v0.0.5"},
-	},
+	{Name: "cluster", Target: configtypes.TargetTMC, Version: "v0.0.5"},
 }
 
 const createGroupsStmt = `
@@ -255,36 +248,6 @@ func setupTestPluginCatalog(t *testing.T) {
 		assert.Nil(t, err)
 	}
 	cc.Unlock()
-
-	for ctxName, plugins := range installedContextPlugins {
-		cc, err := catalog.NewContextCatalogUpdater(ctxName)
-		assert.Nil(t, err)
-		assert.NotNil(t, cc)
-
-		var target configtypes.Target
-		for _, plugin := range plugins {
-			entry := cli.PluginInfo{
-				Name:             plugin.Name,
-				Target:           plugin.Target,
-				Version:          plugin.Version,
-				Description:      fmt.Sprintf("Plugin %s/%s description", plugin.Name, plugin.Target),
-				InstallationPath: "/path/" + string(plugin.Target) + "/" + plugin.Name,
-			}
-
-			err = cc.Upsert(&entry)
-			assert.Nil(t, err)
-
-			target = plugin.Target
-		}
-
-		err = configlib.SetContext(&configtypes.Context{
-			Name:   ctxName,
-			Target: target,
-		}, true)
-		assert.Nil(t, err)
-
-		cc.Unlock()
-	}
 }
 
 func setupPluginSourceForTesting(t *testing.T) func() {

--- a/pkg/command/plugin_search.go
+++ b/pkg/command/plugin_search.go
@@ -138,7 +138,7 @@ func displayPluginDetails(plugins []discovery.Discovered, writer io.Writer) {
 	}
 
 	// For the table format, we will use individual yaml output for each plugin
-	if outputFormat == "" || outputFormat == string(component.TableOutputType) {
+	if isTableOutputFormat() {
 		for i := range plugins {
 			if i > 0 {
 				fmt.Println()

--- a/pkg/command/plugin_test.go
+++ b/pkg/command/plugin_test.go
@@ -44,7 +44,7 @@ func TestPluginList(t *testing.T) {
 			plugins:         []string{},
 			args:            []string{"plugin", "list"},
 			expectedFailure: false,
-			expected:        "NAME DESCRIPTION TARGET VERSION STATUS",
+			expected:        "NAME DESCRIPTION TARGET INSTALLED STATUS",
 		},
 		{
 			test:            "With empty config file(no discovery sources added) and when one additional plugin installed",
@@ -53,7 +53,7 @@ func TestPluginList(t *testing.T) {
 			targets:         []configtypes.Target{configtypes.TargetK8s},
 			args:            []string{"plugin", "list"},
 			expectedFailure: false,
-			expected:        "NAME DESCRIPTION TARGET VERSION STATUS foo some foo description kubernetes v0.1.0 installed",
+			expected:        "NAME DESCRIPTION TARGET INSTALLED STATUS foo some foo description kubernetes v0.1.0 installed",
 		},
 		{
 			test:            "With empty config file(no discovery sources added) and when more than one plugin is installed",
@@ -62,7 +62,7 @@ func TestPluginList(t *testing.T) {
 			targets:         []configtypes.Target{configtypes.TargetTMC, configtypes.TargetK8s},
 			args:            []string{"plugin", "list"},
 			expectedFailure: false,
-			expected:        "NAME DESCRIPTION TARGET VERSION STATUS bar some bar description kubernetes v0.2.0 installed foo some foo description mission-control v0.1.0 installed",
+			expected:        "NAME DESCRIPTION TARGET INSTALLED STATUS bar some bar description kubernetes v0.2.0 installed foo some foo description mission-control v0.1.0 installed",
 		},
 		{
 			test:            "when json output is requested",
@@ -71,7 +71,7 @@ func TestPluginList(t *testing.T) {
 			targets:         []configtypes.Target{configtypes.TargetK8s},
 			args:            []string{"plugin", "list", "-o", "json"},
 			expectedFailure: false,
-			expected:        `[ { "context": "", "description": "some foo description", "name": "foo", "status": "installed", "target": "kubernetes", "version": "v0.1.0" } ]`,
+			expected:        `[ { "active": true, "context": "", "description": "some foo description", "installed": "v0.1.0", "name": "foo", "recommended": "", "status": "installed", "target": "kubernetes", "version": "v0.1.0" } ]`,
 		},
 		{
 			test:            "when yaml output is requested",
@@ -80,7 +80,7 @@ func TestPluginList(t *testing.T) {
 			targets:         []configtypes.Target{configtypes.TargetK8s},
 			args:            []string{"plugin", "list", "-o", "yaml"},
 			expectedFailure: false,
-			expected:        `- context: "" description: some foo description name: foo status: installed target: kubernetes version: v0.1.0`,
+			expected:        `- active: true context: "" description: some foo description installed: v0.1.0 name: foo recommended: "" status: installed target: kubernetes version: v0.1.0`,
 		},
 		{
 			test:            "plugin describe json output requested",

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -6,11 +6,13 @@ package common
 
 // Plugin status and scope constants
 const (
-	PluginStatusInstalled       = "installed"
-	PluginStatusNotInstalled    = "not installed"
-	PluginStatusUpdateAvailable = "update available"
-	PluginScopeStandalone       = "Standalone"
-	PluginScopeContext          = "Context"
+	PluginStatusInstalled        = "installed"
+	PluginStatusNotInstalled     = "not installed"
+	PluginStatusRecommendInstall = "install recommended"
+	PluginStatusRecommendUpdate  = "update recommended"
+	PluginStatusUpdateAvailable  = "update available"
+	PluginScopeStandalone        = "Standalone"
+	PluginScopeContext           = "Context"
 )
 
 // DiscoveryType constants

--- a/pkg/pluginmanager/manager.go
+++ b/pkg/pluginmanager/manager.go
@@ -175,11 +175,11 @@ func DiscoverServerPlugins() ([]discovery.Discovered, error) {
 	for _, context := range currentContextMap {
 		contexts = append(contexts, context)
 	}
-	return DiscoverServerPluginsForGivenContexts(contexts)
+	return discoverServerPluginsForGivenContexts(contexts)
 }
 
-// DiscoverServerPluginsForGivenContexts returns the available discovered plugins associated with specific contexts
-func DiscoverServerPluginsForGivenContexts(contexts []*configtypes.Context) ([]discovery.Discovered, error) {
+// discoverServerPluginsForGivenContexts returns the available discovered plugins associated with specific contexts
+func discoverServerPluginsForGivenContexts(contexts []*configtypes.Context) ([]discovery.Discovered, error) {
 	var plugins []discovery.Discovered
 	var errList []error
 	if len(contexts) == 0 {
@@ -477,14 +477,6 @@ func InstallStandalonePlugin(pluginName, version string, target configtypes.Targ
 	return installPlugin(pluginName, version, target, "")
 }
 
-// InstallPluginFromContext installs a plugin by name, version and target as a context-scope plugin.
-func InstallPluginFromContext(pluginName, version string, target configtypes.Target, contextName string) error {
-	if contextName == "" {
-		log.Warningf("Missing context name for a context-scope plugin: %s/%s/%s", pluginName, version, string(target))
-	}
-	return installPlugin(pluginName, version, target, contextName)
-}
-
 // installs a plugin by name, version and target.
 // If the contextName is not empty, it implies the plugin is a context-scope plugin, otherwise
 // we are installing a standalone plugin.
@@ -739,7 +731,7 @@ func installOrUpgradePlugin(p *discovery.Discovered, version string, installTest
 		// already local to the machine.
 		plugin = getPluginFromCache(p, version)
 		if p.ContextName == "" {
-			isPluginAlreadyInstalled = pluginsupplier.IsStandalonePluginInstalled(p.Name, p.Target, version)
+			isPluginAlreadyInstalled = pluginsupplier.IsPluginInstalled(p.Name, p.Target, version)
 		}
 	}
 
@@ -1125,10 +1117,14 @@ func SyncPlugins() error {
 	if err != nil {
 		errList = append(errList, err)
 	}
-	err = InstallDiscoveredContextPlugins(plugins)
-	if err != nil {
-		errList = append(errList, err)
+
+	for i := range plugins {
+		err = InstallStandalonePlugin(plugins[i].Name, plugins[i].RecommendedVersion, plugins[i].Target)
+		if err != nil {
+			errList = append(errList, err)
+		}
 	}
+
 	return kerrors.NewAggregate(errList)
 }
 
@@ -1140,44 +1136,15 @@ func DiscoverPluginsForContextType(contextType configtypes.ContextType) ([]disco
 	if ctx == nil {
 		return nil, fmt.Errorf(errorNoActiveContexForGivenContextType, contextType)
 	}
-	log.Infof("Checking for required plugins for context '%s'...", ctx.Name)
-	return DiscoverServerPluginsForGivenContexts([]*configtypes.Context{ctx})
+	log.Infof("Fetching recommended plugins for active context '%s'...", ctx.Name)
+	return discoverServerPluginsForGivenContexts([]*configtypes.Context{ctx})
 }
 
 // UpdatePluginsInstallationStatus updates the installation status of the given plugins
 func UpdatePluginsInstallationStatus(plugins []discovery.Discovered) {
-	if installedPlugins, err := pluginsupplier.GetInstalledServerPlugins(); err == nil {
+	if installedPlugins, err := pluginsupplier.GetInstalledPlugins(); err == nil {
 		setAvailablePluginsStatus(plugins, installedPlugins)
 	}
-}
-
-// InstallDiscoveredContextPlugins installs the given context scope plugins
-func InstallDiscoveredContextPlugins(plugins []discovery.Discovered) error {
-	var errList []error
-	var err error
-	installed := false
-	UpdatePluginsInstallationStatus(plugins)
-	for idx := range plugins {
-		if plugins[idx].Status == common.PluginStatusNotInstalled || plugins[idx].Status == common.PluginStatusUpdateAvailable {
-			installed = true
-			p := plugins[idx]
-			err = InstallPluginFromContext(p.Name, p.RecommendedVersion, p.Target, p.ContextName)
-			if err != nil {
-				errList = append(errList, err)
-			}
-		}
-	}
-	err = kerrors.NewAggregate(errList)
-	if err != nil {
-		return err
-	}
-
-	if !installed {
-		log.Info("All required plugins are already installed and up-to-date")
-	} else {
-		log.Info("Successfully installed all required plugins")
-	}
-	return nil
 }
 
 // InstallPluginsFromLocalSource installs plugin from local source directory

--- a/pkg/pluginmanager/manager_helper_test.go
+++ b/pkg/pluginmanager/manager_helper_test.go
@@ -57,19 +57,12 @@ var testPluginsNoARM64 = []plugininventory.PluginIdentifier{
 
 var installedStandalonePlugins = []plugininventory.PluginIdentifier{
 	{Name: "management-cluster", Target: configtypes.TargetK8s, Version: "v0.1.0"},
+	{Name: "cluster", Target: configtypes.TargetK8s, Version: "v0.0.1"},
+	{Name: "feature", Target: configtypes.TargetK8s, Version: "v0.0.2"},
 	{Name: "secret", Target: configtypes.TargetK8s, Version: "v0.3.0"},
 
 	{Name: "management-cluster", Target: configtypes.TargetTMC, Version: "v0.0.1"},
-}
-
-var installedContextPlugins = map[string][]plugininventory.PluginIdentifier{
-	"myK8sCtx": {
-		{Name: "cluster", Target: configtypes.TargetK8s, Version: "v0.0.1"},
-		{Name: "feature", Target: configtypes.TargetK8s, Version: "v0.0.2"},
-	},
-	"myTMCCtx": {
-		{Name: "cluster", Target: configtypes.TargetTMC, Version: "v0.0.5"},
-	},
+	{Name: "cluster", Target: configtypes.TargetTMC, Version: "v0.0.5"},
 }
 
 const createGroupsStmt = `
@@ -337,41 +330,6 @@ func setupTestPluginCatalog() {
 		}
 	}
 	cc.Unlock()
-
-	for ctxName, plugins := range installedContextPlugins {
-		cc, err := catalog.NewContextCatalogUpdater(ctxName)
-		if err != nil {
-			log.Fatal(err, "unable to create catalog updater")
-		}
-
-		var target configtypes.Target
-		for _, plugin := range plugins {
-			entry := cli.PluginInfo{
-				Name:             plugin.Name,
-				Target:           plugin.Target,
-				Version:          plugin.Version,
-				Description:      fmt.Sprintf("Plugin %s/%s description", plugin.Name, plugin.Target),
-				InstallationPath: "/path/" + string(plugin.Target) + "/" + plugin.Name,
-			}
-
-			err = cc.Upsert(&entry)
-			if err != nil {
-				log.Fatal(err, "unable to insert into catalog")
-			}
-
-			target = plugin.Target
-		}
-
-		err = configlib.SetContext(&configtypes.Context{
-			Name:   ctxName,
-			Target: target,
-		}, true)
-		if err != nil {
-			log.Fatal(err, "unable to set context")
-		}
-
-		cc.Unlock()
-	}
 }
 
 func setupPluginSourceForTesting() func() {

--- a/pkg/pluginmanager/manager_test.go
+++ b/pkg/pluginmanager/manager_test.go
@@ -409,12 +409,9 @@ func Test_InstallStandalonePlugin(t *testing.T) {
 	}
 
 	// Verify installed plugins
-	installedStandalonePlugins, err := pluginsupplier.GetInstalledStandalonePlugins()
+	installedStandalonePlugins, err := pluginsupplier.GetInstalledPlugins()
 	assertions.Nil(err)
 	assertions.Equal(len(expectedInstalledStandalonePlugins), len(installedStandalonePlugins))
-	installedServerPlugins, err := pluginsupplier.GetInstalledServerPlugins()
-	assertions.Nil(err)
-	assertions.Equal(0, len(installedServerPlugins))
 
 	for i := 0; i < len(expectedInstalledStandalonePlugins); i++ {
 		pd := findPluginInfo(installedStandalonePlugins, expectedInstalledStandalonePlugins[i].Name, expectedInstalledStandalonePlugins[i].Target)
@@ -446,7 +443,7 @@ func Test_InstallPluginsFromGroup(t *testing.T) {
 	assertions.Nil(err)
 	assertions.Equal(groupID, fullGroupID)
 
-	installedStandalonePlugins, err := pluginsupplier.GetInstalledStandalonePlugins()
+	installedStandalonePlugins, err := pluginsupplier.GetInstalledPlugins()
 	assertions.Nil(err)
 	assertions.Equal(1, len(installedStandalonePlugins))
 	pd := findPluginInfo(installedStandalonePlugins, "management-cluster", configtypes.TargetK8s)
@@ -462,7 +459,7 @@ func Test_InstallPluginsFromGroup(t *testing.T) {
 	assertions.Nil(err)
 	assertions.Equal(groupID+":v2.2.0", fullGroupID)
 
-	installedStandalonePlugins, err = pluginsupplier.GetInstalledStandalonePlugins()
+	installedStandalonePlugins, err = pluginsupplier.GetInstalledPlugins()
 	assertions.Nil(err)
 	assertions.Equal(2, len(installedStandalonePlugins))
 	pd = findPluginInfo(installedStandalonePlugins, "management-cluster", configtypes.TargetK8s)
@@ -479,7 +476,7 @@ func Test_InstallPluginsFromGroup(t *testing.T) {
 	assertions.Nil(err)
 	assertions.Equal(groupID, fullGroupID)
 
-	installedStandalonePlugins, err = pluginsupplier.GetInstalledStandalonePlugins()
+	installedStandalonePlugins, err = pluginsupplier.GetInstalledPlugins()
 	assertions.Nil(err)
 	assertions.Equal(4, len(installedStandalonePlugins))
 	pd = findPluginInfo(installedStandalonePlugins, "management-cluster", configtypes.TargetK8s)
@@ -503,7 +500,7 @@ func Test_InstallPluginsFromGroup(t *testing.T) {
 	assertions.Nil(err)
 	assertions.Equal(groupID+":v2.1.0", fullGroupID)
 
-	installedStandalonePlugins, err = pluginsupplier.GetInstalledStandalonePlugins()
+	installedStandalonePlugins, err = pluginsupplier.GetInstalledPlugins()
 	assertions.Nil(err)
 	assertions.Equal(4, len(installedStandalonePlugins))
 	pd = findPluginInfo(installedStandalonePlugins, "management-cluster", configtypes.TargetK8s)
@@ -591,7 +588,7 @@ func Test_InstallPlugin_InstalledPlugins_From_LocalSource(t *testing.T) {
 	err = InstallPluginsFromLocalSource("login", "v0.2.0", configtypes.TargetUnknown, localPluginSourceDir, false)
 	assertions.Nil(err)
 	// Verify installed plugin
-	installedStandalonePlugins, err := pluginsupplier.GetInstalledStandalonePlugins()
+	installedStandalonePlugins, err := pluginsupplier.GetInstalledPlugins()
 	assertions.Nil(err)
 	assertions.Equal(1, len(installedStandalonePlugins))
 	assertions.Equal("login", installedStandalonePlugins[0].Name)
@@ -599,12 +596,9 @@ func Test_InstallPlugin_InstalledPlugins_From_LocalSource(t *testing.T) {
 	// Try installing cluster plugin from local source directory
 	err = InstallPluginsFromLocalSource("cluster", "v0.2.0", configtypes.TargetTMC, localPluginSourceDir, false)
 	assertions.Nil(err)
-	installedStandalonePlugins, err = pluginsupplier.GetInstalledStandalonePlugins()
+	installedStandalonePlugins, err = pluginsupplier.GetInstalledPlugins()
 	assertions.Nil(err)
 	assertions.Equal(2, len(installedStandalonePlugins))
-	installedServerPlugins, err := pluginsupplier.GetInstalledServerPlugins()
-	assertions.Nil(err)
-	assertions.Equal(0, len(installedServerPlugins))
 
 	// Try installing a plugin from incorrect local path
 	err = InstallPluginsFromLocalSource("cluster", "v0.2.0", configtypes.TargetTMC, "fakepath", false)
@@ -769,15 +763,6 @@ func Test_SyncPlugins(t *testing.T) {
 	// There is an error for the kubernetes discovery since we don't have a cluster
 	// but other server plugins will be found, so we use those
 	assertions.Contains(err.Error(), `Failed to load Kubeconfig file from "config"`)
-
-	installedServerPlugins, err := pluginsupplier.GetInstalledServerPlugins()
-	assertions.Nil(err)
-	assertions.Equal(len(installedServerPlugins), len(serverPlugins))
-
-	for _, isp := range installedServerPlugins {
-		p := findDiscoveredPlugin(serverPlugins, isp.Name, isp.Target)
-		assertions.NotNil(p)
-	}
 }
 
 func Test_setAvailablePluginsStatus(t *testing.T) {
@@ -904,13 +889,10 @@ func Test_InstallPluginsFromLocalSourceWithLegacyDirectoryStructure(t *testing.T
 	assertions.Nil(err)
 
 	// Verify installed plugin
-	installedStandalonePlugins, err := pluginsupplier.GetInstalledStandalonePlugins()
+	installedStandalonePlugins, err := pluginsupplier.GetInstalledPlugins()
 	assertions.Nil(err)
 	assertions.Equal(2, len(installedStandalonePlugins))
 	assertions.ElementsMatch([]string{"bar", "foo"}, []string{installedStandalonePlugins[0].Name, installedStandalonePlugins[1].Name})
-	installedServerPlugins, err := pluginsupplier.GetInstalledServerPlugins()
-	assertions.Nil(err)
-	assertions.Equal(0, len(installedServerPlugins))
 }
 
 func Test_VerifyRegistry(t *testing.T) {

--- a/pkg/pluginsupplier/plugin_supplier_test.go
+++ b/pkg/pluginsupplier/plugin_supplier_test.go
@@ -5,6 +5,7 @@ package pluginsupplier
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/otiai10/copy"
@@ -25,7 +26,7 @@ func TestPluginSupplierSuite(t *testing.T) {
 	RunSpecs(t, "plugin supplier test suite")
 }
 
-var _ = Describe("GetInstalledStandalonePlugins", func() {
+var _ = Describe("GetInstalledPlugins", func() {
 	var (
 		cdir string
 		err  error
@@ -45,7 +46,7 @@ var _ = Describe("GetInstalledStandalonePlugins", func() {
 		})
 
 		It("should return empty plugin list", func() {
-			installedPlugins, err := GetInstalledStandalonePlugins()
+			installedPlugins, err := GetInstalledPlugins()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(installedPlugins)).To(Equal(0))
 		})
@@ -57,7 +58,7 @@ var _ = Describe("GetInstalledStandalonePlugins", func() {
 		})
 
 		It("should return installed standalone plugin ", func() {
-			installedPlugins, err := GetInstalledStandalonePlugins()
+			installedPlugins, err := GetInstalledPlugins()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(installedPlugins)).To(Equal(1))
 			Expect(installedPlugins).Should(ContainElement(*pd1))
@@ -65,101 +66,7 @@ var _ = Describe("GetInstalledStandalonePlugins", func() {
 	})
 })
 
-var _ = Describe("GetInstalledServerPlugins", func() {
-	var (
-		cdir         string
-		err          error
-		configFile   *os.File
-		configFileNG *os.File
-		pd1          *cli.PluginInfo
-		pd2          *cli.PluginInfo
-	)
-	const (
-		tmcContextName = "test-tmc-context"
-		k8sContextName = "test-mc"
-	)
-	BeforeEach(func() {
-		cdir, err = os.MkdirTemp("", "test-catalog-cache")
-		Expect(err).ToNot(HaveOccurred())
-		common.DefaultCacheDir = cdir
-
-		configFile, err = os.CreateTemp("", "config")
-		Expect(err).To(BeNil())
-		err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config.yaml"), configFile.Name())
-		Expect(err).To(BeNil(), "Error while copying tanzu config file for testing")
-		os.Setenv("TANZU_CONFIG", configFile.Name())
-
-		configFileNG, err = os.CreateTemp("", "config_ng")
-		Expect(err).To(BeNil())
-		os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
-		err = copy.Copy(filepath.Join("..", "fakes", "config", "tanzu_config_ng.yaml"), configFileNG.Name())
-		Expect(err).To(BeNil(), "Error while coping tanzu config-ng file for testing")
-	})
-	AfterEach(func() {
-		os.RemoveAll(cdir)
-		os.Unsetenv("TANZU_CONFIG")
-		os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
-		os.RemoveAll(configFile.Name())
-		os.RemoveAll(configFileNG.Name())
-	})
-
-	Context("when no server/context plugins installed", func() {
-		It("should return empty plugin list", func() {
-			installedPlugins, err := GetInstalledServerPlugins()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(installedPlugins)).To(Equal(0))
-		})
-	})
-	Context("when a server plugin for k8s target installed", func() {
-		BeforeEach(func() {
-			contextNameFromConfig := k8sContextName
-			pd1, err = fakeInstallPlugin(contextNameFromConfig, "fake-server-plugin1", types.TargetK8s, "v1.0.0")
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("should return installed server plugin ", func() {
-			installedPlugins, err := GetInstalledServerPlugins()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(installedPlugins)).To(Equal(1))
-			Expect(installedPlugins).Should(ContainElement(*pd1))
-		})
-	})
-	Context("when a server plugin for tmc target installed", func() {
-		BeforeEach(func() {
-			contextNameFromConfig := tmcContextName
-			pd1, err = fakeInstallPlugin(contextNameFromConfig, "fake-server-plugin2", types.TargetTMC, "v1.0.0")
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("should return installed server plugin ", func() {
-			installedPlugins, err := GetInstalledServerPlugins()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(installedPlugins)).To(Equal(1))
-			Expect(installedPlugins).Should(ContainElement(*pd1))
-		})
-	})
-	Context("when a server plugin for both tmc and k8s targets installed", func() {
-		BeforeEach(func() {
-			contextNameFromConfig := k8sContextName
-			pd1, err = fakeInstallPlugin(contextNameFromConfig, "fake-server-plugin1", types.TargetTMC, "v1.0.0")
-			Expect(err).ToNot(HaveOccurred())
-
-			contextNameFromConfig = tmcContextName
-			pd2, err = fakeInstallPlugin(contextNameFromConfig, "fake-server-plugin2", types.TargetTMC, "v1.0.0")
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("should return installed server plugins ", func() {
-			installedPlugins, err := GetInstalledServerPlugins()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(installedPlugins)).To(Equal(2))
-			Expect(installedPlugins).Should(ContainElement(*pd1))
-			Expect(installedPlugins).Should(ContainElement(*pd2))
-		})
-	})
-})
-
-var _ = Describe("GetInstalledPlugins (both standalone and context plugins)", func() {
+var _ = Describe("GetInstalledPlugins (standalone plugins)", func() {
 	var (
 		cdir             string
 		err              error
@@ -227,13 +134,14 @@ var _ = Describe("GetInstalledPlugins (both standalone and context plugins)", fu
 			Expect(installedPlugins).Should(ContainElement(*pd1))
 		})
 
-		It("should return correct result for IsStandalonePluginInstalled", func() {
-			isInstalled := IsStandalonePluginInstalled("fake-server-plugin1", types.TargetK8s, "v1.0.0")
+		It("should return correct result for IsPluginInstalled", func() {
+			isInstalled := IsPluginInstalled("fake-server-plugin1", types.TargetK8s, "v1.0.0")
 			Expect(isInstalled).To(BeTrue())
-			isInstalled = IsStandalonePluginInstalled("random-plugin", types.TargetK8s, "v1.0.0")
+			isInstalled = IsPluginInstalled("random-plugin", types.TargetK8s, "v1.0.0")
 			Expect(isInstalled).To(BeFalse())
 		})
 	})
+
 	Context("when a standalone and server plugin for k8s target installed", func() {
 		BeforeEach(func() {
 			pd1, err = fakeInstallPlugin("", "fake-server-plugin1", types.TargetK8s, "v1.0.0")
@@ -247,7 +155,7 @@ var _ = Describe("GetInstalledPlugins (both standalone and context plugins)", fu
 		It("should return installed plugins ", func() {
 			installedPlugins, err := GetInstalledPlugins()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(installedPlugins)).To(Equal(2))
+			Expect(len(installedPlugins)).To(Equal(2)) // server plugins will be migrated as standalone
 			Expect(installedPlugins).Should(ContainElement(*pd1))
 			Expect(installedPlugins).Should(ContainElement(*pd2))
 		})
@@ -270,7 +178,7 @@ var _ = Describe("GetInstalledPlugins (both standalone and context plugins)", fu
 		It("should return installed plugins ", func() {
 			installedPlugins, err := GetInstalledPlugins()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(installedPlugins)).To(Equal(3))
+			Expect(len(installedPlugins)).To(Equal(3)) // server plugins will be migrated as standalone
 			Expect(installedPlugins).Should(ContainElement(*pd1))
 			Expect(installedPlugins).Should(ContainElement(*pd2))
 			Expect(installedPlugins).Should(ContainElement(*pd3))
@@ -294,15 +202,6 @@ var _ = Describe("GetInstalledPlugins (both standalone and context plugins)", fu
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(installedPlugins)).To(Equal(1))
 			Expect(installedPlugins).Should(ContainElement(*pd2))
-		})
-		It("if TANZU_CLI_STANDALONE_OVER_CONTEXT_PLUGINS=1 it should return the standalone plugin only", func() {
-			err := os.Setenv(constants.ConfigVariableStandaloneOverContextPlugins, "1")
-			Expect(err).ToNot(HaveOccurred())
-
-			installedPlugins, err := GetInstalledPlugins()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(installedPlugins)).To(Equal(1))
-			Expect(installedPlugins).Should(ContainElement(*pd1))
 		})
 	})
 
@@ -330,27 +229,19 @@ var _ = Describe("GetInstalledPlugins (both standalone and context plugins)", fu
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should not return any standalone plugins that are also server plugins", func() {
+		It("should not return any server plugins and only standalone plugins should be listed", func() {
 			installedPlugins, err := GetInstalledPlugins()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(installedPlugins)).To(Equal(4))
 			Expect(installedPlugins).Should(ContainElement(*pd1))
 			Expect(installedPlugins).Should(ContainElement(*pd2))
+			Expect(installedPlugins).ShouldNot(ContainElement(*pd3))
 			Expect(installedPlugins).Should(ContainElement(*pd4))
+			Expect(installedPlugins).ShouldNot(ContainElement(*pd5))
 			Expect(installedPlugins).Should(ContainElement(*pd6))
 		})
-		It("if TANZU_CLI_STANDALONE_OVER_CONTEXT_PLUGINS=1 it should not return any server plugins that are also standalone plugins", func() {
-			err := os.Setenv(constants.ConfigVariableStandaloneOverContextPlugins, "1")
-			Expect(err).ToNot(HaveOccurred())
-			installedPlugins, err := GetInstalledPlugins()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(installedPlugins)).To(Equal(4))
-			Expect(installedPlugins).Should(ContainElement(*pd1))
-			Expect(installedPlugins).Should(ContainElement(*pd2))
-			Expect(installedPlugins).Should(ContainElement(*pd3))
-			Expect(installedPlugins).Should(ContainElement(*pd5))
-		})
 	})
+
 	Context("with a catalog cache from an older CLI version", func() {
 		BeforeEach(func() {
 			cdir, err = os.MkdirTemp("", "test-catalog-cache")
@@ -383,18 +274,19 @@ var _ = Describe("GetInstalledPlugins (both standalone and context plugins)", fu
 			os.RemoveAll(configFileNG.Name())
 		})
 
-		It("should find the installed server plugin", func() {
-			installedServerPlugins, err := GetInstalledServerPlugins()
+		It("should find the installed standalone plugin along with server plugins with server plugins migrated in catalog", func() {
+			installedStandalonePlugins, err := GetInstalledPlugins()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(installedServerPlugins)).To(Equal(2))
-			Expect(installedServerPlugins).Should(ContainElement(
+			sort.Sort(cli.PluginInfoSorter(installedStandalonePlugins))
+			Expect(len(installedStandalonePlugins)).To(Equal(3))
+			Expect(installedStandalonePlugins[0]).Should(Equal(
 				cli.PluginInfo{
 					Name:                         "cluster",
 					Description:                  "cluster functionality",
 					Version:                      "v0.0.1",
 					BuildSHA:                     "01234567",
 					Digest:                       "",
-					Group:                        plugin.SystemCmdGroup,
+					Group:                        "System",
 					DocURL:                       "",
 					Hidden:                       false,
 					CompletionType:               0,
@@ -406,19 +298,21 @@ var _ = Describe("GetInstalledPlugins (both standalone and context plugins)", fu
 					Scope:                        "",
 					Status:                       "",
 					DiscoveredRecommendedVersion: "v0.0.1",
-					Target:                       types.TargetK8s,
-					DefaultFeatureFlags:          nil,
+					Target:                       "kubernetes",
 					PostInstallHook:              nil,
+					DefaultFeatureFlags:          map[string]bool{},
+					InvokedAs:                    nil,
+					SupportedContextType:         nil,
 				},
 			))
-			Expect(installedServerPlugins).Should(ContainElement(
+			Expect(installedStandalonePlugins[1]).Should(Equal(
 				cli.PluginInfo{
 					Name:                         "iam",
 					Description:                  "IAM Policies for tmc resources",
 					Version:                      "v0.0.1",
 					BuildSHA:                     "01234567",
 					Digest:                       "",
-					Group:                        plugin.ManageCmdGroup,
+					Group:                        "Manage",
 					DocURL:                       "",
 					Hidden:                       false,
 					CompletionType:               0,
@@ -430,17 +324,14 @@ var _ = Describe("GetInstalledPlugins (both standalone and context plugins)", fu
 					Scope:                        "",
 					Status:                       "",
 					DiscoveredRecommendedVersion: "v0.0.1",
-					Target:                       types.TargetTMC,
-					DefaultFeatureFlags:          nil,
+					Target:                       "mission-control",
 					PostInstallHook:              nil,
+					DefaultFeatureFlags:          map[string]bool{},
+					InvokedAs:                    nil,
+					SupportedContextType:         nil,
 				},
 			))
-		})
-		It("should find the installed standalone plugin", func() {
-			installedStandalonePlugins, err := GetInstalledStandalonePlugins()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(installedStandalonePlugins)).To(Equal(1))
-			Expect(installedStandalonePlugins[0]).Should(Equal(
+			Expect(installedStandalonePlugins[2]).Should(Equal(
 				cli.PluginInfo{
 					Name:                         "isolated-cluster",
 					Description:                  "Prepopulating images/bundle for internet-restricted environments",
@@ -460,7 +351,7 @@ var _ = Describe("GetInstalledPlugins (both standalone and context plugins)", fu
 					Status:                       "",
 					DiscoveredRecommendedVersion: "v0.29.0",
 					Target:                       types.TargetUnknown,
-					DefaultFeatureFlags:          nil,
+					DefaultFeatureFlags:          map[string]bool{},
 					PostInstallHook:              nil,
 				},
 			))

--- a/test/e2e/framework/framework_constants.go
+++ b/test/e2e/framework/framework_constants.go
@@ -80,11 +80,13 @@ const (
 	CLIE2ETestEnvironment = "TANZU_CLI_E2E_TEST_ENVIRONMENT"
 
 	// General constants
-	True            = "true"
-	Installed       = "installed"
-	UpdateAvailable = "update available"
-	NotInstalled    = "not installed"
-	JSONOtuput      = "-o json"
+	True             = "true"
+	Installed        = "installed"
+	UpdateAvailable  = "update available"
+	NotInstalled     = "not installed"
+	RecommendInstall = "install recommended"
+	RecommendUpdate  = "update recommended"
+	JSONOtuput       = "-o json"
 
 	// Context commands
 	CreateContextWithEndPoint              = "%s context create --endpoint %s %s"
@@ -152,7 +154,7 @@ const (
 	NoErrorForPluginGroupGet                      = "should not get any error for plugin group get"
 	NoErrorForPluginSearch                        = "should not get any error for plugin search"
 	PluginSearchOutputShouldBeSortedByName        = "plugin search output should be sorted by name"
-	UnableToSync                                  = "unable to automatically sync the plugins from target context. Please run 'tanzu plugin sync' command to sync plugins manually"
+	UnableToSync                                  = "unable to automatically sync the plugins recommended by the active context. Please run 'tanzu plugin sync' command to sync plugins manually"
 	PluginDescribeShouldNotThrowErr               = "should not get any error for plugin describe"
 	PluginDescShouldExist                         = "there should be one plugin description"
 	PluginNameShouldMatch                         = "plugin name should be same as input value"

--- a/test/e2e/framework/framework_helper.go
+++ b/test/e2e/framework/framework_helper.go
@@ -83,7 +83,11 @@ func PluginListToMap(pluginsList []*PluginInfo) map[string]*PluginInfo {
 
 // GetMapKeyForPlugin takes the plugin and returns the map key for the plugin
 func GetMapKeyForPlugin(pluginsList *PluginInfo) string {
-	return fmt.Sprintf(PluginKey, pluginsList.Name, pluginsList.Target, pluginsList.Version)
+	if pluginsList.Version != "" {
+		return fmt.Sprintf(PluginKey, pluginsList.Name, pluginsList.Target, pluginsList.Version)
+	} else {
+		return fmt.Sprintf(PluginKey, pluginsList.Name, pluginsList.Target, pluginsList.Recommended)
+	}
 }
 
 // LegacyPluginListToMap converts the given PluginInfo slice to map type, key is combination  of plugin's name_target_version and value is PluginInfo

--- a/test/e2e/framework/output_handling.go
+++ b/test/e2e/framework/output_handling.go
@@ -11,6 +11,8 @@ type PluginInfo struct {
 	Scope       string `json:"scope"`
 	Status      string `json:"status"`
 	Version     string `json:"version"`
+	Installed   string `json:"installed"`
+	Recommended string `json:"recommended"`
 	Context     string `json:"context"`
 }
 

--- a/test/e2e/framework/plugin_lifecycle_operations.go
+++ b/test/e2e/framework/plugin_lifecycle_operations.go
@@ -19,8 +19,8 @@ type PluginBasicOps interface {
 	ListPlugins(opts ...E2EOption) ([]*PluginInfo, string, string, error)
 	// ListInstalledPlugins lists all installed plugins
 	ListInstalledPlugins(opts ...E2EOption) ([]*PluginInfo, error)
-	// ListPluginsForGivenContext lists all plugins for a given context and either installed only or all
-	ListPluginsForGivenContext(context string, installedOnly bool, opts ...E2EOption) ([]*PluginInfo, error)
+	// ListRecommendedPluginsFromActiveContext lists all recommended plugins for the active context
+	ListRecommendedPluginsFromActiveContext(installedOnly bool, opts ...E2EOption) ([]*PluginInfo, error)
 	// SearchPlugins searches all plugins for given filter (keyword|regex) by running 'tanzu plugin search' command
 	SearchPlugins(filter string, opts ...E2EOption) ([]*PluginInfo, string, string, error)
 	// InstallPlugin installs given plugin and flags
@@ -150,21 +150,21 @@ func (po *pluginCmdOps) ListInstalledPlugins(opts ...E2EOption) ([]*PluginInfo, 
 	return installedPlugins, err
 }
 
-func (po *pluginCmdOps) ListPluginsForGivenContext(context string, installedOnly bool, opts ...E2EOption) ([]*PluginInfo, error) {
+func (po *pluginCmdOps) ListRecommendedPluginsFromActiveContext(installedOnly bool, opts ...E2EOption) ([]*PluginInfo, error) {
 	plugins, _, _, err := ExecuteCmdAndBuildJSONOutput[PluginInfo](po.cmdExe, ListPluginsCmdWithJSONOutputFlag, opts...)
-	contextSpecificPlugins := make([]*PluginInfo, 0)
+	recommendedPlugins := make([]*PluginInfo, 0)
 	for i := range plugins {
-		if plugins[i].Context == context {
+		if plugins[i].Recommended != "" {
 			if installedOnly {
-				if plugins[i].Status == Installed || plugins[i].Status == UpdateAvailable {
-					contextSpecificPlugins = append(contextSpecificPlugins, plugins[i])
+				if plugins[i].Status == Installed || plugins[i].Status == UpdateAvailable || plugins[i].Status == RecommendUpdate {
+					recommendedPlugins = append(recommendedPlugins, plugins[i])
 				}
 			} else {
-				contextSpecificPlugins = append(contextSpecificPlugins, plugins[i])
+				recommendedPlugins = append(recommendedPlugins, plugins[i])
 			}
 		}
 	}
-	return contextSpecificPlugins, err
+	return recommendedPlugins, err
 }
 
 func (po *pluginCmdOps) Sync(opts ...E2EOption) (string, string, error) {

--- a/test/e2e/plugin_sync/k8s/plugin_sync_k8s_lifecycle_test.go
+++ b/test/e2e/plugin_sync/k8s/plugin_sync_k8s_lifecycle_test.go
@@ -66,6 +66,11 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 		var clusterInfo *f.ClusterInfo
 		var contextName string
 		var err error
+
+		It("clean plugins", func() {
+			err = tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin cleanup")
+		})
 		// Test case: a. create k8s context for the KIND cluster
 		It("create KIND cluster", func() {
 			// Create KIND cluster, which is used in test cases to create context's
@@ -82,11 +87,11 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 			Expect(err).To(BeNil(), "there should be a active context")
 			Expect(active).To(Equal(contextName), "the active context should be recently added context")
 		})
-		// Test case: c. list plugins and make sure no plugins installed
-		It("list plugins and check number plugins should be same as installed in previous test", func() {
-			pluginsList, err := tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
+		// Test case: c. list recommended plugins and make sure no plugins are installed
+		It("list recommended plugins and make sure no plugins are installed", func() {
+			recommendedInstalledPluginsList, err := tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
-			Expect(len(pluginsList)).Should(Equal(0), "there should not be any context specific plugins")
+			Expect(len(recommendedInstalledPluginsList)).Should(Equal(0), "there should not be any context specific plugins")
 		})
 		// Test case: d. delete current context and KIND cluster
 		It("delete current context and the KIND cluster", func() {
@@ -108,12 +113,16 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 	// g. uninstall one of the installed plugin, make sure plugin is uninstalled,
 	//		run plugin sync, make sure the uninstalled plugin has installed again.
 	// h. delete current context and KIND cluster
-	Context("Use case 2: Install KIND Cluster, Apply CRD, Apply specific plugin CRs, create context and validate plugin sync, simulate plugin upgrade by applyging different CRs, sync and validate plugins", func() {
+	Context("Use case 2: Install KIND Cluster, Apply CRD, Apply specific plugin CRs, create context and validate plugin sync, simulate plugin upgrade by applying different CRs, sync and validate plugins", func() {
 		var clusterInfo *f.ClusterInfo
 		var pluginCRFilePaths []string
-		var pluginsInfoForCRsApplied, installedPluginsList []*f.PluginInfo
+		var pluginsInfoForCRsApplied, installedPluginsList, recommendedPluginsList, recommendedInstalledPlugins []*f.PluginInfo
 		var contextName string
 		var err error
+		It("clean plugins", func() {
+			err = tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin cleanup")
+		})
 		// Test case: a. create KIND cluster, apply CRD
 		It("create KIND cluster", func() {
 			// Create KIND cluster, which is used in test cases to create context's
@@ -144,12 +153,14 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 			Expect(err).To(BeNil(), "there should be a active context")
 			Expect(active).To(Equal(contextName), "the active context should be recently added context")
 		})
-		// Test case: d. list plugins and validate plugins info, make sure all plugins are installed for which CRs were present on the cluster
-		It("list plugins and validate plugins being installed after context being created", func() {
-			installedPluginsList, err = tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
+		// Test case: d. list all recommended plugins and validate all of them are installed. Also validate plugins info, make sure all plugins are installed for which CRs were present on the cluster
+		It("list recommended and installed plugins and validate plugins being installed after context being created", func() {
+			recommendedPluginsList, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(false)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
-			Expect(len(installedPluginsList)).Should(Equal(len(pluginsInfoForCRsApplied)), "number of plugins should be same as number of plugins CRs applied")
-			Expect(f.CheckAllPluginsExists(installedPluginsList, pluginsInfoForCRsApplied)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
+			Expect(f.CheckAllPluginsExists(recommendedPluginsList, pluginsInfoForCRsApplied)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
+			for _, p := range recommendedPluginsList {
+				Expect(p.Status).To(Equal(f.Installed), "all recommended plugins should be installed")
+			}
 		})
 		// Test case: e. simulate context-scoped plugin upgrade by applying updated CRs again (with updated plugin versions) to KIND cluster to validate sync
 		It("apply updated CRs (with updated plugin versions) to KIND cluster to validate sync", func() {
@@ -166,67 +177,75 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 		})
 		// Test case: f. list plugins and validate plugins info, make sure all plugins are installed for which CRs were present on the cluster
 		It("list plugins and validate plugins being installed after context being created", func() {
-			installedPluginsList, err = tf.PluginCmd.ListPluginsForGivenContext(contextName, false)
+			recommendedInstalledPlugins, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
-			Expect(len(installedPluginsList)).Should(Equal(len(pluginsInfoForCRsApplied)), "number of installed status plugins should be same as number of plugins CRs applied")
-			for i := range installedPluginsList {
-				Expect(installedPluginsList[i].Status).To(Equal(f.UpdateAvailable), "all installed context-scoped plugin status should show 'update available'")
+			for i := range recommendedInstalledPlugins {
+				Expect(recommendedInstalledPlugins[i].Status).To(Equal(f.RecommendUpdate), "all installed context-scoped plugin status should show 'update recommended'")
 			}
 
 			_, _, err = tf.PluginCmd.Sync()
 			Expect(err).To(BeNil(), "should not get any error for plugin sync")
-			installedPluginsList, err = tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
-			Expect(err).To(BeNil(), "should not get any error for plugin list")
-			Expect(len(installedPluginsList)).Should(Equal(len(pluginsInfoForCRsApplied)), "number of installed status plugins should be same as number of plugins CRs applied")
 
+			installedPluginsList, err = tf.PluginCmd.ListInstalledPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin list")
 			Expect(f.CheckAllPluginsExists(installedPluginsList, pluginsInfoForCRsApplied)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
 		})
 		// Test case: g. uninstall one of the installed plugin, make sure plugin is uninstalled,
 		//				run plugin sync, make sure the uninstalled plugin has installed again.
 		It("Uninstall one of the installed plugin", func() {
+			installedPluginsList, err = tf.PluginCmd.ListInstalledPlugins()
+
 			pluginToUninstall := pluginsInfoForCRsApplied[0]
 			err = tf.PluginCmd.UninstallPlugin(pluginToUninstall.Name, pluginToUninstall.Target)
 			Expect(err).To(BeNil(), "should not get any error for plugin uninstall")
-
-			latestPluginsInstalledList := pluginsInfoForCRsApplied[1:]
-			allPluginsList, err := tf.PluginCmd.ListPluginsForGivenContext(contextName, false)
+			installedPluginsListAfterUninstall, err := tf.PluginCmd.ListInstalledPlugins()
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
-			installedPluginsList = f.GetInstalledPlugins(allPluginsList)
-			Expect(f.IsPluginExists(allPluginsList, f.GetGivenPluginFromTheGivenPluginList(allPluginsList, pluginToUninstall), f.NotInstalled)).To(BeTrue(), "uninstalled plugin should be listed as not installed")
-			Expect(len(installedPluginsList)).Should(Equal(len(latestPluginsInstalledList)), "number of plugins should be same as number of plugins CRs applied")
-			Expect(f.CheckAllPluginsExists(installedPluginsList, latestPluginsInstalledList)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
+
+			Expect(len(installedPluginsList)).Should(Equal(len(installedPluginsListAfterUninstall)+1), "only one plugin should be uninstalled")
+
+			recommendedPluginsList, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(false)
+			Expect(err).To(BeNil(), "should not get any error for plugin list")
+
+			uninstalledPluginInfo := f.GetGivenPluginFromTheGivenPluginList(recommendedPluginsList, pluginToUninstall)
+			Expect(uninstalledPluginInfo.Status).To(Equal(f.RecommendInstall), "uninstalled plugin should be listed as 'install recommended'")
+			Expect(uninstalledPluginInfo.Recommended).To(Equal(pluginToUninstall.Version), "uninstalled plugin should also specify correct recommended column")
 
 			_, _, err = tf.PluginCmd.Sync()
 			Expect(err).To(BeNil(), "should not get any error for plugin sync")
 
-			installedPluginsList, err = tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
+			installedPluginsList, err = tf.PluginCmd.ListInstalledPlugins()
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
-			Expect(len(installedPluginsList)).Should(Equal(len(pluginsInfoForCRsApplied)), "number of plugins should be same as number of plugins CRs applied")
 			Expect(f.CheckAllPluginsExists(installedPluginsList, pluginsInfoForCRsApplied)).Should(BeTrue(), "plugins being installed and plugins info for which CRs applied should be same")
 		})
-		// Test case: h.1 Unset the context and make sure plugin are deactivated, and set the context again
-		It("list plugins and validate plugins being installed after context being created", func() {
-			installedPluginsList, err = tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
+		// Test case: h.1 Unset the context and make sure installed plugin are still available, and set the context again
+		It("list plugins and validate plugins being installed are still available after un-setting the context", func() {
+			installedPluginsList, err = tf.PluginCmd.ListInstalledPlugins()
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
 			stdOut, _, err = tf.ContextCmd.UnsetContext(contextName)
-			Expect(err).To(BeNil(), "unset context should unset context without any error")
-			for i := range installedPluginsList {
-				Expect(stdOut).To(ContainSubstring(fmt.Sprintf(f.DeactivatingPlugin, installedPluginsList[i].Name, installedPluginsList[i].Version, contextName)))
-			}
+
+			installedPluginsListAfterUnset, err := tf.PluginCmd.ListInstalledPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin list")
+
+			Expect(len(installedPluginsList)).To(Equal(len(installedPluginsListAfterUnset)), "same number of installed plugins should be available after the context unset and plugins should not get deactivated")
+			Expect(f.CheckAllPluginsExists(installedPluginsList, installedPluginsListAfterUnset)).Should(BeTrue(), "plugins being installed before and after the context unset should be same")
+
 			_, _, err = tf.ContextCmd.UseContext(contextName)
 			Expect(err).To(BeNil(), "use context should set context without any error")
 		})
 		// Test case: h.2 delete current context and the KIND cluster
 		It("delete current context and the KIND cluster", func() {
-			installedPluginsList, err = tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
+			installedPluginsList, err = tf.PluginCmd.ListInstalledPlugins()
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
 			stdOut, _, err = tf.ContextCmd.DeleteContext(contextName)
 			Expect(err).To(BeNil(), "context should be deleted without error")
-			// delete context should deactivate all installed plugins
-			for i := range installedPluginsList {
-				Expect(stdOut).To(ContainSubstring(fmt.Sprintf(f.DeactivatingPlugin, installedPluginsList[i].Name, installedPluginsList[i].Version, contextName)))
-			}
-			_, _, err := tf.KindCluster.DeleteCluster(clusterInfo.Name)
+
+			installedPluginsListAfterCtxDelete, err := tf.PluginCmd.ListInstalledPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin list")
+
+			Expect(len(installedPluginsList)).To(Equal(len(installedPluginsListAfterCtxDelete)), "same number of installed plugins should be available after the context delete and plugins should not get deactivated")
+			Expect(f.CheckAllPluginsExists(installedPluginsList, installedPluginsListAfterCtxDelete)).Should(BeTrue(), "plugins being installed before and after the context unset should be same")
+
+			_, _, err = tf.KindCluster.DeleteCluster(clusterInfo.Name)
 			Expect(err).To(BeNil(), "kind cluster should be deleted without any error")
 		})
 	})
@@ -236,15 +255,19 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 	// a. create KIND cluster
 	// b. apply CRD and CRs for a few plugins which are available in the central repo and CRs for plugins which are not available in the central repo
 	// c. create context and make sure context has been created
-	// d. list plugins and validate plugins info, make sure all plugins installed for which CRs have applied to the KIND cluster and are available in the central repo
+	// d. list recommended installed plugins and validate plugins info, make sure all plugins installed for which CR's has applied to KIND cluster and available in central repo
 	// e. run plugin sync and validate the plugin list
 	// f. delete the KIND cluster
 	Context("Use case 3: Install KIND Cluster, Apply CRD, Apply specific plugin CRs, create context and validate plugin sync", func() {
 		var clusterInfo *f.ClusterInfo
 		var pluginCRFilePaths, pluginWithIncorrectVerCRFilePaths []string
-		var pluginsInfoForCRsApplied, pluginsWithIncorrectVer, pluginsList []*f.PluginInfo
+		var pluginsInfoForCRsApplied, pluginsWithIncorrectVer, recommendedInstalledPlugins []*f.PluginInfo
 		var contextName string
 		var err error
+		It("clean plugins", func() {
+			err = tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin cleanup")
+		})
 		// Test case: a. create KIND cluster
 		It("create KIND cluster", func() {
 			// Create KIND cluster, which is used in test cases to create context's
@@ -283,24 +306,24 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 			Expect(err).To(BeNil(), "there should be a active context")
 			Expect(active).To(Equal(contextName), "the active context should be recently added context")
 		})
-		// Test case: d. list plugins and validate plugins info, make sure all plugins installed for which CR's has applied to KIND cluster and available in central repo
-		It("list plugins and validate plugins being installed after context being created", func() {
-			pluginsList, err = tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
+		// Test case: d. list recommended installed plugins and validate plugins info, make sure all plugins installed for which CR's has applied to KIND cluster and available in central repo
+		It("list recommended installed plugins and validate plugins being installed after context being created", func() {
+			recommendedInstalledPlugins, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
-			Expect(len(pluginsList)).Should(Equal(len(pluginsInfoForCRsApplied)), "number of plugins should be same as number of plugins CRs applied")
-			Expect(f.CheckAllPluginsExists(pluginsList, pluginsInfoForCRsApplied)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
+			Expect(len(recommendedInstalledPlugins)).Should(Equal(len(pluginsInfoForCRsApplied)), "number of plugins should be same as number of plugins CRs applied")
+			Expect(f.CheckAllPluginsExists(recommendedInstalledPlugins, pluginsInfoForCRsApplied)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
 		})
 
 		const (
 			ContextActivated         = "Successfully activated context '%s'"
-			PluginWillBeInstalled    = "The following plugins will be installed for context '%s' of contextType '%s':"
-			PluginsTableHeaderRegExp = "NAME\\s+TARGET\\s+VERSION"
+			PluginWillBeInstalled    = "Installing following plugins recommended by the context '%s':"
+			PluginsTableHeaderRegExp = "NAME\\s+TARGET\\s+RECOMMENDED"
 			PluginsRow               = "%s\\s+%s\\s+%s"
 			PluginInstalledRegExp    = "Installed plugin '%s:.+' with target '%s'|Reinitialized plugin '%s:.+' with target '%s'"
 		)
 		// validate the 'context use' output UX
 		// clean plugins, unset context, set context, validate UX
-		It("perform plugin cleanup", func() {
+		It("perform plugin cleanup, reset the context as active context and validate UX", func() {
 			err = tf.PluginCmd.CleanPlugins()
 			Expect(err).To(BeNil(), "should not get any error for plugin cleanup")
 			// unset the context
@@ -310,14 +333,15 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 			stdOut, stdErr, err = tf.ContextCmd.UseContext(contextName)
 			Expect(len(stdOut)).Should(Equal(0), "should not get any output for context use")
 			Expect(err).To(BeNil(), "use context should set context without any error")
-			pluginsList, err = tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
+
+			recommendedInstalledPlugins, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
 			Expect(stdErr).To(ContainSubstring(fmt.Sprintf(ContextActivated, contextName)))
-			Expect(stdErr).To(ContainSubstring(fmt.Sprintf(PluginWillBeInstalled, contextName, types.TargetK8s)))
+			Expect(stdErr).To(ContainSubstring(fmt.Sprintf(PluginWillBeInstalled, contextName)))
 			Expect(stdErr).To(MatchRegexp(PluginsTableHeaderRegExp))
-			for i := range pluginsList {
+			for i := range recommendedInstalledPlugins {
 				// Validate plugin list output
-				Expect(stdErr).To(MatchRegexp(fmt.Sprintf(PluginsRow, pluginsList[i].Name, pluginsList[i].Target, pluginsList[i].Version)))
+				Expect(stdErr).To(MatchRegexp(fmt.Sprintf(PluginsRow, recommendedInstalledPlugins[i].Name, recommendedInstalledPlugins[i].Target, recommendedInstalledPlugins[i].Recommended)))
 			}
 		})
 
@@ -327,10 +351,10 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 			_, _, err = tf.PluginCmd.Sync()
 			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(f.UnableToFindPluginWithVersionForTarget, pluginsWithIncorrectVer[0].Name, pluginsWithIncorrectVer[0].Version, pluginsWithIncorrectVer[0].Target)))
 
-			pluginsList, err = tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
+			recommendedInstalledPlugins, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
-			Expect(len(pluginsList)).Should(Equal(len(pluginsInfoForCRsApplied)), "number of plugins should be same as number of plugins CRs applied")
-			Expect(f.CheckAllPluginsExists(pluginsList, pluginsInfoForCRsApplied)).Should(BeTrue(), "plugins being installed and plugins info for which CRs applied should be same")
+			Expect(len(recommendedInstalledPlugins)).Should(Equal(len(pluginsInfoForCRsApplied)), "number of plugins should be same as number of plugins CRs applied")
+			Expect(f.CheckAllPluginsExists(recommendedInstalledPlugins, pluginsInfoForCRsApplied)).Should(BeTrue(), "plugins being installed and plugins info for which CRs applied should be same")
 		})
 
 		// Test case: f. delete the KIND cluster
@@ -341,20 +365,26 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 			Expect(err).To(BeNil(), "kind cluster should be deleted without any error")
 		})
 	})
-	// Use case 4: test delete context use case, it should uninstall plugins installed for the context
+
+	// Use case 4: test delete context use case, it should not uninstall plugins installed from the context
 	// Steps:
 	// a. create KIND cluster
 	// b. apply CRD and CRs for few plugins
 	// c. create context and make sure context gets created, list plugins, make sure all
 	//    plugins installed for which CRs are applied in KIND cluster
-	// d. delete the context, make sure all context specific plugins are uninstalled
+	// d. delete the context, make sure the same plugins are still installed after the context delete
 	// e. delete the KIND cluster
 	Context("Use case 4: Install KIND Cluster, Apply CRD, Apply specific plugin CRs, create context and validate plugin sync", func() {
 		var clusterInfo *f.ClusterInfo
 		var pluginCRFilePaths []string
-		var pluginsInfoForCRsApplied, pluginsList []*f.PluginInfo
+		var pluginsInfoForCRsApplied, recommendedInstalledPlugins []*f.PluginInfo
 		var contextName string
 		var err error
+
+		It("clean plugins", func() {
+			err = tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin cleanup")
+		})
 		// Test case: a. create KIND cluster
 		It("create KIND cluster", func() {
 			// Create KIND cluster, which is used in test cases to create context's
@@ -381,19 +411,23 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 			contextName = f.ContextPrefixK8s + f.RandomString(4)
 			_, _, err = tf.ContextCmd.CreateContextWithKubeconfig(contextName, clusterInfo.KubeConfigPath, clusterInfo.ClusterKubeContext)
 			Expect(err).To(BeNil(), "context should create without any error")
-			pluginsList, err = tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
+			recommendedInstalledPlugins, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
-			Expect(len(pluginsList)).Should(Equal(len(pluginsInfoForCRsApplied)), "number of plugins should be same as number of plugins CRs applied")
-			Expect(f.CheckAllPluginsExists(pluginsList, pluginsInfoForCRsApplied)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
+			Expect(len(recommendedInstalledPlugins)).Should(Equal(len(pluginsInfoForCRsApplied)), "number of plugins should be same as number of plugins CRs applied")
+			Expect(f.CheckAllPluginsExists(recommendedInstalledPlugins, pluginsInfoForCRsApplied)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
 		})
-		// Test case: d. delete the context, make sure all context specific plugins are uninstalled
-		It("delete context, validate installed plugins list, should uninstalled all context plugins", func() {
+		// Test case: d. delete the context, make sure all context specific plugins are still installed
+		It("delete context, validate installed plugins list, should not uninstalled all context plugins", func() {
+			installedPluginsListBeforeCtxDelete, err := tf.PluginCmd.ListInstalledPlugins()
+			Expect(err).To(BeNil(), "there should be no error for plugin list")
+
 			_, _, err = tf.ContextCmd.DeleteContext(contextName)
 			Expect(err).To(BeNil(), "there should be no error for delete context")
 
-			pluginsList, err = tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
+			installedPluginsListAfterCtxDelete, err := tf.PluginCmd.ListInstalledPlugins()
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
-			Expect(len(pluginsList)).Should(Equal(0), "all context plugins should be uninstalled as context delete")
+
+			Expect(f.CheckAllPluginsExists(installedPluginsListBeforeCtxDelete, installedPluginsListAfterCtxDelete)).Should(BeTrue(), " plugins being installed before and after the context delete should be same")
 		})
 
 		// Test case: e. delete the KIND cluster
@@ -410,16 +444,20 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 	// b. for both clusters, apply CRD and CRs for few plugins
 	// c. for cluster one, create random context and validate the plugin list should show all plugins for which CRs are applied
 	// d. for cluster two, create random context and validate the plugin list should show all plugins for which CRs are applied
-	// e. switch context's, make sure installed plugins also updated
-	// f. delete the KIND clusters
+	// e. validate the recommended plugins from context one is still installed after creating context two because no plugins were overlapping
+	// f. switch context, make sure installed plugins are kept as it is because all required plugins are already installed
+	// g. delete the KIND clusters
 	Context("Use case 5: Install KIND Cluster, Apply CRD, Apply specific plugin CRs, create context and validate plugin sync", func() {
 		var clusterOne, clusterTwo *f.ClusterInfo
 		var pluginCRFilePathsClusterOne, pluginCRFilePathsClusterTwo []string
-		var pluginsInfoForCRsAppliedClusterOne, pluginsListClusterOne []*f.PluginInfo
-		var pluginsInfoForCRsAppliedClusterTwo, pluginsListClusterTwo []*f.PluginInfo
+		var pluginsInfoForCRsAppliedClusterOne, pluginsInfoForCRsAppliedClusterTwo, recommendedInstalledPluginsFromOne, recommendedInstalledPluginsFromTwo []*f.PluginInfo
 		var contextNameClusterOne, contextNameClusterTwo string
 		var err error
 
+		It("clean plugins", func() {
+			err = tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin cleanup")
+		})
 		// Test case: a. create KIND clusters
 		It("create KIND cluster", func() {
 			// Create KIND cluster, which is used in test cases to create context's
@@ -455,42 +493,54 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 			contextNameClusterOne = f.ContextPrefixK8s + f.RandomString(4)
 			_, _, err = tf.ContextCmd.CreateContextWithKubeconfig(contextNameClusterOne, clusterOne.KubeConfigPath, clusterOne.ClusterKubeContext)
 			Expect(err).To(BeNil(), "context should create without any error")
-			pluginsListClusterOne, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameClusterOne, true)
+
+			recommendedInstalledPluginsFromOne, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
-			Expect(len(pluginsListClusterOne)).Should(Equal(len(pluginsInfoForCRsAppliedClusterOne)), "number of plugins should be same as number of plugins CRs applied")
-			Expect(f.CheckAllPluginsExists(pluginsListClusterOne, pluginsInfoForCRsAppliedClusterOne)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
+			Expect(len(recommendedInstalledPluginsFromOne)).Should(Equal(len(pluginsInfoForCRsAppliedClusterOne)), "number of plugins should be same as number of plugins CRs applied")
+			Expect(f.CheckAllPluginsExists(recommendedInstalledPluginsFromOne, pluginsInfoForCRsAppliedClusterOne)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
 		})
 
-		// Test case: d. for cluster two, create random context and validate the plugin list should show all plugins for which CRs are applied
+		// Test case: d for cluster two, create random context and validate the plugin list should show all plugins for which CRs are applied
 		It("create context and validate installed plugins list, should installed all plugins for which CRs has applied in KIND cluster", func() {
 			By("create context with kubeconfig and context")
 			contextNameClusterTwo = f.ContextPrefixK8s + f.RandomString(4)
 			_, _, err = tf.ContextCmd.CreateContextWithKubeconfig(contextNameClusterTwo, clusterTwo.KubeConfigPath, clusterTwo.ClusterKubeContext)
 			Expect(err).To(BeNil(), "context should create without any error")
-			pluginsListClusterTwo, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameClusterTwo, true)
+
+			recommendedInstalledPluginsFromTwo, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
-			Expect(len(pluginsListClusterTwo)).Should(Equal(len(pluginsInfoForCRsAppliedClusterTwo)), "number of plugins should be same as number of plugins CRs applied")
-			Expect(f.CheckAllPluginsExists(pluginsListClusterTwo, pluginsInfoForCRsAppliedClusterTwo)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
+			Expect(len(recommendedInstalledPluginsFromTwo)).Should(Equal(len(pluginsInfoForCRsAppliedClusterTwo)), "number of plugins should be same as number of plugins CRs applied")
+			Expect(f.CheckAllPluginsExists(recommendedInstalledPluginsFromTwo, pluginsInfoForCRsAppliedClusterTwo)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
 		})
 
-		// Test case: e. switch context's, make sure installed plugins also updated
-		It("switch context, make sure installed plugins also updated", func() {
+		// Test case: e validate the recommended plugins from context one is still installed after creating context two because no plugins were overlapping
+		It("validate the recommended plugins from context one is still installed after creating context two because no plugins are overlapping", func() {
+			allInstalledPlugins, err := tf.PluginCmd.ListInstalledPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin list")
+			Expect(f.CheckAllPluginsExists(allInstalledPlugins, recommendedInstalledPluginsFromOne)).Should(BeTrue(), "plugins being installed and plugins info for which CRs applied should be same")
+		})
+
+		// Test case: f. switch context, make sure installed plugins are kept as it is because all required plugins are already installed
+		It("switch context, make sure installed plugins are kept as it is because all required plugins are already installed", func() {
+			allInstalledPlugins, err := tf.PluginCmd.ListInstalledPlugins()
+			Expect(err).To(BeNil(), "there should not be any error for plugin list")
+
 			_, _, err = tf.ContextCmd.UseContext(contextNameClusterTwo)
 			Expect(err).To(BeNil(), "there should not be any error for use context")
-			pluginsListClusterTwo, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameClusterTwo, true)
+			allInstalledPluginsAfterSwitchToTwo, err := tf.PluginCmd.ListInstalledPlugins()
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
-			Expect(len(pluginsListClusterTwo)).Should(Equal(len(pluginsInfoForCRsAppliedClusterTwo)), "number of plugins should be same as number of plugins CRs applied")
-			Expect(f.CheckAllPluginsExists(pluginsListClusterTwo, pluginsInfoForCRsAppliedClusterTwo)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
+			Expect(len(allInstalledPlugins)).Should(Equal(len(allInstalledPluginsAfterSwitchToTwo)), "number of installed plugins before and after the switch should be same")
+			Expect(f.CheckAllPluginsExists(allInstalledPlugins, allInstalledPluginsAfterSwitchToTwo)).Should(BeTrue(), "plugins being installed before and after context switch should be same")
 
 			_, _, err = tf.ContextCmd.UseContext(contextNameClusterOne)
 			Expect(err).To(BeNil(), "there should not be any error for use context")
-			pluginsListClusterOne, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameClusterOne, true)
+			allInstalledPluginsAfterSwitchToOne, err := tf.PluginCmd.ListInstalledPlugins()
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
-			Expect(len(pluginsListClusterOne)).Should(Equal(len(pluginsInfoForCRsAppliedClusterOne)), "number of plugins should be same as number of plugins CRs applied")
-			Expect(f.CheckAllPluginsExists(pluginsListClusterOne, pluginsInfoForCRsAppliedClusterOne)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
+			Expect(len(allInstalledPlugins)).Should(Equal(len(allInstalledPluginsAfterSwitchToOne)), "number of installed plugins before and after the switch should be same")
+			Expect(f.CheckAllPluginsExists(allInstalledPlugins, allInstalledPluginsAfterSwitchToOne)).Should(BeTrue(), "plugins being installed before and after context switch should be same")
 		})
 
-		// Test case: f. delete the KIND clusters
+		// Test case: g. delete the KIND clusters
 		It("delete the KIND cluster", func() {
 			_, _, err = tf.ContextCmd.DeleteContext(contextNameClusterOne)
 			Expect(err).To(BeNil(), "context should be deleted without error")
@@ -516,6 +566,11 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 		var pluginsList []*f.PluginInfo
 		var contextName string
 		var err error
+
+		It("clean plugins", func() {
+			err = tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin cleanup")
+		})
 		// Test case: a. create KIND cluster
 		It("create KIND cluster", func() {
 			// Create KIND cluster, which is used in test cases to create context's
@@ -541,7 +596,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 
 		// Test case: d. apply CRs with different plugin versions and validate plugins being installed after context being created
 		It("apply CRs with different plugin versions and validate plugins being installed after context being created", func() {
-			pluginsList, err = tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
+			pluginsList, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
 			Expect(len(pluginsList)).Should(Equal(0), "no plugins should be available at this time")
 
@@ -591,6 +646,11 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 			if os.Getenv("CRD_PACKAGE_IMAGE") == "" {
 				Skip("Skipping test because CRD_PACKAGE_IMAGE is not set")
 			}
+		})
+
+		It("clean plugins", func() {
+			err = tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin cleanup")
 		})
 
 		It("create KIND cluster, deploying kapp-controller and crd package", func() {
@@ -652,7 +712,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 
 		// apply CRs with different plugin versions and validate plugins being installed after context being created
 		It("apply CRs with different plugin versions and validate plugins being installed after context being created", func() {
-			pluginsList, err = tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
+			pluginsList, err = tf.PluginCmd.ListInstalledPlugins()
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
 			Expect(len(pluginsList)).Should(Equal(0), "no plugins should be available at this time")
 

--- a/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_test.go
+++ b/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_test.go
@@ -52,9 +52,13 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 	// b. create context and validate current active context
 	// c. list plugins and make sure no plugins installed
 	// d. delete current context
-	Context("Use case: create context when there are no plugins to sync", func() {
+	Context("Use case 1: create context when there are no plugins to sync", func() {
 		var contextName string
 		var err error
+		It("clean plugins", func() {
+			err := tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin cleanup")
+		})
 		// Test case: a. create empty mock response, and start mock http server
 		It("mock tmc endpoint with expected plugins response and start REST API mock server", func() {
 			pluginsToGenerateMockResponse := make([]*f.PluginInfo, 0)
@@ -83,7 +87,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		})
 		// Test case: c. list plugins and make sure no plugins installed
 		It("list plugins and check number plugins should be same as installed in previous test", func() {
-			pluginsList, err := tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
+			pluginsList, err := tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), noErrorForPluginList)
 			Expect(len(pluginsList)).Should(Equal(0), "there should not be any context specific plugins")
 		})
@@ -100,16 +104,20 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 	// Steps:
 	// a. mock tmc endpoint with plugins info, start the mock server
 	// b. create context and make sure context has created
-	// c. list plugins and validate plugins info, make sure all plugins are installed as per mock response
+	// c. list recommended installed plugins and validate plugins info, make sure all plugins are installed as per mock response
 	// d. uninstall one of the installed plugin, make sure plugin is uninstalled, run plugin sync, make sure the uninstalled plugin has installed again.
 	// e. delete current context, make sure all context specific plugins are uninstalled
-	Context("Use case: create context, uninstall plugin, sync plugins", func() {
+	Context("Use case 2: create context, uninstall plugin, sync plugins", func() {
 		//var pluginCRFilePaths []string
 		var pluginsToGenerateMockResponse, installedPluginsList, pluginsList []*f.PluginInfo
 		var contextName string
 		var err error
 		var ok bool
 
+		It("clean plugins", func() {
+			err = tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin cleanup")
+		})
 		// Test case: a. mock tmc endpoint with plugins info, start the mock server
 		It("mock tmc endpoint with expected plugins response and restart REST API mock server", func() {
 			// get plugins from a group
@@ -142,17 +150,16 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			Expect(active).To(Equal(contextName), activeContextShouldBeRecentlyAddedOne)
 		})
 
-		// Test case: c. list plugins and validate plugins info, make sure all plugins are installed as per mock response
+		// Test case: c. list recommended installed plugins and validate plugins info, make sure all plugins are installed as per mock response
 		It("list plugins and validate plugins being installed after context being created", func() {
-			installedPluginsList, err = tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
+			recommendedInstalledPluginsList, err := tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), noErrorForPluginList)
-			Expect(len(installedPluginsList)).Should(Equal(len(pluginsToGenerateMockResponse)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
-			Expect(f.CheckAllPluginsExists(installedPluginsList, pluginsToGenerateMockResponse)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
+			Expect(len(recommendedInstalledPluginsList)).Should(Equal(len(pluginsToGenerateMockResponse)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
+			Expect(f.CheckAllPluginsExists(recommendedInstalledPluginsList, pluginsToGenerateMockResponse)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
 		})
 
 		// Test case: d. uninstall one of the installed plugin, make sure plugin is uninstalled,
-		//				run plugin sync, make sure the uninstalled plugin has installed again.
-		//
+		//				run plugin sync, make sure the uninstalled plugin is installed again.
 		It("uninstall one of the installed plugin", func() {
 
 			var pluginToUninstall *f.PluginInfo
@@ -167,15 +174,23 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 				}
 			}
 			if pluginToUninstall != nil && len(latestPluginsInstalledList) > 0 {
+				installedPluginsList, err = tf.PluginCmd.ListInstalledPlugins()
+				Expect(err).To(BeNil(), "should not get any error for plugin list")
+
 				err := tf.PluginCmd.UninstallPlugin(pluginToUninstall.Name, pluginToUninstall.Target)
 				Expect(err).To(BeNil(), "should not get any error for plugin uninstall")
 
-				allPluginsList, err := tf.PluginCmd.ListPluginsForGivenContext(contextName, false)
-				Expect(err).To(BeNil(), noErrorForPluginList)
-				installedPluginsList = f.GetInstalledPlugins(allPluginsList)
-				Expect(f.IsPluginExists(allPluginsList, f.GetGivenPluginFromTheGivenPluginList(allPluginsList, pluginToUninstall), f.NotInstalled)).To(BeTrue(), "uninstalled plugin should be listed as not installed")
-				Expect(len(installedPluginsList)).Should(Equal(len(latestPluginsInstalledList)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
-				Expect(f.CheckAllPluginsExists(installedPluginsList, latestPluginsInstalledList)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
+				installedPluginsListAfterUninstall, err := tf.PluginCmd.ListInstalledPlugins()
+				Expect(err).To(BeNil(), "should not get any error for plugin list")
+
+				Expect(len(installedPluginsList)).Should(Equal(len(installedPluginsListAfterUninstall)+1), "only one plugin should be uninstalled")
+
+				recommendedPluginsList, err := tf.PluginCmd.ListRecommendedPluginsFromActiveContext(false)
+				Expect(err).To(BeNil(), "should not get any error for plugin list")
+
+				uninstalledPluginInfo := f.GetGivenPluginFromTheGivenPluginList(recommendedPluginsList, pluginToUninstall)
+				Expect(uninstalledPluginInfo.Status).To(Equal(f.RecommendInstall), "uninstalled plugin should be listed as 'install recommended'")
+				Expect(uninstalledPluginInfo.Recommended).To(Equal(pluginToUninstall.Version), "uninstalled plugin should also specify correct recommended column")
 			} else {
 				// fail the test case if at least two plugins are not available in the mock response
 				Fail("there should be at least two plugins to uninstall")
@@ -184,37 +199,41 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			_, _, err = tf.PluginCmd.Sync()
 			Expect(err).To(BeNil(), "should not get any error for plugin sync")
 
-			installedPluginsList, err = tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
-			Expect(err).To(BeNil(), noErrorForPluginList)
-			Expect(len(installedPluginsList)).Should(Equal(len(pluginsToGenerateMockResponse)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
-			Expect(f.CheckAllPluginsExists(installedPluginsList, pluginsToGenerateMockResponse)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
+			installedPluginsList, err = tf.PluginCmd.ListInstalledPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin list")
+			Expect(f.CheckAllPluginsExists(installedPluginsList, pluginsToGenerateMockResponse)).Should(BeTrue(), "plugins being installed and plugins for the mocked plugins should be same")
 		})
 		// e. delete current context, make sure all context specific plugins are uninstalled
 		It("delete current context", func() {
 			_, _, err = tf.ContextCmd.DeleteContext(contextName)
 			Expect(err).To(BeNil(), deleteContextWithoutError)
 
-			pluginsList, err = tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
+			pluginsList, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), noErrorForPluginList)
 			Expect(len(pluginsList)).Should(Equal(0), "all context plugins should be uninstalled as context delete")
 			err = f.StopContainer(tf, f.HTTPMockServerName)
 			Expect(err).To(BeNil(), mockServerShouldStopWithoutError)
 		})
 	})
+
 	// Use case 3: create a context (plugin sync) when test central repo does not have all plugins mocked in tmc endpoint response
 	// Steps:
 	// a. update tmc endpoint mock response (make sure at least a plugin does not exists in test central repo) and restart REST API mock server
 	// b. create context and make sure context has created
-	// c. list plugins and validate plugins info, make sure all plugins installed for which response mocked and available in central repo, the unavailable plugin (with incorrect version) should not be installed
+	// c. list recommended plugins and validate plugins info, make sure all plugins installed for which response mocked and available in central repo, the unavailable plugin (with incorrect version) should not be installed
 	// d. run plugin sync and validate the plugin list
-	// e. delete current context
-
-	Context("Use case: Create context should not install unavailable plugins, plugin sync also should not install unavailable plugins", func() {
-		var pluginsToGenerateMockResponse, pluginsGeneratedMockResponseWithCorrectInfo, pluginsList []*f.PluginInfo
+	// e. unset the context and make sure plugins are still installed and set the context again
+	// f. delete current context
+	Context("Use case 3: Create context should not install unavailable plugins, plugin sync also should not install unavailable plugins", func() {
+		var pluginsToGenerateMockResponse, pluginsGeneratedMockResponseWithCorrectInfo []*f.PluginInfo
 		var pluginWithIncorrectVersion *f.PluginInfo
 		var contextName, randomPluginVersion string
 		var err error
 		var ok bool
+		It("clean plugins", func() {
+			err = tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin cleanup")
+		})
 		// Test case: a. update tmc endpoint mock response (make sure at least a plugin does not exists in test central repo) and restart REST API mock server
 		It("mock tmc endpoint with expected plugins response and restart REST API mock server", func() {
 			// get plugins from a group
@@ -262,12 +281,12 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			Expect(active).To(Equal(contextName), activeContextShouldBeRecentlyAddedOne)
 		})
 
-		// Test case: c. list plugins and validate plugins info, make sure all plugins installed for which response mocked and available in central repo, the unavailable plugin (with incorrect version) should not be installed
+		// Test case: c. list recommended plugins and validate plugins info, make sure all plugins installed for which response mocked and available in central repo, the unavailable plugin (with incorrect version) should not be installed
 		It("list plugins and validate plugins being installed after context being created", func() {
-			pluginsList, err = tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
+			recommendedInstalledPlugins, err := tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), noErrorForPluginList)
-			Expect(len(pluginsList)).Should(Equal(len(pluginsGeneratedMockResponseWithCorrectInfo)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
-			Expect(f.CheckAllPluginsExists(pluginsList, pluginsGeneratedMockResponseWithCorrectInfo)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
+			Expect(len(recommendedInstalledPlugins)).Should(Equal(len(pluginsGeneratedMockResponseWithCorrectInfo)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
+			Expect(f.CheckAllPluginsExists(recommendedInstalledPlugins, pluginsGeneratedMockResponseWithCorrectInfo)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
 		})
 
 		// Test case: d. run plugin sync and validate the plugin list
@@ -275,33 +294,41 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			_, _, err = tf.PluginCmd.Sync()
 			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(f.UnableToFindPluginWithVersionForTarget, pluginWithIncorrectVersion.Name, randomPluginVersion, pluginWithIncorrectVersion.Target)))
 
-			pluginsList, err = tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
+			recommendedInstalledPlugins, err := tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), noErrorForPluginList)
-			Expect(len(pluginsList)).Should(Equal(len(pluginsGeneratedMockResponseWithCorrectInfo)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
-			Expect(f.CheckAllPluginsExists(pluginsList, pluginsGeneratedMockResponseWithCorrectInfo)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
+			Expect(len(recommendedInstalledPlugins)).Should(Equal(len(pluginsGeneratedMockResponseWithCorrectInfo)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
+			Expect(f.CheckAllPluginsExists(recommendedInstalledPlugins, pluginsGeneratedMockResponseWithCorrectInfo)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
 		})
-		// Test case: e.1 Unset the context and make sure plugin are deactivated, and set the context again
+		// Test case: e. unset the context and make sure plugins are still installed and set the context again
 		It("list plugins and validate plugins being installed after context being created", func() {
-			installedPluginsList, err := tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
+			installedPluginsList, err := tf.PluginCmd.ListInstalledPlugins()
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
+
 			stdOut, _, err = tf.ContextCmd.UnsetContext(contextName)
 			Expect(err).To(BeNil(), "unset context should unset context without any error")
-			for i := range installedPluginsList {
-				Expect(stdOut).To(ContainSubstring(fmt.Sprintf(f.DeactivatingPlugin, installedPluginsList[i].Name, installedPluginsList[i].Version, contextName)))
-			}
+
+			installedPluginsListAfterUnset, err := tf.PluginCmd.ListInstalledPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin list")
+
+			Expect(len(installedPluginsList)).To(Equal(len(installedPluginsListAfterUnset)), "same number of installed plugins should be available after the context unset and plugins should not get deactivated")
+			Expect(f.CheckAllPluginsExists(installedPluginsList, installedPluginsListAfterUnset)).Should(BeTrue(), "plugins being installed before and after the context unset should be same")
+
 			_, _, err = tf.ContextCmd.UseContext(contextName)
 			Expect(err).To(BeNil(), "use context should set context without any error")
 		})
-		// e.2 delete current context and stop mock server
+		// Test case: f. delete current context and stop mock server
 		It("delete current context", func() {
-			installedPluginsList, err := tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
+			installedPluginsList, err := tf.PluginCmd.ListInstalledPlugins()
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
+
 			stdOut, _, err = tf.ContextCmd.DeleteContext(contextName)
 			Expect(err).To(BeNil(), deleteContextWithoutError)
-			// delete context should deactivate all installed plugins
-			for i := range installedPluginsList {
-				Expect(stdOut).To(ContainSubstring(fmt.Sprintf(f.DeactivatingPlugin, installedPluginsList[i].Name, installedPluginsList[i].Version, contextName)))
-			}
+
+			installedPluginsListAfterCtxDelete, err := tf.PluginCmd.ListInstalledPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin list")
+			Expect(len(installedPluginsList)).To(Equal(len(installedPluginsListAfterCtxDelete)), "same number of installed plugins should be available after the context unset and plugins should not get deactivated")
+			Expect(f.CheckAllPluginsExists(installedPluginsList, installedPluginsListAfterCtxDelete)).Should(BeTrue(), "plugins being installed before and after the context unset should be same")
+
 			err = f.StopContainer(tf, f.HTTPMockServerName)
 			Expect(err).To(BeNil(), mockServerShouldStopWithoutError)
 		})
@@ -313,14 +340,16 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 	// b. update mock response for first context, restart mock server, create context, and validate plugin list
 	// c. update mock response for second context, restart mock server, create context, and validate plugin list
 	// e. delete both contexts
-
-	Context("Use case: create two contexts, and validate plugin list ", func() {
+	Context("Use case 4: create two contexts, and validate plugin list ", func() {
 		var pluginsFromPluginGroup, pluginsToGenerateMockResponseOne, pluginsToGenerateMockResponseTwo, pluginsListOne, pluginsListTwo []*f.PluginInfo
 		var contextNameOne, contextNameTwo string
 		var TMCEndpointResponseOne, TMCEndpointResponseTwo *f.TMCPluginsMockRequestResponseMapping
 		var err error
 		var ok bool
-
+		It("clean plugins", func() {
+			err = tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin cleanup")
+		})
 		// Test case: a. check the plugins availability
 		It("check the plugins availability", func() {
 			// get plugins from a group
@@ -357,7 +386,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			Expect(err).To(BeNil(), activeContextShouldExists)
 			Expect(active).To(Equal(contextNameOne), activeContextShouldBeRecentlyAddedOne)
 
-			pluginsListOne, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameOne, true)
+			pluginsListOne, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), noErrorForPluginList)
 			Expect(len(pluginsListOne)).Should(Equal(len(pluginsToGenerateMockResponseOne)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
 			Expect(f.CheckAllPluginsExists(pluginsListOne, pluginsToGenerateMockResponseOne)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
@@ -388,7 +417,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			Expect(err).To(BeNil(), activeContextShouldExists)
 			Expect(active).To(Equal(contextNameTwo), activeContextShouldBeRecentlyAddedOne)
 
-			pluginsListTwo, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameTwo, true)
+			pluginsListTwo, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), noErrorForPluginList)
 			Expect(len(pluginsListTwo)).Should(Equal(len(pluginsToGenerateMockResponseTwo)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
 			Expect(f.CheckAllPluginsExists(pluginsListTwo, pluginsToGenerateMockResponseTwo)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
@@ -412,13 +441,17 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 	// c. update mock response with additional plugins, restart mock server, run plugin sync, and validate plugin list
 	// d. delete context
 
-	Context("Use case: create two contexts, and validate plugin list ", func() {
+	Context("Use case 5: create two contexts, and validate plugin list ", func() {
 		var pluginsFromPluginGroup, pluginsToGenerateMockResponseOne, pluginsToGenerateMockResponseTwo, pluginsListOne []*f.PluginInfo
 		var contextNameOne string
 		var TMCEndpointResponseOne, TMCEndpointResponseTwo *f.TMCPluginsMockRequestResponseMapping
 		var err error
 		var ok bool
 
+		It("clean plugins", func() {
+			err = tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin cleanup")
+		})
 		// Test case: a. check the plugins availability
 		It("check the plugins availability", func() {
 			// get plugins from a group
@@ -455,7 +488,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			Expect(err).To(BeNil(), activeContextShouldExists)
 			Expect(active).To(Equal(contextNameOne), activeContextShouldBeRecentlyAddedOne)
 
-			pluginsListOne, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameOne, true)
+			pluginsListOne, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), noErrorForPluginList)
 			Expect(len(pluginsListOne)).Should(Equal(len(pluginsToGenerateMockResponseOne)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
 			Expect(f.CheckAllPluginsExists(pluginsListOne, pluginsToGenerateMockResponseOne)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
@@ -482,7 +515,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			_, _, err = tf.PluginCmd.Sync()
 			Expect(err).To(BeNil(), "should not get any error for plugin sync")
 
-			pluginsListOne, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameOne, true)
+			pluginsListOne, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), noErrorForPluginList)
 			Expect(len(pluginsListOne)).Should(Equal(len(pluginsToGenerateMockResponseTwo)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
 			Expect(f.CheckAllPluginsExists(pluginsListOne, pluginsToGenerateMockResponseTwo)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
@@ -497,7 +530,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		})
 	})
 
-	// Use case 6: k8s and tmc contexts coexistnce, create k8s context and tmc context, validate plugins list and plugin sync
+	// Use case 6: k8s and tmc contexts coexistence, create k8s context and tmc context, validate plugins list and plugin sync
 	// test cases:
 	// Test case: a. k8s: create KIND cluster, apply CRD
 	// Test case: b. k8s: apply CRD (cluster resource definition) and CR's (cluster resource) for few plugins
@@ -506,19 +539,24 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 	// Test case: e. TMC: mock tmc endpoint with plugins info, start the mock server
 	// Test case: f. TMC: create context and make sure context has created
 	// Test case: g. TMC: list plugins and validate plugins info, make sure all plugins are installed as per mock response
-	// Test case: h. validate plugin list consistancy, it should sort by context name always
+	// Test case: h. validate plugin list consistency, it should sort by context name always
 	// Test case: i. k8s: use first k8s context and check plugin list
 	// Test case: j. k8s: uninstall one of the installed plugin, make sure plugin is uninstalled, run plugin sync, make sure the uninstalled plugin has installed again.
 	// Test case: k. tmc: use tmc context and check plugin list
 	// Test case: l. delete tmc/k8s contexts and the KIND cluster
-	Context("Use case: create k8s and tmc specific contexts, validate plugins list and perform pluin sync, and perform context switch", func() {
+	Context("Use case 6: create k8s and tmc specific contexts, validate plugins list and perform pluin sync, and perform context switch", func() {
 		var clusterInfo *f.ClusterInfo
 		var pluginCRFilePaths []string
-		var pluginsInfoForCRsApplied, installedPluginsListK8s []*f.PluginInfo
+		var pluginsInfoForCRsApplied, recommendedInstalledPlugins []*f.PluginInfo
 		var contextNameK8s string
 		contexts := make([]string, 0)
 		totalInstalledPlugins := 1 // telemetry plugin that is part of essentials plugin group will always be installed
 		var err error
+
+		It("clean plugins", func() {
+			err = tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin cleanup")
+		})
 		// Test case: a. k8s: create KIND cluster, apply CRD
 		It("create KIND cluster", func() {
 			// Create KIND cluster, which is used in test cases to create context's
@@ -553,12 +591,12 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		})
 		// Test case: d. k8s: list plugins and validate plugins info, make sure all plugins are installed for which CRs were present on the cluster
 		It("Test case: d; list plugins and validate plugins being installed after context being created", func() {
-			installedPluginsListK8s, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameK8s, true)
+			recommendedInstalledPlugins, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
-			Expect(f.CheckAllPluginsExists(installedPluginsListK8s, pluginsInfoForCRsApplied)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
+			Expect(f.CheckAllPluginsExists(recommendedInstalledPlugins, pluginsInfoForCRsApplied)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
 		})
 
-		var pluginsToGenerateMockResponse, installedPluginsListTMC []*f.PluginInfo
+		var pluginsToGenerateMockResponse []*f.PluginInfo
 		var contextNameTMC string
 		var ok bool
 
@@ -598,10 +636,9 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 
 		// Test case: g. TMC: list plugins and validate plugins info, make sure all plugins are installed as per mock response
 		It("Test case: g: list plugins and validate plugins being installed after context being created", func() {
-			installedPluginsListTMC, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameTMC, true)
+			recommendedInstalledPlugins, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), noErrorForPluginList)
-			Expect(len(installedPluginsListTMC)).Should(Equal(len(pluginsToGenerateMockResponse)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
-			Expect(f.CheckAllPluginsExists(installedPluginsListTMC, pluginsToGenerateMockResponse)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
+			Expect(f.CheckAllPluginsExists(recommendedInstalledPlugins, pluginsToGenerateMockResponse)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
 		})
 
 		// Test case: h. validate plugin list consistency, it should sort by context name always
@@ -631,7 +668,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 				// Filter plugins without context
 				var installedPluginsWithContext []*f.PluginInfo
 				for _, plugin := range installedPlugins {
-					if plugin.Context != "" {
+					if plugin.Recommended != "" {
 						installedPluginsWithContext = append(installedPluginsWithContext, plugin)
 					}
 				}
@@ -641,43 +678,25 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 
 		// Test case: i. k8s: use first k8s context and check plugin list
 		It("use first context, check plugin list", func() {
+			err = tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin cleanup")
+
 			_, _, err = tf.ContextCmd.UseContext(contextNameK8s)
 			Expect(err).To(BeNil(), "use context should not return any error")
 			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeK8s))
 			Expect(err).To(BeNil(), activeContextShouldExists)
 			Expect(active).To(Equal(contextNameK8s), active, "the active context should be the recently switched one")
 
-			installedPluginsListK8s, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameK8s, true)
+			recommendedInstalledPlugins, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
-			Expect(len(installedPluginsListK8s)).Should(Equal(len(pluginsInfoForCRsApplied)), "number of plugins should be same as number of plugins CRs applied")
-			Expect(f.CheckAllPluginsExists(installedPluginsListK8s, pluginsInfoForCRsApplied)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
-		})
-
-		// Test case: j. k8s: uninstall one of the installed plugin, make sure plugin is uninstalled, run plugin sync, make sure the uninstalled plugin has installed again.
-		It("Uninstall one of the installed plugin", func() {
-			pluginToUninstall := pluginsInfoForCRsApplied[0]
-			err := tf.PluginCmd.UninstallPlugin(pluginToUninstall.Name, pluginToUninstall.Target)
-			Expect(err).To(BeNil(), "should not get any error for plugin uninstall")
-
-			latestPluginsInstalledList := pluginsInfoForCRsApplied[1:]
-			allPluginsList, err := tf.PluginCmd.ListPluginsForGivenContext(contextNameK8s, false)
-			Expect(err).To(BeNil(), "should not get any error for plugin list")
-			installedPluginsListK8s = f.GetInstalledPlugins(allPluginsList)
-			Expect(f.IsPluginExists(allPluginsList, f.GetGivenPluginFromTheGivenPluginList(allPluginsList, pluginToUninstall), f.NotInstalled)).To(BeTrue(), "uninstalled plugin should be listed as not installed")
-			Expect(len(installedPluginsListK8s)).Should(Equal(len(latestPluginsInstalledList)), "number of plugins should be same as number of plugins CRs applied")
-			Expect(f.CheckAllPluginsExists(installedPluginsListK8s, latestPluginsInstalledList)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
-
-			_, _, err = tf.PluginCmd.Sync()
-			Expect(err).To(BeNil(), "should not get any error for plugin sync")
-
-			installedPluginsListK8s, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameK8s, true)
-			Expect(err).To(BeNil(), "should not get any error for plugin list")
-			Expect(len(installedPluginsListK8s)).Should(Equal(len(pluginsInfoForCRsApplied)), "number of plugins should be same as number of plugins CRs applied")
-			Expect(f.CheckAllPluginsExists(installedPluginsListK8s, pluginsInfoForCRsApplied)).Should(BeTrue(), "plugins being installed and plugins info for which CRs applied should be same")
+			Expect(len(recommendedInstalledPlugins)).Should(Equal(len(pluginsInfoForCRsApplied)), "number of plugins should be same as number of plugins CRs applied")
+			Expect(f.CheckAllPluginsExists(recommendedInstalledPlugins, pluginsInfoForCRsApplied)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
 		})
 
 		// Test case: k. tmc: use tmc context and check plugin list
 		It("use second context again, check plugin list", func() {
+			err = tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin cleanup")
 
 			_, _, err = tf.ContextCmd.UseContext(contextNameTMC)
 			Expect(err).To(BeNil(), "use context should not return any error")
@@ -686,10 +705,10 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			Expect(active).To(Equal(contextNameTMC), activeContextShouldBeRecentlyAddedOne)
 
 			// use context will install the plugins from the tmc endpoint, which is second set of plugins list
-			installedPluginsListTMC, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameTMC, true)
+			recommendedInstalledPlugins, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), noErrorForPluginList)
-			Expect(len(installedPluginsListTMC)).Should(Equal(len(pluginsToGenerateMockResponse)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
-			Expect(f.CheckAllPluginsExists(installedPluginsListTMC, pluginsToGenerateMockResponse)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
+			Expect(len(recommendedInstalledPlugins)).Should(Equal(len(pluginsToGenerateMockResponse)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
+			Expect(f.CheckAllPluginsExists(recommendedInstalledPlugins, pluginsToGenerateMockResponse)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
 		})
 
 		// Test case: l. delete tmc/k8s contexts and the KIND cluster
@@ -710,7 +729,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 	// run context create (make sure another ContextType context is active, but yet to install plugins), it should not perform the sync for all active contexts
 	// run ContextType specific plugin sync (for k8s ContextType), make sync should not happen for tmc context even though its active
 	// run ContextType specific plugin sync (for tmc ContextType), make sync should not happen for k8s context even though its active
-	Context("Use case: create k8s and tmc specific contexts, validate plugins list and perform pluin sync, and perform context switch", func() {
+	Context("Use case 7: create k8s and tmc specific contexts, validate plugins list and perform pluin sync, and perform context switch", func() {
 		var clusterInfo *f.ClusterInfo
 		var pluginCRFilePaths []string
 		var pluginsInfoForCRsApplied, installedPluginsListK8s []*f.PluginInfo
@@ -718,6 +737,10 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		contexts := make([]string, 0)
 		totalInstalledPlugins := 1 // telemetry plugin that is part of essentials plugin group will always be installed
 		var err error
+		It("clean plugins", func() {
+			err = tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin cleanup")
+		})
 		// Test case: a. k8s: create KIND cluster, apply CRD
 		It("create KIND cluster", func() {
 			// Create KIND cluster, which is used in test cases to create context's
@@ -752,7 +775,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		})
 		// Test case: d. k8s: list plugins and validate plugins info, make sure all plugins are installed for which CRs were present on the cluster
 		It("Test case: d; list plugins and validate plugins being installed after context being created", func() {
-			installedPluginsListK8s, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameK8s, true)
+			installedPluginsListK8s, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
 			Expect(f.CheckAllPluginsExists(installedPluginsListK8s, pluginsInfoForCRsApplied)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
 		})
@@ -800,17 +823,17 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		})
 
 		// Test case: g. TMC: list plugins and validate plugins info, make sure all plugins are installed as per mock response
-		// there should not be any k8s specific plugins should be installed/sync as part of tmc context creation
+		// there should not be any k8s specific plugins installed/sync as part of tmc context creation
 		It("Test case: g: list plugins and validate plugins being installed after context being created", func() {
-			installedPluginsListTMC, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameTMC, true)
+			installedPluginsListTMC, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), noErrorForPluginList)
 			Expect(len(installedPluginsListTMC)).Should(Equal(len(pluginsToGenerateMockResponseTMC)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
 			Expect(f.CheckAllPluginsExists(installedPluginsListTMC, pluginsToGenerateMockResponseTMC)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
 
-			// Sync should not happen for the k8s context specific plugins
-			installedPluginsListK8S, err := tf.PluginCmd.ListPluginsForGivenContext(contextNameK8s, true)
-			Expect(len(installedPluginsListK8S)).Should(Equal(0))
-			Expect(err).To(BeNil(), noErrorForPluginList)
+			// // Sync should not happen for the k8s context specific plugins
+			// installedPluginsListK8S, err := tf.PluginCmd.ListRecommendedPluginsFromActiveContext(false)
+			// Expect(len(installedPluginsListK8S)).Should(Equal(0))
+			// Expect(err).To(BeNil(), noErrorForPluginList)
 		})
 
 		// Test case: context use (K8S) - should sync only specific context not all active context's
@@ -837,14 +860,14 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			Expect(err).To(BeNil(), "use context should not return any error")
 
 			// k8s contextType specific plugins only should be installed
-			installedPluginsListK8s, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameK8s, true)
+			installedPluginsListK8s, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
 			Expect(f.CheckAllPluginsExists(installedPluginsListK8s, pluginsInfoForCRsApplied)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
 
-			// Sync should not happen for the tmc context specific plugins, as its contextType specific sync
-			installedPluginsListTMC, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameTMC, true)
-			Expect(len(installedPluginsListTMC)).Should(Equal(0))
-			Expect(err).To(BeNil(), noErrorForPluginList)
+			// // Sync should not happen for the tmc context specific plugins, as its contextType specific sync
+			// installedPluginsListTMC, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
+			// Expect(len(installedPluginsListTMC)).Should(Equal(0))
+			// Expect(err).To(BeNil(), noErrorForPluginList)
 
 			// perform 'tanzu plugin clean' and 'tanzu context use' for k8s context again, and check plugins list, it should be same as previous
 			err = tf.PluginCmd.CleanPlugins()
@@ -854,14 +877,14 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			Expect(err).To(BeNil(), "use context should not return any error")
 
 			// k8s contextType specific plugins only should be installed
-			installedPluginsListK8s, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameK8s, true)
+			installedPluginsListK8s, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
 			Expect(f.CheckAllPluginsExists(installedPluginsListK8s, pluginsInfoForCRsApplied)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
 
-			// Sync should not happen for the tmc context specific plugins, as its contextType specific sync
-			installedPluginsListTMC, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameTMC, true)
-			Expect(len(installedPluginsListTMC)).Should(Equal(0))
-			Expect(err).To(BeNil(), noErrorForPluginList)
+			// // Sync should not happen for the tmc context specific plugins, as its contextType specific sync
+			// installedPluginsListTMC, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
+			// Expect(len(installedPluginsListTMC)).Should(Equal(0))
+			// Expect(err).To(BeNil(), noErrorForPluginList)
 		})
 
 		// Test case: context use (TMC) - should sync only specific context not all active context's
@@ -888,15 +911,15 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			Expect(err).To(BeNil(), "use context should not return any error")
 
 			// tmc contextType specific plugins only should be installed
-			installedPluginsListTMC, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameTMC, true)
+			installedPluginsListTMC, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), noErrorForPluginList)
 			Expect(len(installedPluginsListTMC)).Should(Equal(len(pluginsToGenerateMockResponseTMC)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
 			Expect(f.CheckAllPluginsExists(installedPluginsListTMC, pluginsToGenerateMockResponseTMC)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
 
-			// Sync should not happen for the k8s context specific plugins, as its contextType specific sync
-			installedPluginsListK8s, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameK8s, true)
-			Expect(len(installedPluginsListK8s)).Should(Equal(0))
-			Expect(err).To(BeNil(), noErrorForPluginList)
+			// // Sync should not happen for the k8s context specific plugins, as its contextType specific sync
+			// installedPluginsListK8s, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
+			// Expect(len(installedPluginsListK8s)).Should(Equal(0))
+			// Expect(err).To(BeNil(), noErrorForPluginList)
 
 			// perform 'tanzu plugin clean' and 'tanzu context use' for tmc context again, and check plugins list, it should be same as previous
 			err = tf.PluginCmd.CleanPlugins()
@@ -906,15 +929,15 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			Expect(err).To(BeNil(), "use context should not return any error")
 
 			// tmc contextType specific plugins only should be installed
-			installedPluginsListTMC, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameTMC, true)
+			installedPluginsListTMC, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), noErrorForPluginList)
 			Expect(len(installedPluginsListTMC)).Should(Equal(len(pluginsToGenerateMockResponseTMC)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
 			Expect(f.CheckAllPluginsExists(installedPluginsListTMC, pluginsToGenerateMockResponseTMC)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
 
-			// Sync should not happen for the k8s context specific plugins, as its contextType specific sync
-			installedPluginsListK8s, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameK8s, true)
-			Expect(len(installedPluginsListK8s)).Should(Equal(0))
-			Expect(err).To(BeNil(), noErrorForPluginList)
+			// // Sync should not happen for the k8s context specific plugins, as its contextType specific sync
+			// installedPluginsListK8s, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
+			// Expect(len(installedPluginsListK8s)).Should(Equal(0))
+			// Expect(err).To(BeNil(), noErrorForPluginList)
 
 		})
 
@@ -927,16 +950,12 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			_, _, err = tf.ContextCmd.UseContext(contextNameTMC)
 			Expect(err).To(BeNil(), "use context should not return any error")
 
-			// tmc contextType specific plugins should be installed
-			installedPluginsListTMC, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameTMC, true)
+			// tmc and k8s contextType specific plugins should be installed
+			recommendedInstalledPlugins, err := tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), noErrorForPluginList)
-			Expect(len(installedPluginsListTMC)).Should(Equal(len(pluginsToGenerateMockResponseTMC)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
-			Expect(f.CheckAllPluginsExists(installedPluginsListTMC, pluginsToGenerateMockResponseTMC)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
-
-			// k8s contextType specific plugins should be installed
-			installedPluginsListK8s, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameK8s, true)
-			Expect(err).To(BeNil(), noErrorForPluginList)
-			Expect(f.CheckAllPluginsExists(installedPluginsListK8s, pluginsInfoForCRsApplied)).Should(BeTrue(), "plugins being installed and plugins info for which CRs applied should be same")
+			Expect(len(recommendedInstalledPlugins)).Should(Equal(len(pluginsToGenerateMockResponseTMC)+len(pluginsInfoForCRsApplied)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
+			Expect(f.CheckAllPluginsExists(recommendedInstalledPlugins, pluginsToGenerateMockResponseTMC)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
+			Expect(f.CheckAllPluginsExists(recommendedInstalledPlugins, pluginsInfoForCRsApplied)).Should(BeTrue(), "plugins being installed and plugins info for which CRs applied should be same")
 		})
 
 		// Test case: plugin sync use case, make sure plugins for both contexts are synced
@@ -956,17 +975,12 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			_, _, err = tf.PluginCmd.Sync()
 			Expect(err).To(BeNil(), "plugin sync should not return any error")
 
-			// make sure plugins are synced for both contexts
-			// tmc contextType specific plugins should be installed
-			installedPluginsListTMC, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameTMC, true)
+			// tmc and k8s contextType specific plugins should be installed
+			recommendedInstalledPlugins, err := tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), noErrorForPluginList)
-			Expect(len(installedPluginsListTMC)).Should(Equal(len(pluginsToGenerateMockResponseTMC)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
-			Expect(f.CheckAllPluginsExists(installedPluginsListTMC, pluginsToGenerateMockResponseTMC)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
-
-			// k8s contextType specific plugins should be installed
-			installedPluginsListK8s, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameK8s, true)
-			Expect(err).To(BeNil(), noErrorForPluginList)
-			Expect(f.CheckAllPluginsExists(installedPluginsListK8s, pluginsInfoForCRsApplied)).Should(BeTrue(), "plugins being installed and plugins info for which CRs applied should be same")
+			Expect(len(recommendedInstalledPlugins)).Should(Equal(len(pluginsToGenerateMockResponseTMC)+len(pluginsInfoForCRsApplied)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
+			Expect(f.CheckAllPluginsExists(recommendedInstalledPlugins, pluginsToGenerateMockResponseTMC)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
+			Expect(f.CheckAllPluginsExists(recommendedInstalledPlugins, pluginsInfoForCRsApplied)).Should(BeTrue(), "plugins being installed and plugins info for which CRs applied should be same")
 		})
 
 		// Test case: l. delete tmc/k8s contexts and the KIND cluster
@@ -1009,7 +1023,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 	// Test case: n. plugin group search and plugin group install when active context has issues
 	// Test case: o. delete tmc/k8s contexts
 	// Test case: i. delete tmc/k8s contexts and the KIND cluster
-	Context("Use case: Plugin List, sync, search and install functionalities with Context Issues", func() {
+	Context("Use case 8: Plugin List, sync, search and install functionalities with Context Issues", func() {
 		var clusterInfo *f.ClusterInfo
 		var pluginCRFilePaths []string
 		var pluginsInfoForCRsApplied, installedPluginsListK8s []*f.PluginInfo
@@ -1017,6 +1031,10 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		contexts := make([]string, 0)
 		totalInstalledPlugins := 0
 		var err error
+		It("clean plugins", func() {
+			err = tf.PluginCmd.CleanPlugins()
+			Expect(err).To(BeNil(), "should not get any error for plugin cleanup")
+		})
 		// Test case: a. k8s: create KIND cluster, apply CRD
 		It("create KIND cluster", func() {
 			// Create KIND cluster, which is used in test cases to create context's
@@ -1051,7 +1069,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		})
 		// Test case: d. k8s: list plugins and validate plugins info, make sure all plugins are installed for which CRs were present on the cluster
 		It("Test case: d: list plugins and validate plugins being installed after context being created", func() {
-			installedPluginsListK8s, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameK8s, true)
+			installedPluginsListK8s, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
 			Expect(len(installedPluginsListK8s)).Should(Equal(len(pluginsInfoForCRsApplied)), "number of plugins should be same as number of plugins CRs applied")
 			Expect(f.CheckAllPluginsExists(installedPluginsListK8s, pluginsInfoForCRsApplied)).Should(BeTrue(), " plugins being installed and plugins info for which CRs applied should be same")
@@ -1103,7 +1121,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 
 		// Test case: h. TMC: list plugins and validate plugins info, make sure all plugins are installed as per mock response
 		It("Test case: h: list plugins and validate plugins being installed after context being created", func() {
-			installedPluginsListTMC, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameTMC, true)
+			installedPluginsListTMC, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).NotTo(BeNil(), "there should be an error for plugin list as one of the active context has issues")
 			Expect(len(installedPluginsListTMC)).Should(Equal(len(pluginsToGenerateMockResponse)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
 			Expect(f.CheckAllPluginsExists(installedPluginsListTMC, pluginsToGenerateMockResponse)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)
@@ -1127,7 +1145,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 
 		// Test case: k. validate plugin has installed after above plugin uninstall and install operations
 		It("plugin list validation after specific plugin uninstall and install", func() {
-			pluginList, err := tf.PluginCmd.ListPluginsForGivenContext(contextNameTMC, true)
+			pluginList, err := tf.PluginCmd.ListInstalledPlugins()
 			Expect(err).NotTo(BeNil(), "there should be an error for plugin list as one of the active context has issues")
 			Expect(len(pluginList)).Should(Equal(len(installedPluginsListTMC[1:])), "recently installed plugin should be installed as standalone")
 		})
@@ -1142,7 +1160,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 
 		// Test case: m. validate the plugin list after above plugin sync operation
 		It("plugin list validation after specific plugin delete, and sync", func() {
-			installedPluginsListTMC, err = tf.PluginCmd.ListPluginsForGivenContext(contextNameTMC, true)
+			installedPluginsListTMC, err = tf.PluginCmd.ListRecommendedPluginsFromActiveContext(true)
 			Expect(err).NotTo(BeNil(), "there should be an error for plugin list as one of the active context has issues")
 			Expect(len(installedPluginsListTMC)).Should(Equal(len(pluginsToGenerateMockResponse)), numberOfPluginsSameAsNoOfPluginsInfoMocked)
 			Expect(f.CheckAllPluginsExists(installedPluginsListTMC, pluginsToGenerateMockResponse)).Should(BeTrue(), pluginsInstalledAndMockedShouldBeSame)


### PR DESCRIPTION
### What this PR does / why we need it
- Unify the plugin installation for standalone and context-scoped plugins 
- Use context as a recommendation for which plugin/version to install
- Updates the `tanzu plugin install` and `tanzu plugin sync` experience
- Updates the `tanzu plugin list` output
- Updates the `tanzu plugin describe` output

**Details:**

**`tanzu plugin list`:**
- Rename column from `VERSION` to `INSTALLED`.
- Introduces a new column for recommended version based on active context called `RECOMMENDED`.
- When a plugin is not recommended from an active context, the `RECOMMENDED` is left empty.
- The `RECOMMENDED` column will be dynamic and will only be shown if at least one recommended version.
- The `STATUS` column is used to show the installation and recommended status of the plugin considering the active context. Two new status values are added `install recommended` and `update recommended`.
- Introduce a new flag `--wide` to view additional columns.
- The `ACTIVE` column will be added to show if the plugin is active or not.
- Update the `tanzu plugin list --help` to specify the meaning of INSTALLED and RECOMMENDED columns (TODO)

**`tanzu plugin sync`**

- Use context-plugins as recommended plugins/versions and install all recommended plugins as standalone plugins.
- As mentioned above, the `STATUS` column will be used to reflect the installation status.
- When plugin sync is happening as part of the `tanzu plugin sync` or `tanzu context create` or `tanzu context use` command, a table will be shown with the `INSTALLED` and `RECOMMENDED` columns to show how the plugin is getting updated (install, upgrade, downgrade).

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
- TODO
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
