### PR TITLE
Remove warning message regarding the current kubecontext while deleting the tanzu context

### DIFF
--- a/pkg/auth/utils/kubeconfig/kubeconfig.go
+++ b/pkg/auth/utils/kubeconfig/kubeconfig.go
@@ -10,8 +10,6 @@ import (
 	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/tools/clientcmd"
-
-	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"
 )
 
 func GetDefaultKubeConfigFile() string {
@@ -91,18 +89,12 @@ func DeleteContextFromKubeConfig(kubeconfigPath, context string) error {
 	delete(config.Clusters, clusterName)
 	delete(config.AuthInfos, userName)
 
-	shouldWarn := false
 	if config.CurrentContext == context {
 		config.CurrentContext = ""
-		shouldWarn = true
 	}
 	err = clientcmd.WriteToFile(*config, kubeconfigPath)
 	if err != nil {
 		return errors.Wrapf(err, "failed to delete the kubeconfig context '%s' ", context)
-	}
-
-	if shouldWarn {
-		log.Warningf("WARNING: this removed your active context, use \"kubectl config use-context\" to select a different one")
 	}
 
 	return nil


### PR DESCRIPTION
### What this PR does / why we need it

This PR removed the warning message regarding the current kubecontext while deleting the tanzu context

- Since CLI is using local kubeconfig file instead of default kubeconfig, warning message regarding deletion of current kubecontext doesn't have a relevance.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
Deleted the current CLI context (which also has corresponding kubecontext which is current). There is no warning message shown when the current kubecontext is deleted.

```
❯ ./bin/tanzu context list
  NAME                                  ISACTIVE  TYPE             PROJECT            SPACE
  TAP_pre-integration-staging-d03c5c97  false     tanzu            kmihova-15may
  TAP_staging-staging-2761fd6c          false     tanzu            amitjain           amit-space
  Tap-SaaS-Beta3                        false     tanzu
  mytmc-ctx                             false     mission-control  n/a                n/a
  prem-test-context                     false     tanzu
  tap-saas-ga-1                         true      tanzu            longevity-project  amit-dev
  tkg-mgmt-vc                           false     kubernetes       n/a                n/a
  tt-test-selfmg                        false     mission-control  n/a                n/a
  ucp                                   false     tanzu

[i] Use '--wide' to view additional columns.
❯ ./bin/tanzu context use TAP_staging-staging-2761fd6c
[i] Successfully activated context 'TAP_staging-staging-2761fd6c' (Type: tanzu, Project: amitjain (308a292c-9be4-4974-a993-855b1202d2c9), Space: amit-space)
❯ tk config get-contexts
CURRENT   NAME                                                           CLUSTER                                                        AUTHINFO                                              NAMESPACE
          tanzu-cli-TAP_pre-integration-staging-d03c5c97:kmihova-15may   tanzu-cli-TAP_pre-integration-staging-d03c5c97:kmihova-15may   tanzu-cli-TAP_pre-integration-staging-d03c5c97-user
*         tanzu-cli-TAP_staging-staging-2761fd6c:amitjain:amit-space     tanzu-cli-TAP_staging-staging-2761fd6c:amitjain:amit-space     tanzu-cli-TAP_staging-staging-2761fd6c-user
          tanzu-cli-Tap-SaaS-Beta3:tanzu-platform-demo                   tanzu-cli-Tap-SaaS-Beta3:tanzu-platform-demo                   tanzu-cli-Tap-SaaS-Beta3-user
          tanzu-cli-prem-test-context                                    tanzu-cli-prem-test-context                                    tanzu-cli-prem-test-context-user
          tanzu-cli-tap-saas-ga-1:longevity-project:amit-dev             tanzu-cli-tap-saas-ga-1:longevity-project:amit-dev             tanzu-cli-tap-saas-ga-1-user
❯ ./bin/tanzu context delete TAP_staging-staging-2761fd6c
Deleting the context entry from the config will remove it from the list of tracked contexts. You will need to use `tanzu context create` to re-create this context. Are you sure you want to continue? [y/N]: y
[i] Deleting kubeconfig context 'tanzu-cli-TAP_staging-staging-2761fd6c:amitjain:amit-space' from the file '/Users/pkalle/.config/tanzu/kube/config'
[ok] Successfully deleted context "TAP_staging-staging-2761fd6c"
❯ tk config get-contexts
CURRENT   NAME                                                           CLUSTER                                                        AUTHINFO                                              NAMESPACE
          tanzu-cli-TAP_pre-integration-staging-d03c5c97:kmihova-15may   tanzu-cli-TAP_pre-integration-staging-d03c5c97:kmihova-15may   tanzu-cli-TAP_pre-integration-staging-d03c5c97-user
          tanzu-cli-Tap-SaaS-Beta3:tanzu-platform-demo                   tanzu-cli-Tap-SaaS-Beta3:tanzu-platform-demo                   tanzu-cli-Tap-SaaS-Beta3-user
          tanzu-cli-prem-test-context                                    tanzu-cli-prem-test-context                                    tanzu-cli-prem-test-context-user
          tanzu-cli-tap-saas-ga-1:longevity-project:amit-dev             tanzu-cli-tap-saas-ga-1:longevity-project:amit-dev             tanzu-cli-tap-saas-ga-1-user

```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
