### PR TITLE
Entry-specific active context type check in command mapping

### DIFF
--- a/docs/plugindev/README.md
+++ b/docs/plugindev/README.md
@@ -578,6 +578,7 @@ Each CommandMapEntry has the following fields
 - DestinationCommandPath: is a space-delimited path to the command relative to the root Command of the Tanzu CLI that the command associated with SourceCommandPath should be mapped to and invocable by the user
 - Overrides: By default, the command previously situated at the DestinationCommandPath of the Tanzu CLI, if exist, will be the one overridden by this entry. If this mapping attempt in intended to override another part of the Tanzu CLI command tree, the override path should be used.
 - Description: Required when remapping a subcommand of this plugin outside of the plugin's command tree (e.g. whe elevating a plugin's subcommand to a top level command of the Tanzu CLI). This enables the CLI to provide better help information about the remapped command.
+- RequiredContextType: If this list not empty, the mapping prescribed by the entry will only take effect if the type of the active CLI Context matches one in this list.
 
 Assume there is a plugin named foo with a non empty CommandMap
 
@@ -638,6 +639,19 @@ instead of every plugin command X be invocable via `tanzu foo X`, it is now
 invocable via `tanzu operations foo X`. Note that there is a requirement that
 the command group a plugin is mapping under ("operations" in the example
 provided) has to be already present in the CLI.
+
+### Relocating a plugin command to a different command group when active CLI context is of a specific type
+
+```go
+        plugin.CommandMapEntry{
+            SourceCommandPath:      "echo",
+            DestinationCommandPath: "cluster echo",
+            RequiredContextType:    [types.ContextType{types.ContextTypeTanzu}],
+        },
+```
+
+When the active CLI context is of type 'tanzu', `tanzu cluster echo` will be
+available and provided by this plugin's 'echo' command
 
 ### SupportedContextType
 

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/vmware-tanzu/carvel-ytt v0.40.0
 	github.com/vmware-tanzu/tanzu-cli/test/e2e/framework v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686
-	github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0
+	github.com/vmware-tanzu/tanzu-plugin-runtime v1.4.0-dev.0.20240628172415-c1da15b9ca40
 	go.pinniped.dev v0.20.0
 	golang.org/x/mod v0.15.0
 	golang.org/x/oauth2 v0.8.0
@@ -74,6 +74,7 @@ require (
 	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 // indirect
 	github.com/ThalesIgnite/crypto11 v1.2.5 // indirect
 	github.com/VividCortex/ewma v1.1.1 // indirect
+	github.com/anujc25/tablewriter v0.0.1 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.18.0 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.18.23 // indirect
@@ -176,7 +177,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
-	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc3 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E
 github.com/alexflint/go-filemutex v1.3.0 h1:LgE+nTUWnQCyRKbpoceKZsPQbs84LivvgwUymZXdOcM=
 github.com/alexflint/go-filemutex v1.3.0/go.mod h1:U0+VA/i30mGBlLCrFPGtTe9y6wGQfNAWPBTekHQ+c8A=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/anujc25/tablewriter v0.0.1 h1:mduyh0D5OFVg4Mpwo3kIKyUUo28BFbcDRCumNgTxDdI=
+github.com/anujc25/tablewriter v0.0.1/go.mod h1:kHFBkhjbRmWky4/RaaoJq6EL+P2udNMebDaMTVmNC1Q=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
@@ -544,7 +546,7 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
-github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
@@ -579,8 +581,6 @@ github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
-github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
-github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1lskyM0=
@@ -740,8 +740,8 @@ github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502eb
 github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502ebf68/go.mod h1:e1Uef+Ux5BIHpYwqbeP2ZZmOzehBcez2vUEWXHe+xHE=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686 h1:VcuXqUXFxm5WDqWkzAlU/6cJXua0ozELnqD59fy7J6E=
 github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-20230523145612-1c6fbba34686/go.mod h1:AFGOXZD4tH+KhpmtV0VjWjllXhr8y57MvOsIxTtywc4=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0 h1:bOxm+8XlkroHR1sf1iwsDEfsIm/cb/vrK+l3GMeOKMU=
-github.com/vmware-tanzu/tanzu-plugin-runtime v1.3.0/go.mod h1:FtRiwn4qIsx4yQUbKqcv33Sx5x1c+Cil30/K/3FJ4co=
+github.com/vmware-tanzu/tanzu-plugin-runtime v1.4.0-dev.0.20240628172415-c1da15b9ca40 h1:ruFurbjnhXVAqPCrAAC94ABXh8XHW5y5rxEwB7Uhmxc=
+github.com/vmware-tanzu/tanzu-plugin-runtime v1.4.0-dev.0.20240628172415-c1da15b9ca40/go.mod h1:xerHxk6AjVPw20+Gfw0xyfytTfNPRI/HzhhB/5lvHYE=
 github.com/xanzy/go-gitlab v0.83.0 h1:37p0MpTPNbsTMKX/JnmJtY8Ch1sFiJzVF342+RvZEGw=
 github.com/xanzy/go-gitlab v0.83.0/go.mod h1:5ryv+MnpZStBH8I/77HuQBsMbBGANtVpLWC15qOjWAw=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=

--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -225,8 +225,20 @@ func buildReplacementMap(plugins []cli.PluginInfo) map[string]*cobra.Command {
 	var maskedRemappedPlugins []string
 	result := map[string]*cobra.Command{}
 
+	activeContextMap, err := config.GetAllActiveContextsMap()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to get active contexts : %v\n", err)
+		return result
+	}
+
+	cmp := cli.NewCommandMapProcessor(activeContextMap)
+	if cmp == nil {
+		fmt.Fprintf(os.Stderr, "Unable to process command map from plugins")
+		return result
+	}
+
 	for i := range plugins {
-		cmdMap := cli.GetCommandMapForPlugin(&plugins[i])
+		cmdMap := cmp.GetCommandMapForPlugin(&plugins[i])
 		for pathKey, newCmd := range cmdMap {
 			if _, ok := result[pathKey]; ok {
 				// Remapping a remapped command is unexpected! Note it and skip the attempt.

--- a/pkg/command/root_test.go
+++ b/pkg/command/root_test.go
@@ -1740,6 +1740,133 @@ func TestCommandRemapping(t *testing.T) {
 			unexpected:              []string{"dummy2 commands"},
 		},
 		{
+			test: "no mapping of entry if active context type is not among its requiredContextType list",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:    "dummy",
+					target:  configtypes.TargetK8s,
+					aliases: []string{"dum"},
+				},
+				{
+					name:    "dummy2",
+					target:  configtypes.TargetGlobal,
+					aliases: []string{"dum"},
+					commandMap: []plugin.CommandMapEntry{
+						{
+							DestinationCommandPath: "conditionally-mapped",
+							RequiredContextType:    []configtypes.ContextType{configtypes.ContextTypeTanzu},
+						},
+						{
+							DestinationCommandPath: "always-mapped",
+						},
+						{
+							DestinationCommandPath: "dummy",
+						},
+					},
+				},
+			},
+			activeContextType: configtypes.ContextTypeK8s,
+			args:              []string{},
+			expected:          []string{"always-mapped", "dummy2 commands"},
+			unexpected:        []string{"conditionally-mapped", "dummy commands"},
+		},
+		{
+			test: "apply mapping of entry if active context type is among its requiredContextType list",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:    "dummy",
+					target:  configtypes.TargetK8s,
+					aliases: []string{"dum"},
+				},
+				{
+					name:    "dummy2",
+					target:  configtypes.TargetGlobal,
+					aliases: []string{"dum"},
+					commandMap: []plugin.CommandMapEntry{
+						{
+							DestinationCommandPath: "conditionally-mapped",
+							RequiredContextType:    []configtypes.ContextType{configtypes.ContextTypeTanzu},
+						},
+						{
+							DestinationCommandPath: "always-mapped",
+						},
+						{
+							DestinationCommandPath: "dummy",
+						},
+					},
+				},
+			},
+			activeContextType: configtypes.ContextTypeTanzu,
+			args:              []string{},
+			expected:          []string{"conditionally-mapped", "always-mapped", "dummy2 commands"},
+			unexpected:        []string{"dummy commands"},
+		},
+		{
+			test: "supportedContextType has no bearing on effect of RequiredContextType",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:    "dummy",
+					target:  configtypes.TargetK8s,
+					aliases: []string{"dum"},
+				},
+				{
+					name:                 "dummy2",
+					target:               configtypes.TargetGlobal,
+					aliases:              []string{"dum"},
+					supportedContextType: []configtypes.ContextType{configtypes.ContextTypeTanzu},
+					commandMap: []plugin.CommandMapEntry{
+						{
+							DestinationCommandPath: "conditionally-mapped",
+							RequiredContextType:    []configtypes.ContextType{configtypes.ContextTypeTanzu},
+						},
+						{
+							DestinationCommandPath: "always-mapped",
+						},
+						{
+							DestinationCommandPath: "dummy",
+						},
+					},
+				},
+			},
+			activeContextType: configtypes.ContextTypeK8s,
+			args:              []string{},
+			expected:          []string{"always-mapped", "dummy2 commands"},
+			unexpected:        []string{"conditionally-mapped", "dummy commands"},
+		},
+		{
+			test: "when feature flag is set supportedContextType takes precedence over RequiredContextType",
+			pluginVariants: []fakePluginRemapAttributes{
+				{
+					name:    "dummy",
+					target:  configtypes.TargetK8s,
+					aliases: []string{"dum"},
+				},
+				{
+					name:                 "dummy2",
+					target:               configtypes.TargetGlobal,
+					aliases:              []string{"dum"},
+					supportedContextType: []configtypes.ContextType{configtypes.ContextTypeTanzu},
+					commandMap: []plugin.CommandMapEntry{
+						{
+							DestinationCommandPath: "conditionally-mapped",
+							RequiredContextType:    []configtypes.ContextType{configtypes.ContextTypeK8s},
+						},
+						{
+							DestinationCommandPath: "not-always-mapped",
+						},
+						{
+							DestinationCommandPath: "dummy",
+						},
+					},
+				},
+			},
+			activeContextType:       configtypes.ContextTypeK8s,
+			allowActiveContextCheck: true,
+			args:                    []string{},
+			expected:                []string{"dummy commands"},
+			unexpected:              []string{"conditionally-mapped", "not-always-mapped", "dummy2 commands"},
+		},
+		{
 			test: "nesting plugin within another plugin is not supported",
 			pluginVariants: []fakePluginRemapAttributes{
 				{


### PR DESCRIPTION
Introduce CommandMapProcessor to facilitate processing a plugin's command map. Uses an instance of said processor that is aware of the active contexts so that each command map entry can be evaluated against them for applicability.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Updated unit tests.

Manual:
Created sample plugin containing CommandMapEntry with explicity RequireContextType, verify
that the mapping only takes effect when a context of matching type is active. 

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Support entry-specific active context type check in command mapping
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
