### PR TITLE
Update the tanzu context kubeconfig to use projectID instead of projectName if the projectID is not empty string

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/vmware-tanzu/carvel-ytt v0.40.0
 	github.com/vmware-tanzu/tanzu-cli/test/e2e/framework v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686
-	github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0-dev.0.20240318165331-8d6ca07d5468
+	github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0-dev.0.20240325202145-db9795bb1426
 	go.pinniped.dev v0.20.0
 	golang.org/x/mod v0.12.0
 	golang.org/x/oauth2 v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -738,8 +738,8 @@ github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502eb
 github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502ebf68/go.mod h1:e1Uef+Ux5BIHpYwqbeP2ZZmOzehBcez2vUEWXHe+xHE=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686 h1:VcuXqUXFxm5WDqWkzAlU/6cJXua0ozELnqD59fy7J6E=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686/go.mod h1:AFGOXZD4tH+KhpmtV0VjWjllXhr8y57MvOsIxTtywc4=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0-dev.0.20240318165331-8d6ca07d5468 h1:pzw554vh4Q3TqtVhgcPzei3c+TPfF88tcIBdCjd9vJA=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0-dev.0.20240318165331-8d6ca07d5468/go.mod h1:5m73y796B4EoeXZtvkq8jbQPPQXeYkLPLS2BBbxZp7o=
+github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0-dev.0.20240325202145-db9795bb1426 h1:TfrHyAdZ3iWj2apKPk87YUY/4V1aafWrCkxhWEEIhHQ=
+github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0-dev.0.20240325202145-db9795bb1426/go.mod h1:5m73y796B4EoeXZtvkq8jbQPPQXeYkLPLS2BBbxZp7o=
 github.com/xanzy/go-gitlab v0.83.0 h1:37p0MpTPNbsTMKX/JnmJtY8Ch1sFiJzVF342+RvZEGw=
 github.com/xanzy/go-gitlab v0.83.0/go.mod h1:5ryv+MnpZStBH8I/77HuQBsMbBGANtVpLWC15qOjWAw=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=

--- a/pkg/command/context_test.go
+++ b/pkg/command/context_test.go
@@ -599,7 +599,26 @@ clusterOpts:
 			spaceStr = testSpace
 			err = setTanzuCtxActiveResource(cmd, []string{testContextName})
 			Expect(err).ToNot(BeNil())
-			Expect(err.Error()).To(ContainSubstring("space cannot be set without project name. Please provide project name also using --project option"))
+			Expect(err.Error()).To(ContainSubstring("space cannot be set without project. Please set the project"))
+		})
+		It("should update the tanzu context active resource to project given project name only and also update the kubeconfig cluster URL accordingly", func() {
+			tanzuContext.GlobalOpts.Auth.Expiration = time.Now().Add(-time.Hour)
+
+			err = config.SetContext(tanzuContext, false)
+			Expect(err).To(BeNil())
+
+			projectStr = testProject
+			projectIDStr = ""
+			err = setTanzuCtxActiveResource(cmd, []string{testContextName})
+			Expect(err).To(BeNil())
+
+			ctx, err := config.GetContext(testContextName)
+			Expect(err).To(BeNil())
+			Expect(ctx.AdditionalMetadata[config.ProjectNameKey]).To(Equal(testProject))
+			Expect(ctx.AdditionalMetadata[config.SpaceNameKey]).To(BeEmpty())
+			kubeconfig, err := clientcmd.LoadFromFile(kubeconfigFilePath.Name())
+			Expect(err).To(BeNil())
+			Expect(kubeconfig.Clusters["tanzu-cli-mytanzu/current"].Server).To(Equal(tanzuContext.ClusterOpts.Endpoint + "/project/" + testProject))
 		})
 		It("should update the tanzu context active resource to project given project(name and ID) and also update the kubeconfig cluster URL accordingly", func() {
 			tanzuContext.GlobalOpts.Auth.Expiration = time.Now().Add(-time.Hour)
@@ -618,7 +637,7 @@ clusterOpts:
 			Expect(ctx.AdditionalMetadata[config.SpaceNameKey]).To(BeEmpty())
 			kubeconfig, err := clientcmd.LoadFromFile(kubeconfigFilePath.Name())
 			Expect(err).To(BeNil())
-			Expect(kubeconfig.Clusters["tanzu-cli-mytanzu/current"].Server).To(Equal(tanzuContext.ClusterOpts.Endpoint + "/project/" + testProject))
+			Expect(kubeconfig.Clusters["tanzu-cli-mytanzu/current"].Server).To(Equal(tanzuContext.ClusterOpts.Endpoint + "/project/" + testProjectID))
 		})
 		It("should update the tanzu context active resource to space given project(name and ID) and space names and also update the kubeconfig cluster URL accordingly", func() {
 			err = config.SetContext(tanzuContext, false)
@@ -636,7 +655,7 @@ clusterOpts:
 			Expect(ctx.AdditionalMetadata[config.SpaceNameKey]).To(Equal(testSpace))
 			kubeconfig, err := clientcmd.LoadFromFile(kubeconfigFilePath.Name())
 			Expect(err).To(BeNil())
-			Expect(kubeconfig.Clusters["tanzu-cli-mytanzu/current"].Server).To(Equal(tanzuContext.ClusterOpts.Endpoint + "/project/" + testProject + "/space/" + testSpace))
+			Expect(kubeconfig.Clusters["tanzu-cli-mytanzu/current"].Server).To(Equal(tanzuContext.ClusterOpts.Endpoint + "/project/" + testProjectID + "/space/" + testSpace))
 		})
 		It("should update the tanzu context active resource to clustergroup given project and clustergroup names and also update the kubeconfig cluster URL accordingly", func() {
 			err = config.SetContext(tanzuContext, false)
@@ -656,7 +675,7 @@ clusterOpts:
 			Expect(ctx.AdditionalMetadata[config.ClusterGroupNameKey]).To(Equal(testClustergroup))
 			kubeconfig, err := clientcmd.LoadFromFile(kubeconfigFilePath.Name())
 			Expect(err).To(BeNil())
-			Expect(kubeconfig.Clusters["tanzu-cli-mytanzu/current"].Server).To(Equal(tanzuContext.ClusterOpts.Endpoint + "/project/" + testProject + "/clustergroup/" + testClustergroup))
+			Expect(kubeconfig.Clusters["tanzu-cli-mytanzu/current"].Server).To(Equal(tanzuContext.ClusterOpts.Endpoint + "/project/" + testProjectID + "/clustergroup/" + testClustergroup))
 		})
 		It("should throw an error if the clustergroup and space both are provided by the user when setting active resource", func() {
 			err = config.SetContext(tanzuContext, false)

--- a/pkg/telemetry/metrics_helper.go
+++ b/pkg/telemetry/metrics_helper.go
@@ -58,10 +58,16 @@ func hashString(str string) string {
 }
 
 func computeEndpointSHAForTanzuContext(ctx *configtypes.Context) string {
-	// returns SHA256 of concatenated string of Endpoint and orgId/ProjectName/SpaceName
+	// use projectID if not empty, else use projectName
+	projectVal := stringValue(ctx.AdditionalMetadata[configlib.ProjectNameKey])
+	projectID := stringValue(ctx.AdditionalMetadata[configlib.ProjectIDKey])
+	if projectID != "" {
+		projectVal = projectID
+	}
+	// returns SHA256 of concatenated string of Endpoint and orgId/Project/SpaceName
 	return hashString(ctx.GlobalOpts.Endpoint +
 		stringValue(ctx.AdditionalMetadata[configlib.OrgIDKey]) +
-		stringValue(ctx.AdditionalMetadata[configlib.ProjectNameKey]) +
+		projectVal +
 		stringValue(ctx.AdditionalMetadata[configlib.SpaceNameKey]) +
 		stringValue(ctx.AdditionalMetadata[configlib.ClusterGroupNameKey]))
 }

--- a/pkg/telemetry/metrics_helper_test.go
+++ b/pkg/telemetry/metrics_helper_test.go
@@ -25,6 +25,7 @@ var _ = Describe("metrics helper tests", func() {
 	)
 	const (
 		testProjectName      = "project-A"
+		testProjectID        = "project-A-ID"
 		testSpaceName        = "space-A"
 		testClusterGroupName = "clustergroup-A"
 	)
@@ -85,6 +86,7 @@ var _ = Describe("metrics helper tests", func() {
 
 			// when tanzu context has active project
 			ctx.AdditionalMetadata[configlib.ProjectNameKey] = testProjectName
+			ctx.AdditionalMetadata[configlib.ProjectIDKey] = testProjectID
 			ctx.AdditionalMetadata[configlib.SpaceNameKey] = ""
 			ctx.AdditionalMetadata[configlib.ClusterGroupNameKey] = ""
 			err = configlib.SetContext(ctx, true)
@@ -96,6 +98,7 @@ var _ = Describe("metrics helper tests", func() {
 
 			// when tanzu context has active space
 			ctx.AdditionalMetadata[configlib.ProjectNameKey] = testProjectName
+			ctx.AdditionalMetadata[configlib.ProjectIDKey] = testProjectID
 			ctx.AdditionalMetadata[configlib.SpaceNameKey] = testSpaceName
 			ctx.AdditionalMetadata[configlib.ClusterGroupNameKey] = ""
 			err = configlib.SetContext(ctx, true)
@@ -103,6 +106,7 @@ var _ = Describe("metrics helper tests", func() {
 
 			// when tanzu context has active clustergroup
 			ctx.AdditionalMetadata[configlib.ProjectNameKey] = testProjectName
+			ctx.AdditionalMetadata[configlib.ProjectIDKey] = testProjectID
 			ctx.AdditionalMetadata[configlib.SpaceNameKey] = ""
 			ctx.AdditionalMetadata[configlib.ClusterGroupNameKey] = testClusterGroupName
 			err = configlib.SetContext(ctx, true)


### PR DESCRIPTION
### What this PR does / why we need it
This PR updates the tanzu context kubeconfig generation logic to use projectID instead of projectName if the projectID is not empty string

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Tested updating the context with only the project name and it is sucess
```
❯ ./bin/tanzu context update tanzu-active-resource TAP_SAAS_PRD --project e2e

# kubeconfigs cluster.server URL has been updated with project name 
❯ kubectl config view --minify
apiVersion: v1
clusters:
- cluster:
    server: https://api.tanzu.cloud.vmware.com/org/bc6f01a5-8618-4fed-a457-161d3a138052/project/e2e
  name: tanzu-cli-TAP_SAAS_PRD/current
contexts:
- context:
    cluster: tanzu-cli-TAP_SAAS_PRD/current
    user: tanzu-cli-TAP_SAAS_PRD-user
  name: tanzu-cli-TAP_SAAS_PRD
current-context: tanzu-cli-TAP_SAAS_PRD
kind: Config
preferences: {}
users:
- name: tanzu-cli-TAP_SAAS_PRD-user
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1
      args:
      - context
      - get-token
      - TAP_SAAS_PRD
      command: tanzu
      env: []
      interactiveMode: IfAvailable
      provideClusterInfo: false

❯ kubectl get spaces
NAME          AGE
amit-space    11d
wfd-prode2e   11d


# CLI context additionalMetadata updated with projectName
    additionalMetadata:
        tanzuClusterGroupName: ""
        tanzuMissionControlEndpoint: https://tmc.tanzu.cloud.vmware.com
        tanzuOrgID: bc6f01a5-8618-4fed-a457-161d3a138052
        tanzuOrgName: TAP SAAS PRD
        tanzuProjectID: ""
        tanzuProjectName: e2e
        tanzuSpaceName: ""
```


Tested updating the context with both project-id and name and verified the kubeconfig genreated has cluster.server URL is using `projectID` specified instead of project name
```
❯ ./bin/tanzu context update tanzu-active-resource prem-ucp-intg-lat-stg --project beta2-workflow-demo --project-id 8aeb4bd3-3e14-4763-a3d7-1c6eb1da2b8e

# kubeconfig showing the cluster.server URL has been updated to use project-id instead of project name if project-id is provided 
❯ kubectl config view --minify
apiVersion: v1
clusters:
- cluster:
    server: https://api.tanzu-dev.cloud.vmware.com/org/b1d48027-bb69-4a56-a5b8-e941ef29fa4b/project/8aeb4bd3-3e14-4763-a3d7-1c6eb1da2b8e
  name: tanzu-cli-prem-ucp-intg-lat-stg/current
contexts:
- context:
    cluster: tanzu-cli-prem-ucp-intg-lat-stg/current
    user: tanzu-cli-prem-ucp-intg-lat-stg-user
  name: tanzu-cli-prem-ucp-intg-lat-stg
current-context: tanzu-cli-prem-ucp-intg-lat-stg
kind: Config
preferences: {}
users:
- name: tanzu-cli-prem-ucp-intg-lat-stg-user
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1
      args:
      - context
      - get-token
      - prem-ucp-intg-lat-stg
      command: tanzu
      env: []
      interactiveMode: IfAvailable
      provideClusterInfo: false

```


Tested with the test environment where the project UCP resource is named with project id and ucp resource has annotation for project displayName
```
❯ ./bin/tanzu context create testprojectsyncer --type tanzu --staging --endpoint https://test-project-syncer.stacks.bluesky.tmc-dev.cloud.vmware.com/
[i] Opening the browser window to complete the login
Log in by visiting this link:

    https://console-stg.cloud.vmware.com/csp/gateway/discovery?client_id=tanzu-cli-client-id&code_challenge=HbKyNt8N0ShSN_bz7pPXHwQDKv6dFTqFvmvVBqZDdqg&code_challenge_method=S256&redirect_uri=http%3A%2F%2F127.0.0.1%3A51618%2Fcallback&response_type=code&state=5853660f83c71e77b9baead92b8fc8a2

    Optionally, paste your authorization code: [...]


[ok] Successfully logged into 'TestProjectSyncer' organization and created a tanzu context
[i] Checking for required plugins for context 'testprojectsyncer'...
[i] All required plugins are already installed and up-to-date
❯ ./bin/tanzu context list
  NAME                                ISACTIVE  TYPE             PROJECT      SPACE
  TAP_SAAS_PRD                        false     tanzu            sre-project  test
  TestProjectSyncer-staging-3d4f75b3  false     tanzu
  mytmc-ctx                           true      mission-control  n/a          n/a
  prem-ucp-prod-test                  false     tanzu            sre-project  test
  testprojectsyncer                   true      tanzu
  tkg-mgmt-vc                         false     kubernetes       n/a          n/a
  tt-test-selfmg                      false     mission-control  n/a          n/a

[i] Use '--wide' flag to view additional columns.

      
❯ kubectl get projects
NAME                                   DISPLAYNAME
9ba6ba75-9782-48a2-ae3b-eaa11c6e5316   newpRojje
3351bd40-5150-46f7-96c5-d368b5f99932   newProjectTestne
fd72b29b-bd90-40a6-a684-3e78de397028   Project4
default
```
Changed the tanzu context active resource to project  and tested the kubeconfig works
```
❯ ./bin/tanzu context update tanzu-active-resource testprojectsyncer --project newpRojje --project-id 9ba6ba75-9782-48a2-ae3b-eaa11c6e5316
❯ ./bin/tanzu project list
Listing projects from dcd7e146-57e6-4a1b-905c-0d4079dc9f38 org, current context is newpRojje project
NAME                                   ACTIVE   AGE
9ba6ba75-9782-48a2-ae3b-eaa11c6e5316   false    36h
3351bd40-5150-46f7-96c5-d368b5f99932   false    30h
fd72b29b-bd90-40a6-a684-3e78de397028   false    29h
default                                false    13h

❯ kubectl get spaces
No resources found

❯ kubectl config view --minify
apiVersion: v1
clusters:
- cluster:
    server: https://test-project-syncer.stacks.bluesky.tmc-dev.cloud.vmware.com//org/dcd7e146-57e6-4a1b-905c-0d4079dc9f38/project/9ba6ba75-9782-48a2-ae3b-eaa11c6e5316
  name: tanzu-cli-testprojectsyncer/current
contexts:
- context:
    cluster: tanzu-cli-testprojectsyncer/current
    user: tanzu-cli-testprojectsyncer-user
  name: tanzu-cli-testprojectsyncer
current-context: tanzu-cli-testprojectsyncer
kind: Config
preferences: {}
users:
- name: tanzu-cli-testprojectsyncer-user
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1
      args:
      - context
      - get-token
      - testprojectsyncer
      command: tanzu
      env: []
      interactiveMode: IfAvailable
      provideClusterInfo: false
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
