### PR TITLE
Fix setting of invocation context env vars on mapped targeted commands

### DIFF
--- a/pkg/cli/plugin_cmd.go
+++ b/pkg/cli/plugin_cmd.go
@@ -56,7 +56,8 @@ func GetCommandMapForPlugin(p *PluginInfo) map[string]*cobra.Command {
 			dstPath := pathFromHierarchy(cmdHierarchy)
 			cmdMap[dstPath] = getCmdForPluginEx(p, cmdHierarchy[len(cmdHierarchy)-1], &mapEntry)
 			if alternateLocation := alternateRemapLocation(p, dstPath); alternateLocation != "" {
-				cmdMap[alternateLocation] = cmdMap[dstPath]
+				mapEntry.DestinationCommandPath = alternateLocation
+				cmdMap[alternateLocation] = getCmdForPluginEx(p, cmdHierarchy[len(cmdHierarchy)-1], &mapEntry)
 			}
 		}
 	}

--- a/pkg/command/root_test.go
+++ b/pkg/command/root_test.go
@@ -1825,7 +1825,7 @@ func TestCommandRemapping(t *testing.T) {
 			expected: []string{"hello !!"},
 		},
 		{
-			test: "command-level: invocation details available when plugin command is mapped to xxtop level",
+			test: "command-level: invocation details available when plugin command is mapped to top level",
 			pluginVariants: []fakePluginRemapAttributes{
 				{
 					name:   "dummy",
@@ -1841,6 +1841,24 @@ func TestCommandRemapping(t *testing.T) {
 			},
 			args:     []string{"invoke-info", "arg1", "arg2"},
 			expected: []string{"args = (show-invoke-context arg1 arg2), context is ():(invoke-info):(show-invoke-context)"},
+		},
+		{
+			test: "command-level: invocation details available when plugin command is mapped to top level and invoked via a target",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:   "dummy",
+					target: configtypes.TargetK8s,
+					commandMap: []plugin.CommandMapEntry{
+						plugin.CommandMapEntry{
+							DestinationCommandPath: "invoke-info",
+							SourceCommandPath:      "show-invoke-context",
+							Description:            "Shows invocation details",
+						},
+					},
+				},
+			},
+			args:     []string{"kubernetes", "invoke-info", "arg1", "arg2"},
+			expected: []string{"args = (show-invoke-context arg1 arg2), context is (kubernetes):(invoke-info):(show-invoke-context)"},
 		},
 		{
 			test: "command-level: invocation details available when plugin command is mapped to deeper level",


### PR DESCRIPTION
Ensure the correct destination command path is associated with the targeted mapped command so the env vars set on invocation is correct.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

See unit tests update.

manually:
(requires https://github.com/vmware-tanzu/tanzu-plugin-runtime/pull/180)

```
> ./artifacts/plugins/darwin/arm64/kubernetes/sample/v1.3.0-dev/tanzu-sample-darwin_arm64 info | jq .
{
  "name": "sample",
  "description": "sample plugin to test command mapping",
  "target": "kubernetes",
  "version": "v1.3.0-dev",
  "buildSHA": "44f2a55d-dirty",
  "digest": "",
  "group": "Manage",
  "docURL": "",
  "completionType": 0,
  "commandMap": [
    {
      "srcPath": "",
      "dstPath": "samp",
      "overrides": "",
      "description": ""
    },
    {
      "srcPath": "deeper",
      "dstPath": "dpr",
      "overrides": "",
      "description": "deeper commands",
      "aliases": [
        "deep"
      ]
    },
...

> tz kubernetes dpr dshout foo
 foo!!
Invocation Context:
&plugin.InvocationContext{invokedGroup:"kubernetes", invokedCommand:"dpr", sourceCommandPath:"deeper"}
Invocation String:
kubernetes dpr
Invocation String For Cmd:
kubernetes dpr dshout

> tz dpr dshout foo
 foo!!
Invocation Context:
&plugin.InvocationContext{invokedGroup:"", invokedCommand:"dpr", sourceCommandPath:"deeper"}
Invocation String:
dpr
Invocation String For Cmd:
dpr dshout
```


### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
