### PR TITLE
Add support for the Authenticated Registries

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -80,6 +80,7 @@ Below is the list of these variables:
 | -------------------- | ----------- | ----- |
 | `SQL_STATEMENTS_LOG_FILE` | Specifies a log file where SQL commands will be logged when _modifying_ the plugin inventory database.  This is done when publishing plugins using the `builder` plugin. | A file name with its path |
 | `TANZU_CLI_ADDITIONAL_PLUGIN_DISCOVERY_IMAGES_TEST_ONLY` | Specifies test plugin repositories to use as a supplement to the production Central Repository of plugins. Ignored if `TANZU_CLI_PRIVATE_PLUGIN_DISCOVERY_IMAGES` is set. | Comma-separated list of test plugin repository URIs| |
+| `TANZU_CLI_AUTHENTICATED_REGISTRY` | Specifies the list of registry hosts that requires authentication to pull images. Tanzu CLI will use default docker auth to communicate to these registries | Comma-separated list of registry host-names | |
 | `TANZU_CLI_ESSENTIALS_PLUGIN_GROUP_NAME` | Override the default name (`vmware-tanzucli/essentials`) of the Essential Plugins group.  Should not be needed. | Group name |
 | `TANZU_CLI_ESSENTIALS_PLUGIN_GROUP_VERSION` | Specify a fixed version to use for the Essential Plugins group instead of the latest.  Should not be needed. | Group version |
 | `TANZU_CLI_SKIP_CONTEXT_RECOMMENDED_PLUGIN_INSTALLATION` | Skips the auto-installation of the context recommended plugins

--- a/pkg/carvelhelpers/fetcher.go
+++ b/pkg/carvelhelpers/fetcher.go
@@ -4,11 +4,16 @@
 package carvelhelpers
 
 import (
+	"os"
+	"strings"
+
 	"github.com/pkg/errors"
 
 	ctlimg "github.com/vmware-tanzu/carvel-imgpkg/pkg/imgpkg/registry"
 
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/registry"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/utils"
 )
 
 // GetFilesMapFromImage returns map of files metadata
@@ -32,8 +37,11 @@ func GetImageDigest(imageWithTag string) (string, string, error) {
 // newRegistry returns a new registry object by also taking
 // into account for any custom registry provided by the user
 func newRegistry(registryHost string) (registry.Registry, error) {
-	registryOpts := &ctlimg.Opts{
-		Anon: true,
+	registryOpts := &ctlimg.Opts{}
+
+	authenticatedRegistries := strings.Split(os.Getenv(constants.AuthenticatedRegistry), ",")
+	if !utils.ContainsRegistry(authenticatedRegistries, registryHost) {
+		registryOpts.Anon = true
 	}
 
 	regCertOptions, err := registry.GetRegistryCertOptions(registryHost)

--- a/pkg/constants/env_variables.go
+++ b/pkg/constants/env_variables.go
@@ -79,4 +79,8 @@ const (
 	// SkipTAPScopesValidationOnTanzuContext skips the TAP scopes validation on the token acquired while creating "tanzu"
 	// context using tanzu login or tanzu context create command
 	SkipTAPScopesValidationOnTanzuContext = "TANZU_CLI_SKIP_TAP_SCOPES_VALIDATION_ON_TANZU_CONTEXT"
+
+	// AuthenticatedRegistry provides a comma separated list of registry hosts that requires authentication
+	// to pull images. Tanzu CLI will use default docker auth to communicate to these registries
+	AuthenticatedRegistry = "TANZU_CLI_AUTHENTICATED_REGISTRY"
 )

--- a/pkg/utils/url.go
+++ b/pkg/utils/url.go
@@ -51,3 +51,22 @@ func JoinURL(baseURL, relativeURL string) (string, error) {
 	// Return the joined URL as a string
 	return parsedBaseURL.String(), nil
 }
+
+// ContainsRegistry returns true if the specified registryHost is part of registries
+func ContainsRegistry(registries []string, registryHost string) bool {
+	cleanRegistryURL := func(u string) string {
+		u = strings.TrimSpace(u)
+		u = strings.TrimPrefix(u, "http://")
+		u = strings.TrimPrefix(u, "https://")
+		return strings.Split(u, "/")[0]
+	}
+	registryHost = cleanRegistryURL(registryHost)
+
+	for _, reg := range registries {
+		reg = cleanRegistryURL(reg)
+		if strings.EqualFold(reg, registryHost) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/utils/url_test.go
+++ b/pkg/utils/url_test.go
@@ -630,3 +630,31 @@ func TestJoinUrl(t *testing.T) {
 		})
 	}
 }
+
+func TestContainsRegistry(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected bool
+	}{
+		{"google.com", true},
+		{"facebook.com", false},
+		{"xyz.com", false},
+		{"packages.xyz.com", true},
+		{"packages.example.com", false},
+		{"projects.example.com", true},
+		{"packages.repo.com", false},
+		{"registry.packages.repo.com", true},
+		{"registry.packages.repo.com/projects", true},
+		{"https://registry.packages.repo.com/projects", true},
+		{"registry.packages", false},
+	}
+
+	registries := []string{"https://google.com", "http://fb.com", "https://packages.xyz.com", "projects.example.com", "registry.packages.repo.com/projects/cli"}
+
+	for _, tc := range testCases {
+		got := ContainsRegistry(registries, tc.input)
+		if got != tc.expected {
+			t.Errorf("ContainsRegistry(%q, %q) = %t; want %t", registries, tc.input, got, tc.expected)
+		}
+	}
+}

--- a/test/e2e/airgapped/airgapped_suite_test.go
+++ b/test/e2e/airgapped/airgapped_suite_test.go
@@ -33,6 +33,7 @@ var (
 	e2eAirgappedCentralRepoWithAuth         string
 	e2eAirgappedCentralRepoWithAuthUsername string
 	e2eAirgappedCentralRepoWithAuthPassword string
+	e2eAirgappedCentralRepoWithAuthImage    string
 	pluginsSearchList                       []*framework.PluginInfo
 	pluginGroups                            []*framework.PluginGroup
 	tempDir                                 string
@@ -58,8 +59,9 @@ var _ = BeforeSuite(func() {
 	Expect(e2eAirgappedCentralRepoWithAuthUsername).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with airgapped central repository URL", framework.TanzuCliE2ETestAirgappedRepoWithAuthUsername))
 	e2eAirgappedCentralRepoWithAuthPassword = os.Getenv(framework.TanzuCliE2ETestAirgappedRepoWithAuthPassword)
 	Expect(e2eAirgappedCentralRepoWithAuthPassword).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with airgapped central repository URL", framework.TanzuCliE2ETestAirgappedRepoWithAuthPassword))
+	e2eAirgappedCentralRepoWithAuthImage = fmt.Sprintf("%s%s", e2eAirgappedCentralRepoWithAuth, filepath.Base(e2eTestLocalCentralRepoImage))
 
-	os.Setenv(framework.TanzuCliPluginDiscoverySignatureVerificationSkipList, fmt.Sprintf("%v,%v", e2eAirgappedCentralRepoImage, e2eTestLocalCentralRepoImage))
+	os.Setenv(framework.TanzuCliPluginDiscoverySignatureVerificationSkipList, fmt.Sprintf("%v,%v,%v", e2eAirgappedCentralRepoImage, e2eTestLocalCentralRepoImage, e2eAirgappedCentralRepoWithAuthImage))
 
 	e2eTestLocalCentralRepoPluginHost := os.Getenv(framework.TanzuCliE2ETestLocalCentralRepositoryHost)
 	Expect(e2eTestLocalCentralRepoPluginHost).NotTo(BeEmpty(), fmt.Sprintf("environment variable %s should set with local central repository host", framework.TanzuCliE2ETestLocalCentralRepositoryHost))


### PR DESCRIPTION
### What this PR does / why we need it
- Add support for the Authenticated Registry
- To use registries that require authentication to host Tanzu CLI Plugins images users are expected to do the following:

1. Use `docker login <registry>` or `crane auth login <registry>` to authenticate with the registry
2. Specify environment variable `TANZU_CLI_AUTHENTICATED_REGISTRY=<registry>`. By specifying this environment variable, Tanzu CLI will use the default authentication mechanism instead of using `Anonymous` access to fetch images.


**Pending**
- Add E2E tests

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

* Start local authenticated registry for testing
```
# Start local registry at `localhost:5001`
$ make start-test-central-repo

# Start local registry requiring authentication at `localhost:6002`
$ make start-airgapped-local-registry
```

* Setup local authenticated registry with plugins
```
$ tz plugin download-bundle --to-tar /tmp/plugins.tar.gz --image localhost:9876/tanzu-cli/plugins/airgapped:small
...
[i] saving plugin bundle at: /tmp/plugins.tar.gz

---

$ tz plugin upload-bundle --tar /tmp/plugins.tar.gz --to-repo localhost:6002/test/plugins
[i] extracting "/tmp/plugins.tar.gz" for processing...
[i] ---------------------------
[i] uploading image "localhost:6002/test/plugins/airgapped"
[i] copy | importing 2 images...

[i] copy |
copy | done uploading images
[i] copy | Error: Error uploading images: HEAD http://localhost:6002/v2/test/plugins/airgapped/manifests/sha256-b3e204740c44151562050f9f5b839386231c135a7cde944f150bca0503cbeb8f.imgpkg: unexpected status code 401 Unauthorized (HEAD responses have no body, use GET for details)
[x] : error while uploading image: HEAD http://localhost:6002/v2/test/plugins/airgapped/manifests/sha256-b3e204740c44151562050f9f5b839386231c135a7cde944f150bca0503cbeb8f.imgpkg: unexpected status code 401 Unauthorized (HEAD responses have no body, use GET for details)

---

$ docker login localhost:6002
Username: testuser
Password:
Login Succeeded

---

$ tz plugin upload-bundle --tar /tmp/plugins.tar.gz --to-repo localhost:6002/test/plugins
...
[i] successfully published all plugin images to "localhost:6002/test/plugins/airgapped:small"

---

$ docker logout localhost:6002
Removing login credentials for localhost:6002
```

* Now, Try to use the authenticated registry `localhost:6002` as discovery source
```
export TANZU_CLI_PLUGIN_DISCOVERY_IMAGE_SIGNATURE_VERIFICATION_SKIP_LIST=localhost:6002/test/plugins/airgapped:small
export TANZU_CLI_AUTHENTICATED_REGISTRY=localhost:6002/test/plugins/airgapped:small

$ tz plugin source update default -u localhost:6002/test/plugins/airgapped:small
[i] Refreshing plugin inventory cache for "localhost:6002/test/plugins/airgapped:small", this will take a few seconds.
[x] : unable to fetch the inventory of discovery 'default' for plugins: plugins discovery image resolution failed. Please check that the repository image URL "localhost:6002/test/plugins/airgapped:small" is correct: error getting the image digest: GET http://localhost:6002/v2/test/plugins/airgapped/manifests/small: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:test/plugins/airgapped Type:repository]]
```

* Authenticate with the registry with (`docker login` or `crane auth login`) and try again
```
$ docker login localhost:6002
Username: testuser
Password:
Login Succeeded

---

$ tz plugin source update default -u localhost:6002/test/plugins/airgapped:small
[i] Refreshing plugin inventory cache for "localhost:6002/test/plugins/airgapped:small", this will take a few seconds.
[i] Reading plugin inventory for "localhost:6002/test/plugins/airgapped:small", this will take a few seconds.
[!] Skipping the plugins discovery image signature verification for "localhost:6002/test/plugins/airgapped:small"

[ok] updated discovery source default

---

$ tz plugin search
[i] The tanzu cli essential plugins are outdated and are being updated now. The update may take a few seconds.
[i] Installing plugins from plugin group 'vmware-tanzucli/essentials:v9.9.9'
[i] Installed plugin 'telemetry:v9.9.9' with target 'global'

  NAME              DESCRIPTION                     TARGET           LATEST
  account           account functionality           mission-control  v9.9.9
  cluster           cluster functionality           kubernetes       v9.9.9
  clustergroup      clustergroup functionality      operations       v9.9.9
  isolated-cluster  isolated-cluster functionality  global           v9.9.9
  plugin-with-sha   plugin-with-sha functionality   global           v9.9.9
  telemetry         telemetry functionality         global           v9.9.9

---

$ tz plugin install account
[i] Installed plugin 'account:v9.9.9' with target 'mission-control'
[ok] successfully installed 'account' plugin

```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add support for the Authenticated Registry to host Tanzu CLI plugin images
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
