### PR TITLE
Skip plugin-group verification when TANZU_CLI_SKIP_PLUGIN_GROUP_VERIF…

### DIFF
--- a/pkg/constants/env_variables.go
+++ b/pkg/constants/env_variables.go
@@ -66,4 +66,9 @@ const (
 	// If environment variable 'TANZU_CLI_PLUGIN_DISCOVERY_PATH_FOR_TANZU_CONTEXT' is not configured
 	// default discovery endpoint configured with TanzuContextPluginDiscoveryEndpointPath will be used
 	TanzuPluginDiscoveryPathforTanzuContext = "TANZU_CLI_PLUGIN_DISCOVERY_PATH_FOR_TANZU_CONTEXT"
+
+	// SkipPluginGroupVerificationOnPublish skips the plugin group verification of whether the plugins specified
+	// in the plugin-group are available in the database or not.
+	// Note: THIS SHOULD ONLY BE USED FOR TEST AND NON PRODUCTION ENVIRONMENTS.
+	SkipPluginGroupVerificationOnPublish = "TANZU_CLI_SKIP_PLUGIN_GROUP_VERIFICATION_ON_PUBLISH"
 )


### PR DESCRIPTION
…ICATION_ON_PUBLISH is specified

### What this PR does / why we need it
- This PR provides a means to skip the plugin group verification of whether the plugins specified in the plugin-group are available in the database or not.
- If `TANZU_CLI_SKIP_PLUGIN_GROUP_VERIFICATION_ON_PUBLISH` is set to `true` while publishing the plugin-group, publishing process will bypass the plugin validation and continue with the plugin-group publishing.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

- Start new local registry
```
$ make plugin-local-registry
docker stop temp-package-registry && docker rm -v temp-package-registry || true
temp-package-registry
temp-package-registry
docker run -d -p 5001:5000 --name temp-package-registry library/registry:2
0157614d4e621854551fc80fd68e45cd9a20667148a7ea7c3702a7a69e8c56e5
```

- Initialize inventory database
```
$ make inventory-init
/Users/anujc/Documents/code/tanzu-cli/bin/builder inventory init \
                --repository localhost:5001/test/v1/tanzu-cli/plugins \
                --plugin-inventory-image-tag latest \

2024-04-10T11:16:32-07:00 [i] created database locally at: "/var/folders/xc/12mmbpb50qxfb3ch8vv9nvwm0000gq/T/plugin_inventory.db"
2024-04-10T11:16:32-07:00 [i] publishing database at: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
2024-04-10T11:16:33-07:00 [i] successfully published plugin inventory database
```

- Run plugin-group creation without publishing the plugins. It should fail.
```
make inventory-plugin-group-add PLUGIN_GROUP_NAME_VERSION="default:v0.0.4" PLUGIN_GROUP_DESCRIPTION="THIS IS A Test desc"
/Users/anujc/Documents/code/tanzu-cli/bin/builder inventory plugin-group add \
                --repository localhost:5001/test/v1/tanzu-cli/plugins \
                --plugin-inventory-image-tag latest \
                --publisher tanzucli \
                --vendor vmware \
                --manifest /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins/plugin_group_manifest.yaml \
                --name default \
                --version v0.0.4 \
                --plugin-inventory-db-file "" \
                --description "THIS IS A Test desc" \

2024-04-10T11:16:44-07:00 [i] pulling plugin inventory database from: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
2024-04-10T11:16:44-07:00 [i] updating plugin inventory database with plugin group entry
Error: error while inserting plugin group 'default': specified plugin 'name:builder', 'target:global', 'version:v1' is not present in the database
2024-04-10T11:16:44-07:00 [x] : error while inserting plugin group 'default': specified plugin 'name:builder', 'target:global', 'version:v1' is not present in the database
make: *** [inventory-plugin-group-add] Error 1
```

- Re-run the plugin-group publishing with export `TANZU_CLI_SKIP_PLUGIN_GROUP_VERIFICATION_ON_PUBLISH=true` env specified.
```
 $ make inventory-plugin-group-add PLUGIN_GROUP_NAME_VERSION="default:v0.0.4" PLUGIN_GROUP_DESCRIPTION="THIS IS A Test desc"
/Users/anujc/Documents/code/tanzu-cli/bin/builder inventory plugin-group add \
                --repository localhost:5001/test/v1/tanzu-cli/plugins \
                --plugin-inventory-image-tag latest \
                --publisher tanzucli \
                --vendor vmware \
                --manifest /Users/anujc/Documents/code/tanzu-cli/artifacts/plugins/plugin_group_manifest.yaml \
                --name default \
                --version v0.0.4 \
                --plugin-inventory-db-file "" \
                --description "THIS IS A Test desc" \

2024-04-10T11:17:07-07:00 [i] pulling plugin inventory database from: "localhost:5001/test/v1/tanzu-cli/plugins/plugin-inventory:latest"
2024-04-10T11:17:07-07:00 [i] updating plugin inventory database with plugin group entry
2024-04-10T11:17:07-07:00 [i] publishing plugin inventory database
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
None
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
