### PR TITLE
Conditionally enable active context type check for plugin override

### DIFF
--- a/pkg/constants/featureflags.go
+++ b/pkg/constants/featureflags.go
@@ -13,6 +13,11 @@ const (
 	// FeaturePluginDiscoveryForTanzuContext determines whether to enable context-scoped plugin discovery for Tanzu context.
 	// This is disabled by default
 	FeaturePluginDiscoveryForTanzuContext = "features.global.plugin-discovery-for-tanzu-context"
+
+	// FeaturePluginOverrideOnActiveContextType determines whether a plugin-level mapping that potentially
+	// overrides an existing CLI command group should be conditional on the active context type or not.
+	// When false, the mapping will be unconditionally applied.
+	FeaturePluginOverrideOnActiveContextType = "features.global.plugin-override-on-active-context-type"
 )
 
 // DefaultCliFeatureFlags is used to populate an initially empty config file with default values for feature flags.


### PR DESCRIPTION
Unless features.global.plugin-override-on-active-context-type is set to true, and plugin-level mapping is performed unconditionally, possibly overriding some other existing CLI command group.

However, when said flag is set, mapping that would override an existing command is only be allowed if the active context's type matches one of the types that this mapping supports.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

See updated unit tests.

Manual testing:

```
  # appsv2 has plugin level mapping to tanzu app
  > tz plugin list | grep Appli | grep app
    appsv2        Applications on Kubernetes for TAP (SaaS distribution)  kubernetes       v0.1.0-beta.2-dev-1b714668  installed

  # mapping is in place
  > tz  | grep Appli | grep app
      app                     Applications on Kubernetes for TAP (SaaS distribution)

  # feature flag is not set
  > tanzu config get | grep override
              plugin-override-on-active-context-type: "false"

  # install apps plugin
  > tz plugin install apps
  [i] Installed plugin 'apps:v0.13.0' with target 'kubernetes' (from cache)
  [ok] successfully installed 'apps' plugin

  # both plugins installed
  > tz plugin list | grep Appli | grep app
    apps          Applications on Kubernetes                              kubernetes       v0.13.0                     installed
    appsv2        Applications on Kubernetes for TAP (SaaS distribution)  kubernetes       v0.1.0-beta.2-dev-1b714668  installed

  # mapping still in place
  > tz  | grep Appli | grep app
      app                     Applications on Kubernetes for TAP (SaaS distribution)

  # active context type is tanzu
  > tz context list --current
    NAME                  ISACTIVE  TYPE   PROJECT           SPACE
    tanzu_test_env        true      tanzu  mytanzu-project

  # unset context
  > tz context unset tanzu_test_env
  The context 'tanzu_test_env' of type 'tanzu' has been set as inactive

  # mapping still unconditionally applied...
  > tz  | grep Appli | grep app
      app                     Applications on Kubernetes for TAP (SaaS distribution)
  # despite no matching context type
  > tz context list --current
    NAME  ISACTIVE  TYPE

  # however, when feature flag is set
  > tz config set features.global.plugin-override-on-active-context-type true
  > tanzu config get | grep override
              plugin-override-on-active-context-type: "true"

  # the mapping is suppressed, because active context type is checked
  > tz  | grep Appli | grep app
      apps                    Applications on Kubernetes

  # set a tanzu context as active again
  > tz context use tanzu_test_env
  [i] Successfully activated context 'tanzu_test_env' (Type: tanzu, Project: mytanzu-project (2d59a92e-1694-4123-b89a-809e241e53f6))
  > tz context list --current
    NAME                  ISACTIVE  TYPE   PROJECT           SPACE
    tanzu_test_env        true      tanzu  mytanzu-project

  # now the mapping is reapplied
  > tz  | grep Appli | grep app
      app                     Applications on Kubernetes for TAP (SaaS distribution)
```


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Unless features.global.plugin-override-on-active-context-type is set to true, and plugin-level mapping is performed unconditionally, possibly overriding some other existing CLI command group. However, when said flag is set, mapping that would override an existing command is only be allowed if the active context's type matches one of the types that this mapping supports.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
