### PR TITLE
Hide the init command

### DIFF
--- a/pkg/command/init.go
+++ b/pkg/command/init.go
@@ -17,14 +17,15 @@ func init() {
 }
 
 var initCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Initialize the CLI",
+	Use:    "init",
+	Hidden: true,
+	Short:  "Initialize the CLI",
 	Annotations: map[string]string{
 		"group": string(plugin.SystemCmdGroup),
 	},
 	SilenceErrors:     true,
 	ValidArgsFunction: noMoreCompletions,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		// Currently nothing to initialize.
 		// We are keeping this command as it may become useful
 		// again in the future.


### PR DESCRIPTION
### What this PR does / why we need it

There was a time when the `tanzu init` command did a fair bit, but it is a no-op now and kept around for backward compatibility.  There is however, no need to keep it visible, as it also leads to some confusion with other commands like "tanzu app init".

This commit hides the command.

We don't deprecate it because it may become useful again in the future.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

```
# notice there is no `init` command shown in the `system` group
$ tz
The Tanzu CLI

Usage:
  tanzu [command]

Available command groups:

  Admin
    builder                 Build Tanzu components
[...]
  System
    completion              Output shell completion code
    config                  Configuration for the CLI
    context                 Configure and manage contexts for the Tanzu CLI
    login                   Login to Tanzu Application Platform
    plugin                  Manage CLI plugins
    version                 Version information
  Target
    kubernetes              Commands that interact with a Kubernetes endpoint
    operations              Commands that support Kubernetes operations for Tanzu Application Platform

Flags:
  -h, --help   help for tanzu

Use "tanzu [command] --help" for more information about a command.

# Shell completion no longer suggests `init`
$ tz ini<TAB>

# The init command is still available to avoid breaking scripts
$ tz init
[ok] successfully initialized CLI

$ tz init -h
Initialize the CLI

Usage:
  tanzu init [flags]

Flags:
  -h, --help   help for init
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Hide the `tanzu init` command which is no longer performing any actual initialization.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
