### PR TITLE
Allow customizing the Tanzu Hub endpoint when creating tanzu context

### DIFF
--- a/pkg/command/context_test.go
+++ b/pkg/command/context_test.go
@@ -932,12 +932,13 @@ type ContextListInfo struct {
 
 var _ = Describe("create new context", func() {
 	const (
-		existingContext    = "test-mc"
-		testKubeContext    = "test-k8s-context"
-		testKubeConfigPath = "/fake/path/kubeconfig"
-		testContextName    = "fake-context-name"
-		fakeTMCEndpoint    = "tmc.cloud.vmware.com:443"
-		fakeTanzuEndpoint  = "https://fake.api.tanzu.cloud.vmware.com"
+		existingContext      = "test-mc"
+		testKubeContext      = "test-k8s-context"
+		testKubeConfigPath   = "/fake/path/kubeconfig"
+		testContextName      = "fake-context-name"
+		fakeTMCEndpoint      = "tmc.cloud.vmware.com:443"
+		fakeTanzuEndpoint    = "https://fake.api.tanzu.cloud.vmware.com"
+		fakeTanzuHubEndpoint = "https://fake.api.tanzu.hub.vmware.com"
 	)
 	var (
 		tkgConfigFile   *os.File
@@ -1115,6 +1116,19 @@ var _ = Describe("create new context", func() {
 					Expect(ctx.Name).To(ContainSubstring("fake-context-name"))
 					Expect(string(ctx.ContextType)).To(ContainSubstring(contextTypeTanzu))
 					Expect(ctx.GlobalOpts.Endpoint).To(ContainSubstring(endpoint))
+				})
+			})
+			Context("with endpoint, tanzuHubEndpoint and context name provided", func() {
+				It("should create context with given endpoint and context name", func() {
+					endpoint = fakeTanzuEndpoint
+					tanzuHubEndpoint = fakeTanzuHubEndpoint
+					ctxName = testContextName
+					ctx, err = createNewContext()
+					Expect(err).To(BeNil())
+					Expect(ctx.Name).To(ContainSubstring("fake-context-name"))
+					Expect(string(ctx.ContextType)).To(ContainSubstring(contextTypeTanzu))
+					Expect(ctx.GlobalOpts.Endpoint).To(ContainSubstring(endpoint))
+					Expect(ctx.AdditionalMetadata[config.TanzuHubEndpointKey].(string)).To(ContainSubstring(tanzuHubEndpoint))
 				})
 			})
 			Context("context name already exists", func() {

--- a/pkg/command/login.go
+++ b/pkg/command/login.go
@@ -47,8 +47,11 @@ func init() {
 	loginCmd.Flags().BoolVar(&staging, "staging", false, "use CSP staging issuer")
 	loginCmd.Flags().StringVar(&endpointCACertPath, "endpoint-ca-certificate", "", "path to the endpoint public certificate")
 	loginCmd.Flags().BoolVar(&skipTLSVerify, "insecure-skip-tls-verify", false, "skip endpoint's TLS certificate verification")
+	loginCmd.Flags().StringVar(&tanzuHubEndpoint, "tanzu-hub-endpoint", "", "customize the Tanzu Hub endpoint associated with the context")
+
 	utils.PanicOnErr(loginCmd.Flags().MarkHidden("api-token"))
 	utils.PanicOnErr(loginCmd.Flags().MarkHidden("staging"))
+	utils.PanicOnErr(loginCmd.Flags().MarkHidden("tanzu-hub-endpoint"))
 	loginCmd.SetUsageFunc(cli.SubCmdUsageFunc)
 	loginCmd.MarkFlagsMutuallyExclusive("endpoint-ca-certificate", "insecure-skip-tls-verify")
 


### PR DESCRIPTION
### What this PR does / why we need it

- Allow customizing the Tanzu Hub endpoint when creating a tanzu context.
- Implements a hidden flag `tanzu-hub-endpoint` with `tanzu login` and `tanzu context create` commands.
- If configured, the `tanzu` context will be created with the specified value in the `tanzuHubEndpoint` field under `additionalMetadata`.
- An additional log line `This tanzu context is being created with the custom Tanzu Hub endpoint: "<specified-endpoint>"` will be printed when this flag is specified while creating the context.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Verify with `tanzu login`
```
$ tz login --tanzu-hub-endpoint https://api.be-tis.symphony-dev.com/hub
[i] Opening the browser window to complete the login
Log in by visiting this link:

    https://console.cloud.vmware.com/csp/gateway/discovery?client_id=tanzu-cli-client-id&code_challenge=pVnmvp7umB7r0cGI-cvnU6yT8GVwj8vINhw_ASevFtM&code_challenge_method=S256&redirect_uri=http%3A%2F%2F127.0.0.1%3A52346%2Fcallback&response_type=code&state=ff12de5be3480b15c797115d05380dd1

    Optionally, paste your authorization code: [...]

[!] This tanzu context is being created with the custom Tanzu Hub endpoint: "https://api.be-tis.symphony-dev.com/hub"

[ok] Successfully logged into 'Tanzu Platform for K8s SaaS - Internal 1' organization and created a tanzu context

----

$ tz context get Tanzu_Platform_for_K8s_SaaS_-_Internal_1
name: Tanzu_Platform_for_K8s_SaaS_-_Internal_1
target: tanzu
contextType: tanzu
...
additionalMetadata:
    tanzuClusterGroupName: ""
    tanzuHubEndpoint: https://api.be-tis.symphony-dev.com/hub
    tanzuMissionControlEndpoint: https://tmc.tanzu.cloud.vmware.com
    tanzuOrgID: 8406e52e-6e36-445a-be7b-9dab6903341e
    tanzuOrgName: Tanzu Platform for K8s SaaS - Internal 1
    tanzuProjectID: 0f49c031-6294-4bdf-b363-55ae96788402
    tanzuProjectName: longevity-project
    tanzuSpaceName: tshaine
```

Verify with `tanzu context create`:
```
$ tz context create TP-context-with-custom-hub-endpoint --type tanzu --tanzu-hub-endpoint https://api.be-tis.symphony-dev.com/hub
? Enter control plane endpoint https://api.tanzu.cloud.vmware.com
[i] Opening the browser window to complete the login
Log in by visiting this link:

    https://console.cloud.vmware.com/csp/gateway/discovery?client_id=tanzu-cli-client-id&code_challenge=YDlk-X3c7vgZc98K_VdSb9-OxS_os2bNZA4ADc1GEKo&code_challenge_method=S256&redirect_uri=http%3A%2F%2F127.0.0.1%3A52981%2Fcallback&response_type=code&state=e0d2bf13bc93e612d2b5b77d6ac4dd7e

    Optionally, paste your authorization code: [...]

[!] This tanzu context is being created with the custom Tanzu Hub endpoint: "https://api.be-tis.symphony-dev.com/hub"

[ok] Successfully logged into 'Tanzu Platform for K8s SaaS - Internal 1' organization and created a tanzu context

---

$ tz context get TP-context-with-custom-hub-endpoint
name: TP-context-with-custom-hub-endpoint
target: tanzu
contextType: tanzu
...
additionalMetadata:
    tanzuHubEndpoint: https://api.be-tis.symphony-dev.com/hub
    tanzuMissionControlEndpoint: https://tmc.tanzu.cloud.vmware.com
    tanzuOrgID: 8406e52e-6e36-445a-be7b-9dab6903341e
    tanzuOrgName: Tanzu Platform for K8s SaaS - Internal 1
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
None
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
