### PR TITLE
Update error for Broadcom Foundation Agreement

### DIFF
--- a/pkg/command/eula_test.go
+++ b/pkg/command/eula_test.go
@@ -107,7 +107,7 @@ var _ = Describe("EULA command tests", func() {
 				cmd.SetArgs([]string{"context", "list"})
 				err = cmd.Execute()
 				Expect(err).ToNot(BeNil())
-				Expect(err.Error()).To(ContainSubstring("terms not accepted"))
+				Expect(err.Error()).To(ContainSubstring("agreement not accepted"))
 				os.Unsetenv("TANZU_CLI_EULA_PROMPT_ANSWER")
 			})
 

--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -356,8 +356,8 @@ func newRootCmd() *cobra.Command {
 				}
 				configVal, _ := config.GetEULAStatus()
 				if configVal != config.EULAStatusAccepted {
-					fmt.Fprintf(os.Stderr, "The Tanzu CLI is only usable with reduced functionality until the General Terms are agreed to.\nPlease use `tanzu config eula show` to review the terms, or `tanzu config eula accept` to accept them directly\n")
-					return errors.New("terms not accepted")
+					fmt.Fprintf(os.Stderr, "The Tanzu CLI is only usable with reduced functionality until the Broadcom Foundation Agreement is accepted.\nPlease use `tanzu config eula show` to review the Agreement, or `tanzu config eula accept` to accept it directly\n")
+					return errors.New("agreement not accepted")
 				}
 
 				// Prompt for CEIP agreement


### PR DESCRIPTION
### What this PR does / why we need it

This PR adjusts the error message when the EULA is rejected to use the "Broadcom Foundation Agreement" term instead of "General Terms" which came from the previous EULA which mentioned: "VMware General Terms"

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Before this PR notice the error message after the `==` which refers to "General Terms" which was the formulation of the old EULA ("You must agree to the VMware General Terms in order to download..."):
```
$ tz plugin search
? You must agree to the Broadcom Foundation Agreement in order to download,
install, or use software from this registry via Tanzu CLI. Acceptance of the
Broadcom Foundation Agreement covers all software installed via the Tanzu CLI
during any Session. "Session" means the period from acceptance until any of the
following occurs: (1) a change to Broadcom Foundation Agreement, (2) a new
major release of the Tanzu CLI is installed, (3) software is accessed in a
separate software distribution registry, or (4) re-acceptance of the Foundation
Agreement is prompted by Broadcom.

To view the Broadcom Foundation Agreement, please see
https://www.broadcom.com/company/legal/licensing.

If you agree, the essential plugins (required by the Tanzu CLI) will be
automatically installed.

Note: this prompt can be avoided by running "tanzu config eula accept".

Do you agree to the Broadcom Foundation Agreement?
 No

==
The Tanzu CLI is only usable with reduced functionality until the General Terms are agreed to.
Please use `tanzu config eula show` to review the terms, or `tanzu config eula accept` to accept them directly
[x] : terms not accepted
```

With this PR notice the new error message after the `==`:
```
$ tz plugin search
? You must agree to the Broadcom Foundation Agreement in order to download,
install, or use software from this registry via Tanzu CLI. Acceptance of the
Broadcom Foundation Agreement covers all software installed via the Tanzu CLI
during any Session. "Session" means the period from acceptance until any of the
following occurs: (1) a change to Broadcom Foundation Agreement, (2) a new
major release of the Tanzu CLI is installed, (3) software is accessed in a
separate software distribution registry, or (4) re-acceptance of the Foundation
Agreement is prompted by Broadcom.

To view the Broadcom Foundation Agreement, please see
https://www.broadcom.com/company/legal/licensing.

If you agree, the essential plugins (required by the Tanzu CLI) will be
automatically installed.

Note: this prompt can be avoided by running "tanzu config eula accept".

Do you agree to the Broadcom Foundation Agreement?
 No

==
The Tanzu CLI is only usable with reduced functionality until the Broadcom Foundation Agreement is accepted.
Please use `tanzu config eula show` to review the Agreement, or `tanzu config eula accept` to accept it directly
[x] : agreement not accepted
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Update message when rejecting the Broadcom Foundation Agreement
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
