### PR TITLE
Switch default discovery source registry to `projects.packages.broadcom.com`

### DIFF
--- a/docs/cli/commands/tanzu_plugin_download-bundle.md
+++ b/docs/cli/commands/tanzu_plugin_download-bundle.md
@@ -27,7 +27,7 @@ tanzu plugin download-bundle [flags]
 ```
       --group strings   only download the plugins specified in the plugin-group version (can specify multiple)
   -h, --help            help for download-bundle
-      --image string    URI of the plugin discovery image providing the plugins (default "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest")
+      --image string    URI of the plugin discovery image providing the plugins (default "projects.packages.broadcom.com/tanzu_cli/plugins/plugin-inventory:latest")
       --to-tar string   local tar file path to store the plugin images
 ```
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,7 +59,10 @@ Do you agree to the VMware General Terms?
 	// accepted semver versions matches in the major.minor of this value.
 	// If this value is empty, however, any previously recorded acceptance
 	// is considered valid.
-	CurrentEULAVersion = ""
+	//
+	// Update the EULA version to v1.1.0 to re-prompt users because of the
+	// default plugin discovery source change
+	CurrentEULAVersion = "v1.1.0"
 )
 
 func init() {

--- a/pkg/constants/defaults.go
+++ b/pkg/constants/defaults.go
@@ -18,7 +18,11 @@ const (
 
 	// TanzuCLIDefaultCentralPluginDiscoveryImage defines the default discovery image
 	// from where the CLI will discover the plugins
-	TanzuCLIDefaultCentralPluginDiscoveryImage = "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest"
+	TanzuCLIDefaultCentralPluginDiscoveryImage = "projects.packages.broadcom.com/tanzu_cli/plugins/plugin-inventory:latest"
+
+	// TanzuCLIOldCentralPluginDiscoveryImage defines the old discovery image
+	// from where the CLI used to discover the plugins
+	TanzuCLIOldCentralPluginDiscoveryImage = "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest"
 
 	// DefaultCLIEssentialsPluginGroupName  name of the essentials plugin group which is used to install essential plugins
 	DefaultCLIEssentialsPluginGroupName = "vmware-tanzucli/essentials"

--- a/pkg/globalinit/plugin_discovery_source_update.go
+++ b/pkg/globalinit/plugin_discovery_source_update.go
@@ -39,13 +39,6 @@ func updatePluginDiscoverySource(outStream io.Writer) error {
 		return nil
 	}
 
-	// Considering we are updating the discovery source to point to new registry,
-	// User must be prompted to access the EULA again. So, let's first unset EULA status
-	err = config.SetEULAStatus(config.EULAStatusUnset)
-	if err != nil {
-		return err
-	}
-
 	// Update the `default` discovery source to point to the new central plugin discovery image
 	// Note: This update only modifies the discovery source and does not trigger a database refresh.
 	// This is intentional, as we want to avoid downloading the image without the user re-accepting the EULA.

--- a/pkg/globalinit/plugin_discovery_source_update.go
+++ b/pkg/globalinit/plugin_discovery_source_update.go
@@ -1,0 +1,56 @@
+// Copyright 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package globalinit
+
+import (
+	"fmt"
+	"io"
+
+	cliconfig "github.com/vmware-tanzu/tanzu-cli/pkg/config"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/lastversion"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
+)
+
+// This global initializer checks if the last executed CLI version is < 1.3.0.
+// If so it tries to update the plugin discovery source if needed
+
+func init() {
+	RegisterInitializer("Plugin Discovery Source Updater", triggerForPluginDiscoverySourceUpdater, updatePluginDiscoverySource)
+}
+
+func triggerForPluginDiscoverySourceUpdater() bool {
+	// If the last executed CLI version is < 1.3.0, we need to update the discovery image source
+	return lastversion.GetLastExecutedCLIVersion() == lastversion.OlderThan1_3_0
+}
+
+// updatePluginDiscoverySource updates the plugin discovery source to point CLI to
+// new `projects.packages.broadcom.com` and also clears the EULA acceptance state
+// stored in the CLI config file. So that EULA prompt is shown to the user again.
+func updatePluginDiscoverySource(outStream io.Writer) error {
+	ds, err := config.GetCLIDiscoverySource(cliconfig.DefaultStandaloneDiscoveryName)
+	if err != nil {
+		return err
+	}
+
+	if ds == nil || ds.OCI == nil || ds.OCI.Image != constants.TanzuCLIOldCentralPluginDiscoveryImage {
+		// User must have manually updated discovery source. So do not overwrite that change.
+		return nil
+	}
+
+	// Considering we are updating the discovery source to point to new registry,
+	// User must be prompted to access the EULA again. So, let's first unset EULA status
+	err = config.SetEULAStatus(config.EULAStatusUnset)
+	if err != nil {
+		return err
+	}
+
+	// Update the `default` discovery source to point to the new central plugin discovery image
+	// Note: This update only modifies the discovery source and does not trigger a database refresh.
+	// This is intentional, as we want to avoid downloading the image without the user re-accepting the EULA.
+	// The database will be refreshed automatically by the CLI as part of its periodic refresh process.
+	ds.OCI.Image = constants.TanzuCLIDefaultCentralPluginDiscoveryImage
+	fmt.Fprintf(outStream, "Updating default plugin discovery source to %q...\n", constants.TanzuCLIDefaultCentralPluginDiscoveryImage)
+	return config.SetCLIDiscoverySource(*ds)
+}


### PR DESCRIPTION
### What this PR does / why we need it
- Switch the default discovery source registry to `projects.packages.broadcom.com`.
- All the plugins have been migrated to the new registry at `projects.packages.broadcom.com/tanzu_cli`
- Previous registry `project.registry.vmware.com/tanzu_cli` will be kept for some time for users consuming older versions of Tanzu CLI and both `projects.packages.broadcom.com/tanzu_cli` and `project.registry.vmware.com/tanzu_cli`.
- The expectation is that all Tanzu CLI will gradually move to Tanzu CLI v1.3.0 or greater.

**Details:**
- When the user switches from pre-v1.3.0 Tanzu CLI to v1.3.0 or newer version, Tanzu CLI will automatically update the discovery source to use the new location `projects.packages.broadcom.com/tanzu_cli/plugins/plugin-inventory:latest`
- Considering the registry from where the plugins will get installed going forward has been updated, users will see the EULA acceptance prompt again and users must accept terms before continuing to use Tanzu CLI.
- If the user is in the internet-restricted environment and has already updated the discovery source to point to a different registry, no changes will be made in that case.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

* User is using the pre-v1.3.0 (v1.2.0) version of Tanzu CLI.
```
$ tanzu version
version: v1.2.0
buildDate: 2024-02-07
sha: f3abe62e
arch: amd64

$ tanzu plugin source list
  NAME     IMAGE                                                                   
  default  projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest
```

* User installs the `v1.3.0` version of Tanzu CLI and runs any command for the first time, CLI will update the discovery source and prompt for EULA.
```
$ tz version
version: v1.3.0-dev
buildDate: 2024-04-29
sha: 82ca2e91-dirty
arch: amd64

$ tz plugin list
Some initialization of the CLI is required.
Let's set things up for you.  This will just take a few seconds.

Refreshing the 2 installed plugins...
Updating default plugin discovery source to "projects.packages.broadcom.com/tanzu_cli/plugins/plugin-inventory:latest"...

Initialization done!
==
? You must agree to the VMware General Terms in order to download, install, or
use software from this registry via Tanzu CLI. Acceptance of the VMware General
Terms covers all software installed via the Tanzu CLI during any Session.
“Session” means the period from acceptance until any of the following occurs:
(1) a change to VMware General Terms, (2) a new major release of the Tanzu CLI
is installed, (3) software is accessed in a separate software distribution
registry, or (4) re-acceptance of the General Terms is prompted by VMware.

To view the VMware General Terms, please see https://www.vmware.com/vmware-general-terms.html.

If you agree, the essential plugins (required by the tanzu cli) will be automatically installed.

Note: this prompt can be avoided by running "tanzu config eula accept".

Do you agree to the VMware General Terms?
 Yes

==
  NAME       DESCRIPTION                                                 TARGET  INSTALLED  STATUS     
  builder    Build Tanzu components                                      global  v1.2.0     installed  
  telemetry  configure cluster-wide settings for vmware tanzu telemetry  global  v1.1.0     installed


# Verify that the plugin discovery source has been updated
$ tz plugin source list
  NAME     IMAGE                                                                     
  default  projects.packages.broadcom.com/tanzu_cli/plugins/plugin-inventory:latest 

```

* If the user does not accept EULA, Tanzu CLI will throw an error like below
```
$ tz plugin list
Some initialization of the CLI is required.
Let's set things up for you.  This will just take a few seconds.

Refreshing the 2 installed plugins...
Updating default plugin discovery source to "projects.packages.broadcom.com/tanzu_cli/plugins/plugin-inventory:latest"...

Initialization done!
==
? You must agree to the VMware General Terms in order to download, install, or
use software from this registry via Tanzu CLI. Acceptance of the VMware General
Terms covers all software installed via the Tanzu CLI during any Session.
“Session” means the period from acceptance until any of the following occurs:
(1) a change to VMware General Terms, (2) a new major release of the Tanzu CLI
is installed, (3) software is accessed in a separate software distribution
registry, or (4) re-acceptance of the General Terms is prompted by VMware.

To view the VMware General Terms, please see https://www.vmware.com/vmware-general-terms.html.

If you agree, the essential plugins (required by the tanzu cli) will be automatically installed.

Note: this prompt can be avoided by running "tanzu config eula accept".

Do you agree to the VMware General Terms?
 No

==
The Tanzu CLI is only usable with reduced functionality until the General Terms are agreed to.
Please use `tanzu config eula show` to review the terms, or `tanzu config eula accept` to accept them directly
[x] : terms not accepted
```

- If user has configured custom discovery source for internet restricted use-case it should not be updated on upgrade
```
$ tanzu version
version: v1.2.0
buildDate: 2024-02-07
sha: f3abe62e
arch: amd64

$ tanzu plugin source update default -u harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest
[i] Refreshing plugin inventory cache for "harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Reading plugin inventory for "harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest", this will take a few seconds.
[ok] updated discovery source default

--------

$ tz version
version: v1.3.0-dev
buildDate: 2024-04-29
sha: 82ca2e91-dirty
arch: amd64

# Note: The discovery source is not getting updated here because it was manually updated by the user to point to custom registry.
$ tz plugin list
Some initialization of the CLI is required.
Let's set things up for you.  This will just take a few seconds.

Refreshing the 2 installed plugins...

Initialization done!
==
  NAME       DESCRIPTION                                                 TARGET  INSTALLED  STATUS     
  builder    Build Tanzu components                                      global  v1.2.0     installed 


-----
$ tz plugin source list
  NAME     IMAGE                                                                   
  default  harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest

```


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Switch the default discovery source registry to `projects.packages.broadcom.com`.

For any reason, if the user wants to switch back to the old registry `projects.registry.vmware.com`, run the following command to update discovery source `tanzu plugin source update default -u projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest`. To switch back to the new default registry run the `tanzu plugin source init` command.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
