### PR TITLE
Respect command mapping for help from plugins

### DIFF
--- a/pkg/cli/plugin_cmd.go
+++ b/pkg/cli/plugin_cmd.go
@@ -164,6 +164,7 @@ func getCmdForPluginEx(p *PluginInfo, cmdName string, mapEntry *plugin.CommandMa
 
 		runner := NewRunner(p.Name, p.InstallationPath, completion)
 		ctx := context.Background()
+		setupPluginEnv(srcHierarchy, dstHierarchy)
 		output, _, err := runner.RunOutput(ctx)
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
@@ -198,10 +199,14 @@ func getCmdForPluginEx(p *PluginInfo, cmdName string, mapEntry *plugin.CommandMa
 		// calls such as "tanzu help cluster list", we need to do some argument
 		// parsing ourselves and modify what gets passed along to the plugin.
 		helpArgs := getHelpArguments()
+		if len(srcHierarchy) > 0 {
+			helpArgs = append(srcHierarchy, helpArgs...)
+		}
 
 		// Pass this new command in to our plugin to have it handle help output
 		runner := NewRunner(p.Name, p.InstallationPath, helpArgs)
 		ctx := context.Background()
+		setupPluginEnv(srcHierarchy, dstHierarchy)
 		err := runner.Run(ctx)
 		if err != nil {
 			log.Errorf("Help output for '%s' is not available.", c.Name())

--- a/pkg/command/root_test.go
+++ b/pkg/command/root_test.go
@@ -1381,7 +1381,7 @@ func TestCommandRemapping(t *testing.T) {
 					name:   "dummy2",
 					target: configtypes.TargetK8s,
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "dummy",
 						},
 					},
@@ -1397,7 +1397,7 @@ func TestCommandRemapping(t *testing.T) {
 					name:   "dummy2",
 					target: configtypes.TargetK8s,
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "dummy",
 						},
 					},
@@ -1419,7 +1419,7 @@ func TestCommandRemapping(t *testing.T) {
 					target:  configtypes.TargetK8s,
 					aliases: []string{"dum"},
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "dummy3",
 						},
 					},
@@ -1440,7 +1440,7 @@ func TestCommandRemapping(t *testing.T) {
 					name:   "bar2",
 					target: configtypes.TargetK8s,
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "bar",
 						},
 					},
@@ -1463,7 +1463,7 @@ func TestCommandRemapping(t *testing.T) {
 					target:  configtypes.TargetK8s,
 					aliases: []string{"dum"},
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "dummy",
 						},
 					},
@@ -1486,7 +1486,7 @@ func TestCommandRemapping(t *testing.T) {
 					target:  configtypes.TargetK8s,
 					aliases: []string{"dum"},
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "dummy3",
 							Overrides:              "dummy",
 						},
@@ -1504,10 +1504,10 @@ func TestCommandRemapping(t *testing.T) {
 					name:   "dummy2",
 					target: configtypes.TargetK8s,
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "dummy",
 						},
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "operations dummy",
 						},
 					},
@@ -1523,7 +1523,7 @@ func TestCommandRemapping(t *testing.T) {
 					name:   "dummy2",
 					target: configtypes.TargetK8s,
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "dummy",
 						},
 					},
@@ -1539,7 +1539,7 @@ func TestCommandRemapping(t *testing.T) {
 					name:   "dummy2",
 					target: configtypes.TargetK8s,
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "kubernetes dummy",
 						},
 					},
@@ -1555,7 +1555,7 @@ func TestCommandRemapping(t *testing.T) {
 					name:   "dummy2",
 					target: configtypes.TargetK8s,
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "nonexistentprefix dummy",
 						},
 					},
@@ -1571,10 +1571,10 @@ func TestCommandRemapping(t *testing.T) {
 					name:   "dummy2",
 					target: configtypes.TargetTMC,
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "mission-control dummy",
 						},
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "dummy",
 						},
 					},
@@ -1591,7 +1591,7 @@ func TestCommandRemapping(t *testing.T) {
 					target:  configtypes.TargetK8s,
 					aliases: []string{"dum"},
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "dummy",
 						},
 					},
@@ -1601,7 +1601,7 @@ func TestCommandRemapping(t *testing.T) {
 					target:  configtypes.TargetK8s,
 					aliases: []string{"dum"},
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "dummy",
 						},
 					},
@@ -1619,7 +1619,7 @@ func TestCommandRemapping(t *testing.T) {
 					aliases:              []string{"dum"},
 					supportedContextType: []configtypes.ContextType{configtypes.ContextTypeTanzu},
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "dummy",
 						},
 					},
@@ -1637,7 +1637,7 @@ func TestCommandRemapping(t *testing.T) {
 					target:  configtypes.TargetK8s,
 					aliases: []string{"dum"},
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "dummy",
 						},
 					},
@@ -1655,7 +1655,7 @@ func TestCommandRemapping(t *testing.T) {
 					aliases:              []string{"dum"},
 					supportedContextType: []configtypes.ContextType{configtypes.ContextTypeTMC},
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "mission-control dummy",
 						},
 					},
@@ -1679,7 +1679,7 @@ func TestCommandRemapping(t *testing.T) {
 					aliases:              []string{"dum"},
 					supportedContextType: []configtypes.ContextType{configtypes.ContextTypeTanzu},
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "dummy",
 						},
 					},
@@ -1705,7 +1705,7 @@ func TestCommandRemapping(t *testing.T) {
 					aliases:              []string{"dum"},
 					supportedContextType: []configtypes.ContextType{configtypes.ContextTypeTanzu},
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "dummy",
 						},
 					},
@@ -1731,7 +1731,7 @@ func TestCommandRemapping(t *testing.T) {
 					aliases:              []string{"dum"},
 					supportedContextType: []configtypes.ContextType{configtypes.ContextTypeTanzu},
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "dummy",
 						},
 					},
@@ -1755,7 +1755,7 @@ func TestCommandRemapping(t *testing.T) {
 					name:   "deeper",
 					target: configtypes.TargetK8s,
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "kubernetes dummy deeper",
 						},
 					},
@@ -1772,7 +1772,7 @@ func TestCommandRemapping(t *testing.T) {
 					name:   "dummy",
 					target: configtypes.TargetK8s,
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "topshout",
 							SourceCommandPath:      "shout",
 							Description:            "extracted shout command",
@@ -1790,7 +1790,7 @@ func TestCommandRemapping(t *testing.T) {
 					name:   "dummy",
 					target: configtypes.TargetK8s,
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "topshout",
 							SourceCommandPath:      "shout",
 							Description:            "extracted shout command",
@@ -1808,7 +1808,7 @@ func TestCommandRemapping(t *testing.T) {
 					name:   "dummy",
 					target: configtypes.TargetK8s,
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "topshout",
 							SourceCommandPath:      "shout",
 							Description:            "extracted shout command",
@@ -1826,7 +1826,7 @@ func TestCommandRemapping(t *testing.T) {
 					name:   "dummy",
 					target: configtypes.TargetK8s,
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "invoke-info",
 							SourceCommandPath:      "show-invoke-context",
 							Description:            "Shows invocation details",
@@ -1844,7 +1844,7 @@ func TestCommandRemapping(t *testing.T) {
 					name:   "dummy",
 					target: configtypes.TargetK8s,
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "invoke-info",
 							SourceCommandPath:      "show-invoke-context",
 							Description:            "Shows invocation details",
@@ -1862,7 +1862,7 @@ func TestCommandRemapping(t *testing.T) {
 					name:   "dummy",
 					target: configtypes.TargetK8s,
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "plugin source invoke-info",
 							SourceCommandPath:      "show-invoke-context",
 							Description:            "Shows invocation details",
@@ -1885,7 +1885,7 @@ func TestCommandRemapping(t *testing.T) {
 					name:   "dummy2",
 					target: configtypes.TargetK8s,
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "dummy",
 							SourceCommandPath:      "show-invoke-context",
 							Description:            "Shows invocation details",
@@ -1908,7 +1908,7 @@ func TestCommandRemapping(t *testing.T) {
 					name:   "dummy2",
 					target: configtypes.TargetK8s,
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "dummy say",
 							SourceCommandPath:      "show-invoke-context",
 							Description:            "Shows invocation details",
@@ -1931,7 +1931,7 @@ func TestCommandRemapping(t *testing.T) {
 					name:   "dummy2",
 					target: configtypes.TargetK8s,
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "dummy",
 							SourceCommandPath:      "show-invoke-context",
 							Description:            "Shows invocation details",
@@ -1955,7 +1955,7 @@ func TestCommandRemapping(t *testing.T) {
 					name:   "dummy2",
 					target: configtypes.TargetGlobal,
 					commandMap: []plugin.CommandMapEntry{
-						plugin.CommandMapEntry{
+						{
 							DestinationCommandPath: "platform-engineering dummy",
 						},
 					},
@@ -1964,6 +1964,39 @@ func TestCommandRemapping(t *testing.T) {
 			args:       []string{"tpe"},
 			expected:   []string{"dummy2 commands"},
 			unexpected: []string{"No plugins are currently installed for \"platform-engineering\""},
+		},
+		// --- Command level mapping tests for the "tanzu help" command
+		{
+			test: "help command for one unmapped plugin",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:   "dummy",
+					target: configtypes.TargetGlobal,
+				},
+			},
+			args: []string{"help", "dummy"},
+			// Help output for the dummy plugin
+			expected: []string{"dummy functionality\n\nUsage:\n  tanzu dummy [command]"},
+		},
+		{
+			test: "help command for one mapped plugin",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:   "dummy2",
+					target: configtypes.TargetGlobal,
+					commandMap: []plugin.CommandMapEntry{
+						{
+							SourceCommandPath:      "show-invoke-context",
+							DestinationCommandPath: "dummy",
+						},
+					},
+				},
+			},
+			args: []string{"help", "dummy"},
+			// Output for the show-invoke-context command which prints the passed arguments
+			// and environment.  So we confirm that the show-invoke-context was called, passed -h
+			// and received the remapping environment.
+			expected: []string{"args = (show-invoke-context -h), context is ():(dummy):(show-invoke-context)"},
 		},
 	}
 
@@ -2015,7 +2048,11 @@ func TestCommandRemapping(t *testing.T) {
 
 			rootCmd, err := NewRootCmd()
 			assert.Nil(err)
-			rootCmd.SetArgs(spec.args)
+			// To be able to test the "tanzu help" command, we need to set the os.Args
+			// instead of using the cobra command's SetArgs method.
+			// rootCmd.SetArgs(spec.args)
+			// See getHelpArguments() in pkg/cli/plugin_cmd.go
+			os.Args = append([]string{"tanzu"}, spec.args...)
 
 			os.Unsetenv("TANZU_CLI_INVOKED_GROUP")
 			os.Unsetenv("TANZU_CLI_INVOKED_COMMAND")


### PR DESCRIPTION
### What this PR does / why we need it

When remapping plugin commands, the `tanzu help` command on those remapped commands is not correct.

For example
```
# The trait commands is actually remapped from "space trait"
# Notice that we are getting the help from "space" instead of "trait"
$ tz help trait
Tanzu space lifecycle management

Usage:
  tanzu space [command]

Aliases:
  space, spaces, sp

Available Commands:
  create              Create a Space with specified configuration
  delete              Delete a space
[...]

# The deploy command is remapped from "resource deploy"
# Notice that we are getting the help from "resource" instead of "deploy"
$ tz help deploy
manage resources in a Kubernetes cluster

Usage:

Flags:
  -h, --help   help for resource
```

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

After the PR:

```
$ tz help trait
Trait lifecycle management

Usage:
  tanzu trait [command]

Aliases:
  trait, traits, tr

Available Commands:
  create      Create a trait with specified configuration
  delete      Delete a trait
  generate    Generate a trait manifest with specified configuration.
  get         Get details from a trait.
  list        List the traits in the current workspace.

Flags:
  -h, --help   help for trait

Global Flags:
      --no-color       deactivate color, bold, animations, and emoji output
      --project name   name of the project to use when creating resources, or switching spaces (default is project name from current-context defined by Application Engine)

Use "tanzu trait [command] --help" for more information about a command.

$ tz help deploy
Deploy resources on the cluster

Usage:
  tanzu deploy [flags]

Flags:
      --diff                Show diff
      --from-build string   Set build output directory (format: /tmp/foo)
  -h, --help                help for deploy
      --only strings        Set files or directories to patch, ignoring tanzu.yml (format: file1.yml, dirname/) (can repeat)
      --patch               Patch resources
  -y, --yes                 Confirm all prompts with yes
```

Notice that the invocation form is respected:
```
# Calling "space trait" instead of "trait" is reflected in the help
$ tz help space trait
Trait lifecycle management

Usage:
  tanzu space trait [command]
[...]

# Aliases also work
$ tz help tr
Trait lifecycle management

Usage:
  tanzu trait [command]

Aliases:
  trait, traits, tr

[...]

$ tz help space tr
Trait lifecycle management

Usage:
  tanzu space trait [command]

Aliases:
  trait, traits, tr
[...]
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Respect command mapping for the help command for plugins
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
