### PR TITLE
Use shared values of latest version of plugins

### DIFF
--- a/pkg/plugininventory/sqlite_inventory.go
+++ b/pkg/plugininventory/sqlite_inventory.go
@@ -312,6 +312,16 @@ func (b *SQLiteInventory) extractPluginsFromRows(rows *sql.Rows) ([]*PluginInven
 				artifacts[currentVersion] = artifactList
 				artifactList = distribution.ArtifactList{}
 			}
+
+			// When we get a new version, let's update the shared fields of the plugin
+			// These shared fields apply to all versions of this plugin, so let's use
+			// the values of the latest version.  We know each version is more recent than
+			// the previous because we queried the DB in ascending order of version.
+			currentPlugin.Description = row.description
+			currentPlugin.Publisher = row.publisher
+			currentPlugin.Vendor = row.vendor
+			currentPlugin.RecommendedVersion = row.recommendedVersion
+
 			currentVersion = row.version
 		}
 

--- a/pkg/plugininventory/sqlite_inventory_test.go
+++ b/pkg/plugininventory/sqlite_inventory_test.go
@@ -245,9 +245,9 @@ INSERT INTO PluginBinaries VALUES(
 	'',
 	'v0.0.1',
 	'false',
-	'Mission-control management cluster operations',
-	'tmc',
-	'vmware',
+	'Description 1',
+	'publisher 1',
+	'vendor 1',
 	'linux',
 	'amd64',
 	'0000000000',
@@ -258,9 +258,9 @@ INSERT INTO PluginBinaries VALUES(
 	'',
 	'v0.0.2',
 	'false',
-	'Mission-control management cluster operations',
-	'tmc',
-	'vmware',
+	'Description 2',
+	'publisher 2',
+	'vendor 2',
 	'linux',
 	'amd64',
 	'1111111111',
@@ -271,9 +271,9 @@ INSERT INTO PluginBinaries VALUES(
     '',
     'v0.0.3',
     'true',
-    'Mission-control management cluster operations',
-    'tmc',
-    'vmware',
+    'Description 3',
+    'publisher 3',
+    'vendor 3',
     'linux',
     'amd64',
     '2222222222',
@@ -781,8 +781,6 @@ var _ = Describe("Unit tests for plugin inventory", func() {
 
 					Expect(p.RecommendedVersion).To(Equal("v0.0.2"))
 					Expect(string(p.Target)).To(Equal("mission-control"))
-					Expect(p.Vendor).To(Equal("vmware"))
-					Expect(p.Publisher).To(Equal("tmc"))
 
 					artifactList := p.Artifacts["v0.0.2"]
 					Expect(len(artifactList)).To(Equal(1))
@@ -791,6 +789,17 @@ var _ = Describe("Unit tests for plugin inventory", func() {
 					Expect(a.Arch).To(Equal("amd64"))
 					Expect(a.Digest).To(Equal("1111111111"))
 					Expect(a.Image).To(Equal(tmpDir + "/vmware/tmc/linux/amd64/tmc/management-cluster:v0.0.2"))
+				})
+				It("should return the description, publisher and vendor of the latest version", func() {
+					plugins, err := inventory.GetAllPlugins()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(len(plugins)).To(Equal(1))
+
+					p := plugins[0]
+					Expect(p.Name).To(Equal("management-cluster"))
+					Expect(p.Description).To(Equal("Description 2"))
+					Expect(p.Vendor).To(Equal("vendor 2"))
+					Expect(p.Publisher).To(Equal("publisher 2"))
 				})
 			})
 			Context("When getting all plugins including hidden ones", func() {
@@ -808,8 +817,9 @@ var _ = Describe("Unit tests for plugin inventory", func() {
 
 					Expect(p.RecommendedVersion).To(Equal("v0.0.3"))
 					Expect(string(p.Target)).To(Equal("mission-control"))
-					Expect(p.Vendor).To(Equal("vmware"))
-					Expect(p.Publisher).To(Equal("tmc"))
+					Expect(p.Description).To(Equal("Description 3"))
+					Expect(p.Vendor).To(Equal("vendor 3"))
+					Expect(p.Publisher).To(Equal("publisher 3"))
 
 					artifactList := p.Artifacts["v0.0.2"]
 					Expect(len(artifactList)).To(Equal(1))


### PR DESCRIPTION
### What this PR does / why we need it

If we want to modify the description of a plugin, we can publish a new version with the new description.  The problem is that the `plugin search` command shows the description of the *oldest* plugin version.

This commit makes sure the shared values of a plugin are taken from the most recent version.

This allows to change the description, the vendor and/or the publisher by publishing a new version of the plugin.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Add unit tests.

We had the problem with the `appsv2` plugin where we tried to change its description but `plugin search` still showed the old description.  What we did was to deactivate the old `appsv2` version `v0.2.0` to only have the new description.  I wanted to confirm this PR fixed the issue so I did:

1. locally reactivate `appsv2:v0.2.0` in my own DB cache
2. run a `plugin search` with CLI `v1.3.0` to see the old description
3. run a `plugin search` with this PR to see the new description

```
# Broken CLI
$ /opt/homebrew/bin/tanzu version
version: v1.3.0
buildDate: 2024-05-09
sha: d59f47c8
arch: arm64

# Fixed CLI
$ tz version
version: v1.3.0-dev
buildDate: 2024-05-13
sha: c95c9ca4a
arch: arm64

# Check that only v0.2.1 is visible to start and check the description
$ /opt/homebrew/bin/tanzu plugin search --name appsv2 -t global --show-details
name: appsv2
description: Applications on Tanzu Platform
target: global
latest: v0.2.1
versions:
    - v0.2.1

# Re-activate appsv2:v0.2.0 locally
$ echo "UPDATE PluginBinaries SET hidden='false' where PluginName ='appsv2' and Version='v0.2.0'" |sqlite3 ~/.cache/tanzu/plugin_inventory/default/plugin_inventory.db

# Check that the description is now the old one with the broken CLI
$ /opt/homebrew/bin/tanzu plugin search --name appsv2 -t global --show-details
name: appsv2
description: Applications on Kubernetes for TAP (SaaS distribution)
target: global
latest: v0.2.1
versions:
    - v0.2.0
    - v0.2.1

$ /opt/homebrew/bin/tanzu plugin search --name appsv2 -t global
  NAME    DESCRIPTION                                             TARGET  LATEST
  appsv2  Applications on Kubernetes for TAP (SaaS distribution)  global  v0.2.1

# Check with the PR
$ tz plugin search --name appsv2 -t global
  NAME    DESCRIPTION                     TARGET  LATEST
  appsv2  Applications on Tanzu Platform  global  v0.2.1
$ tz plugin search --name appsv2 -t global --show-details
name: appsv2
description: Applications on Tanzu Platform
target: global
latest: v0.2.1
versions:
    - v0.2.0
    - v0.2.1
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Show the description of the latest (instead of oldest) version of a plugin in the `tanzu plugin search` output.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
