### PR TITLE
Enable overriding a command if its alias matches the mapping candidate.

### DIFF
--- a/pkg/command/root_test.go
+++ b/pkg/command/root_test.go
@@ -1014,6 +1014,24 @@ func TestPluginLevelRemapping(t *testing.T) {
 			expected: []string{"hello", "the alias dum is duplicated across plugins: dummy, dummy3"},
 		},
 		{
+			test: "plugin replaces another if former maps to an alias of the latter",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:    "bars",
+					target:  configtypes.TargetK8s,
+					aliases: []string{"bar"},
+				},
+				{
+					name:      "bar2",
+					target:    configtypes.TargetK8s,
+					invokedAs: []string{"bar"},
+				},
+			},
+			args:       []string{""},
+			expected:   []string{"bar2 commands"},
+			unexpected: []string{"bars commands"},
+		},
+		{
 			test: "two plugins sharing aliases does not show duplicate warning if one replaces another",
 			pluginVariants: []fakePluginRemapAttributes{
 				{


### PR DESCRIPTION
This is temporary heuristic to ensure a command mapping candidate command replaces one whose alias matches the candidate's name.

An upcoming change would enable the plugin to be more explicit about what commands it intends to override.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

ran unit tests

also tested by building an installing a plugin whose invokedAs only matches an alias of an existing plugin (e.g. apps plugin's alias, "app")

observe when running `tanzu` that only the invokedAs name appears in the list of top-level invocable commands

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
