### PR TITLE
Perform a catalog initialization if needed

### DIFF
--- a/pkg/command/plugin_search_test.go
+++ b/pkg/command/plugin_search_test.go
@@ -11,9 +11,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
-	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 )
 
 func TestPluginSearch(t *testing.T) {
@@ -60,10 +57,6 @@ func TestPluginSearch(t *testing.T) {
 	os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
 	os.Setenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER", "No")
 	os.Setenv("TANZU_CLI_EULA_PROMPT_ANSWER", "Yes")
-
-	featureArray := strings.Split(constants.FeatureContextCommand, ".")
-	err = config.SetFeature(featureArray[1], featureArray[2], "true")
-	assert.Nil(err)
 
 	defer func() {
 		os.Unsetenv("TANZU_CONFIG")

--- a/pkg/command/plugin_test.go
+++ b/pkg/command/plugin_test.go
@@ -17,8 +17,6 @@ import (
 	"github.com/vmware-tanzu/tanzu-cli/pkg/catalog"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
-	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
-	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/plugin"
 )
@@ -108,11 +106,6 @@ func TestPluginList(t *testing.T) {
 		os.Setenv("TEST_CUSTOM_CATALOG_CACHE_DIR", dir)
 		os.Setenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER", "No")
 		os.Setenv("TANZU_CLI_EULA_PROMPT_ANSWER", "Yes")
-
-		// Always turn on the context feature
-		featureArray := strings.Split(constants.FeatureContextCommand, ".")
-		err = config.SetFeature(featureArray[1], featureArray[2], "true")
-		assert.Nil(t, err)
 
 		var completionType uint8
 		t.Run(spec.test, func(t *testing.T) {
@@ -389,10 +382,6 @@ func TestInstallPlugin(t *testing.T) {
 	os.Setenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER", "No")
 	os.Setenv("TANZU_CLI_EULA_PROMPT_ANSWER", "Yes")
 
-	featureArray := strings.Split(constants.FeatureContextCommand, ".")
-	err = config.SetFeature(featureArray[1], featureArray[2], "true")
-	assert.Nil(err)
-
 	defer func() {
 		os.Unsetenv("TANZU_CONFIG")
 		os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
@@ -443,10 +432,6 @@ func TestUpgradePlugin(t *testing.T) {
 	os.Setenv("TANZU_CONFIG_NEXT_GEN", tkgConfigFileNG.Name())
 	os.Setenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER", "No")
 	os.Setenv("TANZU_CLI_EULA_PROMPT_ANSWER", "Yes")
-
-	featureArray := strings.Split(constants.FeatureContextCommand, ".")
-	err = config.SetFeature(featureArray[1], featureArray[2], "true")
-	assert.Nil(err)
 
 	defer func() {
 		os.Unsetenv("TANZU_CONFIG")

--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -25,6 +25,7 @@ import (
 	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/discovery"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/globalinit"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/lastversion"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/pluginmanager"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/pluginsupplier"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/recommendedversion"
@@ -297,6 +298,16 @@ func newRootCmd() *cobra.Command {
 			// for any other logic below.
 			if !shouldSkipGlobalInit(cmd) {
 				checkGlobalInit(cmd)
+
+				// Store the last executed CLI version in the datastore.
+				// This can be useful for future features.
+				// This must be done after the global initialization so initializers can
+				// use the previously stored version if necessary.
+				//
+				// Note that we cannot run this in the PersistentPostRunE because if the command fails,
+				// the PersistentPostRunE will not be called.  This could lead to the global initialization
+				// running again on the next command execution.
+				lastversion.SetLastExecutedCLIVersion()
 			}
 
 			// Ensure mutual exclusion in current contexts just in case if any plugins with old

--- a/pkg/config/defaults_test.go
+++ b/pkg/config/defaults_test.go
@@ -5,7 +5,6 @@ package config
 
 import (
 	"os"
-	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -47,10 +46,6 @@ var _ = Describe("defaults test cases", func() {
 				configFileNG, err = os.CreateTemp("", "config_ng")
 				Expect(err).To(BeNil())
 				os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
-
-				featureArray := strings.Split(constants.FeatureContextCommand, ".")
-				err = configlib.SetFeature(featureArray[1], featureArray[2], "true")
-				Expect(err).To(BeNil())
 			})
 			AfterEach(func() {
 				os.Unsetenv("TANZU_CONFIG")

--- a/pkg/config/discovery_test.go
+++ b/pkg/config/discovery_test.go
@@ -5,7 +5,6 @@ package config
 
 import (
 	"os"
-	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -31,10 +30,6 @@ var _ = Describe("Populate default central discovery", func() {
 		os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
 		os.Setenv("TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER", "No")
 		os.Setenv("TANZU_CLI_EULA_PROMPT_ANSWER", "Yes")
-
-		featureArray := strings.Split(constants.FeatureContextCommand, ".")
-		err = configlib.SetFeature(featureArray[1], featureArray[2], "true")
-		Expect(err).To(BeNil())
 	})
 	AfterEach(func() {
 		os.Unsetenv("TANZU_CONFIG")

--- a/pkg/config/init.go
+++ b/pkg/config/init.go
@@ -10,6 +10,10 @@ import (
 )
 
 func init() {
+	runInit()
+}
+
+func runInit() {
 	// Configure default feature flags
 	_ = config.ConfigureFeatureFlags(constants.DefaultCliFeatureFlags, config.SkipIfExists())
 

--- a/pkg/config/init_test.go
+++ b/pkg/config/init_test.go
@@ -1,0 +1,82 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package config contains useful functionality for config updates
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
+)
+
+func TestFeatureContextCommandDoesNotGetSet(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup a temporary configuration
+	configFile, err := os.CreateTemp("", "config")
+	assert.Nil(err)
+	err = os.Setenv("TANZU_CONFIG", configFile.Name())
+	assert.Nil(err)
+	defer os.RemoveAll(configFile.Name())
+	defer os.Unsetenv("TANZU_CONFIG")
+
+	configFileNG, err := os.CreateTemp("", "config_ng")
+	assert.Nil(err)
+	err = os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
+	assert.Nil(err)
+	defer os.RemoveAll(configFileNG.Name())
+	defer os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
+
+	runInit()
+
+	// Starting with CLI 1.3.0 we no longer set the feature flag features.global.context-target-v2.
+	// This is important because it allows us to determine if the last version executed was < 1.3.0.
+	assert.False(config.IsFeatureActivated(constants.FeatureContextCommand))
+}
+
+func TestCentralRepoGetsSet(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup a temporary configuration
+	configFile, err := os.CreateTemp("", "config")
+	assert.Nil(err)
+	err = os.Setenv("TANZU_CONFIG", configFile.Name())
+	assert.Nil(err)
+	defer os.RemoveAll(configFile.Name())
+	defer os.Unsetenv("TANZU_CONFIG")
+
+	configFileNG, err := os.CreateTemp("", "config_ng")
+	assert.Nil(err)
+	err = os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
+	assert.Nil(err)
+	defer os.RemoveAll(configFileNG.Name())
+	defer os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
+
+	// Check that the central repo gets set
+	runInit()
+
+	sources, err := config.GetCLIDiscoverySources()
+	assert.Nil(err)
+	assert.Equal(1, len(sources))
+	assert.Equal(DefaultStandaloneDiscoveryName, sources[0].OCI.Name)
+	assert.Equal(constants.TanzuCLIDefaultCentralPluginDiscoveryImage, sources[0].OCI.Image)
+
+	// Check that the central repo does not get set if the user has deleted it
+	err = config.DeleteCLIDiscoverySource(DefaultStandaloneDiscoveryName)
+	assert.Nil(err)
+
+	sources, err = config.GetCLIDiscoverySources()
+	assert.Nil(err)
+	assert.Equal(0, len(sources))
+
+	runInit()
+
+	sources, err = config.GetCLIDiscoverySources()
+	assert.Nil(err)
+	assert.Equal(0, len(sources))
+}

--- a/pkg/constants/featureflags.go
+++ b/pkg/constants/featureflags.go
@@ -6,6 +6,8 @@ package constants
 // This block is for global feature constants, to allow them to be used more broadly
 const (
 	// FeatureContextCommand determines whether to surface the context command. This is disabled by default.
+	// This feature flag is no longer used.  However, we keep it defined so that it can be used to know
+	// if an older CLI (< 1.3.0) was last executed.
 	FeatureContextCommand = "features.global.context-target-v2"
 
 	// FeaturePluginDiscoveryForTanzuContext determines whether to enable context-scoped plugin discovery for Tanzu context.
@@ -25,10 +27,5 @@ const (
 // mainstreaming the feature (with a default true value) under the flag name "features.global.foo-bar", as there will be
 // no conflict with previous installs (that have a false value for the entry "features.global.foo-bar-beta").
 var (
-	DefaultCliFeatureFlags = map[string]bool{
-		FeatureContextCommand: true,
-		// Do NOT include the test feature flag to disable the central repo.
-		// We don't want to publicize this feature flag.
-		// It defaults to false when not specified, which is what is needed.
-	}
+	DefaultCliFeatureFlags = map[string]bool{}
 )

--- a/pkg/discovery/oci_test.go
+++ b/pkg/discovery/oci_test.go
@@ -5,14 +5,11 @@ package discovery
 
 import (
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
-	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
-	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 )
 
 func Test_NewOCIDiscovery(t *testing.T) {
@@ -25,10 +22,6 @@ func Test_NewOCIDiscovery(t *testing.T) {
 	configFileNG, err := os.CreateTemp("", "config_ng")
 	assert.Nil(err)
 	os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
-
-	featureArray := strings.Split(constants.FeatureContextCommand, ".")
-	err = config.SetFeature(featureArray[1], featureArray[2], "true")
-	assert.Nil(err)
 
 	defer func() {
 		os.Unsetenv("TANZU_CONFIG")

--- a/pkg/globalinit/catalog_cache_init.go
+++ b/pkg/globalinit/catalog_cache_init.go
@@ -1,0 +1,89 @@
+// Copyright 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package globalinit
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"sort"
+
+	"github.com/pkg/errors"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/catalog"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/lastversion"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/pluginsupplier"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
+)
+
+// This global initializer checks if the last executed CLI version is < 1.3.0.
+// If so it refreshes the plugin catalog to make sure any remapping data is in the catalog.
+
+func init() {
+	RegisterInitializer("Plugin Info Catalog Initializer", triggerForPreCommandRemapping, refreshPluginCatalog)
+}
+
+func triggerForPreCommandRemapping() bool {
+	// If the last executed CLI version is < 1.3.0, we need to refresh the plugin catalog.
+	return lastversion.GetLastExecutedCLIVersion() == lastversion.OlderThan1_3_0
+}
+
+// refreshPluginCatalog reads the info from each installed plugin
+// and updates the plugin catalog with the latest info.
+// We need to do this to make sure the command re-mapping data is in the cache.
+func refreshPluginCatalog(outStream io.Writer) error {
+	plugins, err := pluginsupplier.GetInstalledPlugins()
+	if err != nil {
+		return err
+	}
+	if len(plugins) == 0 {
+		return nil
+	}
+	sort.Sort(cli.PluginInfoSorter(plugins))
+
+	fmt.Fprintf(outStream, "Refreshing the %d installed plugins...\n", len(plugins))
+	log.SetStderr(outStream)
+	for i := range plugins {
+		log.V(7).Infof("Refreshing plugin %s...", plugins[i].Name)
+
+		if pInfo, err := refreshPluginInfo(&plugins[i], plugins[i].InstallationPath); err == nil {
+			// Create a new catalog for each plugin in case a plugin tries to access the
+			// catalog.  For example, the "test" plugin does access the catalog.
+			c, err := catalog.NewContextCatalogUpdater("")
+			if err != nil {
+				log.V(7).Infof("Error creating catalog for plugin %s...", plugins[i].Name)
+			} else {
+				err = c.Upsert(pInfo)
+				if err != nil {
+					log.V(7).Infof("Error refreshing plugin %s...", plugins[i].Name)
+				}
+			}
+			c.Unlock()
+		} else {
+			log.V(7).Infof("Error getting info for plugin %s...", plugins[i].Name)
+		}
+	}
+	return nil
+}
+
+func refreshPluginInfo(plugin *cli.PluginInfo, pluginPath string) (*cli.PluginInfo, error) {
+	bytesInfo, err := exec.Command(pluginPath, "info").Output()
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not get the info for plugin %q", plugin.Name)
+	}
+
+	var newInfo cli.PluginInfo
+	if err = json.Unmarshal(bytesInfo, &newInfo); err != nil {
+		return nil, errors.Wrapf(err, "could not unmarshal plugin %q info", plugin.Name)
+	}
+
+	// Update the plugin info with the new info that older CLIs were not aware of.
+	plugin.InvokedAs = newInfo.InvokedAs
+	plugin.SupportedContextType = newInfo.SupportedContextType
+	plugin.CommandMap = newInfo.CommandMap
+
+	return plugin, nil
+}

--- a/pkg/lastversion/last_version.go
+++ b/pkg/lastversion/last_version.go
@@ -1,0 +1,56 @@
+// Copyright 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package lastversion contains functionality to store and retrieve the last
+// executed CLI version in the datastore.
+package lastversion
+
+import (
+	"strings"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/buildinfo"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/datastore"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
+)
+
+// lastExecutedCLIVersionKey is the key used to store the last executed CLI version in the datastore.
+const (
+	lastExecutedCLIVersionKey = "lastExecutedCLIVersion"
+	OlderThan1_3_0            = "olderThan1_3_0"
+)
+
+// lastExecutedCLIVersion is a struct used to store the last executed CLI version in the datastore.
+// We use a struct to be able to add more fields in the future if needed.
+type lastExecutedCLIVersion struct {
+	Version string `json:"version" yaml:"version"`
+}
+
+// GetLastExecutedCLIVersion gets the last executed CLI version from the datastore.
+// If the last executed version is < 1.3.0, it returns an empty string, otherwise
+// it returns the last executed version.
+func GetLastExecutedCLIVersion() string {
+	if config.IsFeatureActivated(constants.FeatureContextCommand) {
+		// If this feature flag is present, then we know that the
+		// last version executed was < 1.3.0.  We cannot know which version
+		// specifically was last run because version 1.3.0 is the first version
+		// to set the last executed version.  In this case, we return an empty string.
+		// Don't return an empty string as it would be the same as the value returned
+		// if the datastore is removed. Instead, return a constant value.
+		return OlderThan1_3_0
+	}
+
+	var lastVersion lastExecutedCLIVersion
+	_ = datastore.GetDataStoreValue(lastExecutedCLIVersionKey, &lastVersion)
+	return lastVersion.Version
+}
+
+// SetLastExecutedCLIVersion sets the last executed CLI version in the datastore.
+func SetLastExecutedCLIVersion() {
+	_ = datastore.SetDataStoreValue(lastExecutedCLIVersionKey, lastExecutedCLIVersion{Version: buildinfo.Version})
+
+	// Just in case the 'features.global.context-target-v2' feature flag is still set
+	// because the last version executed was < 1.3.0, we must remove it.
+	parts := strings.Split(constants.FeatureContextCommand, ".")
+	_ = config.DeleteFeature(parts[1], parts[2])
+}

--- a/pkg/lastversion/last_version_test.go
+++ b/pkg/lastversion/last_version_test.go
@@ -1,0 +1,166 @@
+// Copyright 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package lastversion
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/buildinfo"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/datastore"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/utils"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
+)
+
+func TestGetLastExecutedCLIVersion(t *testing.T) {
+	tests := []struct {
+		test            string
+		lastVersion     string
+		expectedVersion string
+	}{
+		{
+			test:            "last version > 1.3.0",
+			lastVersion:     "1.4.0",
+			expectedVersion: "1.4.0",
+		},
+		{
+			test:            "last version == 1.3.0",
+			lastVersion:     "1.3.0",
+			expectedVersion: "1.3.0",
+		},
+		{
+			test:            "last version > 1.3.0 pre-release",
+			lastVersion:     "2.0.1-dev",
+			expectedVersion: "2.0.1-dev",
+		},
+		{
+			test:            "last version older than 1.3.0 ",
+			lastVersion:     "1.2.0",
+			expectedVersion: OlderThan1_3_0,
+		},
+	}
+
+	assert := assert.New(t)
+
+	// Setup a temporary configuration
+	configFile, err := os.CreateTemp("", "config")
+	assert.Nil(err)
+	err = os.Setenv("TANZU_CONFIG", configFile.Name())
+	assert.Nil(err)
+	defer os.RemoveAll(configFile.Name())
+	defer os.Unsetenv("TANZU_CONFIG")
+
+	configFileNG, err := os.CreateTemp("", "config_ng")
+	assert.Nil(err)
+	err = os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
+	assert.Nil(err)
+	defer os.RemoveAll(configFileNG.Name())
+	defer os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
+
+	tmpDataStoreFile, _ := os.CreateTemp("", "data-store.yaml")
+	defer os.RemoveAll(tmpDataStoreFile.Name())
+	os.Setenv("TEST_CUSTOM_DATA_STORE_FILE", tmpDataStoreFile.Name())
+	defer os.Unsetenv("TEST_CUSTOM_DATA_STORE_FILE")
+
+	for _, spec := range tests {
+		t.Run(spec.test, func(t *testing.T) {
+			if utils.IsNewVersion("v1.3.0", spec.lastVersion) {
+				// We need to set the 'features.global.context-target-v2' feature flag
+				// to indicate that the last version executed was < 1.3.0.
+				parts := strings.Split(constants.FeatureContextCommand, ".")
+				_ = config.SetFeature(parts[1], parts[2], "true")
+			}
+			// Set the last executed version in the datastore
+			_ = datastore.SetDataStoreValue(lastExecutedCLIVersionKey, lastExecutedCLIVersion{Version: spec.lastVersion})
+
+			// Get the last executed version and verify
+			lastVersion := GetLastExecutedCLIVersion()
+			assert.Equal(spec.expectedVersion, lastVersion)
+
+			// Clean up
+			parts := strings.Split(constants.FeatureContextCommand, ".")
+			_ = config.DeleteFeature(parts[1], parts[2])
+		})
+	}
+}
+
+func TestSetLastExecutedCLIVersion(t *testing.T) {
+	tests := []struct {
+		test            string
+		lastVersion     string
+		expectedVersion string
+	}{
+		{
+			test:            "last version is 1.3.0",
+			lastVersion:     "1.3.0",
+			expectedVersion: "1.3.0",
+		},
+		{
+			test:            "last version is > 1.3.0",
+			lastVersion:     "1.4.0",
+			expectedVersion: "1.4.0",
+		},
+		{
+			test:            "last version is a pre-release",
+			lastVersion:     "2.0.1-dev",
+			expectedVersion: "2.0.1-dev",
+		},
+	}
+
+	assert := assert.New(t)
+
+	// Setup a temporary configuration
+	configFile, err := os.CreateTemp("", "config")
+	assert.Nil(err)
+	err = os.Setenv("TANZU_CONFIG", configFile.Name())
+	assert.Nil(err)
+	defer os.RemoveAll(configFile.Name())
+	defer os.Unsetenv("TANZU_CONFIG")
+
+	configFileNG, err := os.CreateTemp("", "config_ng")
+	assert.Nil(err)
+	err = os.Setenv("TANZU_CONFIG_NEXT_GEN", configFileNG.Name())
+	assert.Nil(err)
+	defer os.RemoveAll(configFileNG.Name())
+	defer os.Unsetenv("TANZU_CONFIG_NEXT_GEN")
+
+	tmpDataStoreFile, _ := os.CreateTemp("", "data-store.yaml")
+	defer os.RemoveAll(tmpDataStoreFile.Name())
+	os.Setenv("TEST_CUSTOM_DATA_STORE_FILE", tmpDataStoreFile.Name())
+	defer os.Unsetenv("TEST_CUSTOM_DATA_STORE_FILE")
+
+	originalVersion := buildinfo.Version
+	defer func() {
+		buildinfo.Version = originalVersion
+	}()
+
+	for _, spec := range tests {
+		t.Run(spec.test, func(t *testing.T) {
+			// Run the test twice.  Once with the 'features.global.context-target-v2' feature flag set
+			// and once without it set.
+			for i := 0; i < 2; i++ {
+				if i == 1 {
+					parts := strings.Split(constants.FeatureContextCommand, ".")
+					_ = config.SetFeature(parts[1], parts[2], "true")
+				}
+
+				buildinfo.Version = spec.lastVersion
+				SetLastExecutedCLIVersion()
+
+				// Get the last executed version and verify
+				var lastVersion lastExecutedCLIVersion
+				err := datastore.GetDataStoreValue(lastExecutedCLIVersionKey, &lastVersion)
+				assert.Nil(err)
+				assert.Equal(spec.expectedVersion, lastVersion.Version)
+
+				// Check that the 'features.global.context-target-v2' feature flag is removed
+				assert.False(config.IsFeatureActivated(constants.FeatureContextCommand))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This will need to be updated for the changes of https://github.com/vmware-tanzu/tanzu-plugin-runtime/pull/177

### What this PR does / why we need it

If the last executed CLI version is < 1.3.0, we refresh some of the catalog data to make sure all the command remapping data is properly stored.

The commit also stores the last executed CLI version in the datastore to make it available for future use.

E2E tests are missing but we may need to merge this before they are done if we want this PR for v1.3.0-alpha.3

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Related to #687 and #736 

### Describe testing done for PR

```
# Install a plugin that uses command mapping using an old CLI
$ ~/bin/tanzu.v1.2.0 plugin install appsv2
[i] Reinitialized plugin 'appsv2:v0.2.0-beta.3' with target 'kubernetes'
[ok] successfully installed 'appsv2' plugin

# Use the new CLI and notice that at the start it shows `appsv2` as a command
# Note that the help does not trigger the global initializer which will fix this
$ tz -h
Usage:
  tanzu [command]

Available command groups:

  Build
    apps                    Applications on Kubernetes
    appsv2                  Applications on Kubernetes for TAP (SaaS distribution)
[...]

# Now run pretty much any command with the new CLI
# and notice the global initializer
$ tz plugin list
Some initialization of the CLI is required.
Let's set things up for you.  This will just take a few seconds.

Refreshing plugin accelerator...
Refreshing plugin apps...
Refreshing plugin appsv2...
Refreshing plugin build-service...
Refreshing plugin external-secrets...
Refreshing plugin insight...
Refreshing plugin package...
Refreshing plugin secret...
Refreshing plugin services...
Refreshing plugin supplychain...
Refreshing plugin telemetry...

Initialization done!
==
  NAME              DESCRIPTION                                                      TARGET      INSTALLED      STATUS
  accelerator       Manage accelerators in a Kubernetes cluster                      kubernetes  v1.7.0         installed
  apps              Applications on Kubernetes                                       kubernetes  v0.13.0        installed
  appsv2            Applications on Kubernetes for TAP (SaaS distribution)           kubernetes  v0.2.0-beta.3  installed
  build-service     plugin to interact with tanzu build service (tbs) crds           kubernetes  v1.0.0         installed
  external-secrets  interacts with external-secrets.io resources                     kubernetes  v0.1.0         installed
  insight           post & query image, package, source, and vulnerability data      kubernetes  v1.7.0         installed
  package           tanzu package management                                         kubernetes  v0.32.1        installed
  secret            Tanzu secret management                                          kubernetes  v0.32.0        installed
  services          Commands for working with service instances, classes and claims  kubernetes  v0.8.0         installed
  supplychain       supplychain management                                           kubernetes  v0.1.0-beta.3  installed
  telemetry         configure cluster-wide settings for vmware tanzu telemetry       global      v1.1.0         installed

# Now try the help again and notice `appsv2` no longer shows
$ tz -h
Usage:
  tanzu [command]

Available command groups:

  Build
    app                     Applications on Kubernetes for TAP (SaaS distribution)
    build-service           plugin to interact with tanzu build service (tbs) crds
[...]
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add a global initializer to ensure the command-remapping information is properly stored in the catalog cache.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
