### PR TITLE
Ignore command PreRun logic for tanzu context get-token command

### DIFF
--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -601,6 +601,10 @@ func shouldSkipPrompts(cmd *cobra.Command) bool {
 		"tanzu pinniped-auth",
 		// Can be used to set the prompt on every shell command
 		"tanzu context current",
+		// This command is being invoked by the kubectl exec binary where the user doesn't
+		// get to see the prompts and the kubectl command execution just gets stuck, and it
+		// is very hard for users to figure out what is going wrong
+		"tanzu context get-token",
 	}
 	return isSkipCommand(skipCommands, cmd.CommandPath())
 }
@@ -619,11 +623,14 @@ func shouldSkipEssentialPlugins(cmd *cobra.Command) bool {
 
 		// Can be used to set the prompt on every shell command
 		"tanzu context current",
-
+		// This command is being invoked by the kubectl exec binary where the user doesn't
+		// get to see the output, so it is better to avoid printing essential plugins
+		// installation messages
+		"tanzu context get-token",
 		"tanzu config eula",
 		"tanzu ceip-participation set",
 		// This command is being invoked by the kubectl exec binary where the user doesn't
-		// get to see the output so it is better to avoid prinint essential plugins
+		// get to see the output so, it is better to avoid printing essential plugins
 		// installation messages
 		"tanzu pinniped-auth",
 		// Avoid trying to install essential plugins when the user wants to remove all plugins.
@@ -649,6 +656,12 @@ func shouldSkipVersionCheck(cmd *cobra.Command) bool {
 		"tanzu version",
 		// Can be used to set the prompt on every shell command
 		"tanzu context current",
+		// This command is being invoked by the kubectl exec binary where the user doesn't
+		// get to see the output so, we should avoid printing the new version availability
+		"tanzu context get-token",
+		// This command is being invoked by the kubectl exec binary where the user doesn't
+		// get to see the output so, we should avoid printing the new version availability
+		"tanzu pinniped-auth",
 	}
 	return isSkipCommand(skipVersionCheckCommands, cmd.CommandPath())
 }
@@ -665,6 +678,9 @@ func shouldSkipGlobalInit(cmd *cobra.Command) bool {
 		"tanzu version",
 		// Can be used to set the prompt on every shell command
 		"tanzu context current",
+		// This command is being invoked by the kubectl exec binary, and it is not interactive,
+		// so it should not trigger the global initialization of the CLI
+		"tanzu context get-token",
 	}
 	return isSkipCommand(skipGlobalInitCommands, cmd.CommandPath())
 }


### PR DESCRIPTION
### What this PR does / why we need it
This PR would ignore command PreRun logic for `tanzu context get-token` command.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Tested the kubectl command (which internally would call the tanzu context get-token command) after removing the CEIP and EULA opt-in status from the CLI config file. Verified that CLI binary without the fix get stuck and later with updated binary path , the CLI didn't get hang for prompt.

```
// removed the CEIP and EULA status form the config file.
❯ vim ~/.config/tanzu/config-ng.yaml

❯ kubectl api-resources
[x] : failed to get EULA status: prompt failed: interrupt
NAME   SHORTNAMES   APIVERSION   NAMESPACED   KIND
Unable to connect to the server: getting credentials: exec: executable tanzu failed with exit code 1

//updated the path of the tanzu binary in the exec plugin of the kubeconfig
❯ vim ~/.kube/config
- name: tanzu-cli-TAP_pre-integration-staging-d03c5c97-user
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1
      args:
      - context
      - get-token
      - TAP_pre-integration-staging-d03c5c97
      command: /Users/pkalle/projects/tanzu-cli/bin/tanzu
      env: []
      interactiveMode: IfAvailable
      provideClusterInfo: false



// now with updated CLI binary the login works

❯ kubectl api-resources
[i] Opening the browser window to complete the login
Log in by visiting this link:

    https://console-stg.cloud.vmware.com/csp/gateway/discovery?client_id=tanzu-cli-client-id&code_challenge=ND_rBKs_kxm_TPAyq-n4Qf3mzYGug2ceQuiz4TG5G40&code_challenge_method=S256&orgId=ae93ebb4-a249-4553-aa1e-c87c4b7f75e5&redirect_uri=http%3A%2F%2F127.0.0.1%3A56182%2Fcallback&response_type=code&state=63537b30798749af61469c7d21250095

    Optionally, paste your authorization code: [...]

NAME   SHORTNAMES   APIVERSION   NAMESPACED   KIND

```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Ignore command PreRun logic for the tanzu context get-token command 
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
