### PR TITLE
Prevent tanzu.md from being overwritten

### DIFF
--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -283,7 +283,8 @@ func setupTargetPlugins() error {
 
 func newRootCmd() *cobra.Command {
 	var rootCmd = &cobra.Command{
-		Use: "tanzu",
+		Use:   "tanzu",
+		Short: "The Tanzu CLI",
 		// Don't have Cobra print the error message, the CLI will
 		// print it itself in a nicer format.
 		SilenceErrors: true,


### PR DESCRIPTION
Since the plugin's generate-docs will be updated to produce a plugin-consistent toplevel tanzu.md, it is important that same file name produced by the CLI ifself be preserved.

The approach taken is to make a backup of the file before running the doc generation for each plugin, and restoring the file from backup.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

run generate-all-docs with plugins updated to produce its own tanzu.md
verified that the tanzu.md generated the CLI is retained.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
