### PR TITLE
Add support for command-level remapping (old)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ replace cloud.google.com/go => cloud.google.com/go v0.102.1
 
 replace github.com/vmware-tanzu/tanzu-cli/test/e2e/framework => ./test/e2e/framework
 
+replace github.com/vmware-tanzu/tanzu-plugin-runtime => github.com/vuil/tanzu-plugin-runtime v1.3.0-dev.0.20240415164801-ab146575bef4
+
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/Masterminds/semver v1.5.0
@@ -42,7 +44,7 @@ require (
 	github.com/vmware-tanzu/carvel-ytt v0.40.0
 	github.com/vmware-tanzu/tanzu-cli/test/e2e/framework v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686
-	github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0-alpha.2
+	github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0-dev.0.20240325202145-db9795bb1426
 	go.pinniped.dev v0.20.0
 	golang.org/x/mod v0.12.0
 	golang.org/x/oauth2 v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -738,8 +738,8 @@ github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502eb
 github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502ebf68/go.mod h1:e1Uef+Ux5BIHpYwqbeP2ZZmOzehBcez2vUEWXHe+xHE=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686 h1:VcuXqUXFxm5WDqWkzAlU/6cJXua0ozELnqD59fy7J6E=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686/go.mod h1:AFGOXZD4tH+KhpmtV0VjWjllXhr8y57MvOsIxTtywc4=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0-alpha.2 h1:eZLXCLpw1N0XYW4fnVcE9gC5R6o8IrYrHEPqt7uB1Gs=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0-alpha.2/go.mod h1:5m73y796B4EoeXZtvkq8jbQPPQXeYkLPLS2BBbxZp7o=
+github.com/vuil/tanzu-plugin-runtime v1.3.0-dev.0.20240415164801-ab146575bef4 h1:4PSOXU2uYGIsa5iypNzXP0tnaBnZLgBNzBQa6YWr6l0=
+github.com/vuil/tanzu-plugin-runtime v1.3.0-dev.0.20240415164801-ab146575bef4/go.mod h1:5m73y796B4EoeXZtvkq8jbQPPQXeYkLPLS2BBbxZp7o=
 github.com/xanzy/go-gitlab v0.83.0 h1:37p0MpTPNbsTMKX/JnmJtY8Ch1sFiJzVF342+RvZEGw=
 github.com/xanzy/go-gitlab v0.83.0/go.mod h1:5ryv+MnpZStBH8I/77HuQBsMbBGANtVpLWC15qOjWAw=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=

--- a/pkg/cli/plugin_cmd.go
+++ b/pkg/cli/plugin_cmd.go
@@ -14,6 +14,7 @@ import (
 
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/plugin"
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
 )
@@ -35,19 +36,49 @@ func alternateRemapLocation(p *PluginInfo, remapLocation string) string {
 	return ""
 }
 
+func hierarchyFromPath(cmdPath string) []string {
+	return strings.Fields(cmdPath)
+}
+
+func pathFromHierarchy(hierarchy []string) string {
+	return strings.Join(hierarchy, " ")
+}
+
 // GetCommandMapForPlugin returns how the plugin's commands should be mapped
 func GetCommandMapForPlugin(p *PluginInfo) map[string]*cobra.Command {
 	cmdMap := map[string]*cobra.Command{}
 
-	for _, invokedAsItem := range p.InvokedAs {
-		remapLocation := strings.TrimSpace(invokedAsItem)
-		cmdHierarchy := strings.Split(remapLocation, " ")
+	for i := range p.CommandMap {
+		mapEntry := p.CommandMap[i]
+		cmdHierarchy := hierarchyFromPath(mapEntry.DestinationCommandPath)
 
 		if len(cmdHierarchy) > 0 {
-			cmdMap[remapLocation] = getCmdForPluginEx(p, cmdHierarchy[len(cmdHierarchy)-1])
+			dstPath := pathFromHierarchy(cmdHierarchy)
+			cmdMap[dstPath] = getCmdForPluginEx(p, cmdHierarchy[len(cmdHierarchy)-1], &mapEntry)
+			if alternateLocation := alternateRemapLocation(p, dstPath); alternateLocation != "" {
+				cmdMap[alternateLocation] = cmdMap[dstPath]
+			}
 		}
-		if alternateLocation := alternateRemapLocation(p, remapLocation); alternateLocation != "" {
-			cmdMap[alternateLocation] = cmdMap[remapLocation]
+	}
+
+	// identify commands for removal
+	for _, mapEntry := range p.CommandMap {
+		if mapEntry.Overrides != "" {
+			cmdHierarchy := hierarchyFromPath(mapEntry.Overrides)
+
+			if len(cmdHierarchy) > 0 {
+				dstPathToRemove := pathFromHierarchy(cmdHierarchy)
+
+				// represents intention to explicitly remove part(s) of the CLI command tree
+				if _, ok := cmdMap[dstPathToRemove]; !ok {
+					cmdMap[dstPathToRemove] = nil
+				}
+				if alternateLocation := alternateRemapLocation(p, dstPathToRemove); alternateLocation != "" {
+					if _, ok := cmdMap[alternateLocation]; !ok {
+						cmdMap[alternateLocation] = nil
+					}
+				}
+			}
 		}
 	}
 
@@ -56,28 +87,56 @@ func GetCommandMapForPlugin(p *PluginInfo) map[string]*cobra.Command {
 
 // GetCmdForPlugin returns a cobra command for the plugin.
 func GetCmdForPlugin(p *PluginInfo) *cobra.Command {
-	return getCmdForPluginEx(p, p.Name)
+	return getCmdForPluginEx(p, p.Name, nil)
 }
 
 // GetUnmappedCmdForPlugin returns a cobra command for the plugin unless there
 // are remapping directives in the plugin info, in which case it will return
 // nil instead.
 func GetUnmappedCmdForPlugin(p *PluginInfo) *cobra.Command {
-	if len(p.InvokedAs) > 0 {
-		return nil
+	for _, mapEntry := range p.CommandMap {
+		// this is a plugin level map
+		if mapEntry.SourceCommandPath == "" {
+			return nil
+		}
 	}
-	return getCmdForPluginEx(p, p.Name)
+	return GetCmdForPlugin(p)
 }
 
 // getCmdForPluginEx returns a cobra command for the plugin.
-func getCmdForPluginEx(p *PluginInfo, cmdGroupName string) *cobra.Command {
+func getCmdForPluginEx(p *PluginInfo, cmdName string, mapEntry *plugin.CommandMapEntry) *cobra.Command {
+	var srcHierarchy, dstHierarchy []string
+	aliases := p.Aliases
+	description := p.Description
+
+	if mapEntry != nil {
+		srcHierarchy = hierarchyFromPath(mapEntry.SourceCommandPath)
+		dstHierarchy = hierarchyFromPath(mapEntry.DestinationCommandPath)
+
+		// is not a toplevel command
+		if len(srcHierarchy) > 0 {
+			// TODO(vuil): support aliases for command-level mapped?
+			aliases = []string{}
+		}
+		if mapEntry.Description != "" {
+			description = mapEntry.Description
+		} else if len(srcHierarchy) > 0 {
+			// force a fallback to a generic description
+			description = fmt.Sprintf("%s %s functionality", p.Description, cmdName)
+		}
+	}
+
 	cmd := &cobra.Command{
-		Use:   cmdGroupName,
-		Short: p.Description,
+		Use:   cmdName,
+		Short: description,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(srcHierarchy) > 0 {
+				args = append(srcHierarchy, args...)
+			}
+
 			runner := NewRunner(p.Name, p.InstallationPath, args)
 			ctx := context.Background()
-			setupPluginEnv()
+			setupPluginEnv(srcHierarchy, dstHierarchy)
 			return runner.Run(ctx)
 		},
 		DisableFlagParsing: true,
@@ -88,7 +147,7 @@ func getCmdForPluginEx(p *PluginInfo, cmdGroupName string) *cobra.Command {
 			"pluginInstallationPath": p.InstallationPath,
 		},
 		Hidden:  p.Hidden,
-		Aliases: p.Aliases,
+		Aliases: aliases,
 	}
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -172,11 +231,21 @@ func getHelpArguments() []string {
 
 // setupPluginEnv prepares some extra environment variables
 // that communicate certain information to plugins.
-func setupPluginEnv() {
+func setupPluginEnv(srcHierarchy, dstHierarchy []string) {
 	env := make(map[string]string, 10)
 
 	// The location of the tanzu binary
 	env["TANZU_BIN"] = os.Args[0]
+
+	// Information about if command invocation is via a mapped command
+	numParts := len(dstHierarchy)
+	if numParts > 0 {
+		env["TANZU_CLI_INVOKED_COMMAND"] = dstHierarchy[numParts-1]
+		if numParts > 1 {
+			env["TANZU_CLI_INVOKED_GROUP"] = strings.Join(dstHierarchy[:numParts-1], "")
+		}
+		env["TANZU_CLI_COMMAND_MAPPED_FROM"] = pathFromHierarchy(srcHierarchy)
+	}
 
 	for key, val := range env {
 		os.Setenv(key, val)

--- a/pkg/cli/plugin_info.go
+++ b/pkg/cli/plugin_info.go
@@ -75,12 +75,17 @@ type PluginInfo struct {
 	DefaultFeatureFlags map[string]bool `json:"defaultFeatureFlags" yaml:"defaultFeatureFlags"`
 
 	// InvokedAs provides a specific mapping to how any command provided by this plugin should be invoked as.
-	// EXPERIMENTAL: subject to change prior to the next official minor release
+	// OBSOLETE: will be removed prior to the next official minor release
 	InvokedAs []string `json:"invokedAs,omitempty" yaml:"invokedAs,omitempty"`
 
 	// SupportedContextType specifies one of more ContextType that this plugin will specifically apply to.
 	// EXPERIMENTAL: subject to change prior to the next official minor release
 	SupportedContextType []configtypes.ContextType `json:"supportedContextType,omitempty" yaml:"supportedContextType,omitempty"`
+
+	// CommandMap specifies one or more CommandMapEntry's and describes how one
+	// or more parts of the plugin's command tree will be remapped in the Tanzu CLI
+	// EXPERIMENTAL: subject to change prior to the next official minor release
+	CommandMap []plugin.CommandMapEntry `json:"commandMap,omitempty" yaml:"commandMap,omitempty"`
 }
 
 // PluginInfoSorter sorts PluginInfo objects.

--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -34,6 +34,23 @@ import (
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/plugin"
 )
 
+// temporary function to still support invokedAs data by converting them to
+// CommandMapEntry's. Will remove its use before the next minor update, at
+// which point we will no longer recognized mapping information via invokedAs
+func convertInvokedAs(plugins []cli.PluginInfo) {
+	for i := range plugins {
+		for _, invokedAsPath := range (plugins)[i].InvokedAs {
+			for _, mapEntry := range (plugins)[i].CommandMap {
+				if mapEntry.DestinationCommandPath == invokedAsPath {
+					continue
+				}
+			}
+
+			(plugins)[i].CommandMap = append((plugins)[i].CommandMap, plugin.CommandMapEntry{DestinationCommandPath: invokedAsPath})
+		}
+	}
+}
+
 // NewRootCmd creates a root command.
 func NewRootCmd() (*cobra.Command, error) { //nolint: gocyclo,funlen
 	var rootCmd = newRootCmd()
@@ -72,10 +89,13 @@ func NewRootCmd() (*cobra.Command, error) { //nolint: gocyclo,funlen
 	if err != nil {
 		return nil, err
 	}
+
 	plugins, err := pluginsupplier.FilterPluginsByActiveContextType(allPlugins)
 	if err != nil {
 		return nil, err
 	}
+
+	convertInvokedAs(plugins)
 
 	telemetry.Client().SetInstalledPlugins(plugins)
 	if err = config.CopyLegacyConfigDir(); err != nil {
@@ -161,7 +181,9 @@ func remapCommandTree(rootCmd *cobra.Command, plugins []cli.PluginInfo) {
 		} else {
 			if parentCmd != nil {
 				parentCmd.RemoveCommand(matchedCmd)
-				parentCmd.AddCommand(cmd)
+				if cmd != nil {
+					parentCmd.AddCommand(cmd)
+				}
 			}
 		}
 	}
@@ -176,7 +198,9 @@ func buildReplacementMap(plugins []cli.PluginInfo) map[string]*cobra.Command {
 		for pathKey, newCmd := range cmdMap {
 			if _, ok := result[pathKey]; ok {
 				// Remapping a remapped command is unexpected! Note it and skip the attempt.
-				maskedRemappedPlugins = append(maskedRemappedPlugins, newCmd.Name())
+				if newCmd != nil {
+					maskedRemappedPlugins = append(maskedRemappedPlugins, newCmd.Name())
+				}
 			} else {
 				result[pathKey] = newCmd
 			}
@@ -218,6 +242,8 @@ func setupTargetPlugins() error {
 	if err != nil {
 		return err
 	}
+
+	convertInvokedAs(plugins)
 
 	// Insert the plugin commands under the appropriate target command
 	for i := range plugins {

--- a/pkg/command/root_test.go
+++ b/pkg/command/root_test.go
@@ -49,12 +49,14 @@ say() { shift && echo $@; }
 shout() { shift && echo $@ "!!"; }
 post-install() { exit %d; }
 bad() { echo "bad command failed"; exit 1; }
+show-invoke-context() { echo "args = ($@), context is (${TANZU_CLI_INVOKED_GROUP}):(${TANZU_CLI_INVOKED_COMMAND}):(${TANZU_CLI_COMMAND_MAPPED_FROM})"; exit 0; }
 
 case "$1" in
     info)  $1 "$@";;
     say)   $1 "$@";;
     shout) $1 "$@";;
     bad)   $1 "$@";;
+    show-invoke-context) $1 "$@";;
     post-install)  $1 "$@";;
     *) cat << EOF
 %s functionality
@@ -66,6 +68,7 @@ Available Commands:
   say     Say a phrase
   shout   Shout a phrase
   bad     (non-working)
+  show-invoke-context Shows invocation details
 EOF
        exit 0
        ;;
@@ -912,6 +915,7 @@ type fakePluginRemapAttributes struct {
 	supportedContextType []configtypes.ContextType
 	invokedAs            []string
 	aliases              []string
+	commandMap           []plugin.CommandMapEntry
 }
 
 func setupFakePluginInfo(p fakePluginRemapAttributes, pluginDir string) *cli.PluginInfo {
@@ -935,6 +939,7 @@ func setupFakePluginInfo(p fakePluginRemapAttributes, pluginDir string) *cli.Plu
 		Target:               p.target,
 		InvokedAs:            []string{},
 		SupportedContextType: []configtypes.ContextType{},
+		CommandMap:           p.commandMap,
 	}
 
 	if len(p.invokedAs) != 0 {
@@ -949,8 +954,8 @@ func setupFakePluginInfo(p fakePluginRemapAttributes, pluginDir string) *cli.Plu
 	return pi
 }
 
-// Tests behavior of command tree with plugins remapped (at a plugin level)
-func TestPluginLevelRemapping(t *testing.T) {
+// Tests behavior of command tree with commands remapped at plugin and command level
+func TestCommandRemapping(t *testing.T) {
 	tests := []struct {
 		test              string
 		pluginVariants    []fakePluginRemapAttributes
@@ -1170,33 +1175,6 @@ func TestPluginLevelRemapping(t *testing.T) {
 			expected: []string{"No plugins are currently installed for the \"mission-control\" target"},
 		},
 		{
-			test: "with supportedContextType and no invokedAs, command is hidden at target when no active context",
-			pluginVariants: []fakePluginRemapAttributes{
-				{
-					name:                 "dummy2",
-					target:               configtypes.TargetTMC,
-					supportedContextType: []configtypes.ContextType{configtypes.ContextTypeTMC},
-					aliases:              []string{"dum"},
-				},
-			},
-			args:     []string{"mission-control"},
-			expected: []string{"No plugins are currently installed for the \"mission-control\" target"},
-		},
-		{
-			test: "with supportedContextType set, target not shown at top level when no active context",
-			pluginVariants: []fakePluginRemapAttributes{
-				{
-					name:                 "dummy2",
-					target:               configtypes.TargetTMC,
-					supportedContextType: []configtypes.ContextType{configtypes.ContextTypeTMC},
-					aliases:              []string{"dum"},
-				},
-			},
-			activeContextType: configtypes.ContextTypeTanzu,
-			args:              []string{},
-			unexpected:        []string{"mission-control"},
-		},
-		{
 			test: "mapping plugins when conditional on active contexts",
 			pluginVariants: []fakePluginRemapAttributes{
 				{
@@ -1255,6 +1233,530 @@ func TestPluginLevelRemapping(t *testing.T) {
 			args:     []string{"kubernetes", "dummy", "deeper", "say", "hello"},
 			expected: []string{"Remap of plugin into command tree (dummy) associated with another plugin is not supported"},
 		},
+		// ---------- test mapping with CommandMapEntry directives
+		{
+			test: "one mapped k8s plugin",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:   "dummy2",
+					target: configtypes.TargetK8s,
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "dummy",
+						},
+					},
+				},
+			},
+			args:     []string{"dummy", "say", "hello"},
+			expected: []string{"hello"},
+		},
+		{
+			test: "once mapped, command using original plugin name is not accessible",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:   "dummy2",
+					target: configtypes.TargetK8s,
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "dummy",
+						},
+					},
+				},
+			},
+			args:            []string{"dummy2"},
+			expectedFailure: true,
+		},
+		{
+			test: "two plugins share aliases shows duplicate warning",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:    "dummy",
+					target:  configtypes.TargetK8s,
+					aliases: []string{"dum"},
+				},
+				{
+					name:    "dummy2",
+					target:  configtypes.TargetK8s,
+					aliases: []string{"dum"},
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "dummy3",
+						},
+					},
+				},
+			},
+			args:     []string{"dummy3", "say", "hello"},
+			expected: []string{"hello", "the alias dum is duplicated across plugins: dummy, dummy3"},
+		},
+		{
+			test: "plugin replaces another if former maps to an alias of the latter",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:    "bars",
+					target:  configtypes.TargetK8s,
+					aliases: []string{"bar"},
+				},
+				{
+					name:   "bar2",
+					target: configtypes.TargetK8s,
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "bar",
+						},
+					},
+				},
+			},
+			args:       []string{""},
+			expected:   []string{"bar2 commands"},
+			unexpected: []string{"bars commands"},
+		},
+		{
+			test: "two plugins sharing aliases does not show duplicate warning if one replaces another",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:    "dummy",
+					target:  configtypes.TargetK8s,
+					aliases: []string{"dum"},
+				},
+				{
+					name:    "dummy2",
+					target:  configtypes.TargetK8s,
+					aliases: []string{"dum"},
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "dummy",
+						},
+					},
+				},
+			},
+			args:       []string{"dummy", "say", "hello"},
+			expected:   []string{"hello"},
+			unexpected: []string{"duplicated across plugins"},
+		},
+		{
+			test: "two plugins sharing aliases does not show duplicate warning if one is explicitly removed",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:    "dummy",
+					target:  configtypes.TargetK8s,
+					aliases: []string{"dum"},
+				},
+				{
+					name:    "dummy2",
+					target:  configtypes.TargetK8s,
+					aliases: []string{"dum"},
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "dummy3",
+							Overrides:              "dummy",
+						},
+					},
+				},
+			},
+			args:       []string{"dummy3", "say", "hello"},
+			expected:   []string{"hello"},
+			unexpected: []string{"duplicated across plugins"},
+		},
+		{
+			test: "create deeper subcommand via mapping is valid as long as parent exists",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:   "dummy2",
+					target: configtypes.TargetK8s,
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "dummy",
+						},
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "operations dummy",
+						},
+					},
+				},
+			},
+			args:     []string{"operations", "dummy", "say", "hello"},
+			expected: []string{"hello"},
+		},
+		{
+			test: "k8s-target plugins also maps to kubernetes command group",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:   "dummy2",
+					target: configtypes.TargetK8s,
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "dummy",
+						},
+					},
+				},
+			},
+			args:     []string{"kubernetes", "dummy", "say", "hello"},
+			expected: []string{"hello"},
+		},
+		{
+			test: "k8s-target plugins remapping in kubernetes command group also remap top-level command group",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:   "dummy2",
+					target: configtypes.TargetK8s,
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "kubernetes dummy",
+						},
+					},
+				},
+			},
+			args:     []string{"dummy", "say", "hello"},
+			expected: []string{"hello"},
+		},
+		{
+			test: "map to deeper subcommand is invalid if parent missing",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:   "dummy2",
+					target: configtypes.TargetK8s,
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "nonexistentprefix dummy",
+						},
+					},
+				},
+			},
+			args:            []string{"nonexistentprefix", "dummy"},
+			expectedFailure: true,
+		},
+		{
+			test: "one mapped tmc plugin",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:   "dummy2",
+					target: configtypes.TargetTMC,
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "mission-control dummy",
+						},
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "dummy",
+						},
+					},
+				},
+			},
+			args:     []string{"mission-control", "dummy", "say", "hello"},
+			expected: []string{"hello"},
+		},
+		{
+			test: "two plugins remapped to same location will warn",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:    "dummy2",
+					target:  configtypes.TargetK8s,
+					aliases: []string{"dum"},
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "dummy",
+						},
+					},
+				},
+				{
+					name:    "dummy3",
+					target:  configtypes.TargetK8s,
+					aliases: []string{"dum"},
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "dummy",
+						},
+					},
+				},
+			},
+			args:     []string{"dummy", "say", "hello"},
+			expected: []string{"hello", "Warning, multiple command groups are being remapped to the same command names : \"dummy, dummy\""},
+		},
+		{
+			test: "mapped plugin with supportedContextType, command is hidden at target when no active context",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:                 "dummy2",
+					target:               configtypes.TargetK8s,
+					aliases:              []string{"dum"},
+					supportedContextType: []configtypes.ContextType{configtypes.ContextTypeTanzu},
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "dummy",
+						},
+					},
+				},
+			},
+			args:     []string{"kubernetes"},
+			expected: []string{"No plugins are currently installed for the \"kubernetes\" target"},
+		},
+		{
+			test: "mapped plugin is only one for target, top level should show target",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:    "dummy2",
+					target:  configtypes.TargetK8s,
+					aliases: []string{"dum"},
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "dummy",
+						},
+					},
+				},
+			},
+			args:     []string{""},
+			expected: []string{"kubernetes"},
+		},
+		{
+			test: "mapped plugin is only one for target with no active context for type hides target",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:    "dummy2",
+					target:  configtypes.TargetTMC,
+					aliases: []string{"dum"},
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "dummy",
+						},
+					},
+				},
+			},
+			args:     []string{"mission-control"},
+			expected: []string{"No plugins are currently installed for the \"mission-control\" target"},
+		},
+		{
+			test: "with supportedContextType and no invokedAs, command is hidden at target when no active context",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:                 "dummy2",
+					target:               configtypes.TargetTMC,
+					supportedContextType: []configtypes.ContextType{configtypes.ContextTypeTMC},
+					aliases:              []string{"dum"},
+				},
+			},
+			args:     []string{"mission-control"},
+			expected: []string{"No plugins are currently installed for the \"mission-control\" target"},
+		},
+		{
+			test: "with supportedContextType set, target not shown at top level when no active context",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:                 "dummy2",
+					target:               configtypes.TargetTMC,
+					supportedContextType: []configtypes.ContextType{configtypes.ContextTypeTMC},
+					aliases:              []string{"dum"},
+				},
+			},
+			activeContextType: configtypes.ContextTypeTanzu,
+			args:              []string{},
+			unexpected:        []string{"mission-control"},
+		},
+		{
+			test: "mapping plugins when conditional on active contexts",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:    "dummy",
+					target:  configtypes.TargetK8s,
+					aliases: []string{"dum"},
+				},
+				{
+					name:                 "dummy2",
+					target:               configtypes.TargetK8s,
+					aliases:              []string{"dum"},
+					supportedContextType: []configtypes.ContextType{configtypes.ContextTypeTanzu},
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "dummy",
+						},
+					},
+				},
+			},
+			activeContextType: configtypes.ContextTypeTanzu,
+			args:              []string{},
+			expected:          []string{"dummy2 commands"},
+			unexpected:        []string{"dummy commands"},
+		},
+		{
+			test: "no mapping if active context not one of supportContextType list",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:    "dummy",
+					target:  configtypes.TargetK8s,
+					aliases: []string{"dum"},
+				},
+				{
+					name:                 "dummy2",
+					target:               configtypes.TargetK8s,
+					aliases:              []string{"dum"},
+					supportedContextType: []configtypes.ContextType{configtypes.ContextTypeTanzu},
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "dummy",
+						},
+					},
+				},
+			},
+			activeContextType: configtypes.ContextTypeK8s,
+			args:              []string{},
+			expected:          []string{"dummy commands"},
+			unexpected:        []string{"dummy2 commands"},
+		},
+		{
+			test: "nesting plugin within another plugin is not supported",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:    "dummy",
+					target:  configtypes.TargetK8s,
+					aliases: []string{"dum"},
+				},
+				{
+					name:   "deeper",
+					target: configtypes.TargetK8s,
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "kubernetes dummy deeper",
+						},
+					},
+				},
+			},
+			args:     []string{"kubernetes", "dummy", "deeper", "say", "hello"},
+			expected: []string{"Remap of plugin into command tree (dummy) associated with another plugin is not supported"},
+		},
+		// --- Command level mapping tests
+		{
+			test: "command-level: plugin command is mapped to top level appears at top level",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:   "dummy",
+					target: configtypes.TargetK8s,
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "topshout",
+							SourceCommandPath:      "shout",
+							Description:            "extracted shout command",
+						},
+					},
+				},
+			},
+			args:     []string{},
+			expected: []string{"topshout", "extracted shout command"},
+		},
+		{
+			test: "command-level: plugin command mapped to top level fails when not invoked with destination command name",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:   "dummy",
+					target: configtypes.TargetK8s,
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "topshout",
+							SourceCommandPath:      "shout",
+							Description:            "extracted shout command",
+						},
+					},
+				},
+			},
+			args:            []string{"shout", "hello"},
+			expectedFailure: true,
+		},
+		{
+			test: "command-level: plugin command is mapped to top level fails when not using destination command",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:   "dummy",
+					target: configtypes.TargetK8s,
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "topshout",
+							SourceCommandPath:      "shout",
+							Description:            "extracted shout command",
+						},
+					},
+				},
+			},
+			args:     []string{"topshout", "hello"},
+			expected: []string{"hello !!"},
+		},
+		{
+			test: "command-level: invocation details available when plugin command is mapped to xxtop level",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:   "dummy",
+					target: configtypes.TargetK8s,
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "invoke-info",
+							SourceCommandPath:      "show-invoke-context",
+							Description:            "Shows invocation details",
+						},
+					},
+				},
+			},
+			args:     []string{"invoke-info", "arg1", "arg2"},
+			expected: []string{"args = (show-invoke-context arg1 arg2), context is ():(invoke-info):(show-invoke-context)"},
+		},
+		{
+			test: "command-level: invocation details available when plugin command is mapped to deeper level",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:   "dummy",
+					target: configtypes.TargetK8s,
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "operations invoke-info",
+							SourceCommandPath:      "show-invoke-context",
+							Description:            "Shows invocation details",
+						},
+					},
+				},
+			},
+			args:     []string{"operations", "invoke-info", "arg1", "arg2"},
+			expected: []string{"args = (show-invoke-context arg1 arg2), context is (operations):(invoke-info):(show-invoke-context)"},
+		},
+		{
+			test: "command-level: subcommand replaces another top-level command group",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:    "dummy",
+					target:  configtypes.TargetK8s,
+					aliases: []string{"dum"},
+				},
+				{
+					name:   "dummy2",
+					target: configtypes.TargetK8s,
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "dummy",
+							SourceCommandPath:      "show-invoke-context",
+							Description:            "Shows invocation details",
+						},
+					},
+				},
+			},
+			args:     []string{"dummy", "arg1", "arg2"},
+			expected: []string{"args = (show-invoke-context arg1 arg2), context is ():(dummy):(show-invoke-context)"},
+		},
+		{
+			test: "command-level: subcommand replaces another subcommand of another plugin group is not allowed",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:    "dummy",
+					target:  configtypes.TargetK8s,
+					aliases: []string{"dum"},
+				},
+				{
+					name:   "dummy2",
+					target: configtypes.TargetK8s,
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "dummy say",
+							SourceCommandPath:      "show-invoke-context",
+							Description:            "Shows invocation details",
+						},
+					},
+				},
+			},
+			args:     []string{"dummy", "arg1", "arg2"},
+			expected: []string{"Remap of plugin into command tree (dummy) associated with another plugin is not supported"},
+		},
 	}
 
 	for _, spec := range tests {
@@ -1303,6 +1805,9 @@ func TestPluginLevelRemapping(t *testing.T) {
 			assert.Nil(err)
 			rootCmd.SetArgs(spec.args)
 
+			os.Unsetenv("TANZU_CLI_INVOKED_GROUP")
+			os.Unsetenv("TANZU_CLI_INVOKED_COMMAND")
+			os.Unsetenv("TANZU_CLI_COMMAND_MAPPED_FROM")
 			err = rootCmd.Execute()
 
 			w.Close()


### PR DESCRIPTION
### What this PR does / why we need it
```
    Add support for command-level remapping

    This is done via processing any CommandMapEntry's specified the plugin's
    'info' output

    The CommandMapEntry enables mapping of the plugin's root command or one
    of its sub-command to another location in the CLI's command tree.

    Also: enables the override of an existing plugin with the
    Overrides field of the CommandMapEntry. It is uncommon for this to be
    needed; it is useful when deploying a plugin that needs to explicitly
    remove certain commands from the CLI even though the plugin itself does
    not provide commands of the same names.

    For any command created via the commandMap, details about the invocation
    of said command be communicated to the plugin binary via the following
    environment variables:

    - TANZU_CLI_INVOKED_GROUP:  a space-delimited portion of the Tanzu CLI
    command invocation between the CLI binary and the command name itself.
    Empty when invoking a top-level command. e.g. "tanzu apply"

    - TANZU_CLI_INVOKED_COMMAND: the name of the command in a Tanzu CLI
    command invocation

    - TANZU_CLI_COMMAND_MAPPED_FROM: a space-delimited path relative to the
    plugin's root command of the command being invoked. The value is empty
    unless the CLI command invoked is mapped to a non-root command of the plugin.

    Note: The complete CLI command invocation can thus be reconstructed with
    tanzu_cli_binary_name "$TANZU_CLI_INVOKED_GROUP" "$TANZU_CLI_INVOKED_COMMAND" args*

    Plugins employing any form of command mapping are expected to make use
    of these values to adjust any command invocation references in their
    commands' outputs (e.g. help, examples)
```

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

See unit tests added. 

In addition, built and installed a sample plugin modified with additional command and command map.

#### Baseline

Use a sample plugin with some trivial commands in this branch as baseline:
https://github.com/vuil/tanzu-cli/blob/sample-plugin-with-remap/test/sample-plugin/cmd/plugin/sample-plugin/main.go

Running CLI when sample plugin is installed:

```
~> tz
Usage:
  tanzu [command]

Available command groups:

  Admin
    builder                 Build Tanzu components
    test                    Test the CLI
  Build
    apps                    Applications on Kubernetes
    space                   Tanzu space, space profile, and space trait management
    supplychain             supplychain management
  Manage
    project                 View, list and use Tanzu Projects.
    sample                  sample plugin to test e2e framework
...
  Target
    kubernetes              Commands that interact with a Kubernetes endpoint
    mission-control         Commands that provide functionality for Tanzu Mission Control
    operations              Commands that support Kubernetes operations for Tanzu Application Platform

Flags:
  -h, --help   help for tanzu

Use "tanzu [command] --help" for more information about a command.

~> tz sample deeper
deeper commands

Usage:
  tanzu sample deeper [command]

Aliases:
  deeper, deep

Available Commands:
  yell        yell something

Flags:
  -h, --help   help for deeper

Use "tanzu sample deeper [command] --help" for more information about a command.

~> tz sample deeper yell hello
hello weeeee!!!!!

~> tz sample shout hey
hey!!
Invocation Context:
(*plugin.InvocationContext)(nil)


~> tz sample echo foo
foo
```

#### Test behavior of CLI by reinstalling above plugin built with the following command maping customizations:

##### 1. elevate command

```
--- a/test/sample-plugin/cmd/plugin/sample-plugin/main.go
+++ b/test/sample-plugin/cmd/plugin/sample-plugin/main.go
@@ -24,3 +24,9 @@ var descriptor = plugin.PluginDescriptor{
        Group:       plugin.ManageCmdGroup,
-       CommandMap:  []plugin.CommandMapEntry{},
+       CommandMap: []plugin.CommandMapEntry{
+               plugin.CommandMapEntry{
+                       SourceCommandPath:      "echo",
+                       DestinationCommandPath: "echo",
+                       Description:            "the echo command elevated to the top level",
+               },
+       },
 }
@@ -47,3 +53,3 @@ func newEchoCmd() *cobra.Command {
                Args:   cobra.ExactArgs(1),
-               Hidden: false,
+               Hidden: true,
                RunE: func(cmd *cobra.Command, args []string) error {
~
~> tz
Usage:
  tanzu [command]

Available command groups:

  Admin
    builder                 Build Tanzu components
    test                    Test the CLI
  Build
    apps                    Applications on Kubernetes
    space                   Tanzu space, space profile, and space trait management
    supplychain             supplychain management
  Manage
    echo                    the echo command elevated to the top level
    project                 View, list and use Tanzu Projects.
    sample                  sample plugin to test e2e framework
  Run
...

Flags:
  -h, --help   help for tanzu

Use "tanzu [command] --help" for more information about a command.
~> tz echo foo
foo
~> tz echo --help
echo something

Usage:
  tanzu echo

Flags:
  -h, --help   help for echo
~> tz sample
sample plugin to test e2e framework

Usage:
  tanzu sample [command]

Available Commands:
  deeper        deeper commands
  shout         shout something

Flags:
  -h, --help   help for sample

Use "tanzu sample [command] --help" for more information about a command.
-----------
```

##### 2.plugin level mapping to second level of CLI command tree

```
+       CommandMap: []plugin.CommandMapEntry{
+               plugin.CommandMapEntry{
+                       SourceCommandPath:      "echo",
+                       DestinationCommandPath: "echo",
+                       Description:            "the echo command elevated to the top level",
+               },
+               plugin.CommandMapEntry{
+                       SourceCommandPath:      "",
+                       DestinationCommandPath: "operations sample",
+               },
+       },
 }
@@ -47,3 +57,3 @@ func newEchoCmd() *cobra.Command {
                Args:   cobra.ExactArgs(1),
-               Hidden: false,
+               Hidden: true,
                RunE: func(cmd *cobra.Command, args []string) error {
@@ -63,3 +73,4 @@ func newShoutCmd() *cobra.Command {
                RunE: func(cmd *cobra.Command, args []string) error {
-                       fmt.Printf("%s!!\n", args[0])
+                       ic := plugin.GetInvocationContext()
+                       fmt.Printf("%s!!\nInvocation Context:\n% #v\n", args[0], ic)
                        return nil
~
~> tz sample
[x] : unknown command "sample" for "tanzu"
~> tz operations
Commands that support Kubernetes operations for Tanzu Application Platform

Usage:
  tanzu operations [command]

Aliases:
  operations, ops

Available command groups:

  Manage
    clustergroup            A group of Kubernetes clusters
    sample                  sample plugin to test e2e framework

Flags:
  -h, --help   help for operations

Use "tanzu operations [command] --help" for more information about a command.

~> tz operations sample
sample plugin to test e2e framework

Usage:
  tanzu operations sample [command]

Available Commands:
  deeper        deeper commands
  shout         shout something

Flags:
  -h, --help   help for sample

Use "tanzu operations sample [command] --help" for more information about a command.

~> tz operations sample shout --help
shout something

Usage:
  tanzu operations sample shout MESSAGE [flags]

Flags:
  -h, --help   help for shout
  
~> tz echo "the echo command still works"
the echo command still works

~> tz operations sample shout hey
hey!!
Invocation Context:
&plugin.InvocationContext{invokedGroup:"operations", invokedCommand:"sample", sourceCommandPath:""}
```

##### 3. Lone command elevated
```
~/tanzu-cli-cln2/test/sample-plugin ~
diff --git a/test/sample-plugin/cmd/plugin/sample-plugin/main.go b/test/sample-plugin/cmd/plugin/sample-plugin/main.go
index b3b6dc15..51245c21 100644
--- a/test/sample-plugin/cmd/plugin/sample-plugin/main.go
+++ b/test/sample-plugin/cmd/plugin/sample-plugin/main.go
@@ -24,3 +24,12 @@ var descriptor = plugin.PluginDescriptor{
        Group:       plugin.ManageCmdGroup,
-       CommandMap:  []plugin.CommandMapEntry{},
+       CommandMap: []plugin.CommandMapEntry{
+               plugin.CommandMapEntry{
+                       SourceCommandPath:      "",
+                       DestinationCommandPath: "",
+               },
+               plugin.CommandMapEntry{
+                       SourceCommandPath:      "shout",
+                       DestinationCommandPath: "shout",
+               },
+       },
 }
@@ -33,5 +42,5 @@ func main() {
        p.AddCommands(
-               newEchoCmd(),
+               //newEchoCmd(),
                newShoutCmd(),
-               newDeeperCmd(),
+               //newDeeperCmd(),
        )
@@ -61,3 +70,3 @@ func newShoutCmd() *cobra.Command {
                Args:   cobra.ExactArgs(1),
-               Hidden: false,
+               Hidden: true,
                RunE: func(cmd *cobra.Command, args []string) error {
~
~> tz
Usage:
  tanzu [command]

Available command groups:

  Admin
    builder                 Build Tanzu components
    test                    Test the CLI
  Build
    apps                    Applications on Kubernetes
    space                   Tanzu space, space profile, and space trait management
    supplychain             supplychain management
  Manage
    project                 View, list and use Tanzu Projects.
    shout                   sample plugin to test command mapping shout functionality
  Run
    telemetry               configure cluster-wide settings for vmware tanzu telemetry
  System
    completion              Output shell completion code
    config                  Configuration for the CLI
    context                 Configure and manage contexts for the Tanzu CLI
    init                    Initialize the CLI
    login                   Login to Tanzu Application Platform
    plugin                  Manage CLI plugins
    version                 Version information
  Target
    kubernetes              Commands that interact with a Kubernetes endpoint
    mission-control         Commands that provide functionality for Tanzu Mission Control
    operations              Commands that support Kubernetes operations for Tanzu Application Platform

Flags:
  -h, --help   help for tanzu

Use "tanzu [command] --help" for more information about a command.
~> tz shout hey
hey!!
Invocation Context:
&plugin.InvocationContext{invokedGroup:"", invokedCommand:"shout", sourceCommandPath:"shout"}
~> tz sample
[x] : unknown command "sample" for "tanzu"
```

##### 4. Plugin level remap with overrides

```
diff --git a/test/sample-plugin/cmd/plugin/sample-plugin/main.go b/test/sample-plugin/cmd/plugin/sample-plugin/main.go
index b3b6dc15..cf47702e 100644
--- a/test/sample-plugin/cmd/plugin/sample-plugin/main.go
+++ b/test/sample-plugin/cmd/plugin/sample-plugin/main.go
@@ -24,3 +24,9 @@ var descriptor = plugin.PluginDescriptor{
        Group:       plugin.ManageCmdGroup,
-       CommandMap:  []plugin.CommandMapEntry{},
+       CommandMap: []plugin.CommandMapEntry{
+               plugin.CommandMapEntry{
+                       SourceCommandPath:      "",
+                       DestinationCommandPath: "sound",
+                       Overrides:              "mission-control clustergroup",
+               },
+       },
 }
~
~> tz mission-control
Commands that provide functionality for Tanzu Mission Control

Usage:
  tanzu mission-control [command]

Aliases:
  mission-control, tmc

Available command groups:

  Manage
    policy                  Policy management for resources

Flags:
  -h, --help   help for mission-control

Use "tanzu mission-control [command] --help" for more information about a command.
~> tz sound shout hey
hey!!
Invocation Context:
&plugin.InvocationContext{invokedGroup:"", invokedCommand:"sound", sourceCommandPath:""}
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add support for mapping of a plugin at a command-level
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

Testing with a plugin with mapping configuration such as the sample plugin requires that the built plugin be installed using a Tanzu CLI updated with the new plugin-runtime updates (under review in https://github.com/vmware-tanzu/tanzu-plugin-runtime/pull/176)

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
