### PR TITLE
Add support for individual plugin download with `tanzu plugin download-bundle` command

### DIFF
--- a/docs/quickstart/install.md
+++ b/docs/quickstart/install.md
@@ -447,13 +447,16 @@ If you do not specify a group's version, the latest version available for the gr
 tanzu plugin download-bundle --group vmware-tkg/default --to-tar /tmp/plugin_bundle_tkg_latest.tar.gz
 ```
 
-If you want to download a specific plugin, the `--plugin` flag can be used. Below are the support format for `--plugin` flag:
+If you want to download a specific plugin, the `--plugin` flag can be used. Using
+the `--plugin` flag is for cases where a plugin is not part of a plugin group,
+but that normally using `--group` is the recommended approach.
+Below are the supported formats for the `--plugin` flag:
 
 ```sh
---plugin name                 : Downloads all available versions of the plugin for all matching targets.
---plugin name:version         : Downloads specified version of the plugin for all matching targets. Use 'latest' as version for latest available version
---plugin name@target:version  : Downloads specified version of the plugin for the specified target. Use 'latest' as version for latest available version
---plugin name@target          : Downloads all available versions of the plugin for the specified target.
+--plugin name                 : Downloads the latest available version of the plugin for all matching targets.
+--plugin name:version         : Downloads the specified version of the plugin for all matching targets. Use 'latest' as version for latest available version
+--plugin name@target:version  : Downloads the specified version of the plugin for the specified target. Use 'latest' as version for latest available version
+--plugin name@target          : Downloads the latest available version of the plugin for the specified target.
 ```
 
 ```sh

--- a/docs/quickstart/install.md
+++ b/docs/quickstart/install.md
@@ -414,10 +414,10 @@ resulting images without authentication.
 To download plugins you will use the `tanzu plugin download-bundle` command and
 specify the different plugin groups or plugins relevant to your environment.
 
-This command will download the plugin bundle containing specified plugins and
-the plugin versions specified in the plugin group definition. The bundle will
-also include the plugin group definition itself if specified, so that it can be
-used for plugin installation by users.
+This command will download the plugin bundle containing the specified plugin
+versions as well as the plugin versions specified in the plugin group definition.
+The bundle will also include the plugin group definition itself if specified,
+so that it can be used for plugin installation by users.
 
 Note that the latest version of the `vmware-tanzucli/essentials` plugin group
 and the plugin versions it contains will automatically be included in any plugin
@@ -449,21 +449,21 @@ tanzu plugin download-bundle --group vmware-tkg/default --to-tar /tmp/plugin_bun
 
 If you want to download a specific plugin, the `--plugin` flag can be used. Using
 the `--plugin` flag is for cases where a plugin is not part of a plugin group,
-but that normally using `--group` is the recommended approach.
+however, when possible, using `--group` is the recommended approach.
 Below are the supported formats for the `--plugin` flag:
 
 ```sh
---plugin name                 : Downloads the latest available version of the plugin for all matching targets.
---plugin name:version         : Downloads the specified version of the plugin for all matching targets. Use 'latest' as version for latest available version
---plugin name@target:version  : Downloads the specified version of the plugin for the specified target. Use 'latest' as version for latest available version
+--plugin name                 : Downloads the latest available version of the plugin. (Returns an error if the specified plugin name is available across multiple targets)
+--plugin name:version         : Downloads the specified version of the plugin. (Returns an error if the specified plugin name is available across multiple targets)
+--plugin name@target:version  : Downloads the specified version of the plugin for the specified target.
 --plugin name@target          : Downloads the latest available version of the plugin for the specified target.
 ```
 
 ```sh
-# To download plugin bundle with all available versions 'cluster' plugin across all targets
+# To download plugin bundle with the latest available version of the 'cluster' plugin. (Returns an error if the specified plugin name is available across multiple targets)
 tanzu plugin download-bundle --plugin cluster --to-tar /tmp/plugin_bundle_cluster.tar.gz
 
-# To download plugin bundle with all available versions 'cluster' plugin for `kubernetes` target
+# To download plugin bundle with the latest available version of the 'cluster' plugin for `kubernetes` target
 tanzu plugin download-bundle --plugin cluster@kubernetes --to-tar /tmp/plugin_bundle_cluster.tar.gz
 
 # To download plugin bundle with v1.0.0 version of 'cluster' plugin for `kubernetes` target
@@ -473,7 +473,7 @@ tanzu plugin download-bundle --plugin cluster@kubernetes:v1.0.0 --to-tar /tmp/pl
 tanzu plugin download-bundle --plugin cluster@kubernetes:latest --to-tar /tmp/plugin_bundle_cluster.tar.gz
 ```
 
-Using `--group` and `--plugin` flag together are also supported and if specified the union of all the
+Using the `--group` and `--plugin` flags together is also supported.  In such a case the union of all the
 plugins and plugin-groups will be downloaded.
 
 To migrate plugins from a specific plugin repository and not use the default

--- a/docs/quickstart/install.md
+++ b/docs/quickstart/install.md
@@ -412,11 +412,12 @@ resulting images without authentication.
 #### Downloading plugin bundle
 
 To download plugins you will use the `tanzu plugin download-bundle` command and
-specify the different plugin groups relevant to your environment.
+specify the different plugin groups or plugins relevant to your environment.
 
-This command will download the plugin bundle containing the plugin versions specified
-in the plugin group definition.  The bundle will also include the plugin group
-definition itself, so that it can be used for plugin installation by users.
+This command will download the plugin bundle containing specified plugins and
+the plugin versions specified in the plugin group definition. The bundle will
+also include the plugin group definition itself if specified, so that it can be
+used for plugin installation by users.
 
 Note that the latest version of the `vmware-tanzucli/essentials` plugin group
 and the plugin versions it contains will automatically be included in any plugin
@@ -445,6 +446,32 @@ If you do not specify a group's version, the latest version available for the gr
 ```sh
 tanzu plugin download-bundle --group vmware-tkg/default --to-tar /tmp/plugin_bundle_tkg_latest.tar.gz
 ```
+
+If you want to download a specific plugin, the `--plugin` flag can be used. Below are the support format for `--plugin` flag:
+
+```sh
+--plugin name                 : Downloads all available versions of the plugin for all matching targets.
+--plugin name:version         : Downloads specified version of the plugin for all matching targets. Use 'latest' as version for latest available version
+--plugin name@target:version  : Downloads specified version of the plugin for the specified target. Use 'latest' as version for latest available version
+--plugin name@target          : Downloads all available versions of the plugin for the specified target.
+```
+
+```sh
+# To download plugin bundle with all available versions 'cluster' plugin across all targets
+tanzu plugin download-bundle --plugin cluster --to-tar /tmp/plugin_bundle_cluster.tar.gz
+
+# To download plugin bundle with all available versions 'cluster' plugin for `kubernetes` target
+tanzu plugin download-bundle --plugin cluster@kubernetes --to-tar /tmp/plugin_bundle_cluster.tar.gz
+
+# To download plugin bundle with v1.0.0 version of 'cluster' plugin for `kubernetes` target
+tanzu plugin download-bundle --plugin cluster@kubernetes:v1.0.0 --to-tar /tmp/plugin_bundle_cluster.tar.gz
+
+# To download plugin bundle with latest available version of 'cluster' plugin for `kubernetes` target
+tanzu plugin download-bundle --plugin cluster@kubernetes:latest --to-tar /tmp/plugin_bundle_cluster.tar.gz
+```
+
+Using `--group` and `--plugin` flag together are also supported and if specified the union of all the
+plugins and plugin-groups will be downloaded.
 
 To migrate plugins from a specific plugin repository and not use the default
 plugin repository you can provide a `--image` flag with the above command, for example:

--- a/pkg/airgapped/plugin_bundle_download.go
+++ b/pkg/airgapped/plugin_bundle_download.go
@@ -194,11 +194,12 @@ func (o *DownloadPluginBundleOptions) getSelectedPluginInfo() ([]*plugininventor
 func (o *DownloadPluginBundleOptions) getPluginFromPluginID(pluginID string, pi plugininventory.PluginInventory) ([]*plugininventory.PluginInventoryEntry, error) {
 	pluginName, pluginTarget, pluginVersion := utils.ParsePluginID(pluginID)
 	if pluginVersion == "" {
-		pluginVersion = "latest"
+		pluginVersion = cli.VersionLatest
 	}
+
 	pluginEntries, err := pi.GetPlugins(&plugininventory.PluginInventoryFilter{
 		Name:          pluginName,
-		Target:        configtypes.Target(pluginTarget),
+		Target:        configtypes.StringToTarget(pluginTarget),
 		Version:       pluginVersion,
 		IncludeHidden: true,
 	}) // Include the hidden plugins during plugin migration

--- a/pkg/airgapped/plugin_bundle_test.go
+++ b/pkg/airgapped/plugin_bundle_test.go
@@ -203,6 +203,60 @@ imagesToCopy:
     - sourceTarFilePath: telemetry-global-darwin_amd64-v0.0.1.tar.gz
       relativeImagePath: /path/darwin/amd64/global/telemetry
 `
+	// Plugin bundle manifest file generated based on the above mentioned
+	// plugin entry in the inventory database with only foo plugin specified
+	pluginBundleManifestFooPluginOnlyString := `relativeInventoryImagePathWithTag: /plugin-inventory:latest
+inventoryMetadataImage:
+    sourceFilePath: plugin_inventory_metadata.db
+    relativeImagePathWithTag: /plugin-inventory-metadata:latest
+imagesToCopy:
+    - sourceTarFilePath: plugin-inventory-image.tar.gz
+      relativeImagePath: /plugin-inventory
+    - sourceTarFilePath: telemetry-global-darwin_amd64-v0.0.1.tar.gz
+      relativeImagePath: /path/darwin/amd64/global/telemetry
+    - sourceTarFilePath: foo-global-darwin_amd64-v0.0.2.tar.gz
+      relativeImagePath: /path/darwin/amd64/global/foo
+    - sourceTarFilePath: foo-global-linux_amd64-v0.0.2.tar.gz
+      relativeImagePath: /path/linux/amd64/global/foo
+`
+
+	// Plugin bundle manifest file generated based on the above mentioned
+	// plugin entry in the inventory database with only single plugin group and specific plugin specified
+	pluginBundleManifestDefaultGroupAndFooPluginOnlyString := `relativeInventoryImagePathWithTag: /plugin-inventory:latest
+inventoryMetadataImage:
+    sourceFilePath: plugin_inventory_metadata.db
+    relativeImagePathWithTag: /plugin-inventory-metadata:latest
+imagesToCopy:
+    - sourceTarFilePath: plugin-inventory-image.tar.gz
+      relativeImagePath: /plugin-inventory
+    - sourceTarFilePath: bar-kubernetes-darwin_amd64-v0.0.1.tar.gz
+      relativeImagePath: /path/darwin/amd64/kubernetes/bar
+    - sourceTarFilePath: telemetry-global-darwin_amd64-v0.0.1.tar.gz
+      relativeImagePath: /path/darwin/amd64/global/telemetry
+    - sourceTarFilePath: foo-global-darwin_amd64-v0.0.2.tar.gz
+      relativeImagePath: /path/darwin/amd64/global/foo
+    - sourceTarFilePath: foo-global-linux_amd64-v0.0.2.tar.gz
+      relativeImagePath: /path/linux/amd64/global/foo
+`
+
+	// Plugin bundle manifest file generated based on the above mentioned
+	// plugin entry in the inventory database with only foo and bar plugin specified
+	pluginBundleManifestFooAndBarPluginOnlyString := `relativeInventoryImagePathWithTag: /plugin-inventory:latest
+inventoryMetadataImage:
+    sourceFilePath: plugin_inventory_metadata.db
+    relativeImagePathWithTag: /plugin-inventory-metadata:latest
+imagesToCopy:
+    - sourceTarFilePath: plugin-inventory-image.tar.gz
+      relativeImagePath: /plugin-inventory
+    - sourceTarFilePath: telemetry-global-darwin_amd64-v0.0.1.tar.gz
+      relativeImagePath: /path/darwin/amd64/global/telemetry
+    - sourceTarFilePath: foo-global-darwin_amd64-v0.0.2.tar.gz
+      relativeImagePath: /path/darwin/amd64/global/foo
+    - sourceTarFilePath: foo-global-linux_amd64-v0.0.2.tar.gz
+      relativeImagePath: /path/linux/amd64/global/foo
+    - sourceTarFilePath: bar-kubernetes-darwin_amd64-v0.0.1.tar.gz
+      relativeImagePath: /path/darwin/amd64/kubernetes/bar
+`
 
 	// Configure the configuration before running the tests
 	BeforeEach(func() {
@@ -408,6 +462,109 @@ imagesToCopy:
 			bytes, err := os.ReadFile(filepath.Join(tempDir, PluginBundleDirName, PluginMigrationManifestFile))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(bytes)).To(Equal(pluginBundleManifestDefaultGroupOnlyString))
+			manifest := &PluginMigrationManifest{}
+			err = yaml.Unmarshal(bytes, &manifest)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Iterate through all the images in the manifest and verify that all image archive
+			// files mentioned in the manifest exists in the bundle
+			for _, pi := range manifest.ImagesToCopy {
+				exists := utils.PathExists(filepath.Join(tempDir, PluginBundleDirName, pi.SourceTarFilePath))
+				Expect(exists).To(BeTrue())
+			}
+		})
+
+		var _ = It("when group and plugin is specified and everything works as expected, it should download plugin bundle as tar file", func() {
+			fakeImageOperations.DownloadImageAndSaveFilesToDirCalls(downloadInventoryImageAndSaveFilesToDirStub)
+			fakeImageOperations.CopyImageToTarCalls(copyImageToTarStub)
+
+			// Provide a plugin group and a plugin
+			dpbo.Groups = []string{"fakevendor-fakepublisher/default:v1.0.0"}
+			dpbo.Plugins = []string{"foo"}
+			err := dpbo.DownloadPluginBundle()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify that tar file was generated correctly with untar
+			tempDir, err := os.MkdirTemp("", "")
+			Expect(tempDir).ToNot(BeEmpty())
+			Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(tempDir)
+
+			err = tarinator.UnTarinate(tempDir, dpbo.ToTar)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify the plugin bundle manifest file is accurate
+			bytes, err := os.ReadFile(filepath.Join(tempDir, PluginBundleDirName, PluginMigrationManifestFile))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(bytes)).To(Equal(pluginBundleManifestDefaultGroupAndFooPluginOnlyString))
+			manifest := &PluginMigrationManifest{}
+			err = yaml.Unmarshal(bytes, &manifest)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Iterate through all the images in the manifest and verify that all image archive
+			// files mentioned in the manifest exists in the bundle
+			for _, pi := range manifest.ImagesToCopy {
+				exists := utils.PathExists(filepath.Join(tempDir, PluginBundleDirName, pi.SourceTarFilePath))
+				Expect(exists).To(BeTrue())
+			}
+		})
+
+		var _ = It("when only one plugin is specified and everything works as expected, it should download plugin bundle as tar file", func() {
+			fakeImageOperations.DownloadImageAndSaveFilesToDirCalls(downloadInventoryImageAndSaveFilesToDirStub)
+			fakeImageOperations.CopyImageToTarCalls(copyImageToTarStub)
+
+			// Provide a plugin
+			dpbo.Plugins = []string{"foo"}
+			err := dpbo.DownloadPluginBundle()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify that tar file was generated correctly with untar
+			tempDir, err := os.MkdirTemp("", "")
+			Expect(tempDir).ToNot(BeEmpty())
+			Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(tempDir)
+
+			err = tarinator.UnTarinate(tempDir, dpbo.ToTar)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify the plugin bundle manifest file is accurate
+			bytes, err := os.ReadFile(filepath.Join(tempDir, PluginBundleDirName, PluginMigrationManifestFile))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(bytes)).To(Equal(pluginBundleManifestFooPluginOnlyString))
+			manifest := &PluginMigrationManifest{}
+			err = yaml.Unmarshal(bytes, &manifest)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Iterate through all the images in the manifest and verify that all image archive
+			// files mentioned in the manifest exists in the bundle
+			for _, pi := range manifest.ImagesToCopy {
+				exists := utils.PathExists(filepath.Join(tempDir, PluginBundleDirName, pi.SourceTarFilePath))
+				Expect(exists).To(BeTrue())
+			}
+		})
+
+		var _ = It("when multiple plugins are specified and everything works as expected, it should download plugin bundle as tar file", func() {
+			fakeImageOperations.DownloadImageAndSaveFilesToDirCalls(downloadInventoryImageAndSaveFilesToDirStub)
+			fakeImageOperations.CopyImageToTarCalls(copyImageToTarStub)
+
+			// Provide multiple plugins
+			dpbo.Plugins = []string{"foo@global:v0.0.2", "bar@kubernetes"}
+			err := dpbo.DownloadPluginBundle()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify that tar file was generated correctly with untar
+			tempDir, err := os.MkdirTemp("", "")
+			Expect(tempDir).ToNot(BeEmpty())
+			Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(tempDir)
+
+			err = tarinator.UnTarinate(tempDir, dpbo.ToTar)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify the plugin bundle manifest file is accurate
+			bytes, err := os.ReadFile(filepath.Join(tempDir, PluginBundleDirName, PluginMigrationManifestFile))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(bytes)).To(Equal(pluginBundleManifestFooAndBarPluginOnlyString))
 			manifest := &PluginMigrationManifest{}
 			err = yaml.Unmarshal(bytes, &manifest)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/airgapped/plugin_bundle_test.go
+++ b/pkg/airgapped/plugin_bundle_test.go
@@ -577,6 +577,17 @@ imagesToCopy:
 			}
 		})
 
+		var _ = It("when specified plugin is invalid and does not exists, it should fail the download bundle command", func() {
+			fakeImageOperations.DownloadImageAndSaveFilesToDirCalls(downloadInventoryImageAndSaveFilesToDirStub)
+			fakeImageOperations.CopyImageToTarCalls(copyImageToTarStub)
+
+			// Provide multiple plugins
+			dpbo.Plugins = []string{"invalid"}
+			err := dpbo.DownloadPluginBundle()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("error while getting selected plugin and plugin group information: no plugins found for pluginID \"invalid\""))
+		})
+
 		var _ = It("when using --dry-run option, it should work and write the images yaml to the standard output", func() {
 			fakeImageOperations.DownloadImageAndSaveFilesToDirCalls(downloadInventoryImageAndSaveFilesToDirStub)
 			fakeImageOperations.CopyImageToTarCalls(copyImageToTarStub)

--- a/pkg/command/plugin_bundle.go
+++ b/pkg/command/plugin_bundle.go
@@ -46,10 +46,10 @@ to an internet-restricted environment. Please also see the "upload-bundle" comma
     tanzu plugin download-bundle --group vmware-tkg/default:v1.0.0 --to-tar /tmp/plugin_bundle_vmware_tkg_default_v1.0.0.tar.gz
 
     # To download plugin bundle with specific plugin from the default discovery source
-    #     --plugin name                 : Downloads all available versions of the plugin for all matching targets.
-    #     --plugin name:version         : Downloads specified version of the plugin for all matching targets. Use 'latest' as version for latest available version
-    #     --plugin name@target:version  : Downloads specified version of the plugin for the specified target. Use 'latest' as version for latest available version
-    #     --plugin name@target          : Downloads all available versions of the plugin for the specified target.
+    #     --plugin name                 : Downloads the latest available version of the plugin for all matching targets.
+    #     --plugin name:version         : Downloads the specified version of the plugin for all matching targets. Use 'latest' as version for latest available version
+    #     --plugin name@target:version  : Downloads the specified version of the plugin for the specified target. Use 'latest' as version for latest available version
+    #     --plugin name@target          : Downloads the latest available version of the plugin for the specified target.
     tanzu plugin download-bundle --plugin cluster:v1.0.0 --to-tar /tmp/plugin_bundle_cluster.tar.gz
 
     # Download a plugin bundle with the entire plugin repository from a custom discovery source
@@ -83,7 +83,7 @@ to an internet-restricted environment. Please also see the "upload-bundle" comma
 	utils.PanicOnErr(downloadBundleCmd.RegisterFlagCompletionFunc("group", completeGroupsAndVersionForBundleDownload))
 
 	f.StringSliceVarP(&dpbo.plugins, "plugin", "", []string{}, "only download plugins matching specified pluginID. Format: name/name:version/name@target:version (can specify multiple)")
-	utils.PanicOnErr(downloadBundleCmd.RegisterFlagCompletionFunc("plugin", cobra.NoFileCompletions)) // TODO: Implement Shell completion
+	utils.PanicOnErr(downloadBundleCmd.RegisterFlagCompletionFunc("plugin", completePluginIDForBundleDownload))
 
 	f.BoolVarP(&dpbo.dryRun, "dry-run", "", false, "perform a dry run by listing the images to download without actually downloading them")
 	_ = downloadBundleCmd.Flags().MarkHidden("dry-run")
@@ -252,6 +252,113 @@ func completeGroupsAndVersionForBundleDownload(_ *cobra.Command, _ []string, toC
 	var comps []string
 	for _, g := range pluginGroups {
 		comps = append(comps, fmt.Sprintf("%s\t%s", plugininventory.PluginGroupToID(g), g.Description))
+	}
+
+	// Sort to allow for testing
+	sort.Strings(comps)
+
+	// Don't add a space after the group name so the uer can add a : if
+	// they want to specify a version.
+	return comps, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+}
+
+func completeVersionInPluginIDForDownloadBundle(plugins []*plugininventory.PluginInventoryEntry, id, _ string) []string {
+	var matchingPluginEntries []*plugininventory.PluginInventoryEntry
+	for _, p := range plugins {
+		if plugininventory.PluginToID(p) == id {
+			matchingPluginEntries = append(matchingPluginEntries, p)
+			break
+		}
+	}
+
+	if len(matchingPluginEntries) == 0 {
+		return cobra.AppendActiveHelp(nil, fmt.Sprintf("There are no plugins matching: '%s'", id))
+	}
+
+	// Since more recent versions are more likely to be
+	// useful, we return the list of versions in reverse order
+	var versions []string
+	for _, pe := range matchingPluginEntries {
+		for v := range pe.Artifacts {
+			versions = append(versions, v)
+		}
+	}
+	// Sort in ascending order
+	_ = utils.SortVersions(versions)
+
+	// Create the completions in reverse order
+	comps := make([]string, len(versions))
+	for i := range versions {
+		comps[len(versions)-1-i] = fmt.Sprintf("%s:%s", id, versions[i])
+	}
+	return comps
+}
+
+func completionGetPluginsForBundleDownload() ([]*plugininventory.PluginInventoryEntry, error) {
+	// For a download-bundle, we cannot use the DB cache.  This is because
+	// the download-bundle does not use the configured plugin sources.  Instead it
+	// uses the repo specified by the `--image`` flag, or, without the `--image` flag,
+	// it uses the default central repo automatically.
+
+	// We start by downloading the inventory of the required repo.  This is not
+	// very fast, but there isn't much we can do about it.
+
+	var err error
+	tempDBDir, err := os.MkdirTemp("", "")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(tempDBDir)
+
+	// Download the plugin inventory oci image to tempDBDir
+	repoImage := dpbo.pluginDiscoveryOCIImage
+	inventoryFile := filepath.Join(tempDBDir, plugininventory.SQliteDBFileName)
+	if err := imageProcessorForDownloadBundleComp.DownloadImageAndSaveFilesToDir(repoImage, filepath.Dir(inventoryFile)); err != nil {
+		return nil, err
+	}
+
+	// Read the plugin inventory database to read the plugin groups it contains
+	pi := plugininventory.NewSQLiteInventory(inventoryFile, path.Dir(repoImage))
+	pluginEntries, err := pi.GetPlugins(&plugininventory.PluginInventoryFilter{IncludeHidden: true}) // Include the hidden plugin groups during plugin migration
+	if err != nil {
+		return nil, err
+	}
+	return pluginEntries, err
+}
+
+func completePluginIDForBundleDownload(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	PluginEntries, err := completionGetPluginsForBundleDownload()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	if PluginEntries == nil {
+		comps := cobra.AppendActiveHelp(nil, fmt.Sprintf("There are no plugins in %s", dpbo.pluginDiscoveryOCIImage))
+		return comps, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	if idx := strings.Index(toComplete, ":"); idx != -1 {
+		// The pluginID is already specified before the :
+		// so now we should complete the group version.
+		// Since more recent versions are more likely to be
+		// useful, we tell the shell to preserve the order
+		// using cobra.ShellCompDirectiveKeepOrder
+		pluginID := toComplete[:idx]
+		versionToComplete := toComplete[idx+1:]
+
+		return completeVersionInPluginIDForDownloadBundle(PluginEntries, pluginID, versionToComplete), cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveKeepOrder
+	}
+
+	// Complete plugin group names
+	var comps []string
+	for _, p := range PluginEntries {
+		id := plugininventory.PluginToID(p)
+		if strings.HasPrefix(id, toComplete) {
+			comps = append(comps, id)
+		}
+	}
+
+	if len(comps) == 0 {
+		return cobra.AppendActiveHelp(nil, fmt.Sprintf("There are no plugins matching: '%s'", toComplete)), cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveKeepOrder
 	}
 
 	// Sort to allow for testing

--- a/pkg/command/plugin_bundle_test.go
+++ b/pkg/command/plugin_bundle_test.go
@@ -123,6 +123,63 @@ func TestCompletionPluginBundle(t *testing.T) {
 				"vmware-tkg/default:v1.1.1\n" +
 				":36\n",
 		},
+
+		{
+			test: "completion for the --plugin flag value for the plugin name part of the download-bundle command",
+			args: []string{"__complete", "plugin", "download-bundle", "--plugin", ""},
+			// This command should trigger downloading an OCI plugin inventory image
+			imageMustBeDownloaded: true,
+			// ":6" is the value of the ShellCompDirectiveNoFileComp | ShellCompDirectiveNoSpace
+			expected: "cluster@kubernetes\n" +
+				"cluster@mission-control\n" +
+				"feature@kubernetes\n" +
+				"isolated-cluster@global\n" +
+				"login@global\n" +
+				"management-cluster@kubernetes\n" +
+				"management-cluster@mission-control\n" +
+				"package@kubernetes\n" +
+				"secret@kubernetes\n" +
+				":6\n",
+		},
+		{
+			test: "completion for the --plugin flag value for the plugin name part with partial name specified of the download-bundle command",
+			args: []string{"__complete", "plugin", "download-bundle", "--plugin", "clu"},
+			// This command should trigger downloading an OCI plugin inventory image
+			imageMustBeDownloaded: true,
+			// ":6" is the value of the ShellCompDirectiveNoFileComp | ShellCompDirectiveNoSpace
+			expected: "cluster@kubernetes\n" +
+				"cluster@mission-control\n" +
+				":6\n",
+		},
+		{
+			test: "completion for the --plugin flag value for the version part of the download-bundle command",
+			args: []string{"__complete", "plugin", "download-bundle", "--plugin", "isolated-cluster@global:"},
+			// This command should trigger downloading an OCI plugin inventory image
+			imageMustBeDownloaded: true,
+			// ":36" is the value of the ShellCompDirectiveNoFileComp | ShellCompDirectiveKeepOrder
+			expected: "isolated-cluster@global:v1.3.0\n" +
+				"isolated-cluster@global:v1.2.3\n" +
+				":36\n",
+		},
+		{
+			test: "completion for the --plugin flag value for the version part of an invalid plugin name for the download-bundle command",
+			args: []string{"__complete", "plugin", "download-bundle", "--plugin", "invalid:"},
+			// This command should trigger downloading an OCI plugin inventory image
+			imageMustBeDownloaded: true,
+			// ":36" is the value of the ShellCompDirectiveNoFileComp | ShellCompDirectiveKeepOrder
+			expected: "_activeHelp_ There are no plugins matching: 'invalid'\n" +
+				":36\n",
+		},
+		{
+			test: "completion for the --plugin flag value for the plugin name of an invalid partial plugin name for the download-bundle command",
+			args: []string{"__complete", "plugin", "download-bundle", "--plugin", "invalid"},
+			// This command should trigger downloading an OCI plugin inventory image
+			imageMustBeDownloaded: true,
+			// ":36" is the value of the ShellCompDirectiveNoFileComp | ShellCompDirectiveKeepOrder
+			expected: "_activeHelp_ There are no plugins matching: 'invalid'\n" +
+				":36\n",
+		},
+
 		// ============================
 		// tanzu plugin upload-bundle
 		// ============================

--- a/pkg/command/plugin_bundle_test.go
+++ b/pkg/command/plugin_bundle_test.go
@@ -130,25 +130,15 @@ func TestCompletionPluginBundle(t *testing.T) {
 			// This command should trigger downloading an OCI plugin inventory image
 			imageMustBeDownloaded: true,
 			// ":6" is the value of the ShellCompDirectiveNoFileComp | ShellCompDirectiveNoSpace
-			expected: "cluster@kubernetes\n" +
-				"cluster@mission-control\n" +
-				"feature@kubernetes\n" +
-				"isolated-cluster@global\n" +
-				"login@global\n" +
-				"management-cluster@kubernetes\n" +
-				"management-cluster@mission-control\n" +
-				"package@kubernetes\n" +
-				"secret@kubernetes\n" +
-				":6\n",
-		},
-		{
-			test: "completion for the --plugin flag value for the plugin name part with partial name specified of the download-bundle command",
-			args: []string{"__complete", "plugin", "download-bundle", "--plugin", "clu"},
-			// This command should trigger downloading an OCI plugin inventory image
-			imageMustBeDownloaded: true,
-			// ":6" is the value of the ShellCompDirectiveNoFileComp | ShellCompDirectiveNoSpace
-			expected: "cluster@kubernetes\n" +
-				"cluster@mission-control\n" +
+			expected: "cluster@kubernetes\tPlugin cluster/kubernetes description\n" +
+				"cluster@mission-control\tPlugin cluster/mission-control description\n" +
+				"feature@kubernetes\tPlugin feature/kubernetes description\n" +
+				"isolated-cluster@global\tPlugin isolated-cluster/global description\n" +
+				"login@global\tPlugin login/global description\n" +
+				"management-cluster@kubernetes\tPlugin management-cluster/kubernetes description\n" +
+				"management-cluster@mission-control\tPlugin management-cluster/mission-control description\n" +
+				"package@kubernetes\tPlugin package/kubernetes description\n" +
+				"secret@kubernetes\tPlugin secret/kubernetes description\n" +
 				":6\n",
 		},
 		{
@@ -164,15 +154,6 @@ func TestCompletionPluginBundle(t *testing.T) {
 		{
 			test: "completion for the --plugin flag value for the version part of an invalid plugin name for the download-bundle command",
 			args: []string{"__complete", "plugin", "download-bundle", "--plugin", "invalid:"},
-			// This command should trigger downloading an OCI plugin inventory image
-			imageMustBeDownloaded: true,
-			// ":36" is the value of the ShellCompDirectiveNoFileComp | ShellCompDirectiveKeepOrder
-			expected: "_activeHelp_ There are no plugins matching: 'invalid'\n" +
-				":36\n",
-		},
-		{
-			test: "completion for the --plugin flag value for the plugin name of an invalid partial plugin name for the download-bundle command",
-			args: []string{"__complete", "plugin", "download-bundle", "--plugin", "invalid"},
 			// This command should trigger downloading an OCI plugin inventory image
 			imageMustBeDownloaded: true,
 			// ":36" is the value of the ShellCompDirectiveNoFileComp | ShellCompDirectiveKeepOrder

--- a/pkg/plugininventory/plugin_inventory.go
+++ b/pkg/plugininventory/plugin_inventory.go
@@ -150,6 +150,10 @@ func PluginGroupToID(pg *PluginGroup) string {
 	return fmt.Sprintf("%s-%s/%s", pg.Vendor, pg.Publisher, pg.Name)
 }
 
+func PluginToID(p *PluginInventoryEntry) string {
+	return fmt.Sprintf("%s@%s", p.Name, p.Target)
+}
+
 // PluginGroupIdentifierFromID converts a plugin group id into a
 // PluginGroupIdentifier structure.
 // A group id can be of the forms:

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -57,3 +57,18 @@ func PanicOnErr(err error) {
 
 	panic(err)
 }
+
+// ParsePluginID parses the plugin id and returns (name, target, version) strings
+func ParsePluginID(pluginID string) (string, string, string) {
+	var name, target, version string
+	parts := strings.Split(pluginID, ":")
+	if len(parts) > 1 {
+		version = parts[1]
+	}
+	parts = strings.Split(parts[0], "@")
+	name = parts[0]
+	if len(parts) > 1 {
+		target = parts[1]
+	}
+	return name, target, version
+}

--- a/pkg/utils/common_test.go
+++ b/pkg/utils/common_test.go
@@ -175,3 +175,33 @@ func TestEnsureMutualExclusiveCurrentContexts(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, len(ccmap), 0)
 }
+
+func TestParsePluginID(t *testing.T) {
+	tests := []struct {
+		input           string
+		expectedName    string
+		expectedTarget  string
+		expectedVersion string
+	}{
+		{"app@kubernetes:v1.2.3", "app", "kubernetes", "v1.2.3"},
+		{"app:v1.2.3", "app", "", "v1.2.3"},
+		{"app", "app", "", ""},
+		{"", "", "", ""},
+	}
+
+	for _, test := range tests {
+		name, target, version := ParsePluginID(test.input)
+
+		if name != test.expectedName {
+			t.Errorf("For input '%s', expected name '%s', but got '%s'", test.input, test.expectedName, name)
+		}
+
+		if target != test.expectedTarget {
+			t.Errorf("For input '%s', expected target '%s', but got '%s'", test.input, test.expectedTarget, target)
+		}
+
+		if version != test.expectedVersion {
+			t.Errorf("For input '%s', expected version '%s', but got '%s'", test.input, test.expectedVersion, version)
+		}
+	}
+}

--- a/test/e2e/airgapped/plugins.go
+++ b/test/e2e/airgapped/plugins.go
@@ -88,3 +88,13 @@ var essentialPlugins = []*framework.PluginInfo{
 var pluginsNotInAnyPGAndUsingSha = []*framework.PluginInfo{
 	{Name: "plugin-with-sha", Target: "global", Version: "v9.9.9", Description: "plugin-with-sha " + functionality},
 }
+
+// allExpectedPluginForPluginMigration when download-bundle is invoked with following pluginIDs
+// 'pinniped-auth', 'isolated-cluster@global:v9.9.9', 'clustergroup@operations'
+var allExpectedPluginForPluginMigration = []*framework.PluginInfo{
+	{Name: "isolated-cluster", Target: "global", Version: "v9.9.9", Description: "isolated-cluster " + functionality},
+	{Name: "pinniped-auth", Target: "global", Version: "v0.0.1", Description: "pinniped-auth " + functionality},
+	{Name: "pinniped-auth", Target: "global", Version: "v9.9.9", Description: "pinniped-auth " + functionality},
+	{Name: "clustergroup", Target: "operations", Version: "v0.0.1", Description: "clustergroup " + functionality},
+	{Name: "clustergroup", Target: "operations", Version: "v9.9.9", Description: "clustergroup " + functionality},
+}

--- a/test/e2e/airgapped/plugins.go
+++ b/test/e2e/airgapped/plugins.go
@@ -93,8 +93,6 @@ var pluginsNotInAnyPGAndUsingSha = []*framework.PluginInfo{
 // 'pinniped-auth', 'isolated-cluster@global:v9.9.9', 'clustergroup@operations'
 var allExpectedPluginForPluginMigration = []*framework.PluginInfo{
 	{Name: "isolated-cluster", Target: "global", Version: "v9.9.9", Description: "isolated-cluster " + functionality},
-	{Name: "pinniped-auth", Target: "global", Version: "v0.0.1", Description: "pinniped-auth " + functionality},
 	{Name: "pinniped-auth", Target: "global", Version: "v9.9.9", Description: "pinniped-auth " + functionality},
-	{Name: "clustergroup", Target: "operations", Version: "v0.0.1", Description: "clustergroup " + functionality},
 	{Name: "clustergroup", Target: "operations", Version: "v9.9.9", Description: "clustergroup " + functionality},
 }

--- a/test/e2e/framework/framework_helper.go
+++ b/test/e2e/framework/framework_helper.go
@@ -286,6 +286,13 @@ func CheckAllPluginsExists(superList, subList []*PluginInfo) bool {
 		// }
 		_, ok := superSet[key]
 		if !ok {
+			for i := range superList {
+				log.Infof("SuperList: %v, %v, %v", superList[i].Name, superList[i].Target, superList[i].Version)
+			}
+			log.Infof("")
+			for i := range subList {
+				log.Infof("SubList: %v, %v, %v", subList[i].Name, subList[i].Target, subList[i].Version)
+			}
 			return false
 		}
 	}

--- a/test/e2e/framework/output_handling.go
+++ b/test/e2e/framework/output_handling.go
@@ -15,10 +15,11 @@ type PluginInfo struct {
 }
 
 type PluginSearch struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Target      string `json:"target"`
-	Latest      string `json:"latest"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Target      string   `json:"target"`
+	Latest      string   `json:"latest"`
+	Versions    []string `json:"versions,omitempty"`
 }
 
 type PluginGroup struct {

--- a/test/e2e/plugin_lifecycle/plugin_lifecycle_helper.go
+++ b/test/e2e/plugin_lifecycle/plugin_lifecycle_helper.go
@@ -30,6 +30,12 @@ func SearchAllPlugins(tf *framework.Framework, opts ...framework.E2EOption) ([]*
 	return pluginsSearchList, err
 }
 
+// SearchAllPluginsAndAllVersions runs the plugin search command and returns all the plugins along with all versions from the search output
+func SearchAllPluginsAndAllVersions(tf *framework.Framework, opts ...framework.E2EOption) ([]*framework.PluginInfo, error) {
+	pluginsSearchList, _, _, err := tf.PluginCmd.SearchPlugins("--show-details", opts...)
+	return pluginsSearchList, err
+}
+
 // SearchAllPluginGroups runs the plugin group search command and returns all the plugin groups
 func SearchAllPluginGroups(tf *framework.Framework, opts ...framework.E2EOption) ([]*framework.PluginGroup, error) {
 	pluginGroups, err := tf.PluginCmd.SearchPluginGroups("--show-details", opts...)


### PR DESCRIPTION
### What this PR does / why we need it

- Add support for individual plugin download with `tanzu plugin download-bundle` command and Add E2E tests

- This PR adds a new flag `--plugin` as part of `tanzu plugin download-bundle` command which takes pluginID as value.
- Based on the specified pluginID, matching plugins will be downloaded as a bundle that can be transferred and uploaded to the airgapped repository. Please see documentation update on how to use `--plugin` flag.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

```sh
~ $ tanzu plugin download-bundle --help
Download a plugin bundle to the local file system to be used when migrating plugins
to an internet-restricted environment. Please also see the "upload-bundle" command.

Usage:
  tanzu plugin download-bundle [flags]

Examples:

    # Download a plugin bundle for a specific group version from the default discovery source
    tanzu plugin download-bundle --group vmware-tkg/default:v1.0.0 --to-tar /tmp/plugin_bundle_vmware_tkg_default_v1.0.0.tar.gz

    # To download plugin bundle with a specific plugin from the default discovery source
    #     --plugin name                 : Downloads the latest available version of the plugin. (Returns an error if the specified plugin name is available across multiple targets)
    #     --plugin name:version         : Downloads the specified version of the plugin. (Returns an error if the specified plugin name is available across multiple targets)
    #     --plugin name@target:version  : Downloads the specified version of the plugin for the specified target.
    #     --plugin name@target          : Downloads the latest available version of the plugin for the specified target.
    tanzu plugin download-bundle --plugin cluster:v1.0.0 --to-tar /tmp/plugin_bundle_cluster.tar.gz

    # Download a plugin bundle with the entire plugin repository from a custom discovery source
    tanzu plugin download-bundle --image custom.registry.vmware.com/tkg/tanzu-plugins/plugin-inventory:latest --to-tar /tmp/plugin_bundle_complete.tar.gz

Flags:
      --group strings    only download the plugins specified in the plugin-group version (can specify multiple)
  -h, --help             help for download-bundle
      --image string     URI of the plugin discovery image providing the plugins (default "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest")
      --plugin strings   only download plugins matching specified pluginID. Format: name/name:version/name@target:version (can specify multiple)
      --to-tar string    local tar file path to store the plugin images
```

- Added E2E tests

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add support for individual plugin download with `tanzu plugin download-bundle` command
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
