### PR TITLE
Update the file locking module dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/Masterminds/semver v1.5.0
 	github.com/adrg/xdg v0.4.0
+	github.com/alexflint/go-filemutex v1.3.0
 	github.com/cppforlife/go-cli-ui v0.0.0-20220425131040-94f26b16bc14
 	github.com/fatih/color v1.15.0
 	github.com/gobwas/glob v0.2.3
@@ -19,7 +20,6 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.0
 	github.com/imdario/mergo v0.3.13
-	github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b
 	github.com/k14s/kbld v0.32.0
 	github.com/lithammer/dedent v1.1.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
@@ -155,6 +155,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b // indirect
 	github.com/k14s/semver/v4 v4.0.1-0.20210701191048-266d47ac6115 // indirect
 	github.com/k14s/starlark-go v0.0.0-20200720175618-3a5c849cc368 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdc
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
 github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
+github.com/alexflint/go-filemutex v1.3.0 h1:LgE+nTUWnQCyRKbpoceKZsPQbs84LivvgwUymZXdOcM=
+github.com/alexflint/go-filemutex v1.3.0/go.mod h1:U0+VA/i30mGBlLCrFPGtTe9y6wGQfNAWPBTekHQ+c8A=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
@@ -940,6 +942,7 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220906165534-d0df966e6959/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
 golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/pkg/telemetry/metrics_db_lock_test.go
+++ b/pkg/telemetry/metrics_db_lock_test.go
@@ -1,0 +1,107 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package telemetry
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAcquireAndReleaseTanzuMetricDBLock(t *testing.T) {
+	// Test acquiring the lock
+	err := AcquireTanzuMetricDBLock()
+	assert.NoError(t, err, "Expected no error while acquiring the lock")
+
+	// Verify the lock is held
+	assert.NotNil(t, cliMetricDBLock, "Expected the lock to be acquired")
+
+	// Test releasing the lock
+	assert.NotPanics(t, func() {
+		ReleaseTanzuMetricDBLock()
+	}, "Expected no panic while releasing the lock")
+
+	// Verify the lock is released
+	assert.Nil(t, cliMetricDBLock, "Expected the lock to be released")
+}
+
+func TestLockTimeout(t *testing.T) {
+	// Acquire the lock for the first time
+	err := AcquireTanzuMetricDBLock()
+	assert.NoError(t, err, "Expected no error while acquiring the lock the first time")
+
+	// Try acquiring the lock again, should time out
+	err = AcquireTanzuMetricDBLock()
+	assert.Error(t, err, "Expected a timeout error while trying to acquire the lock again")
+	assert.ErrorContains(t, err, "timeout waiting for lock")
+
+	// Release the initial lock
+	ReleaseTanzuMetricDBLock()
+}
+
+func TestMultipleAcquireAndRelease(t *testing.T) {
+	// Acquire and release the lock multiple times
+	for i := 0; i < 3; i++ {
+		err := AcquireTanzuMetricDBLock()
+		assert.NoError(t, err, "Expected no error while acquiring the lock")
+
+		assert.NotNil(t, cliMetricDBLock, "Expected the lock to be acquired")
+
+		assert.NotPanics(t, func() {
+			ReleaseTanzuMetricDBLock()
+		}, "Expected no panic while releasing the lock")
+
+		assert.Nil(t, cliMetricDBLock, "Expected the lock to be released")
+	}
+}
+
+func TestParallelLocking(t *testing.T) {
+	const goroutines = 10
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	successCount := int32(0)
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			err := AcquireTanzuMetricDBLock()
+			if err == nil {
+				// sleep and hold lock for more than timeout period
+				// so that all other go routines fail to acquire lock
+				time.Sleep(2 * DefaultMetricsDBLockTimeout)
+				defer ReleaseTanzuMetricDBLock()
+				successCount++
+			}
+		}()
+	}
+
+	wg.Wait()
+	assert.Equal(t, int32(1), successCount, "Expected only one goroutine to successfully acquire the lock")
+}
+
+func TestParallelLockingAndUnlocking(t *testing.T) {
+	const goroutines = 10
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	successCount := int32(0)
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			err := AcquireTanzuMetricDBLock()
+			if err == nil {
+				// sleep and hold lock for less than timeout period
+				// so that all other go routines could acquire and release lock successfully
+				time.Sleep(100 * time.Millisecond)
+				defer ReleaseTanzuMetricDBLock()
+				successCount++
+			}
+		}()
+	}
+
+	wg.Wait()
+	assert.Equal(t, int32(10), successCount, "Expected all the goroutine to successfully acquire the lock")
+}


### PR DESCRIPTION
### What this PR does / why we need it

This PR updates the file locking module dependency

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
Unit tests and CI checks passed

Tested manually the  lock is auto-released on process exit

- Verified manually by adding the `os.Exit(2)`  [here](https://github.com/vmware-tanzu/tanzu-cli/blob/main/pkg/telemetry/sqlite_metrics_db.go#L94) after line 94. Then build and ran the the below command, we can see the CLI exit and didn't save the metric. 

```
❯ make build
build darwin-amd64 CLI with version: v1.3.0-dev
mkdir -p bin
cp /Users/pkalle/projects/tanzu-cli/artifacts/darwin/amd64/cli/core/v1.3.0-dev/tanzu-cli-darwin_amd64 ./bin/tanzu

❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db "select * from tanzu_cli_operations;"
cli_version|os_name|os_arch|plugin_name|plugin_version|command|cli_id|command_start_ts|command_end_ts|target|name_arg|endpoint|flags|exit_status|is_internal|error
v1.3.0|darwin|amd64|appsv2|v0.1.0-beta.2-dev-411403a5|app|8fd081d4-b2d2-413e-b461-5ad917b6635c|1718167006626|1718167009479|global||||0|1|
❯ ./bin/tanzu context list
  NAME                                   ISACTIVE  TYPE             PROJECT            SPACE
  1_ARM_ESO_MAIN_FRESH-staging-d03c5c97  false     tanzu
  TAP_pre-integration-staging-d03c5c97   false     tanzu            jay-project        space3
  TAP_staging-staging-d03c5c97           false     tanzu
  Tap-SaaS-Beta3                         false     tanzu
  mytmc-ctx                              false     mission-control  n/a                n/a
  prem-test-context                      false     tanzu
  tap-saas-ga-1                          true      tanzu            longevity-project  cli-dev-test
  tkg-mgmt-vc                            false     kubernetes       n/a                n/a
  tt-test-selfmg                         false     mission-control  n/a                n/a
  ucp                                    false     tanzu

[i] Use '--wide' to view additional columns.

❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db "select * from tanzu_cli_operations;"
cli_version|os_name|os_arch|plugin_name|plugin_version|command|cli_id|command_start_ts|command_end_ts|target|name_arg|endpoint|flags|exit_status|is_internal|error
v1.3.0|darwin|amd64|appsv2|v0.1.0-beta.2-dev-411403a5|app|8fd081d4-b2d2-413e-b461-5ad917b6635c|1718167006626|1718167009479|global||||0|1|
```
Later compiled the code removing the `os.Exit(2)` and ran the CLI, and this time it successfully updated the metrics which confirms the earlier exit without unlocking auto-released the lock. I will try to add the automated testing for this in separate PR.

```
❯ make  build
build darwin-amd64 CLI with version: v1.3.0-dev
mkdir -p bin
cp /Users/pkalle/projects/tanzu-cli/artifacts/darwin/amd64/cli/core/v1.3.0-dev/tanzu-cli-darwin_amd64 ./bin/tanzu
❯ ./bin/tanzu context list
  NAME                                   ISACTIVE  TYPE             PROJECT            SPACE
  1_ARM_ESO_MAIN_FRESH-staging-d03c5c97  false     tanzu
  TAP_pre-integration-staging-d03c5c97   false     tanzu            jay-project        space3
  TAP_staging-staging-d03c5c97           false     tanzu
  Tap-SaaS-Beta3                         false     tanzu
  mytmc-ctx                              false     mission-control  n/a                n/a
  prem-test-context                      false     tanzu
  tap-saas-ga-1                          true      tanzu            longevity-project  cli-dev-test
  tkg-mgmt-vc                            false     kubernetes       n/a                n/a
  tt-test-selfmg                         false     mission-control  n/a                n/a
  ucp                                    false     tanzu

[i] Use '--wide' to view additional columns.
❯ sqlite3 -batch ~/.config/tanzu-cli-telemetry/cli_metrics.db "select * from tanzu_cli_operations;"
cli_version|os_name|os_arch|plugin_name|plugin_version|command|cli_id|command_start_ts|command_end_ts|target|name_arg|endpoint|flags|exit_status|is_internal|error
v1.3.0|darwin|amd64|appsv2|v0.1.0-beta.2-dev-411403a5|app|8fd081d4-b2d2-413e-b461-5ad917b6635c|1718167006626|1718167009479|global||||0|1|
v1.3.0-dev|darwin|amd64|||context list|8fd081d4-b2d2-413e-b461-5ad917b6635c|1718176704393|1718176704476|||||0|1|
```

Verified it works on Windows as well.

```

H:\windows-cli-test\cli\v1.3.0-dev>tanzu-cli-windows_amd64.exe version
version: v1.3.0-dev
buildDate: 2024-06-12
sha: 8ccca608
arch: amd64

H:\windows-cli-test\cli\v1.3.0-dev>tanzu-cli-windows_amd64.exe context list
  NAME                          ISACTIVE  TYPE   PROJECT  SPACE
  TAP_staging-staging-d03c5c97  true      tanzu

[i] Use '--wide' to view additional columns.

H:\windows-cli-test\cli\v1.3.0-dev>
H:\windows-cli-test\cli\v1.3.0-dev>tanzu-cli-windows_amd64.exe context use TANZU_CLI_SHOW_TELEMETRY_CONSOLE_LOGS
[x] : context TANZU_CLI_SHOW_TELEMETRY_CONSOLE_LOGS not found

H:\windows-cli-test\cli\v1.3.0-dev>tanzu-cli-windows_amd64.exe context use TAP_staging-staging-d03c5c97
[i] Successfully activated context 'TAP_staging-staging-d03c5c97' (Type: tanzu)

H:\windows-cli-test\cli\v1.3.0-dev>tanzu-cli-windows_amd64.exe context delete TAP_staging-staging-d03c5c97
Deleting the context entry from the config will remove it from the list of tracked contexts. You will need to use `tanzu context create` to re-create this context. Are you sure you want to continue? [y/N]: N


//Later copied the sqlite db file to other machine and validated the telemetry entries are updated in the DB which confirms the locking/unlocking is working as expected on windows.

❯ scp sc-dbc2163.eng.vmware.com:/mts/home4/pkalle/windows-cli-test/cli/cli_metrics.db .
pkalle@sc-dbc2163.eng.vmware.com's password:
cli_metrics.db                                                                                                                                                                    100%   12KB 166.9KB/s   00:00
❯ sqlite3 -batch ./cli_metrics.db "select * from tanzu_cli_operations;"
cli_version|os_name|os_arch|plugin_name|plugin_version|command|cli_id|command_start_ts|command_end_ts|target|name_arg|endpoint|flags|exit_status|is_internal|error
v1.3.0-dev|windows|amd64|||context list|22ee360d-13b1-4b42-8b85-9f8e69822d04|1718217033724|1718217033769|||||0|0|
v1.3.0-dev|windows|amd64|||context list|22ee360d-13b1-4b42-8b85-9f8e69822d04|1718217649175|1718217649218|||||0|0|
v1.3.0-dev|windows|amd64|||context list|22ee360d-13b1-4b42-8b85-9f8e69822d04|1718217843421|1718217843465|||||0|0|
v1.3.0-dev|windows|amd64|||context use|22ee360d-13b1-4b42-8b85-9f8e69822d04|1718217856357|1718217856393||be05294ec015003b552b205540ba9b245fc7329259bd223a1d7813494a8984e7|||1|0|
v1.3.0-dev|windows|amd64|||context use|22ee360d-13b1-4b42-8b85-9f8e69822d04|1718217867032|1718217867075||a1467bf1ce39871ed82c8a5197e7b6cebcd6c96ff724c957ef86323753f1b3b6|||0|0|
v1.3.0-dev|windows|amd64|||context delete|22ee360d-13b1-4b42-8b85-9f8e69822d04|1718217888264|1718217890725||a1467bf1ce39871ed82c8a5197e7b6cebcd6c96ff724c957ef86323753f1b3b6|||0|0|
```


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
