### PR TITLE
Add flags validation check to error if `--kubeconfig` flag is specified while creating tanzu context type using `--type` flag

### DIFF
--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -253,7 +253,9 @@ func createCtx(cmd *cobra.Command, args []string) (err error) {
 		}
 		ctxName = args[0]
 	}
-
+	if err := validateContextCreateFlagValues(); err != nil {
+		return err
+	}
 	if !configtypes.IsValidContextType(contextTypeStr) {
 		return errors.New(invalidContextType)
 	}
@@ -282,6 +284,16 @@ func createCtx(cmd *cobra.Command, args []string) (err error) {
 		if err := syncContextPlugins(cmd, ctx.ContextType, ctxName); err != nil {
 			log.Warningf("unable to automatically sync the plugins recommended by the new context. Please run 'tanzu plugin sync' to sync plugins manually, error: '%v'", err.Error())
 		}
+	}
+	return nil
+}
+
+func validateContextCreateFlagValues() error {
+	if contextTypeStr == string(configtypes.ContextTypeTanzu) && kubeConfig != "" {
+		return fmt.Errorf("the '–-kubeconfig' flag is not applicable when creating a context of type 'tanzu'")
+	}
+	if contextTypeStr == string(configtypes.ContextTypeTanzu) && kubeContext != "" {
+		return fmt.Errorf("the '–-kubecontext' flag is not applicable when creating a context of type 'tanzu'")
 	}
 	return nil
 }

--- a/pkg/command/context_test.go
+++ b/pkg/command/context_test.go
@@ -1903,3 +1903,11 @@ func TestMapTanzuEndpointToTMCEndpoint(t *testing.T) {
 		}
 	}
 }
+
+func TestCreateContextWithTanzuTypeAndKubeconfigFlags(t *testing.T) {
+	contextTypeStr = contextTypeTanzu
+	kubeConfig = "fake-kubeconfig"
+	err := createCtx(&cobra.Command{}, []string{})
+	assert.NotNil(t, err)
+	assert.EqualError(t, err, `the '–-kubeconfig' flag is not applicable when creating a context of type 'tanzu'`)
+}


### PR DESCRIPTION
### What this PR does / why we need it
This PR adds validation check to error if `--kubeconfig` flag is specified while creating tanzu context type using `--type` flag
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Tested creating the tanzu context by providing both `--type tanzu` and `--kubeconfig` flags, CLI throws error as expected.
```
❯ ./bin/tanzu context create testTAPSaaSBeta3Prod --type tanzu  --kubeconfig ~/junk/config.yaml
[x] : the '–-kubeconfig' flag is not applicable when creating a context of type 'tanzu'
```
Tested creating the tanzu context by providing both `--type tanzu` and `--kubecontext` flags, CLI throws error as expected.
```
❯ ./bin/tanzu context create  --type tanzu  --kubecontext test
[x] : the '–-kubecontext' flag is not applicable when creating a context of type 'tanzu
```


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
