### PR TITLE
Update the UX for "context use" and "context list" commands to show ProjectID details

### DIFF
--- a/pkg/command/context_test.go
+++ b/pkg/command/context_test.go
@@ -233,7 +233,7 @@ var _ = Describe("Test tanzu context command", func() {
 			columnsString := strings.Join(strings.Fields(lines[0]), " ")
 
 			Expect(err).To(BeNil())
-			Expect(columnsString).To(Equal("NAME ISACTIVE TYPE PROJECT SPACE CLUSTERGROUP ENDPOINT KUBECONFIGPATH KUBECONTEXT"))
+			Expect(columnsString).To(Equal("NAME ISACTIVE TYPE PROJECT PROJECTID SPACE CLUSTERGROUP ENDPOINT KUBECONFIGPATH KUBECONTEXT"))
 		})
 
 		It("should not return tanzu related columns when not listing tanzu contexts without --wide", func() {

--- a/test/e2e/plugin_sync/k8s/plugin_sync_k8s_lifecycle_test.go
+++ b/test/e2e/plugin_sync/k8s/plugin_sync_k8s_lifecycle_test.go
@@ -292,7 +292,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 		})
 
 		const (
-			ContextActivated         = "Successfully activated context '%s'"
+			ContextActivated         = "Activated context '%s' (Type: %s)"
 			PluginWillBeInstalled    = "The following plugins will be installed for context '%s' of contextType '%s':"
 			PluginsTableHeaderRegExp = "NAME\\s+TARGET\\s+VERSION"
 			PluginsRow               = "%s\\s+%s\\s+%s"
@@ -312,7 +312,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-sync-lifecycle]", func() {
 			Expect(err).To(BeNil(), "use context should set context without any error")
 			pluginsList, err = tf.PluginCmd.ListPluginsForGivenContext(contextName, true)
 			Expect(err).To(BeNil(), "should not get any error for plugin list")
-			Expect(stdErr).To(ContainSubstring(fmt.Sprintf(ContextActivated, contextName)))
+			Expect(stdErr).To(ContainSubstring(fmt.Sprintf(ContextActivated, contextName, types.TargetK8s)))
 			Expect(stdErr).To(ContainSubstring(fmt.Sprintf(PluginWillBeInstalled, contextName, types.TargetK8s)))
 			Expect(stdErr).To(MatchRegexp(PluginsTableHeaderRegExp))
 			for i := range pluginsList {


### PR DESCRIPTION
### What this PR does / why we need it
This PR updates the UX for "context use" and "context list" commands to show ProjectID details
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

Context list with `--wide` option shows Project ID
```
❯ ./bin/tanzu context list --wide
  NAME                                ISACTIVE  TYPE             PROJECT           PROJECTID                             SPACE  CLUSTERGROUP  ENDPOINT                                                                                                      KUBECONFIGPATH                           KUBECONTEXT
  TestProjectSyncer-staging-3d4f75b3  true      tanzu            kshaheer-project  2d59a92e-1694-4123-b89a-809e241e53f6                       https://test-project-syncer.stacks.bluesky.tmc-dev.cloud.vmware.com/org/dcd7e146-57e6-4a1b-905c-0d4079dc9f38  /Users/pkalle/.kube/config               tanzu-cli-TestProjectSyncer-staging-3d4f75b3
  mytmc-ctx                           true      mission-control  n/a               n/a                                   n/a    n/a           unstable.tmc-dev.cloud.vmware.com:443                                                                         n/a                                      n/a
  prem-ucp-prod-test                  false     tanzu            sre-project                                             test                 https://api.tanzu.cloud.vmware.com/org/bc6f01a5-8618-4fed-a457-161d3a138052                                   /Users/pkalle/.kube/config               tanzu-cli-prem-ucp-prod-test
  tkg-mgmt-vc                         false     kubernetes       n/a               n/a                                   n/a    n/a                                                                                                                         /Users/pkalle/temp/tkgCluster_admin.kfg  tkg-mgmt-vc-admin@tkg-mgmt-vc
  tt-test-selfmg                      false     mission-control  n/a               n/a                                   n/a    n/a           tmc-sm-main.local-dev.7infra.com:443                                                                          n/a                                      n/a



❯ ./bin/tanzu context list
  NAME                                ISACTIVE  TYPE             PROJECT           SPACE
  TestProjectSyncer-staging-3d4f75b3  true      tanzu            kshaheer-project
  mytmc-ctx                           true      mission-control  n/a               n/a
  prem-ucp-prod-test                  false     tanzu            sre-project       test
  tkg-mgmt-vc                         false     kubernetes       n/a               n/a
  tt-test-selfmg                      false     mission-control  n/a               n/a

[i] Use '--wide' flag to view additional columns.
```

- tanzu context use command shows the project ID along with project name and space details(if available)
```
# for tanzu context with project as active resource
❯ ./bin/tanzu context use testprojectsyncer
[i] Activated context 'testprojectsyncer' (Type: tanzu, Project: kshaheer-project (2d59a92e-1694-4123-b89a-809e241e53f6))
[i] Checking for required plugins for context 'testprojectsyncer'...
[i] All required plugins are already installed and up-to-date


# for tanzu context with space as active resource
❯ ./bin/tanzu context update tanzu-active-resource testprojectsyncer --project kshaheer-project --project-id 2d59a92e-1694-4123-b89a-809e241e53f6  --space test
❯ ./bin/tanzu context use testprojectsyncer
[i] Activated context 'testprojectsyncer' (Type: tanzu, Project: kshaheer-project (2d59a92e-1694-4123-b89a-809e241e53f6), Space: test)
[i] Checking for required plugins for context 'testprojectsyncer'...
[i] All required plugins are already installed and up-to-date

# for mission-control context it would only show the context Type
❯ ./bin/tanzu context use mytmc-ctx
[i] Activated context 'mytmc-ctx' (Type: mission-control) successfully
[i] Checking for required plugins for context 'mytmc-ctx'...
[i] All required plugins are already installed and up-to-date

```




### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Update the UX for "context use" and "context list" commands to show ProjectID details
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
