### PR TITLE
Setup global initializer for missing central config file

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -154,6 +154,13 @@ that is valid yaml.  To read the Central Configuration the `CentralConfig` inter
   err = reader.GetCentralConfigEntry("myStringKey", &myValue)
 ```
 
+## Global Initializers
+
+The CLI has a concept of global initializers accessible from the `globalinit` package.  Such initializers can
+be used by CLI features to initialize/update certain data required for the proper functioning of the CLI itself.
+Such initializers are often useful after an older CLI version was executed and a new CLI version now needs to
+properly setup its data.
+
 ## Deprecation of existing functionality
 
 Any changes aimed to remove functionality in the CLI (e.g. commands, command

--- a/docs/full/README.md
+++ b/docs/full/README.md
@@ -289,3 +289,11 @@ variable to `0` will turn off such notifications.
 
 Note that special consideration must be given for this feature to work in an internet-restricted environment.
 Please refer to [this section](../quickstart/install.md#updating-the-central-configuration) of the documentation.
+
+## Initialization upon the execution of a new version
+
+When a new version of the Tanzu CLI is executed for the first time it may need to be globally initialized.
+If needed, this allows the new CLI to update things like its cache or configuration depending on the needs of
+features being introduced in the new version. This initialization is normally only done once for a new
+version of the CLI, however, if a user goes back and forth between versions of the CLI (which can affect the
+format of the CLI data), the initialization could be performed more than once, as required.

--- a/pkg/centralconfig/central_config.go
+++ b/pkg/centralconfig/central_config.go
@@ -8,11 +8,9 @@ import (
 	"path/filepath"
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
-
-// CentralConfigFileName is the name of the central config file
-const CentralConfigFileName = "central_config.yaml"
 
 // CentralConfig is used to interact with the central configuration.
 type CentralConfig interface {
@@ -28,7 +26,7 @@ type CentralConfig interface {
 // be used to read central configuration values.
 func NewCentralConfigReader(pd *types.PluginDiscovery) CentralConfig {
 	// The central config is stored in the cache
-	centralConfigFile := filepath.Join(common.DefaultCacheDir, common.PluginInventoryDirName, pd.OCI.Name, CentralConfigFileName)
+	centralConfigFile := filepath.Join(common.DefaultCacheDir, common.PluginInventoryDirName, pd.OCI.Name, constants.CentralConfigFileName)
 
 	return &centralConfigYamlReader{configFile: centralConfigFile}
 }

--- a/pkg/centralconfig/central_config_cache_init.go
+++ b/pkg/centralconfig/central_config_cache_init.go
@@ -1,0 +1,79 @@
+// Copyright 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package centralconfig
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/discovery"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/globalinit"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
+)
+
+// The Central Configuration feature uses a central_config.yaml file that gets downloaded
+// along with the plugin inventory cache and is stored in the cache.  Older versions of the
+// CLI (< 1.3.0) do not include this file in the cache.  It is therefore possible that
+// the plugin inventory cache was setup by an older version of the CLI and is missing
+// the central_config.yaml file.  In such a case, the digest of the cache will still indicate
+// that the latest plugin inventory is present and the content of the cache will not be refreshed
+// until the plugin inventory data changes in the central repo itself.  In such a case, to be able
+// to benefit from the central configuration feature once the CLI is upgraded to >= 1.3.0
+// we need to fix the cache.  This initializer checks if the central_config.yaml file is
+// present in the cache and if not, it invalidates the cache.
+
+func init() {
+	globalinit.RegisterInitializer(triggerForInventoryCacheInvalidation, invalidateInventoryCache)
+}
+
+// triggerForInventoryCacheInvalidation returns true if the central_config.yaml file is missing
+// in the plugin inventory cache.
+func triggerForInventoryCacheInvalidation() bool {
+	sources, err := config.GetCLIDiscoverySources()
+	if err != nil {
+		// No discovery source
+		return false
+	}
+
+	for _, source := range sources {
+		centralConfigFile := filepath.Join(common.DefaultCacheDir, common.PluginInventoryDirName, source.OCI.Name, constants.CentralConfigFileName)
+
+		if _, err := os.Stat(centralConfigFile); os.IsNotExist(err) {
+			// As soon as we find a source that doesn't have a central_config.yaml file,
+			// we need to perform some initialization.
+			return true
+		}
+	}
+	// If we get here, then all sources have a central_config.yaml file
+	return false
+}
+
+// invalidateInventoryCache performs the required actions
+func invalidateInventoryCache(_ io.Writer) error {
+	sources, err := config.GetCLIDiscoverySources()
+	if err != nil {
+		// No discovery source
+		return nil
+	}
+
+	var errorList []error
+	for _, source := range sources {
+		centralConfigFile := filepath.Join(common.DefaultCacheDir, common.PluginInventoryDirName, source.OCI.Name, constants.CentralConfigFileName)
+
+		if _, err := os.Stat(centralConfigFile); os.IsNotExist(err) {
+			// This source doesn't have a central_config.yaml file,
+			// we need to invalidate its plugin inventory cache.
+			err = discovery.RefreshDiscoveryDatabaseForSource(source, discovery.WithForceInvalidation())
+			if err != nil {
+				errorList = append(errorList, err)
+			}
+		}
+	}
+	return kerrors.NewAggregate(errorList)
+}

--- a/pkg/centralconfig/central_config_cache_init.go
+++ b/pkg/centralconfig/central_config_cache_init.go
@@ -29,7 +29,7 @@ import (
 // present in the cache and if not, it invalidates the cache.
 
 func init() {
-	globalinit.RegisterInitializer(triggerForInventoryCacheInvalidation, invalidateInventoryCache)
+	globalinit.RegisterInitializer("Central Config Initializer", triggerForInventoryCacheInvalidation, invalidateInventoryCache)
 }
 
 // triggerForInventoryCacheInvalidation returns true if the central_config.yaml file is missing

--- a/pkg/centralconfig/central_config_cache_init_test.go
+++ b/pkg/centralconfig/central_config_cache_init_test.go
@@ -1,0 +1,114 @@
+// Copyright 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package centralconfig
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
+)
+
+func TestTriggerForInventoryCacheInvalidation(t *testing.T) {
+	tcs := []struct {
+		name                 string
+		numDiscoveries       int
+		missingCentralConfig []bool
+		expectedToTrigger    bool
+	}{
+		{
+			name:              "No discovery sources",
+			numDiscoveries:    0,
+			expectedToTrigger: false,
+		},
+		{
+			name:                 "One discovery source with central config",
+			numDiscoveries:       1,
+			missingCentralConfig: []bool{false},
+			expectedToTrigger:    false,
+		},
+		{
+			name:                 "One discovery source with missing central config",
+			numDiscoveries:       1,
+			missingCentralConfig: []bool{true},
+			expectedToTrigger:    true,
+		},
+		{
+			name:                 "Two discovery sources both with central config",
+			numDiscoveries:       2,
+			missingCentralConfig: []bool{false, false},
+			expectedToTrigger:    false,
+		},
+		{
+			name:                 "Two discovery sources with only one missing central config",
+			numDiscoveries:       2,
+			missingCentralConfig: []bool{false, true},
+			expectedToTrigger:    true,
+		},
+	}
+
+	configFile, err := os.CreateTemp("", "config")
+	assert.Nil(t, err)
+	os.Setenv("TANZU_CONFIG", configFile.Name())
+
+	configFileNG, err := os.CreateTemp("", "config_ng")
+	assert.Nil(t, err)
+	os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
+
+	defer func() {
+		os.Unsetenv("TANZU_CONFIG")
+		os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
+		os.RemoveAll(configFile.Name())
+		os.RemoveAll(configFileNG.Name())
+	}()
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a cache directory for the plugin inventory and the central config file
+			cacheDir, err := os.MkdirTemp("", "test-cache-dir")
+			assert.Nil(t, err)
+
+			common.DefaultCacheDir = cacheDir
+
+			// Create the discovery sources
+			var discoveries []types.PluginDiscovery
+			for i := 0; i < tc.numDiscoveries; i++ {
+				discName := fmt.Sprintf("discovery%d", i)
+				discoveries = append(discoveries, types.PluginDiscovery{
+					OCI: &types.OCIDiscovery{
+						Name: discName,
+					},
+				})
+
+				// Create the directory for this discovery source
+				centralCfgDir := filepath.Join(common.DefaultCacheDir, common.PluginInventoryDirName, discName)
+				err = os.MkdirAll(centralCfgDir, 0755)
+				assert.Nil(t, err)
+
+				// Create the central config file if needed by the test
+				if !tc.missingCentralConfig[i] {
+					centralCfgFile := filepath.Join(centralCfgDir, constants.CentralConfigFileName)
+					file, err := os.Create(centralCfgFile)
+					assert.Nil(t, err)
+					assert.NotNil(t, file)
+					file.Close()
+				}
+			}
+
+			err = config.SetCLIDiscoverySources(discoveries)
+			assert.Nil(t, err)
+
+			assert.Equal(t, triggerForInventoryCacheInvalidation(), tc.expectedToTrigger)
+
+			os.RemoveAll(cacheDir)
+		})
+	}
+}

--- a/pkg/centralconfig/central_config_test.go
+++ b/pkg/centralconfig/central_config_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
 
@@ -24,7 +25,7 @@ func TestNewCentralConfigReader(t *testing.T) {
 	})
 
 	path := reader.(*centralConfigYamlReader).configFile
-	expectedPath := filepath.Join(common.DefaultCacheDir, common.PluginInventoryDirName, discoveryName, CentralConfigFileName)
+	expectedPath := filepath.Join(common.DefaultCacheDir, common.PluginInventoryDirName, discoveryName, constants.CentralConfigFileName)
 
 	assert.Equal(t, expectedPath, path)
 }

--- a/pkg/command/discovery_source.go
+++ b/pkg/command/discovery_source.go
@@ -220,12 +220,7 @@ func checkDiscoverySource(source configtypes.PluginDiscovery) error {
 	// the WithForceRefresh() option to ensure we refresh the DB no matter if the TTL has expired or not.
 	// This provides a way for the user to force a refresh of the DB by running "tanzu plugin source init/update"
 	// without waiting for the TTL to expire.
-	discObject, err := discovery.CreateDiscoveryFromV1alpha1(source, discovery.WithForceRefresh())
-	if err != nil {
-		return err
-	}
-	_, err = discObject.List()
-	return err
+	return discovery.RefreshDiscoveryDatabaseForSource(source, discovery.WithForceRefresh())
 }
 
 // ====================================

--- a/pkg/command/plugin_helper_test.go
+++ b/pkg/command/plugin_helper_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/config"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/plugininventory"
 )
 
@@ -233,6 +234,12 @@ func setupTestPluginInventory(t *testing.T) {
 
 	// Add plugin group entries to the DB
 	_, err = db.Exec(createGroupsStmt)
+	assert.Nil(t, err)
+
+	// Create an empty central_config.yaml file to avoid
+	// triggering the global initializer that would invalidate the cache
+	// and add extra printouts to the test output
+	_, err = os.Create(filepath.Join(inventoryDir, constants.CentralConfigFileName))
 	assert.Nil(t, err)
 }
 

--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -345,8 +345,7 @@ func checkGlobalInit(cmd *cobra.Command) {
 
 		err := globalinit.PerformInitializations(outStream)
 		if err != nil {
-			fmt.Fprintln(outStream, "The initialization encountered an error but the CLI remains functional.")
-			log.V(6).Warningf("Error initializing CLI: %v", err)
+			log.Warningf("The initialization encountered the following error: %v", err)
 		}
 
 		fmt.Fprintln(outStream)

--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -24,6 +24,7 @@ import (
 	cliconfig "github.com/vmware-tanzu/tanzu-cli/pkg/config"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/discovery"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/globalinit"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/pluginmanager"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/pluginsupplier"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/recommendedversion"
@@ -265,6 +266,13 @@ func newRootCmd() *cobra.Command {
 			// Sets the verbosity of the logger if TANZU_CLI_LOG_LEVEL is set
 			setLoggerVerbosity()
 
+			// Perform some global initialization of the CLI if necessary
+			// We do this as early as possible to make sure the CLI is ready for use
+			// for any other logic below.
+			if !shouldSkipGlobalInit(cmd) {
+				checkGlobalInit(cmd)
+			}
+
 			// Ensure mutual exclusion in current contexts just in case if any plugins with old
 			// plugin-runtime sets k8s context as current when tanzu context is already set as current
 			if err := utils.EnsureMutualExclusiveCurrentContexts(); err != nil {
@@ -325,6 +333,25 @@ func setLoggerVerbosity() {
 		if err == nil {
 			log.SetVerbosity(int32(logValue))
 		}
+	}
+}
+
+func checkGlobalInit(cmd *cobra.Command) {
+	if globalinit.InitializationRequired() {
+		outStream := cmd.OutOrStderr()
+
+		fmt.Fprintf(outStream, "Some initialization of the CLI is required.\n")
+		fmt.Fprintf(outStream, "Let's set things up for you.  This will just take a few seconds.\n\n")
+
+		err := globalinit.PerformInitializations(outStream)
+		if err != nil {
+			fmt.Fprintln(outStream, "The initialization encountered an error but the CLI remains functional.")
+			log.V(6).Warningf("Error initializing CLI: %v", err)
+		}
+
+		fmt.Fprintln(outStream)
+		fmt.Fprintln(outStream, "Initialization done!")
+		fmt.Fprintln(outStream, "==")
 	}
 }
 
@@ -579,6 +606,20 @@ func shouldSkipVersionCheck(cmd *cobra.Command) bool {
 		"tanzu version",
 	}
 	return isSkipCommand(skipVersionCheckCommands, cmd.CommandPath())
+}
+
+// shouldSkipGlobalInit checks if the initialization of a new CLI version should be skipped
+// for the specified command
+func shouldSkipGlobalInit(cmd *cobra.Command) bool {
+	skipGlobalInitCommands := []string{
+		// The shell completion logic is not interactive, so it should not trigger
+		// the global initialization of the CLI
+		"tanzu __complete",
+		"tanzu completion",
+		// Common first command to run, let's not perform extra tasks
+		"tanzu version",
+	}
+	return isSkipCommand(skipGlobalInitCommands, cmd.CommandPath())
 }
 
 // Execute executes the CLI.

--- a/pkg/command/root_test.go
+++ b/pkg/command/root_test.go
@@ -862,6 +862,7 @@ func TestGlobalInit(t *testing.T) {
 
 			// Setup the specified initializer trigger
 			globalinit.RegisterInitializer(
+				"initializer",
 				func() bool {
 					return spec.trigger
 				},

--- a/pkg/constants/defaults.go
+++ b/pkg/constants/defaults.go
@@ -37,4 +37,7 @@ const (
 	// Until then for testing purpose, user can overwrite this path using `TANZU_CLI_PLUGIN_DISCOVERY_PATH_FOR_TANZU_CONTEXT`
 	// environment variable
 	TanzuContextPluginDiscoveryEndpointPath = "/discovery"
+
+	// CentralConfigFileName is the name of the central config file
+	CentralConfigFileName = "central_config.yaml"
 )

--- a/pkg/discovery/interface.go
+++ b/pkg/discovery/interface.go
@@ -42,6 +42,7 @@ type GroupDiscovery interface {
 type DiscoveryOpts struct {
 	UseLocalCacheOnly       bool // UseLocalCacheOnly used to pull the plugin data from the cache
 	ForceRefresh            bool // ForceRefresh used to force a refresh of the plugin data
+	ForceInvalidation       bool // ForceInvalidation used to force invalidation of the plugin data
 	PluginDiscoveryCriteria *PluginDiscoveryCriteria
 	GroupDiscoveryCriteria  *GroupDiscoveryCriteria
 }
@@ -61,6 +62,14 @@ func WithUseLocalCacheOnly() DiscoveryOptions {
 func WithForceRefresh() DiscoveryOptions {
 	return func(o *DiscoveryOpts) {
 		o.ForceRefresh = true
+	}
+}
+
+// WithForceInvalidation used to force an invalidation of the plugin inventory data
+// to trigger a new download of the OCI image
+func WithForceInvalidation() DiscoveryOptions {
+	return func(o *DiscoveryOpts) {
+		o.ForceInvalidation = true
 	}
 }
 

--- a/pkg/discovery/oci.go
+++ b/pkg/discovery/oci.go
@@ -29,6 +29,7 @@ func NewOCIDiscovery(name, image string, options ...DiscoveryOptions) Discovery 
 		discovery.useLocalCacheOnly = true
 	}
 	discovery.forceRefresh = opts.ForceRefresh
+	discovery.forceInvalidation = opts.ForceInvalidation
 
 	return discovery
 }
@@ -49,6 +50,7 @@ func NewOCIGroupDiscovery(name, image string, options ...DiscoveryOptions) Group
 		discovery.useLocalCacheOnly = true
 	}
 	discovery.forceRefresh = opts.ForceRefresh
+	discovery.forceInvalidation = opts.ForceInvalidation
 
 	return discovery
 }

--- a/pkg/discovery/oci_dbbacked_test.go
+++ b/pkg/discovery/oci_dbbacked_test.go
@@ -406,7 +406,7 @@ var _ = Describe("Unit tests for DB-backed OCI discovery", func() {
 
 				Expect(checkFileContentIsEqual(digestFile, imageURI)).To(BeTrue(), "expected the digest file to have the same content as the image URI")
 			})
-			It("should have update the URI in the digest file if the digest matches but the URI has changed", func() {
+			It("should have updated the URI in the digest file if the digest matches but the URI has changed", func() {
 				newImageURI := "test-image"
 				discovery := NewOCIDiscovery(discoveryName, newImageURI)
 				dbDiscovery, ok := discovery.(*DBBackedOCIDiscovery)
@@ -430,6 +430,20 @@ var _ = Describe("Unit tests for DB-backed OCI discovery", func() {
 				// Check that the existing digest file was removed
 				_, err := os.Stat(digestFile)
 				Expect(os.IsNotExist(err)).To(BeTrue(), "expected the old digest file to be removed")
+			})
+			When("invalidating the cache", func() {
+				It("should return the current digest file name", func() {
+					discovery := NewOCIDiscovery(discoveryName, imageURI, WithForceInvalidation())
+					dbDiscovery, ok := discovery.(*DBBackedOCIDiscovery)
+					Expect(ok).To(BeTrue(), "oci discovery is not of type DBBackedOCIDiscovery")
+
+					digestFileName := dbDiscovery.checkDigestFileExistence(validDigest, "")
+					Expect(digestFileName).To(Equal(digestFile), "expected the same digest filename")
+
+					// Check that the digest file was removed in preparation for re-fetching the image
+					_, err := os.Stat(digestFile)
+					Expect(os.IsNotExist(err)).To(BeTrue(), "expected the old digest file to be removed")
+				})
 			})
 		})
 

--- a/pkg/discovery/utils.go
+++ b/pkg/discovery/utils.go
@@ -121,17 +121,22 @@ func RefreshDatabase() error {
 			if stat, err := os.Stat(matches[0]); err == nil {
 				// Check if the digest timestamp is passed 24 hours if so refresh the database cache
 				if time.Since(stat.ModTime()) > time.Duration(dbCacheRefreshThreshold)*time.Second {
-					if discObject, err := CreateDiscoveryFromV1alpha1(source); err == nil {
-						_, _ = discObject.List()
-					}
+					_ = RefreshDiscoveryDatabaseForSource(source)
 				}
 			}
 		} else {
 			// digest file not found so refresh the database cache
-			if discObject, err := CreateDiscoveryFromV1alpha1(source); err == nil {
-				_, _ = discObject.List()
-			}
+			_ = RefreshDiscoveryDatabaseForSource(source)
 		}
 	}
 	return nil
+}
+
+// RefreshDiscoveryDatabaseForSource function refreshes the plugin inventory database for the given source
+func RefreshDiscoveryDatabaseForSource(source configtypes.PluginDiscovery, options ...DiscoveryOptions) error {
+	discObject, err := CreateDiscoveryFromV1alpha1(source, options...)
+	if err == nil {
+		_, err = discObject.List()
+	}
+	return err
 }

--- a/pkg/globalinit/global_initializers.go
+++ b/pkg/globalinit/global_initializers.go
@@ -7,7 +7,6 @@
 package globalinit
 
 import (
-	"fmt"
 	"io"
 
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -49,10 +48,6 @@ func InitializationRequired() bool {
 
 // PerformInitializations run each initializer which which the trigger function returns true.
 func PerformInitializations(outStream io.Writer) error {
-	if !InitializationRequired() {
-		return fmt.Errorf("no initializations required")
-	}
-
 	var errorList []error
 	for _, i := range initializers {
 		if i.triggerFunc() {

--- a/pkg/globalinit/global_initializers.go
+++ b/pkg/globalinit/global_initializers.go
@@ -1,0 +1,66 @@
+// Copyright 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package globalinit is used to execute different initializers of the CLI
+// based on their specified triggers.  This can be used to cleanup some data
+// or perform some actions based on certain conditions.
+package globalinit
+
+import (
+	"fmt"
+	"io"
+
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+type initializer struct {
+	// The trigger functions are kept separate from the initialization functions
+	// for a couple of reasons:
+	// 1. The trigger functions can be used first to determine if the initialization
+	//    should be performed.  If so, a global message can be printed to the user
+	//    before the initialization is performed.
+	// 2. Some trigger functions or initialization functions could be re-used by
+	//    different features for slightly different purposes.
+	triggerFunc        func() bool
+	initializationFunc func(outStream io.Writer) error
+}
+
+var (
+	initializers []initializer
+)
+
+// RegisterInitializer registers a new initializer with the global list of initializers.
+// The trigger function is used to determine if the initialization function should be run.
+// The initialization function is the function that will be run if the trigger function returns true.
+// The set of initializer triggers is checked whenever the CLI is run.
+func RegisterInitializer(trigger func() bool, initialization func(writer io.Writer) error) {
+	initializers = append(initializers, initializer{triggerFunc: trigger, initializationFunc: initialization})
+}
+
+// InitializationRequired checks if any of the registered initializers should be triggered.
+func InitializationRequired() bool {
+	for _, i := range initializers {
+		if i.triggerFunc() {
+			return true
+		}
+	}
+	return false
+}
+
+// PerformInitializations run each initializer which which the trigger function returns true.
+func PerformInitializations(outStream io.Writer) error {
+	if !InitializationRequired() {
+		return fmt.Errorf("no initializations required")
+	}
+
+	var errorList []error
+	for _, i := range initializers {
+		if i.triggerFunc() {
+			if err := i.initializationFunc(outStream); err != nil {
+				errorList = append(errorList, err)
+			}
+		}
+	}
+
+	return kerrors.NewAggregate(errorList)
+}

--- a/pkg/globalinit/global_initializers_test.go
+++ b/pkg/globalinit/global_initializers_test.go
@@ -1,0 +1,211 @@
+// Copyright 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package globalinit
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegisterInitializer(t *testing.T) {
+	tests := []struct {
+		test               string
+		triggerFunc        func() bool
+		initializationFunc func(io.Writer) error
+	}{
+		{
+			test:               "registering stores the function",
+			triggerFunc:        func() bool { return true },
+			initializationFunc: func(io.Writer) error { return nil },
+		},
+	}
+	for _, spec := range tests {
+		t.Run(spec.test, func(t *testing.T) {
+			assert := assert.New(t)
+
+			// Reset any previous initializers
+			initializers = nil
+
+			RegisterInitializer(spec.triggerFunc, spec.initializationFunc)
+
+			assert.Equal(1, len(initializers))
+			addr1 := fmt.Sprintf("%p", initializers[0].triggerFunc)
+			addr2 := fmt.Sprintf("%p", spec.triggerFunc)
+			assert.Equal(addr1, addr2)
+
+			addr1 = fmt.Sprintf("%p", initializers[0].initializationFunc)
+			addr2 = fmt.Sprintf("%p", spec.initializationFunc)
+			assert.Equal(addr1, addr2)
+		})
+	}
+}
+
+func TestInitializationRequired(t *testing.T) {
+	tests := []struct {
+		test         string
+		triggerFuncs []func() bool
+		expected     bool
+	}{
+		{
+			test:         "single true trigger",
+			triggerFuncs: []func() bool{func() bool { return true }},
+			expected:     true,
+		},
+		{
+			test:         "single false trigger",
+			triggerFuncs: []func() bool{func() bool { return false }},
+			expected:     false,
+		},
+		{
+			test:         "multiple true triggers",
+			triggerFuncs: []func() bool{func() bool { return true }, func() bool { return true }, func() bool { return true }},
+			expected:     true,
+		},
+		{
+			test:         "multiple false triggers",
+			triggerFuncs: []func() bool{func() bool { return false }, func() bool { return false }, func() bool { return false }},
+			expected:     false,
+		},
+		{
+			test:         "mix of true and false triggers",
+			triggerFuncs: []func() bool{func() bool { return false }, func() bool { return true }, func() bool { return false }},
+			expected:     true,
+		},
+	}
+	for _, spec := range tests {
+		t.Run(spec.test, func(t *testing.T) {
+			assert := assert.New(t)
+
+			// Reset any previous initializers
+			initializers = nil
+
+			for _, triggerFunc := range spec.triggerFuncs {
+				RegisterInitializer(triggerFunc, func(io.Writer) error { return nil })
+			}
+
+			assert.Equal(spec.expected, InitializationRequired())
+		})
+	}
+}
+
+func TestPerformInitializations(t *testing.T) {
+	tests := []struct {
+		test          string
+		triggerFuncs  []func() bool
+		initFuncs     []func(io.Writer) error
+		expectError   bool
+		expectedOut   []string
+		unexpectedOut []string
+	}{
+		{
+			test: "single true trigger",
+			triggerFuncs: []func() bool{
+				func() bool { return true },
+			},
+			initFuncs: []func(io.Writer) error{
+				func(w io.Writer) error { fmt.Fprintln(w, "1"); return nil },
+			},
+			expectError:   false,
+			expectedOut:   []string{"1"},
+			unexpectedOut: []string{"2", "3"},
+		},
+		{
+			test: "single false trigger",
+			triggerFuncs: []func() bool{
+				func() bool { return false },
+			},
+			initFuncs: []func(io.Writer) error{
+				func(w io.Writer) error { fmt.Fprintln(w, "1"); return nil },
+			},
+			expectError:   true,
+			unexpectedOut: []string{"1", "2", "3"},
+		},
+		{
+			test: "multiple true triggers",
+			triggerFuncs: []func() bool{
+				func() bool { return true },
+				func() bool { return true },
+				func() bool { return true },
+			},
+			initFuncs: []func(io.Writer) error{
+				func(w io.Writer) error { fmt.Fprintln(w, "1"); return nil },
+				func(w io.Writer) error { fmt.Fprintln(w, "2"); return nil },
+				func(w io.Writer) error { fmt.Fprintln(w, "3"); return nil },
+			},
+			expectError: false,
+			expectedOut: []string{"1", "2", "3"},
+		},
+		{
+			test: "multiple false triggers",
+			triggerFuncs: []func() bool{
+				func() bool { return false },
+				func() bool { return false },
+				func() bool { return false },
+			},
+			initFuncs: []func(io.Writer) error{
+				func(w io.Writer) error { fmt.Fprintln(w, "1"); return nil },
+				func(w io.Writer) error { fmt.Fprintln(w, "2"); return nil },
+				func(w io.Writer) error { fmt.Fprintln(w, "3"); return nil },
+			},
+			expectError:   true,
+			unexpectedOut: []string{"1", "2", "3"},
+		},
+		{
+			test: "mix of true and false triggers",
+			triggerFuncs: []func() bool{
+				func() bool { return false },
+				func() bool { return true },
+				func() bool { return false },
+			},
+			initFuncs: []func(io.Writer) error{
+				func(w io.Writer) error { fmt.Fprintln(w, "1"); return nil },
+				func(w io.Writer) error { fmt.Fprintln(w, "2"); return nil },
+				func(w io.Writer) error { fmt.Fprintln(w, "3"); return nil },
+			},
+			expectError:   false,
+			expectedOut:   []string{"2"},
+			unexpectedOut: []string{"1", "3"},
+		},
+		{
+			test: "init throws error",
+			triggerFuncs: []func() bool{
+				func() bool { return true },
+			},
+			initFuncs: []func(io.Writer) error{
+				func(w io.Writer) error { fmt.Fprintln(w, "1"); return fmt.Errorf("error") },
+			},
+			expectError:   true,
+			expectedOut:   []string{"1"},
+			unexpectedOut: []string{"2", "3"},
+		},
+	}
+	for _, spec := range tests {
+		t.Run(spec.test, func(t *testing.T) {
+			assert := assert.New(t)
+
+			// Reset any previous initializers
+			initializers = nil
+
+			for i := range spec.initFuncs {
+				RegisterInitializer(spec.triggerFuncs[i], spec.initFuncs[i])
+			}
+
+			var buf bytes.Buffer
+			err := PerformInitializations(&buf)
+
+			assert.Equal(spec.expectError, err != nil)
+
+			for i := range spec.expectedOut {
+				assert.Contains(buf.String(), spec.expectedOut[i])
+			}
+			for i := range spec.unexpectedOut {
+				assert.NotContains(buf.String(), spec.unexpectedOut[i])
+			}
+		})
+	}
+}

--- a/pkg/globalinit/global_initializers_test.go
+++ b/pkg/globalinit/global_initializers_test.go
@@ -122,7 +122,7 @@ func TestPerformInitializations(t *testing.T) {
 			initFuncs: []func(io.Writer) error{
 				func(w io.Writer) error { fmt.Fprintln(w, "1"); return nil },
 			},
-			expectError:   true,
+			expectError:   false,
 			unexpectedOut: []string{"1", "2", "3"},
 		},
 		{
@@ -152,7 +152,7 @@ func TestPerformInitializations(t *testing.T) {
 				func(w io.Writer) error { fmt.Fprintln(w, "2"); return nil },
 				func(w io.Writer) error { fmt.Fprintln(w, "3"); return nil },
 			},
-			expectError:   true,
+			expectError:   false,
 			unexpectedOut: []string{"1", "2", "3"},
 		},
 		{
@@ -182,6 +182,21 @@ func TestPerformInitializations(t *testing.T) {
 			expectError:   true,
 			expectedOut:   []string{"1"},
 			unexpectedOut: []string{"2", "3"},
+		},
+		{
+			test: "init success and error",
+			triggerFuncs: []func() bool{
+				func() bool { return true },
+				func() bool { return true },
+				func() bool { return true },
+			},
+			initFuncs: []func(io.Writer) error{
+				func(w io.Writer) error { fmt.Fprintln(w, "1"); return nil },
+				func(w io.Writer) error { fmt.Fprintln(w, "2"); return fmt.Errorf("error") },
+				func(w io.Writer) error { fmt.Fprintln(w, "3"); return nil },
+			},
+			expectError: true,
+			expectedOut: []string{"1", "2", "3"},
 		},
 	}
 	for _, spec := range tests {

--- a/pkg/globalinit/global_initializers_test.go
+++ b/pkg/globalinit/global_initializers_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const initializerName = "my initializer"
+
 func TestRegisterInitializer(t *testing.T) {
 	tests := []struct {
 		test               string
@@ -30,10 +32,11 @@ func TestRegisterInitializer(t *testing.T) {
 
 			// Reset any previous initializers
 			initializers = nil
-
-			RegisterInitializer(spec.triggerFunc, spec.initializationFunc)
+			RegisterInitializer(initializerName, spec.triggerFunc, spec.initializationFunc)
 
 			assert.Equal(1, len(initializers))
+			assert.Equal(initializerName, initializers[0].name)
+
 			addr1 := fmt.Sprintf("%p", initializers[0].triggerFunc)
 			addr2 := fmt.Sprintf("%p", spec.triggerFunc)
 			assert.Equal(addr1, addr2)
@@ -85,7 +88,7 @@ func TestInitializationRequired(t *testing.T) {
 			initializers = nil
 
 			for _, triggerFunc := range spec.triggerFuncs {
-				RegisterInitializer(triggerFunc, func(io.Writer) error { return nil })
+				RegisterInitializer(initializerName, triggerFunc, func(io.Writer) error { return nil })
 			}
 
 			assert.Equal(spec.expected, InitializationRequired())
@@ -207,7 +210,7 @@ func TestPerformInitializations(t *testing.T) {
 			initializers = nil
 
 			for i := range spec.initFuncs {
-				RegisterInitializer(spec.triggerFuncs[i], spec.initFuncs[i])
+				RegisterInitializer(initializerName, spec.triggerFuncs[i], spec.initFuncs[i])
 			}
 
 			var buf bytes.Buffer

--- a/test/e2e/centralconfig/central_config_suite_test.go
+++ b/test/e2e/centralconfig/central_config_suite_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/config"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-cli/test/e2e/framework"
 )
 
@@ -57,7 +58,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).To(BeNil(), "should not get any error for plugin source update")
 
 	// check that the central config file is present
-	centralCfg := filepath.Join(framework.TestHomeDir, ".cache", "tanzu", common.PluginInventoryDirName, config.DefaultStandaloneDiscoveryName, "central_config.yaml")
+	centralCfg := filepath.Join(framework.TestHomeDir, ".cache", "tanzu", common.PluginInventoryDirName, config.DefaultStandaloneDiscoveryName, constants.CentralConfigFileName)
 	_, err = os.Stat(centralCfg)
 	Expect(err).To(BeNil(), "central config file should exist")
 })

--- a/test/e2e/cli_lifecycle/initialize_central_config_test.go
+++ b/test/e2e/cli_lifecycle/initialize_central_config_test.go
@@ -41,41 +41,27 @@ var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Initialize-central-config
 			Expect(errStream).ToNot(ContainSubstring(initErrorStr))
 		})
 		It("initialization when config file is missing", func() {
-			err := deleteCentralConfigFile()
-			Expect(err).To(BeNil())
+			// We test the initializer twice to make sure that even if it ran once,
+			// it will run again if the central config file is missing again.
+			// This is to simulate if an older CLI version is used
+			// after the new CLI was run and the cache was cleaned up.
+			for i := 0; i < 2; i++ {
+				err := deleteCentralConfigFile()
+				Expect(err).To(BeNil())
 
-			// Run any command to see that the global initializer is triggered
-			_, _, errStream, err := tf.PluginCmd.ListPlugins()
-			Expect(err).To(BeNil())
-			Expect(errStream).To(ContainSubstring(initializationStr))
-			Expect(errStream).ToNot(ContainSubstring(initErrorStr))
+				// Run any command to see that the global initializer is triggered
+				_, _, errStream, err := tf.PluginCmd.ListPlugins()
+				Expect(err).To(BeNil())
+				Expect(errStream).To(ContainSubstring(initializationStr))
+				Expect(errStream).ToNot(ContainSubstring(initErrorStr))
 
-			// Run the command again to see that the global initializer is not triggered
-			// since the cache was fixed
-			_, _, errStream, err = tf.PluginCmd.ListPlugins()
-			Expect(err).To(BeNil())
-			Expect(errStream).ToNot(ContainSubstring(initializationStr))
-			Expect(errStream).ToNot(ContainSubstring(initErrorStr))
-		})
-		It("initialization when config file is missing a second time", func() {
-			// Test that if the central config file is missing again, the global initializer
-			// is triggered again.  This is to simulate if an older CLI version is used
-			// after the cache was cleaned up.
-			err := deleteCentralConfigFile()
-			Expect(err).To(BeNil())
-
-			// Run any command to see that the global initializer is triggered
-			_, _, errStream, err := tf.PluginCmd.ListPlugins()
-			Expect(err).To(BeNil())
-			Expect(errStream).To(ContainSubstring(initializationStr))
-			Expect(errStream).ToNot(ContainSubstring(initErrorStr))
-
-			// Run the command again to see that the global initializer is not triggered
-			// since the cache was fixed
-			_, _, errStream, err = tf.PluginCmd.ListPlugins()
-			Expect(err).To(BeNil())
-			Expect(errStream).ToNot(ContainSubstring(initializationStr))
-			Expect(errStream).ToNot(ContainSubstring(initErrorStr))
+				// Run the command again to see that the global initializer is not triggered
+				// since the cache was fixed
+				_, _, errStream, err = tf.PluginCmd.ListPlugins()
+				Expect(err).To(BeNil())
+				Expect(errStream).ToNot(ContainSubstring(initializationStr))
+				Expect(errStream).ToNot(ContainSubstring(initErrorStr))
+			}
 		})
 	})
 })

--- a/test/e2e/cli_lifecycle/initialize_central_config_test.go
+++ b/test/e2e/cli_lifecycle/initialize_central_config_test.go
@@ -1,0 +1,87 @@
+// Copyright 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package clilifecycle
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/config"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
+	"github.com/vmware-tanzu/tanzu-cli/test/e2e/framework"
+)
+
+// These tests verify that when the central config file is missing from the cache,
+// a global initializer is triggered to invalidate the cache.
+var _ = framework.CLICoreDescribe("[Tests:E2E][Feature:Initialize-central-config-cache]", func() {
+	var (
+		tf *framework.Framework
+	)
+	BeforeEach(func() {
+		tf = framework.NewFramework()
+	})
+	Context("tests for the central config global initializer", func() {
+		const initializationStr = "Some initialization of the CLI is required"
+		const initErrorStr = "initialization encountered an error"
+
+		It("no initialization in a normal situation", func() {
+			// Setup the plugin cache which will include the central config
+			_, err := tf.PluginCmd.InitPluginDiscoverySource()
+			Expect(err).To(BeNil(), "should not get any error for plugin source init")
+
+			// Run any command to see that the global initializer is not triggered
+			_, _, errStream, err := tf.PluginCmd.ListPlugins()
+			Expect(err).To(BeNil())
+			Expect(errStream).ToNot(ContainSubstring(initializationStr))
+			Expect(errStream).ToNot(ContainSubstring(initErrorStr))
+		})
+		It("initialization when config file is missing", func() {
+			err := deleteCentralConfigFile()
+			Expect(err).To(BeNil())
+
+			// Run any command to see that the global initializer is triggered
+			_, _, errStream, err := tf.PluginCmd.ListPlugins()
+			Expect(err).To(BeNil())
+			Expect(errStream).To(ContainSubstring(initializationStr))
+			Expect(errStream).ToNot(ContainSubstring(initErrorStr))
+
+			// Run the command again to see that the global initializer is not triggered
+			// since the cache was fixed
+			_, _, errStream, err = tf.PluginCmd.ListPlugins()
+			Expect(err).To(BeNil())
+			Expect(errStream).ToNot(ContainSubstring(initializationStr))
+			Expect(errStream).ToNot(ContainSubstring(initErrorStr))
+		})
+		It("initialization when config file is missing a second time", func() {
+			// Test that if the central config file is missing again, the global initializer
+			// is triggered again.  This is to simulate if an older CLI version is used
+			// after the cache was cleaned up.
+			err := deleteCentralConfigFile()
+			Expect(err).To(BeNil())
+
+			// Run any command to see that the global initializer is triggered
+			_, _, errStream, err := tf.PluginCmd.ListPlugins()
+			Expect(err).To(BeNil())
+			Expect(errStream).To(ContainSubstring(initializationStr))
+			Expect(errStream).ToNot(ContainSubstring(initErrorStr))
+
+			// Run the command again to see that the global initializer is not triggered
+			// since the cache was fixed
+			_, _, errStream, err = tf.PluginCmd.ListPlugins()
+			Expect(err).To(BeNil())
+			Expect(errStream).ToNot(ContainSubstring(initializationStr))
+			Expect(errStream).ToNot(ContainSubstring(initErrorStr))
+		})
+	})
+})
+
+func deleteCentralConfigFile() error {
+	centralCfg := filepath.Join(framework.TestHomeDir, ".cache", "tanzu", common.PluginInventoryDirName, config.DefaultStandaloneDiscoveryName, constants.CentralConfigFileName)
+
+	return os.Remove(centralCfg)
+}


### PR DESCRIPTION
### What this PR does / why we need it

This PR is provided in two commits to make the review easier.

With the introduction of the Central Configuration in #707, there is now a `central_config.yaml` file part of the plugin inventory OCI image; however, CLIs < 1.3.0 do not copy this file into the cache, so this PR forces a cache invalidation and a re-download of the OCI image as soon as a CLI >= 1.3.0 notices the missing file.  This guarantees that the `central_config.yaml` file will be properly installed.  See #722 for more details.

To achieve this, the first commit of the PR implements a small framework allowing a "global initialization" of the CLI based on pre-defined triggers.  Different features can register their own trigger function and a corresponding initialization function which allow for any require global initialization.  The CLI will verify the triggers on any command execution and if the trigger function returns true, the corresponding initialization will be executed.

The first commit implements the global initialization framework.
The second commit uses the framework to initialize the plugin inventory cache if the `central_config.yaml` file is missing.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #722

### Describe testing done for PR

#### What the new feature looks like

```
# Build a new version of the CLI
$ make build BUILD_VERSION=v1.3.1
build darwin-arm64 CLI with version: v1.3.1

# Run this new version on an empty plugin cache
rm ~/.cache/tanzu/plugin_inventory

# Note that the `tz version` command does NOT trigger the initialization
# (same for `completion` and `__complete`)
$ tz version
version: v1.3.1
buildDate: 2024-04-03
sha: b711f5630
arch: arm64

# any other command will trigger the global initializers
$ tz plugin list
Some initialization of the CLI is required.
Let's set things up for you.  This will just take a few seconds.

[i] Refreshing plugin inventory cache for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.

Initialization done!
==
Standalone Plugins
  NAME       DESCRIPTION                                                 TARGET  VERSION  STATUS
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  global  v1.1.0   installed
```

Run the command again to see there is no initialization anymore as it is only run once:
```
$ tz plugin list
Standalone Plugins
  NAME       DESCRIPTION                                                 TARGET  VERSION  STATUS
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  global  v1.1.0   installed
```

Now remove the `central_config.yaml` file to see that the CLI notices:
```
$ rm ~/.cache/tanzu/plugin_inventory/default/central_config.yaml

# Run any command
$ tz context list
Some initialization of the CLI is required.
Let's set things up for you.  This will just take a few seconds.

[i] Refreshing plugin inventory cache for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.

Initialization done!
==
  NAME                                  ISACTIVE  TYPE             PROJECT           SPACE  CLUSTERGROUP
  TAP_pre-integration-staging           false     tanzu

[i] Use '--wide' flag to view additional columns.
```

#### Main scenario motivating this PR

Prepare the test :
```
# We have an old CLI
$ ~/bin/tanzu.v1.2.0 version
version: v1.2.0
buildDate: 2024-02-07
sha: f3abe62e
arch: arm64

# And the new one built with the PR
$ tz version
version: v1.3.0-dev
buildDate: 2024-04-03
sha: b711f5630
arch: arm64

# Use a central repo that has a `central_config.yaml` file
$ tz config set env.TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST localhost:9876/tanzu-cli/plugins/central:small

$ make start-test-central-repo
[...]

# Start with no cache and no data store
$ rm ~/.cache/tanzu/plugin_inventory
```

Use an old CLI to first setup the cache.  This is similar to what a user of CLI v1.2 would have done.
Notice the `central_config.yaml` file is not copied to the cache
```
$ ~/bin/tanzu.v1.2.0 plugin source update default -u localhost:9876/tanzu-cli/plugins/central:small
[i] Refreshing plugin inventory cache for "localhost:9876/tanzu-cli/plugins/central:small", this will take a few seconds.
[i] Reading plugin inventory for "localhost:9876/tanzu-cli/plugins/central:small", this will take a few seconds.
[!] Skipping the plugins discovery image signature verification for "localhost:9876/tanzu-cli/plugins/central:small"

[i] Refreshing plugin inventory cache for "localhost:9876/tanzu-cli/plugins/central:small", this will take a few seconds.
[ok] updated discovery source default

# Notice that the central_config.yaml file is not in the cache
# because CLIs < 1.3.0 don't copy it over
$ ls ~/.cache/tanzu/plugin_inventory/default
digest.ca212530af87bcf8c41b4b89c48cf453c86621e5e8f9fb501d219a582878f336 plugin_inventory.db
metadata.digest.none
```

Now test the actual scenario driving this change.
Normally, when running v1.3.0-alpha.2 with the test repo we should see a notification saying v1.3.3 is available for upgrade. However, notice this does not happen because the `central_config.yaml` file is missing from the cache.

```
$ /opt/homebrew/bin/tanzu version
version: v1.3.0-alpha.2
buildDate: 2024-03-29
sha: fdbe2498
arch: arm64

$ /opt/homebrew/bin/tanzu config set env.TEST 1
# Here there should have been a notification printed about upgrading to v1.3.3 but there is not.  That is the problem.

# Let's try the same thing with this PR
# which will first force a re-download of the OCI image
$ tz config set env.TEST 1
Some initialization of the CLI is required.
Let's set things up for you.  This will just take a few seconds.

[i] Refreshing plugin inventory cache for "localhost:9876/tanzu-cli/plugins/central:small", this will take a few seconds.
[i] Reading plugin inventory for "localhost:9876/tanzu-cli/plugins/central:small", this will take a few seconds.
[!] Skipping the plugins discovery image signature verification for "localhost:9876/tanzu-cli/plugins/central:small"


Initialization done!
==

==
Note: A new version of the Tanzu CLI is available. You are at version: v1.3.0-dev.
To benefit from the latest security and features, please update to a recommended version:
  - v1.5.0-beta.0
  - v1.3.3

Please refer to these instructions for upgrading: https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/quickstart/install.md.

This message will print at most once per 24 hours until you update the CLI.
Set TANZU_CLI_RECOMMEND_VERSION_DELAY_DAYS to adjust this period (0 to disable).

# And finally, just to see it with our own eyes, check the presence of `central_config.yaml`
$ ls ~/.cache/tanzu/plugin_inventory/default
central_config.yaml                                                     metadata.digest.none
digest.ca212530af87bcf8c41b4b89c48cf453c86621e5e8f9fb501d219a582878f336 plugin_inventory.db
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Implement "global initializers" and use them to fix the plugin cache if the `central_config.yaml` file is missing.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
