### PR TITLE
fix: Do not prompt for user confirmation to delete context if not exists

### DIFF
--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -1089,16 +1089,17 @@ func deleteCtx(_ *cobra.Command, args []string) error {
 		name = args[0]
 	}
 
+	ctx, err := config.GetContext(name)
+	if err != nil {
+		return err
+	}
+
 	if !unattended {
 		isAborted := component.AskForConfirmation("Deleting the context entry from the config will remove it from the list of tracked contexts. " +
 			"You will need to use `tanzu context create` to re-create this context. Are you sure you want to continue?")
 		if isAborted != nil {
 			return nil
 		}
-	}
-	ctx, err := config.GetContext(name)
-	if err != nil {
-		return err
 	}
 	installed, _, _, _ := getInstalledAndMissingContextPlugins() //nolint:dogsled
 	log.Infof("Deleting entry for context '%s'", name)

--- a/pkg/command/context_test.go
+++ b/pkg/command/context_test.go
@@ -354,8 +354,8 @@ clusterOpts:
 			unattended = true
 			err = deleteCtx(cmd, []string{"fake-mc"})
 			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).ToNot(ContainSubstring("Deleting the context entry from the config will remove it from the list of tracked contexts. You will need to use `tanzu context create` to re-create this context. Are you sure you want to continue?"))
 			Expect(err.Error()).To(ContainSubstring("context fake-mc not found"))
-
 		})
 		It("should delete context successfully if the config file has contexts available", func() {
 			err = deleteCtx(cmd, []string{existingContext})


### PR DESCRIPTION
### What this PR does / why we need it
When user wants to delete a non-existing context, they would first be prompted about deleting the context and then they'd see the error pointing the context does not exist. 

This MR intends to improve the user experience and not be prompted to any survey if the context does not exist in the firs place. 

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
N/A

### Describe testing done for PR
- Updated unit testing
- Built and executed locally and tried to delete non-existing context.

<img width="675" alt="image" src="https://github.com/vmware-tanzu/tanzu-cli/assets/22118549/d2620710-d973-4885-b59a-fcce9d552543">

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
