### PR TITLE
Add support for command-level remapping

### DIFF
--- a/docs/plugindev/README.md
+++ b/docs/plugindev/README.md
@@ -555,3 +555,111 @@ functionality.
 
 For more details on the deprecation policy and process please refer to the
 [Deprecation document](../dev/deprecation.md).
+
+## Plugin Descriptor and support for command remapping
+
+The output of the plugin binary's `info` command reflects what is specified by
+in the plugin's [Plugin Descriptor](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/plugin/types.go#L60)
+
+### CommandMap
+
+EXPERIMENTAL: subject to change prior to the next official minor release
+
+The descriptor now supports an additional field `commandMap` that customizes
+how plugin's commands are shown in the CLI's command tree. Most plugin authors
+should not need to provide the mapping fields.
+
+The command map specifies one or more CommandMapEntry's and describes how one
+or more parts of the plugin's command tree will be remapped in the Tanzu CLI
+
+Each CommandMapEntry has the following fields
+
+- SourceCommandPath: is a space-delimited path to the command relative to the root Command of this plugin, with the root Command's path being ""
+- DestinationCommandPath: is a space-delimited path to the command relative to the root Command of the Tanzu CLI that the command associated with SourceCommandPath should be mapped to and invocable by the user
+- Overrides: By default, the command previously situated at the DestinationCommandPath of the Tanzu CLI, if exist, will be the one overridden by this entry. If this mapping attempt in intended to override another part of the Tanzu CLI command tree, the override path should be used.
+- Description: Required when remapping a subcommand of this plugin outside of the plugin's command tree (e.g. whe elevating a plugin's subcommand to a top level command of the Tanzu CLI). This enables the CLI to provide better help information about the remapped command.
+
+Assume there is a plugin named foo with a non empty CommandMap
+
+### Rename the plugin command group for plugin
+
+```go
+        plugin.CommandMapEntry{
+            SourceCommandPath:      "",
+            DestinationCommandPath: "bar",
+        },
+```
+
+instead of every plugin command X be invocable via `tanzu foo X`, it is now
+invocable via `tanzu bar X`
+
+### Elevate subcommand to toplevel of Tanzu CLI command tree
+
+```go
+        plugin.CommandMapEntry{
+            SourceCommandPath:      "echo",
+            DestinationCommandPath: "echo",
+            Description:            "the echo command elevated to the top level",
+        },
+```
+
+instead of invoking `tanzu foo echo`, the command is now invocable via `tanzu echo`
+
+Note: if the intention is to "move" not "copy" the `tanzu foo echo` command,
+authors are advised to mark the echo Command as 'Hidden: true'
+
+### Hiding original plugin command group
+
+```go
+        plugin.CommandMapEntry{
+            SourceCommandPath:      "",
+            DestinationCommandPath: "",
+        },
+```
+
+All valid mappings requires that destination path should have a valid parent
+command in the Tanzu CLI command tree.
+As a special case, specifying both the source and destination command path as
+"" indicates that the CLI command mapping to the root command of the plugin
+will NOT be created. This could be useful when all the plugin's command have been
+elevated (see previous section) and nothing interesting should be invoked via
+`tanzu foo ...` anymore.
+
+### Reorganizing the plugin commands under a different category group for plugin
+
+```go
+        plugin.CommandMapEntry{
+            SourceCommandPath:      "",
+            DestinationCommandPath: "operations foo",
+        },
+```
+
+instead of every plugin command X be invocable via `tanzu foo X`, it is now
+invocable via `tanzu operations foo X`
+
+### SupportedContextType
+
+EXPERIMENTAL: subject to change prior to the next official minor release
+
+In some rare situations plugins might elect to conditionally activate based on
+the type of the CLI context that is currently active.
+
+SupportedContextType specifies one or more ContextType that this plugin will specifically apply to.
+When no context of matching type is active, the command tree specified by this plugin should be omitted.
+When unset, the plugin does not define any specific opinions on this aspect.
+
+Note that plugins omitted from the CLI command tree due to the
+SupportedContextType condition appears with a false value for the ACTIVE column
+in the `tanzu plugin list --wide` output.
+
+### Communicating mapped command invocation to the plugin
+
+When command mapping is involved, details about how a TANZU CLI command is invoked
+will be communicated to the plugin via environment variables.
+
+- TANZU_CLI_INVOKED_COMMAND: the name of the mapped CLI command
+- TANZU_CLI_INVOKED_GROUP: the path to the command group under which the TANZU_CLI_INVOKED_COMMAND is found
+- TANZU_CLI_COMMAND_MAPPED_FROM: the command path (relative to the plugin) that a mapped CLI command is mapped to.
+
+Plugin can retrieve the above mentioned information by accessing corresponding
+fields in the result of the GetInvocationContext() functiion.

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/vmware-tanzu/carvel-ytt v0.40.0
 	github.com/vmware-tanzu/tanzu-cli/test/e2e/framework v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686
-	github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0-dev.0.20240410164649-72cfcba566be
+	github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0-dev.0.20240419212412-88223225a6aa
 	go.pinniped.dev v0.20.0
 	golang.org/x/mod v0.12.0
 	golang.org/x/oauth2 v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -738,8 +738,8 @@ github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502eb
 github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502ebf68/go.mod h1:e1Uef+Ux5BIHpYwqbeP2ZZmOzehBcez2vUEWXHe+xHE=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686 h1:VcuXqUXFxm5WDqWkzAlU/6cJXua0ozELnqD59fy7J6E=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686/go.mod h1:AFGOXZD4tH+KhpmtV0VjWjllXhr8y57MvOsIxTtywc4=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0-dev.0.20240410164649-72cfcba566be h1:/rYyMeziawcrVaaq9W7Vogc9MdHsQRn0CcEqa8GwrOA=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0-dev.0.20240410164649-72cfcba566be/go.mod h1:5m73y796B4EoeXZtvkq8jbQPPQXeYkLPLS2BBbxZp7o=
+github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0-dev.0.20240419212412-88223225a6aa h1:iTfXc8CaDaFlKT/9UQFzkmFmgqZCI+k5ljTfR7/CB3A=
+github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0-dev.0.20240419212412-88223225a6aa/go.mod h1:5m73y796B4EoeXZtvkq8jbQPPQXeYkLPLS2BBbxZp7o=
 github.com/xanzy/go-gitlab v0.83.0 h1:37p0MpTPNbsTMKX/JnmJtY8Ch1sFiJzVF342+RvZEGw=
 github.com/xanzy/go-gitlab v0.83.0/go.mod h1:5ryv+MnpZStBH8I/77HuQBsMbBGANtVpLWC15qOjWAw=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=

--- a/pkg/cli/plugin_cmd.go
+++ b/pkg/cli/plugin_cmd.go
@@ -115,8 +115,7 @@ func getCmdForPluginEx(p *PluginInfo, cmdName string, mapEntry *plugin.CommandMa
 
 		// is not a toplevel command
 		if len(srcHierarchy) > 0 {
-			// TODO(vuil): support aliases for command-level mapped?
-			aliases = []string{}
+			aliases = mapEntry.Aliases
 		}
 		if mapEntry.Description != "" {
 			description = mapEntry.Description

--- a/pkg/cli/plugin_info.go
+++ b/pkg/cli/plugin_info.go
@@ -75,12 +75,17 @@ type PluginInfo struct {
 	DefaultFeatureFlags map[string]bool `json:"defaultFeatureFlags" yaml:"defaultFeatureFlags"`
 
 	// InvokedAs provides a specific mapping to how any command provided by this plugin should be invoked as.
-	// EXPERIMENTAL: subject to change prior to the next official minor release
+	// OBSOLETE: will be removed prior to the next official minor release
 	InvokedAs []string `json:"invokedAs,omitempty" yaml:"invokedAs,omitempty"`
 
 	// SupportedContextType specifies one of more ContextType that this plugin will specifically apply to.
 	// EXPERIMENTAL: subject to change prior to the next official minor release
 	SupportedContextType []configtypes.ContextType `json:"supportedContextType,omitempty" yaml:"supportedContextType,omitempty"`
+
+	// CommandMap specifies one or more CommandMapEntry's and describes how one
+	// or more parts of the plugin's command tree will be remapped in the Tanzu CLI
+	// EXPERIMENTAL: subject to change prior to the next official minor release
+	CommandMap []plugin.CommandMapEntry `json:"commandMap,omitempty" yaml:"commandMap,omitempty"`
 }
 
 // PluginInfoSorter sorts PluginInfo objects.

--- a/pkg/command/root_test.go
+++ b/pkg/command/root_test.go
@@ -1855,6 +1855,30 @@ func TestCommandRemapping(t *testing.T) {
 			args:     []string{"dummy", "arg1", "arg2"},
 			expected: []string{"Remap of plugin into command tree (dummy) associated with another plugin is not supported"},
 		},
+		{
+			test: "command-level: subcommand map entry's aliases are used",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:    "dummy",
+					target:  configtypes.TargetK8s,
+					aliases: []string{"dum"},
+				},
+				{
+					name:   "dummy2",
+					target: configtypes.TargetK8s,
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "dummy",
+							SourceCommandPath:      "show-invoke-context",
+							Description:            "Shows invocation details",
+							Aliases:                []string{"sic"},
+						},
+					},
+				},
+			},
+			args:     []string{"sic", "arg1", "arg2"},
+			expected: []string{"args = (show-invoke-context arg1 arg2), context is ():(dummy):(show-invoke-context)"},
+		},
 	}
 
 	for _, spec := range tests {


### PR DESCRIPTION
### What this PR does / why we need it
```
    Add support for command-level remapping

    This is done via processing any CommandMapEntry's specified the plugin's
    'info' output

    The CommandMapEntry enables mapping of the plugin's root command or one
    of its sub-command to another location in the CLI's command tree.

    Also: enables the override of an existing plugin with the
    Overrides field of the CommandMapEntry. It is uncommon for this to be
    needed; it is useful when deploying a plugin that needs to explicitly
    remove certain commands from the CLI even though the plugin itself does
    not provide commands of the same names.

    For any command created via the commandMap, details about the invocation
    of said command will be communicated to the plugin binary via the following
    environment variables:

    - TANZU_CLI_INVOKED_GROUP:  a space-delimited portion of the Tanzu CLI
    command invocation between the CLI binary and the command name itself.
    Empty when invoking a top-level command. e.g. "tanzu apply"

    - TANZU_CLI_INVOKED_COMMAND: the name of the command in a Tanzu CLI
    command invocation

    - TANZU_CLI_COMMAND_MAPPED_FROM: a space-delimited path relative to the
    plugin's root command of the command being invoked. The value is empty
    unless the CLI command invoked is mapped to a non-root command of the plugin.

    Note: The complete CLI command invocation can thus be reconstructed with
    tanzu_cli_binary_name "$TANZU_CLI_INVOKED_GROUP" "$TANZU_CLI_INVOKED_COMMAND" args*

    Plugins employing any form of command mapping are expected to make use
    of these values to adjust any command invocation references in their
    commands' outputs (e.g. help, examples)
```

Notes to documenters:
Much of the information in this PR and additional Markdown changes are relevant for plugin developers, and should have little relevance to user-facing documentation. 

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

See unit tests added. 

In addition, built and installed a sample plugin modified with additional command and command map.

#### Baseline

Use a sample plugin with some trivial commands in this branch as baseline:
https://github.com/vuil/tanzu-cli/blob/sample-plugin-with-remap/test/sample-plugin/cmd/plugin/sample-plugin/main.go

Running CLI when sample plugin is installed:

```
~> tz
Usage:
  tanzu [command]

Available command groups:

  Admin
    builder                 Build Tanzu components
    test                    Test the CLI
  Build
    apps                    Applications on Kubernetes
    space                   Tanzu space, space profile, and space trait management
    supplychain             supplychain management
  Manage
    project                 View, list and use Tanzu Projects.
    sample                  sample plugin to test e2e framework
...
  Target
    kubernetes              Commands that interact with a Kubernetes endpoint
    mission-control         Commands that provide functionality for Tanzu Mission Control
    operations              Commands that support Kubernetes operations for Tanzu Application Platform

Flags:
  -h, --help   help for tanzu

Use "tanzu [command] --help" for more information about a command.

~> tz sample deeper
deeper commands

Usage:
  tanzu sample deeper [command]

Aliases:
  deeper, deep

Available Commands:
  yell        yell something

Flags:
  -h, --help   help for deeper

Use "tanzu sample deeper [command] --help" for more information about a command.

~> tz sample deeper yell hello
hello weeeee!!!!!

~> tz sample shout hey
hey!!
Invocation Context:
(*plugin.InvocationContext)(nil)


~> tz sample echo foo
foo
```

#### Test behavior of CLI by reinstalling above plugin built with the following command maping customizations:

##### 1. elevate command

```
--- a/test/sample-plugin/cmd/plugin/sample-plugin/main.go
+++ b/test/sample-plugin/cmd/plugin/sample-plugin/main.go
@@ -24,3 +24,9 @@ var descriptor = plugin.PluginDescriptor{
        Group:       plugin.ManageCmdGroup,
-       CommandMap:  []plugin.CommandMapEntry{},
+       CommandMap: []plugin.CommandMapEntry{
+               plugin.CommandMapEntry{
+                       SourceCommandPath:      "echo",
+                       DestinationCommandPath: "echo",
+                       Description:            "the echo command elevated to the top level",
+               },
+       },
 }
@@ -47,3 +53,3 @@ func newEchoCmd() *cobra.Command {
                Args:   cobra.ExactArgs(1),
-               Hidden: false,
+               Hidden: true,
                RunE: func(cmd *cobra.Command, args []string) error {
~
~> tz
Usage:
  tanzu [command]

Available command groups:

  Admin
    builder                 Build Tanzu components
    test                    Test the CLI
  Build
    apps                    Applications on Kubernetes
    space                   Tanzu space, space profile, and space trait management
    supplychain             supplychain management
  Manage
    echo                    the echo command elevated to the top level
    project                 View, list and use Tanzu Projects.
    sample                  sample plugin to test e2e framework
  Run
...

Flags:
  -h, --help   help for tanzu

Use "tanzu [command] --help" for more information about a command.
~> tz echo foo
foo
~> tz echo --help
echo something

Usage:
  tanzu echo

Flags:
  -h, --help   help for echo
~> tz sample
sample plugin to test e2e framework

Usage:
  tanzu sample [command]

Available Commands:
  deeper        deeper commands
  shout         shout something

Flags:
  -h, --help   help for sample

Use "tanzu sample [command] --help" for more information about a command.
-----------
```

##### 2.plugin level mapping to second level of CLI command tree

```
+       CommandMap: []plugin.CommandMapEntry{
+               plugin.CommandMapEntry{
+                       SourceCommandPath:      "echo",
+                       DestinationCommandPath: "echo",
+                       Description:            "the echo command elevated to the top level",
+               },
+               plugin.CommandMapEntry{
+                       SourceCommandPath:      "",
+                       DestinationCommandPath: "operations sample",
+               },
+       },
 }
@@ -47,3 +57,3 @@ func newEchoCmd() *cobra.Command {
                Args:   cobra.ExactArgs(1),
-               Hidden: false,
+               Hidden: true,
                RunE: func(cmd *cobra.Command, args []string) error {
@@ -63,3 +73,4 @@ func newShoutCmd() *cobra.Command {
                RunE: func(cmd *cobra.Command, args []string) error {
-                       fmt.Printf("%s!!\n", args[0])
+                       ic := plugin.GetInvocationContext()
+                       fmt.Printf("%s!!\nInvocation Context:\n% #v\n", args[0], ic)
                        return nil
~
~> tz sample
[x] : unknown command "sample" for "tanzu"
~> tz operations
Commands that support Kubernetes operations for Tanzu Application Platform

Usage:
  tanzu operations [command]

Aliases:
  operations, ops

Available command groups:

  Manage
    clustergroup            A group of Kubernetes clusters
    sample                  sample plugin to test e2e framework

Flags:
  -h, --help   help for operations

Use "tanzu operations [command] --help" for more information about a command.

~> tz operations sample
sample plugin to test e2e framework

Usage:
  tanzu operations sample [command]

Available Commands:
  deeper        deeper commands
  shout         shout something

Flags:
  -h, --help   help for sample

Use "tanzu operations sample [command] --help" for more information about a command.

~> tz operations sample shout --help
shout something

Usage:
  tanzu operations sample shout MESSAGE [flags]

Flags:
  -h, --help   help for shout
  
~> tz echo "the echo command still works"
the echo command still works

~> tz operations sample shout hey
hey!!
Invocation Context:
&plugin.InvocationContext{invokedGroup:"operations", invokedCommand:"sample", sourceCommandPath:""}
```

##### 3. Lone command elevated
```
~/tanzu-cli-cln2/test/sample-plugin ~
diff --git a/test/sample-plugin/cmd/plugin/sample-plugin/main.go b/test/sample-plugin/cmd/plugin/sample-plugin/main.go
index b3b6dc15..51245c21 100644
--- a/test/sample-plugin/cmd/plugin/sample-plugin/main.go
+++ b/test/sample-plugin/cmd/plugin/sample-plugin/main.go
@@ -24,3 +24,12 @@ var descriptor = plugin.PluginDescriptor{
        Group:       plugin.ManageCmdGroup,
-       CommandMap:  []plugin.CommandMapEntry{},
+       CommandMap: []plugin.CommandMapEntry{
+               plugin.CommandMapEntry{
+                       SourceCommandPath:      "",
+                       DestinationCommandPath: "",
+               },
+               plugin.CommandMapEntry{
+                       SourceCommandPath:      "shout",
+                       DestinationCommandPath: "shout",
+               },
+       },
 }
@@ -33,5 +42,5 @@ func main() {
        p.AddCommands(
-               newEchoCmd(),
+               //newEchoCmd(),
                newShoutCmd(),
-               newDeeperCmd(),
+               //newDeeperCmd(),
        )
@@ -61,3 +70,3 @@ func newShoutCmd() *cobra.Command {
                Args:   cobra.ExactArgs(1),
-               Hidden: false,
+               Hidden: true,
                RunE: func(cmd *cobra.Command, args []string) error {
~
~> tz
Usage:
  tanzu [command]

Available command groups:

  Admin
    builder                 Build Tanzu components
    test                    Test the CLI
  Build
    apps                    Applications on Kubernetes
    space                   Tanzu space, space profile, and space trait management
    supplychain             supplychain management
  Manage
    project                 View, list and use Tanzu Projects.
    shout                   sample plugin to test command mapping shout functionality
  Run
    telemetry               configure cluster-wide settings for vmware tanzu telemetry
  System
    completion              Output shell completion code
    config                  Configuration for the CLI
    context                 Configure and manage contexts for the Tanzu CLI
    init                    Initialize the CLI
    login                   Login to Tanzu Application Platform
    plugin                  Manage CLI plugins
    version                 Version information
  Target
    kubernetes              Commands that interact with a Kubernetes endpoint
    mission-control         Commands that provide functionality for Tanzu Mission Control
    operations              Commands that support Kubernetes operations for Tanzu Application Platform

Flags:
  -h, --help   help for tanzu

Use "tanzu [command] --help" for more information about a command.
~> tz shout hey
hey!!
Invocation Context:
&plugin.InvocationContext{invokedGroup:"", invokedCommand:"shout", sourceCommandPath:"shout"}
~> tz sample
[x] : unknown command "sample" for "tanzu"
```

##### 4. Plugin level remap with overrides

```
diff --git a/test/sample-plugin/cmd/plugin/sample-plugin/main.go b/test/sample-plugin/cmd/plugin/sample-plugin/main.go
index b3b6dc15..cf47702e 100644
--- a/test/sample-plugin/cmd/plugin/sample-plugin/main.go
+++ b/test/sample-plugin/cmd/plugin/sample-plugin/main.go
@@ -24,3 +24,9 @@ var descriptor = plugin.PluginDescriptor{
        Group:       plugin.ManageCmdGroup,
-       CommandMap:  []plugin.CommandMapEntry{},
+       CommandMap: []plugin.CommandMapEntry{
+               plugin.CommandMapEntry{
+                       SourceCommandPath:      "",
+                       DestinationCommandPath: "sound",
+                       Overrides:              "mission-control clustergroup",
+               },
+       },
 }
~
~> tz mission-control
Commands that provide functionality for Tanzu Mission Control

Usage:
  tanzu mission-control [command]

Aliases:
  mission-control, tmc

Available command groups:

  Manage
    policy                  Policy management for resources

Flags:
  -h, --help   help for mission-control

Use "tanzu mission-control [command] --help" for more information about a command.
~> tz sound shout hey
hey!!
Invocation Context:
&plugin.InvocationContext{invokedGroup:"", invokedCommand:"sound", sourceCommandPath:""}
```

##### 5. Command level aliases and autocomplete

```
--- a/test/sample-plugin/cmd/plugin/sample-plugin/main.go
+++ b/test/sample-plugin/cmd/plugin/sample-plugin/main.go
@@ -22,7 +22,12 @@ var descriptor = plugin.PluginDescriptor{
        Version:     buildinfo.Version,
        BuildSHA:    buildinfo.SHA,
        Group:       plugin.ManageCmdGroup,
-       CommandMap:  []plugin.CommandMapEntry{},
+       CommandMap: []plugin.CommandMapEntry{
+               plugin.CommandMapEntry{
+                       SourceCommandPath:      "shout",
+                       DestinationCommandPath: "shout",
+               },
+       },
 }

 func main() {
@@ -52,20 +57,27 @@ func newEchoCmd() *cobra.Command {
                },
        }
        return cmd
+
 }

 func newShoutCmd() *cobra.Command {
+       var value string
+
        cmd := &cobra.Command{
-               Use:    "shout MESSAGE",
-               Short:  "shout something",
-               Args:   cobra.ExactArgs(1),
-               Hidden: false,
+               Use:     "shout MESSAGE",
+               Short:   "shout something",
+               Aliases: []string{"sh", "sht"},
+               Args:    cobra.ExactArgs(1),
+               Hidden:  false,
                RunE: func(cmd *cobra.Command, args []string) error {
                        ic := plugin.GetInvocationContext()
-                       fmt.Printf("%s!!\nInvocation Context:\n% #v\n", args[0], ic)
+                       fmt.Printf("%s %s!!\nInvocation Context:\n% #v\n", value, args[0], ic)
                        return nil
                },
        }
+
+       cmd.Flags().StringVarP(&value, "value", "v", "", "value to add to shout")
+
        return cmd
 }
```

```
> tz sht --value "stuff"  works
stuff works!!
Invocation Context:
&plugin.InvocationContext{invokedGroup:"", invokedCommand:"shout", sourceCommandPath:"shout"}


> tz __complete shout foo --va
--value value to add to shout
:4
Completion ended with directive: ShellCompDirectiveNoFileComp
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add support for mapping of a plugin at a command-level
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

Testing with a plugin with mapping configuration such as the sample plugin requires that the built plugin be installed using a Tanzu CLI updated with the new plugin-runtime updates (under review in https://github.com/vmware-tanzu/tanzu-plugin-runtime/pull/176)

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
