### PR TITLE
Enable tests that were not being run

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"os"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -17,6 +18,11 @@ var (
 )
 
 const envVar = "test-conf-env"
+
+func TestClient(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config Suite")
+}
 
 var _ = Describe("config env variables", func() {
 	Context("get env from config", func() {


### PR DESCRIPTION
### What this PR does / why we need it

I noticed that the ginko tests in `pkg/config` did not have a test suite and therefore were not being run.

Before this PR, notice the `[no tests to run]`.
The test coverage happens because the `init()` function is automatically run, but nothing is verified, so it is not real test coverage.
```
$ cd tanzu-cli
~tc
$ g co main
Switched to branch 'main'
Your branch is up to date with 'upstream/main'.
$ go test ./pkg/config -coverprofile coverage.txt
ok  	github.com/vmware-tanzu/tanzu-cli/pkg/config	0.634s	coverage: 12.2% of statements [no tests to run]
```

With this PR, notice the increased coverage and the fact that it no longer says `[no tests to run]`:
```
$ go test ./pkg/config -coverprofile coverage.txt
ok  	github.com/vmware-tanzu/tanzu-cli/pkg/config	1.010s	coverage: 36.7% of statements
```
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Let CI run

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
More unit tests
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
