### PR TITLE
Add provision to update the CSP issuer to TCSP

### DIFF
--- a/pkg/auth/csp/token_test.go
+++ b/pkg/auth/csp/token_test.go
@@ -256,15 +256,17 @@ func TestGetToken_Expired(t *testing.T) {
 		Expiration:   expireTime,
 		Type:         APITokenType,
 	}
-
 	fakeHTTPClient := &fakes.FakeHTTPClient{}
-	responseBody := io.NopCloser(bytes.NewReader([]byte(`{
+	responseBodyFmt := `{
 		"id_token": "abc",
 		"token_type": "Test",
 		"expires_in": 86400,
 		"scope": "Test",
-		"access_token": "LetMeIn",
-		"refresh_token": "LetMeInAgain"}`)))
+		"access_token": "%s",
+		"refresh_token": "LetMeInAgain"}`
+
+	responseBodyStr := fmt.Sprintf(responseBodyFmt, accessToken)
+	responseBody := io.NopCloser(bytes.NewReader([]byte(responseBodyStr)))
 	fakeHTTPClient.DoReturns(&http.Response{
 		StatusCode: 200,
 		Body:       responseBody,
@@ -274,6 +276,6 @@ func TestGetToken_Expired(t *testing.T) {
 	tok, err := GetToken(&serverAuth)
 	assert.Nil(err)
 	assert.NotNil(tok)
-	assert.Equal(tok.AccessToken, "LetMeIn")
+	assert.Equal(tok.AccessToken, accessToken)
 	assert.Equal(tok.RefreshToken, "LetMeInAgain")
 }

--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -754,10 +754,7 @@ func updateTanzuContextMetadata(c *configtypes.Context, orgID, orgName, tanzuHub
 // getCSPOrganizationName returns the CSP Org name using the orgID from the claims.
 // It will return empty string if API fails
 func getCSPOrganizationName(c *configtypes.Context, claims *csp.Claims) (string, error) {
-	issuer := csp.ProdIssuer
-	if staging {
-		issuer = csp.StgIssuer
-	}
+	issuer := csp.GetIssuer(staging)
 	if c.GlobalOpts == nil {
 		return "", errors.New("invalid context %q. Missing authorization fields")
 	}
@@ -796,10 +793,7 @@ func doCSPAuthentication(c *configtypes.Context) (*csp.Claims, error) {
 
 func doCSPInteractiveLoginAndUpdateContext(c *configtypes.Context) (claims *csp.Claims, err error) {
 	logCSPOrgIDEnvVariableUsage()
-	issuer := csp.ProdIssuer
-	if staging {
-		issuer = csp.StgIssuer
-	}
+	issuer := csp.GetIssuer(staging)
 	cspOrgIDValue, cspOrgIDExists := os.LookupEnv(constants.CSPLoginOrgID)
 	var loginOptions []csp.LoginOption
 	if cspOrgIDExists && cspOrgIDValue != "" {
@@ -853,10 +847,7 @@ func logCSPOrgIDEnvVariableUsage() {
 }
 
 func doCSPAPITokenAuthAndUpdateContext(c *configtypes.Context, apiTokenValue string) (claims *csp.Claims, err error) {
-	issuer := csp.ProdIssuer
-	if staging {
-		issuer = csp.StgIssuer
-	}
+	issuer := csp.GetIssuer(staging)
 	token, err := csp.GetAccessTokenFromAPIToken(apiTokenValue, issuer)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get the token from CSP")

--- a/pkg/command/root_test.go
+++ b/pkg/command/root_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -19,6 +20,7 @@ import (
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/plugin"
 
+	"github.com/vmware-tanzu/tanzu-cli/pkg/auth/csp"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/buildinfo"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/catalog"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
@@ -2193,5 +2195,111 @@ func TestCommandRemapping(t *testing.T) {
 				assert.NotContains(string(got), unexpected)
 			}
 		})
+	}
+}
+
+func TestUpdateConfigWithTanzuCSPIssuer(t *testing.T) {
+	env := setupTestCLIEnvironment(t)
+	defer tearDownTestCLIEnvironment(env)
+
+	// Set up mocks for the centralConfigIssuerUpdateFlagGetter and cliContextUpdateStatusGetter functions
+	centralConfigIssuerUpdateFlagGetter := func() bool {
+		return true
+	}
+	cliContextUpdateStatusGetter := func(string, interface{}) error {
+		return nil
+	}
+
+	// Test TMC context with the VCSP staging Issuer, is updated to TCSP staging issuer, and refresh token and expiration time are unchanged
+	missionContextWithVCSPStagingIssuer := createFakeContext("mission-context-with-vcsp-staging-issuer", csp.StgIssuer,
+		"refresh-token-should-not-be-modified", csp.APITokenType, configtypes.ContextTypeTMC)
+	err := config.SetContext(missionContextWithVCSPStagingIssuer, false)
+	assert.NoError(t, err)
+	updateConfigWithTanzuCSPIssuer(centralConfigIssuerUpdateFlagGetter, cliContextUpdateStatusGetter)
+	gotCtx, err := config.GetContext(missionContextWithVCSPStagingIssuer.Name)
+	assert.NoError(t, err)
+	assert.Equal(t, csp.StgIssuerTCSP, gotCtx.GlobalOpts.Auth.Issuer)
+	assert.Equal(t, missionContextWithVCSPStagingIssuer.GlobalOpts.Auth.RefreshToken, gotCtx.GlobalOpts.Auth.RefreshToken)
+	assert.Equal(t, missionContextWithVCSPStagingIssuer.GlobalOpts.Auth.Expiration.Local(), gotCtx.GlobalOpts.Auth.Expiration.Local())
+
+	// Test TMC context with the VCSP prod Issuer, is updated to TCSP prod issuer and refresh token and expiration time are unchanged
+	missionContextWithVCSPProdIssuer := createFakeContext("mission-context-with-vcsp-prod-issuer", csp.ProdIssuer,
+		"refresh-token-should-not-be-modified", csp.APITokenType, configtypes.ContextTypeTMC)
+	err = config.SetContext(missionContextWithVCSPProdIssuer, false)
+	assert.NoError(t, err)
+	updateConfigWithTanzuCSPIssuer(centralConfigIssuerUpdateFlagGetter, cliContextUpdateStatusGetter)
+
+	gotCtx, err = config.GetContext(missionContextWithVCSPProdIssuer.Name)
+	assert.NoError(t, err)
+	assert.Equal(t, csp.ProdIssuerTCSP, gotCtx.GlobalOpts.Auth.Issuer)
+	assert.Equal(t, missionContextWithVCSPProdIssuer.GlobalOpts.Auth.RefreshToken, gotCtx.GlobalOpts.Auth.RefreshToken)
+	assert.Equal(t, missionContextWithVCSPProdIssuer.GlobalOpts.Auth.Expiration.Local(), gotCtx.GlobalOpts.Auth.Expiration.Local())
+
+	// Test Tanzu context with the VCSP staging Issuer, is updated to TCSP staging issuer
+	// and refresh token and expiration time are unchanged as the token is API token
+	tanzuContextWithVCSPStagingIssuer := createFakeContext("tanzu-context-with-tcsp-prod-issuer", csp.StgIssuer,
+		"refresh-token-to-be-modified", csp.APITokenType, configtypes.ContextTypeTanzu)
+	err = config.SetContext(tanzuContextWithVCSPStagingIssuer, false)
+	assert.NoError(t, err)
+	updateConfigWithTanzuCSPIssuer(centralConfigIssuerUpdateFlagGetter, cliContextUpdateStatusGetter)
+	gotCtx, err = config.GetContext(tanzuContextWithVCSPStagingIssuer.Name)
+	assert.NoError(t, err)
+	assert.Equal(t, csp.StgIssuerTCSP, gotCtx.GlobalOpts.Auth.Issuer)
+	assert.Equal(t, tanzuContextWithVCSPStagingIssuer.GlobalOpts.Auth.RefreshToken, gotCtx.GlobalOpts.Auth.RefreshToken)
+	assert.Equal(t, tanzuContextWithVCSPStagingIssuer.GlobalOpts.Auth.Expiration.Local(), gotCtx.GlobalOpts.Auth.Expiration.Local())
+
+	// Test Tanzu context with the VCSP prod Issuer, is updated to TCSP prod issuer
+	// and refresh token and expiration time are unchanged as the token is API token
+	tanzuContextWithVCSPProdIssuer := createFakeContext("tanzu-context-with-tcsp-prod-issuer", csp.ProdIssuer,
+		"refresh-token-to-be-modified", csp.APITokenType, configtypes.ContextTypeTanzu)
+	err = config.SetContext(tanzuContextWithVCSPProdIssuer, false)
+	assert.NoError(t, err)
+	updateConfigWithTanzuCSPIssuer(centralConfigIssuerUpdateFlagGetter, cliContextUpdateStatusGetter)
+	gotCtx, err = config.GetContext(tanzuContextWithVCSPProdIssuer.Name)
+	assert.NoError(t, err)
+	assert.Equal(t, csp.ProdIssuerTCSP, gotCtx.GlobalOpts.Auth.Issuer)
+	assert.Equal(t, tanzuContextWithVCSPProdIssuer.GlobalOpts.Auth.RefreshToken, gotCtx.GlobalOpts.Auth.RefreshToken)
+	assert.Equal(t, tanzuContextWithVCSPProdIssuer.GlobalOpts.Auth.Expiration.Local(), gotCtx.GlobalOpts.Auth.Expiration.Local())
+
+	// Test Tanzu context with the VCSP prod Issuer, is updated to TCSP prod issuer
+	// and refresh token and expiration time are invalidated as the token is id-token(interactive login token)
+	tanzuContextWithVCSPProdIssuerWithIDTokenType := createFakeContext("tanzu-context-with-tcsp-prod-issuer-with-IDToken",
+		csp.ProdIssuer, "refresh-token-to-be-modified", csp.IDTokenType, configtypes.ContextTypeTanzu)
+	err = config.SetContext(tanzuContextWithVCSPProdIssuerWithIDTokenType, false)
+	assert.NoError(t, err)
+	updateConfigWithTanzuCSPIssuer(centralConfigIssuerUpdateFlagGetter, cliContextUpdateStatusGetter)
+	gotCtx, err = config.GetContext(tanzuContextWithVCSPProdIssuerWithIDTokenType.Name)
+	assert.NoError(t, err)
+	assert.Equal(t, csp.ProdIssuerTCSP, gotCtx.GlobalOpts.Auth.Issuer)
+	assert.Equal(t, "Invalid", gotCtx.GlobalOpts.Auth.RefreshToken)
+	assert.True(t, gotCtx.GlobalOpts.Auth.Expiration.Before(time.Now().Local()))
+
+	// Test Tanzu context with the TCSP prod Issuer is unchanged
+	tanzuContextWithTCSPProdIssuerWithIDTokenType := createFakeContext("tanzu-context-with-tcsp-prod-issuer-with-IDToken",
+		csp.ProdIssuerTCSP, "refresh-token-to-be-modified", csp.IDTokenType, configtypes.ContextTypeTanzu)
+	err = config.SetContext(tanzuContextWithTCSPProdIssuerWithIDTokenType, false)
+	assert.NoError(t, err)
+	updateConfigWithTanzuCSPIssuer(centralConfigIssuerUpdateFlagGetter, cliContextUpdateStatusGetter)
+	gotCtx, err = config.GetContext(tanzuContextWithTCSPProdIssuerWithIDTokenType.Name)
+	assert.NoError(t, err)
+	assert.Equal(t, tanzuContextWithTCSPProdIssuerWithIDTokenType.GlobalOpts.Auth.Issuer, gotCtx.GlobalOpts.Auth.Issuer)
+	assert.Equal(t, tanzuContextWithTCSPProdIssuerWithIDTokenType.GlobalOpts.Auth.RefreshToken, gotCtx.GlobalOpts.Auth.RefreshToken)
+	assert.Equal(t, tanzuContextWithTCSPProdIssuerWithIDTokenType.GlobalOpts.Auth.Expiration.Local(), gotCtx.GlobalOpts.Auth.Expiration.Local())
+}
+
+func createFakeContext(ctxName, issuer, refreshToken, tokenType string, ctxType configtypes.ContextType) *configtypes.Context {
+	return &configtypes.Context{
+		Name:        ctxName,
+		ContextType: ctxType,
+		GlobalOpts: &configtypes.GlobalServer{
+			Auth: configtypes.GlobalServerAuth{
+				Issuer:       issuer,
+				UserName:     "test-user-name",
+				AccessToken:  "access-token",
+				RefreshToken: refreshToken,
+				Expiration:   time.Now().Local().Add(5 * time.Second),
+				Type:         tokenType,
+			},
+		},
 	}
 }

--- a/pkg/constants/env_variables.go
+++ b/pkg/constants/env_variables.go
@@ -91,4 +91,7 @@ const (
 	// ActivatePluginsOnPluginGroupPublish activates all the plugins specified within the plugin group
 	// as part of the plugin group publishing
 	ActivatePluginsOnPluginGroupPublish = "TANZU_CLI_ACTIVATE_PLUGINS_ON_PLUGIN_GROUP_PUBLISH"
+
+	// UseTanzuCSP uses the Tanzu CSP while login/context creation
+	UseTanzuCSP = "TANZU_CLI_USE_TANZU_CLOUD_SERVICE_PROVIDER"
 )


### PR DESCRIPTION
### What this PR does / why we need it

This PR adds provision to update the CSP issuer to TCSP
Summary of changes:
- Add provision through central configuration to update the CSP issuer from VCSP to TCSP. Also added an option in central configuration so that CLI can react to the configuration flag set in central configuration to update the issuers in the already created contexts.


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

**API_TOKEN testing:**
- login to TAP pre-integration org using API token using the below central configuration (using the VCSP as default Issuer). 
```
#### central configuration used for testing####
cli.core.cli_recommended_versions:
- version: v1.4.0-rc.0
- version: v1.3.0
- version: v1.2.0
- version: v1.1.0
- version: v1.0.0
- version: v0.90.1
cli.core.tanzu_application_platform_scopes:
- scope: tap:viewer
- scope: tap:admin
- scope: tap:member
cli.core.tanzu_hub_metadata:
  cspProductIdentifier: "TANZU-SAAS"
  cspDisplayName: "Tanzu Platform"
  endpointProduction: https://api.mgmt.cloud.vmware.com/hub
  endpointStaging: https://api.staging-tis.symphony-dev.com/hub
  useCentralConfig: true
cli.core.tanzu_default_csp_metadata:
  issuerStaging: https://console-stg.cloud.vmware.com/csp/gateway/am/api
  issuerProduction: https://console.cloud.vmware.com/csp/gateway/am/api
cli.core.tanzu_tcsp_metadata:
  issuerStaging: https://console-stg.tanzu.broadcom.com/csp/gateway/am/api
  issuerProduction: https://console.tanzu.broadcom.com/csp/gateway/am/api
cli.core.tanzu_csp_known_issuer_endpoints:
  https://console-stg.cloud.vmware.com/csp/gateway/am/api:
     authURL: "https://console-stg.cloud.vmware.com/csp/gateway/discovery"
     tokenURL: "https://console-stg.cloud.vmware.com/csp/gateway/am/api/auth/authorize"
  https://console.cloud.vmware.com/csp/gateway/am/api:
     authURL: "https://console.cloud.vmware.com/csp/gateway/discovery"
     tokenURL: "https://console.cloud.vmware.com/csp/gateway/am/api/auth/authorize"
  https://https://console-stg.tanzu.broadcom.com/csp/gateway/am/api:
    authURL: "https://console-stg.tanzu.broadcom.com/csp/gateway/discovery"
    tokenURL: "https://console-stg.tanzu.broadcom.com/csp/gateway/am/api/auth/authorize"
  https://console.tanzu.broadcom.com/csp/gateway/am/api:
    authURL: "https://console.tanzu.broadcom.com/csp/gateway/discovery"
    tokenURL: "https://console.tanzu.broadcom.com/csp/gateway/am/api/auth/authorize"
cli.core.tanzu_cli_config_csp_issuer_update_flag: false

####

❯ ./bin/tanzu login --staging --endpoint https://api.tanzu-dev.cloud.vmware.com
[i] API token env var is set

[ok] Successfully logged into 'TAP pre-integration' organization and created a tanzu context

❯ ./bin/tanzu project list
Listing projects from TAP pre-integration org

  NAME                     READY  AGE
  Sriram Test project      True   4d17h
  abhisheks2               True   4d17h
  alb-test                 True   4d17h
 [...]

❯ ./bin/tanzu context get TAP_pre-integration-staging-d03c5c97
name: TAP_pre-integration-staging-d03c5c97
target: tanzu
contextType: tanzu
globalOpts:
    endpoint: https://api.tanzu-dev.cloud.vmware.com
    auth:
        issuer: https://console-stg.cloud.vmware.com/csp/gateway/am/api
        userName: pkalle
        permissions:
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/project:e2db6ff4-ea19-4804-a694-1ab79ce1d6bd/tap:developer
            - external/5b919bd9-b029-45c7-829d-1a30fad2808e/ensemble:admin
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/project:e2db6ff4-ea19-4804-a694-1ab79ce1d6bd/tap:viewer
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/vrn/org:ae93ebb4-a249-4553-aa1e-c87c4b7f75e5/project:test-cli-proj/tap:member
            - csp:project_admin/vrn/org:ae93ebb4-a249-4553-aa1e-c87c4b7f75e5/project:test-cli-proj
            - csp:org_member
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/vrn/org:ae93ebb4-a249-4553-aa1e-c87c4b7f75e5/project:test-cli-proj/tap:admin
            - csp:developer
            - csp:project_admin/project:e2db6ff4-ea19-4804-a694-1ab79ce1d6bd
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/vrn/org:ae93ebb4-a249-4553-aa1e-c87c4b7f75e5/project:test-cli-proj/tap:developer
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/vrn/org:ae93ebb4-a249-4553-aa1e-c87c4b7f75e5/project:test-cli-proj/tap:viewer
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/tap:developer
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/tap:viewer
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/tap:admin
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/project:e2db6ff4-ea19-4804-a694-1ab79ce1d6bd/tap:admin
            - csp:org_admin
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/project:e2db6ff4-ea19-4804-a694-1ab79ce1d6bd/tap:member
            - external/5b919bd9-b029-45c7-829d-1a30fad2808e/instance:a8c26706-6514-4374-b825-cdb754e9faa6/ensemble:admin
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/tap:member
        accessToken: <REDACTED>
        IDToken: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InNpZ25pbmdfMyJ9.eyJzdWIiOiJ2bXdhcmUuY29tOjMwMjM2YzBhLTk2MjYtNDZmMy1iYTlmLTY3OTc3NjY4NmE5NSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJpc3MiOiJodHRwczovL2dhei1wcmV2aWV3LmNzcC12aWRtLXByb2QuY29tIiwiZ3JvdXBfbmFtZXMiOlsiVGFibGVhdSBTZXJ2ZXIgVXNlcnNAdm13YXJlLmNvbSIsImcudklETVN5bmNAdm13YXJlLmNvbSIsImcuZHluLnZtd2FyZV9hbGxfYWN0aXZlX2VtcGxveWVlc0B2bXdhcmUuY29tIiwiZy5SbkQtSVQtUGx1cmFsc2lnaHQtdXNlci1ncm91cEB2bXdhcmUuY29tIiwiZy5Tb2x1dGlvbkJ1aWxkZXItU2VydmljZXNTYWxlc0B2bXdhcmUuY29tIiwiUlNBQXJjaGVySG9yaXpvbkB2bXdhcmUuY29tIiwiZy5Tb2x1dGlvbkJ1aWxkZXItQ29yZVNhbGVzQHZtd2FyZS5jb20iLCJnLmR5bi5oZWxwbm93X2FsbF9hY3RpdmVfZW1wbG95ZWVzQHZtd2FyZS5jb20iLCJnLlpFTi1HUkMgQ09OVFJJQlVUT1JAdm13YXJlLmNvbSIsImcuZHluLmhlbHBub3dfYWxsX2FjdGl2ZV9lbXBsb3llZXNfZXhjbHVkZV9wcmVoaXJlQHZtd2FyZS5jb20iLCJnLmR5bi5hbGxfdXNlcnNAdm13YXJlLmNvbSIsImcuRG9ja2VyVXNlcnNAdm13YXJlLmNvbSIsImcuYnVpbGR3ZWJfYXV0aG9yaXplZF9ncm91cEB2bXdhcmUuY29tIiwiZy5keW4uZXVjLWVuZ2luZWVyaW5nQHZtd2FyZS5jb20iLCJnLnNjbS5naXRsYWJfYXV0aG9yaXplZF91c2Vyc0B2bXdhcmUuY29tIiwiZy5vcGVuZ3Jva19hdXRob3JpemVkX2dyb3VwQHZtd2FyZS5jb20iLCJnLmR5bi5zc2RzX291X2VuZ0B2bXdhcmUuY29tIiwiZy5jb3JlYXV0b21hdGlvbi5oZWFkc3BpbkB2bXdhcmUuY29tIiwiZy5SYWdodS1SbkQtT3JnLUZURUB2bXdhcmUuY29tIiwiZy5kYmMtdXNlcnNAdm13YXJlLmNvbSIsImcuc2NtLnBlcmZvcmNlX2F1dGhvcml6ZWRfdXNlcnNAdm13YXJlLmNvbSIsImcuZHluLmFsbF9mdGVzX2FuZF9pbnRlcm5zQHZtd2FyZS5jb20iLCJnLmR5bi5tYW1iZy12ZHAtZGVtb0B2bXdhcmUuY29tIl0sImNvbnRleHRfbmFtZSI6ImFlOTNlYmI0LWEyNDktNDU1My1hYTFlLWM4N2M0YjdmNzVlNSIsImdpdmVuX25hbWUiOiJQcmVtIiwiYXVkIjpbImNzcF9zdGdfZ2F6X2ludGVybmFsX2NsaWVudF9pZCJdLCJhdXRoX3RpbWUiOjE3MTMzNzk1NzUsImRvbWFpbiI6InZtd2FyZS5jb20iLCJncm91cF9pZHMiOlsidm13YXJlLmNvbTpiMGUzZWFjMC1mMDhjLTQ1ZmQtOTZmZS04YTUxYTNlM2FmNTAiLCJ2bXdhcmUuY29tOmQwYWI0ZmMxLTE2YjEtNGI0OC05Y2VkLWE0MzNjYTBhOWZhYSIsInZtd2FyZS5jb206NTI3YWM2NmYtZTQ5OC00NjJkLThmOTQtM2JlMmQ2MzRhMTAzIiwidm13YXJlLmNvbTpjMTY5ZTU1Mi03ZGI2LTQ3MWQtOTBmYy0wOGMzMGIzNzBhMjkiLCJ2bXdhcmUuY29tOjQ5YTBiMTZmLWRjNGQtNGMwMy1iYzdiLThhNjEzMTllMWI3NiIsInZtd2FyZS5jb206MmE1ZDdkZDAtNWE1ZC00MmQzLThjMWItMDAxN2VlOTgwMGM0Iiwidm13YXJlLmNvbTo0NGUwZWNkYi1jOGMzLTQwZjAtOGIzOS0wY2Q2NDA2M2E3MTkiLCJ2bXdhcmUuY29tOmUzNjRkMmRjLTQ5NWUtNDI5ZC05ZTQ4LWU2ZDc3N2Q5OWFmNyIsInZtd2FyZS5jb206YTE2MmUxNmYtMjM3ZS00NGY0LTk0OTAtZjA5YzhiNTI5YjIxIiwidm13YXJlLmNvbTpmYzg1MzYyNi01ZThlLTRjMmYtYmE3MS1kZjA2NzMzYjczMTciLCJ2bXdhcmUuY29tOmViMTAwMGMzLTVkNzMtNDBlZS1iMmRkLTI1YjFkNzQ1NTNhNyIsInZtd2FyZS5jb206YTFhZmIwYTctMjgwMC00ZjQwLTg2M2MtOTg3NDllOGZkMTUyIiwidm13YXJlLmNvbToyY2MwNDcyZC0zNzkyLTQyMWQtODlhOS1iYWI4Njk0ODA1NzUiLCJ2bXdhcmUuY29tOmMxM2I1NzhhLTQzYzItNDhiYy05MWQzLWVkMGEyOGMwYTEzNCIsInZtd2FyZS5jb206MjdlZTBhY2ItZmJhOS00OTBjLWIyYzAtNjk1ZmIwZDhkMzI5Iiwidm13YXJlLmNvbTphNmI5ODk0NC0xZjM4LTRhNGYtODIyYS1kYmYyZWNkMDJmODMiLCJ2bXdhcmUuY29tOjc5YjBiMjQ0LTgwYTQtNDcxNy1iYzBhLTc1OGIwOWU0MzU5NCIsInZtd2FyZS5jb206MDIyYzMyZGQtNTljOC00YmMxLWE0ODEtNDc1ZjgwNGI0ZGE3Iiwidm13YXJlLmNvbTo3NjVlMTRiZC01MjQwLTQ0NTItOTE0OC05NTc3ODJlMDY4YWIiLCJ2bXdhcmUuY29tOjliMjkwMWI4LWQ0MzMtNGQxNy04ZjI1LThhZTE0YjExNGE2ZCIsInZtd2FyZS5jb206ZGU1NDU1ZWMtMTE1Yi00NDFiLWIyMzItY2MzOThhODg1OWYyIiwidm13YXJlLmNvbTo1ZDJlNGViNi1jMjJjLTQ0OTQtYTdkOS0yMThkMjQ0NzhlNDgiLCJ2bXdhcmUuY29tOjNmYTE1YTE5LTI3YzQtNDM5Yi05M2EwLTgxOTg1NDQ3MTcxYyJdLCJjb250ZXh0IjoiMzg4NDY0NDktMGFkNS00MjExLThjY2YtMDMwZGMzZTJiMjA5IiwiZXhwIjoxNzIxMDI1NjIxLCJpYXQiOjE3MjEwMjM4MjEsImZhbWlseV9uYW1lIjoiS2FsbGUiLCJqdGkiOiJhNjhmMzAwMi0yYTI2LTQ4YzEtYjk4Mi1kY2E5YWE5ZjFiMTkiLCJlbWFpbCI6InBrYWxsZUB2bXdhcmUuY29tIiwiYWNjdCI6InBrYWxsZUB2bXdhcmUuY29tIiwidXNlcm5hbWUiOiJwa2FsbGUifQ.UjF7QvZfDTbPxXPz_xKp7N7R1V3fxWuRkDqgaGuSFKOLBVO9y65bR8yY5hBGg8tvHmsn9s3j914tPImVrtONyl-qqXiNPeWZZuyPm3Xycd2gxOyi0gPJSJWq6dZ8oCsoNyqmU57ICuUyomOb2yc29qOW2ODcoiy5ZF1Kov-UCQlm5RMOQKR3c_imUrEj_sYS6Ul2_-wEX9VFIVt7umuCahSusrOmS86sIh2EbvBpe2SACU_rR4IhMJrEPjd1c8sjDD-t6djYVE9pe6kuY6k_C-FunllNI6gUrxTFMpxs0-nahhit_glya8JcioxSC8YWSFo2j7XgFCZvTvTdXko91Q
        refresh_token: <REDACTED>
        expiration: 2024-07-14T23:40:20.616767-07:00
        type: api-token
clusterOpts:
    endpoint: https://api.tanzu-dev.cloud.vmware.com/org/ae93ebb4-a249-4553-aa1e-c87c4b7f75e5
    path: /Users/pkalle/.config/tanzu/kube/config
    context: tanzu-cli-TAP_pre-integration-staging-d03c5c97
additionalMetadata:
    tanzuHubEndpoint: https://api.staging-tis.symphony-dev.com/hub
    tanzuMissionControlEndpoint: https://tmc.tanzu-dev.cloud.vmware.com
    tanzuOrgID: ae93ebb4-a249-4553-aa1e-c87c4b7f75e5
    tanzuOrgName: TAP pre-integration
```

- Now verfiy the `$HOME/.config/tanzu/.data-store.yaml` file doesn't the entry `isCLIContextsUpdatedToTCSPIssuers: true`. (This would be set once we set the `cli.core.tanzu_cli_config_csp_issuer_update_flag: true` on a cutover date to update the current CLI contexts created using the old CLI version or current CLI version using the VCSP Issuer. If we set the update the flag to true the contexts issuers would be updated to TCSP.) 

Now set the `cli.core.tanzu_cli_config_csp_issuer_update_flag: true` in the central config file `~/.cache/tanzu/plugin_inventory/default/central_config.yaml` and run any command and verify the context is updated with TCSP issuer.

```
# running any command would update the CLI contexts to use TCSP issuer instead of VCSP issuer. 
❯ ./bin/tanzu version
version: v1.4.0-rc.0
buildDate: 2024-07-12
sha: 6ce31e03
arch: amd64

## you can check the context globalOpts.auth.issuer is updated to TCSP issuer
❯ ./bin/tanzu context get TAP_pre-integration-staging-d03c5c97
name: TAP_pre-integration-staging-d03c5c97
target: tanzu
contextType: tanzu
globalOpts:
    endpoint: https://api.tanzu-dev.cloud.vmware.com
    auth:
        issuer: https://console-stg.tanzu.broadcom.com/csp/gateway/am/api
        userName: pkalle
        permissions:
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/project:e2db6ff4-ea19-4804-a694-1ab79ce1d6bd/tap:developer
            - external/5b919bd9-b029-45c7-829d-1a30fad2808e/ensemble:admin
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/project:e2db6ff4-ea19-4804-a694-1ab79ce1d6bd/tap:viewer
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/vrn/org:ae93ebb4-a249-4553-aa1e-c87c4b7f75e5/project:test-cli-proj/tap:member
            - csp:project_admin/vrn/org:ae93ebb4-a249-4553-aa1e-c87c4b7f75e5/project:test-cli-proj
            - csp:org_member
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/vrn/org:ae93ebb4-a249-4553-aa1e-c87c4b7f75e5/project:test-cli-proj/tap:admin
            - csp:developer
            - csp:project_admin/project:e2db6ff4-ea19-4804-a694-1ab79ce1d6bd
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/vrn/org:ae93ebb4-a249-4553-aa1e-c87c4b7f75e5/project:test-cli-proj/tap:developer
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/vrn/org:ae93ebb4-a249-4553-aa1e-c87c4b7f75e5/project:test-cli-proj/tap:viewer
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/tap:developer
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/tap:viewer
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/tap:admin
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/project:e2db6ff4-ea19-4804-a694-1ab79ce1d6bd/tap:admin
            - csp:org_admin
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/project:e2db6ff4-ea19-4804-a694-1ab79ce1d6bd/tap:member
            - external/5b919bd9-b029-45c7-829d-1a30fad2808e/instance:a8c26706-6514-4374-b825-cdb754e9faa6/ensemble:admin
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/tap:member
        accessToken: <REDACTED>
        IDToken: <REDACTED>
        refresh_token: <REDACTED>
        expiration: 2024-07-14T23:40:20.616767-07:00
        type: api-token
clusterOpts:
    endpoint: https://api.tanzu-dev.cloud.vmware.com/org/ae93ebb4-a249-4553-aa1e-c87c4b7f75e5
    path: /Users/pkalle/.config/tanzu/kube/config
    context: tanzu-cli-TAP_pre-integration-staging-d03c5c97
additionalMetadata:
    tanzuHubEndpoint: https://api.staging-tis.symphony-dev.com/hub
    tanzuMissionControlEndpoint: https://tmc.tanzu-dev.cloud.vmware.com
    tanzuOrgID: ae93ebb4-a249-4553-aa1e-c87c4b7f75e5
    tanzuOrgName: TAP pre-integration

### Now running the project list should fetch the projects, but since the backend UCP is not updated to honor the tokens from TCSP it throws error. This test should be done again when UCP is updated to honor the tokens from both issuers.
❯ ./bin/tanzu project list
Error: failed to get API group resources: unable to retrieve the complete list of server APIs: ucp.tanzu.vmware.com/v1: the server has asked for the client to provide credentials


### However if you check the context token expiration, the token was refreshed successfully and token expiry is updated successfully (globalOpts.auth.expiration)

❯ ./bin/tanzu context get TAP_pre-integration-staging-d03c5c97
name: TAP_pre-integration-staging-d03c5c97
target: tanzu
contextType: tanzu
globalOpts:
    endpoint: https://api.tanzu-dev.cloud.vmware.com
    auth:
        issuer: https://console-stg.tanzu.broadcom.com/csp/gateway/am/api
        userName: pkalle
        permissions:
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/project:e2db6ff4-ea19-4804-a694-1ab79ce1d6bd/tap:developer
            - external/5b919bd9-b029-45c7-829d-1a30fad2808e/ensemble:admin
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/project:e2db6ff4-ea19-4804-a694-1ab79ce1d6bd/tap:viewer
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/vrn/org:ae93ebb4-a249-4553-aa1e-c87c4b7f75e5/project:test-cli-proj/tap:member
            - csp:project_admin/vrn/org:ae93ebb4-a249-4553-aa1e-c87c4b7f75e5/project:test-cli-proj
            - csp:org_member
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/vrn/org:ae93ebb4-a249-4553-aa1e-c87c4b7f75e5/project:test-cli-proj/tap:admin
            - csp:developer
            - csp:project_admin/project:e2db6ff4-ea19-4804-a694-1ab79ce1d6bd
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/vrn/org:ae93ebb4-a249-4553-aa1e-c87c4b7f75e5/project:test-cli-proj/tap:developer
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/vrn/org:ae93ebb4-a249-4553-aa1e-c87c4b7f75e5/project:test-cli-proj/tap:viewer
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/tap:developer
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/tap:viewer
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/tap:admin
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/project:e2db6ff4-ea19-4804-a694-1ab79ce1d6bd/tap:admin
            - csp:org_admin
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/project:e2db6ff4-ea19-4804-a694-1ab79ce1d6bd/tap:member
            - external/5b919bd9-b029-45c7-829d-1a30fad2808e/instance:a8c26706-6514-4374-b825-cdb754e9faa6/ensemble:admin
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/tap:member
            - external/5b919bd9-b029-45c7-829d-1a30fad2808e/instance:a8c26706-6514-4374-b825-cdb754e9faa6/ensemble:viewer
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/instance:a8c26706-6514-4374-b825-cdb754e9faa6/tap:viewer
            - external/39721d32-3962-4a75-83d9-9b3dae23c39d/instance:a8c26706-6514-4374-b825-cdb754e9faa6/tap:admin
        accessToken: <REDACTED>
        IDToken: <REDACTED>
        refresh_token: <REDACTED>
        expiration: 2024-07-15T00:22:23.62953-07:00
        type: api-token
clusterOpts:
    endpoint: https://api.tanzu-dev.cloud.vmware.com/org/ae93ebb4-a249-4553-aa1e-c87c4b7f75e5
    path: /Users/pkalle/.config/tanzu/kube/config
    context: tanzu-cli-TAP_pre-integration-staging-d03c5c97
additionalMetadata:
    tanzuHubEndpoint: https://api.staging-tis.symphony-dev.com/hub
    tanzuMissionControlEndpoint: https://tmc.tanzu-dev.cloud.vmware.com
    tanzuOrgID: ae93ebb4-a249-4553-aa1e-c87c4b7f75e5
    tanzuOrgName: TAP pre-integration
```


**Interactive login test**
- Updated the central config to below before running the tests
```
cli.core.cli_recommended_versions:
- version: v1.4.0-rc.0
- version: v1.3.0
- version: v1.2.0
- version: v1.1.0
- version: v1.0.0
- version: v0.90.1
cli.core.tanzu_application_platform_scopes:
- scope: tap:viewer
- scope: tap:admin
- scope: tap:member
cli.core.tanzu_hub_metadata:
  cspProductIdentifier: "TANZU-SAAS"
  cspDisplayName: "Tanzu Platform"
  endpointProduction: https://api.mgmt.cloud.vmware.com/hub
  endpointStaging: https://api.staging-tis.symphony-dev.com/hub
  useCentralConfig: true
cli.core.tanzu_default_csp_metadata:
  issuerStaging: https://console-stg.cloud.vmware.com/csp/gateway/am/api
  issuerProduction: https://console.cloud.vmware.com/csp/gateway/am/api
cli.core.tanzu_tcsp_metadata:
  issuerStaging: https://console-stg.tanzu.broadcom.com/csp/gateway/am/api
  issuerProduction: https://console.tanzu.broadcom.com/csp/gateway/am/api
cli.core.tanzu_csp_known_issuer_endpoints:
  https://console-stg.cloud.vmware.com/csp/gateway/am/api:
     authURL: "https://console-stg.cloud.vmware.com/csp/gateway/discovery"
     tokenURL: "https://console-stg.cloud.vmware.com/csp/gateway/am/api/auth/authorize"
  https://console.cloud.vmware.com/csp/gateway/am/api:
     authURL: "https://console.cloud.vmware.com/csp/gateway/discovery"
     tokenURL: "https://console.cloud.vmware.com/csp/gateway/am/api/auth/authorize"
  https://console-stg.tanzu.broadcom.com/csp/gateway/am/api:
    authURL: "https://console-stg.tanzu.broadcom.com/csp/gateway/discovery"
    tokenURL: "https://console-stg.tanzu.broadcom.com/csp/gateway/am/api/auth/authorize"
  https://console.tanzu.broadcom.com/csp/gateway/am/api:
    authURL: "https://console.tanzu.broadcom.com/csp/gateway/discovery"
    tokenURL: "https://console.tanzu.broadcom.com/csp/gateway/am/api/auth/authorize"
cli.core.tanzu_cli_config_csp_issuer_update_flag: true
```
- Also reset the flag in `~/.config/tanzu/.data-store.yaml`  to `isCLIContextsUpdatedToTCSPIssuers: false`
- Now use login command to login to `TAP pre-integration` organization using interactive login as shown below
```
❯ unset TANZU_API_TOKEN

❯ ./bin/tanzu context list
  NAME                                  ISACTIVE  TYPE   PROJECT  SPACE
  TAP_pre-integration-staging-d03c5c97  true      tanzu

[i] Use '--wide' to view additional columns.
❯ ./bin/tanzu context delete TAP_pre-integration-staging-d03c5c97
Deleting the context entry from the config will remove it from the list of tracked contexts. You will need to use `tanzu context create` to re-create this context. Are you sure you want to continue? [y/N]: y
[i] Deleting kubeconfig context 'tanzu-cli-TAP_pre-integration-staging-d03c5c97' from the file '/Users/pkalle/.config/tanzu/kube/config'
[ok] Successfully deleted context "TAP_pre-integration-staging-d03c5c97"
❯ tanzu config set env.TANZU_CLI_CLOUD_SERVICES_ORGANIZATION_ID ae93ebb4-a249-4553-aa1e-c87c4b7f75e5
❯ ./bin/tanzu login --staging --endpoint https://api.tanzu-dev.cloud.vmware.com
[i] This tanzu context is being created using organization ID ae93ebb4-a249-4553-aa1e-c87c4b7f75e5 as set in the tanzu configuration (to unset, use `tanzu config unset env.TANZU_CLI_CLOUD_SERVICES_ORGANIZATION_ID`).
[i] Opening the browser window to complete the login
Log in by visiting this link:

    https://console-stg.cloud.vmware.com/csp/gateway/discovery?client_id=tanzu-cli-client-id&code_challenge=nDaWX8MbTJYsKO9_LSMldPiBVHPFQdjnoWh3wZqzkmc&code_challenge_method=S256&orgId=ae93ebb4-a249-4553-aa1e-c87c4b7f75e5&redirect_uri=http%3A%2F%2F127.0.0.1%3A56611%2Fcallback&response_type=code&state=f556c3f4ce594330b8eb42c841c748c5

    Optionally, paste your authorization code: [...]


[ok] Successfully logged into 'TAP pre-integration' organization and created a tanzu context


## access the ucp project list
❯ ./bin/tanzu project list
Listing projects from TAP pre-integration org

  NAME                     READY  AGE
  Sriram Test project      True   5d4h
  abhisheks2               True   5d4h
  alb-test                 True   5d5h
  alexd-project            True   5d5h
  ank-test                 True   5d5h
[...]

### attaching the access_token obtained through interactive login for reference ( you can verify the issuer `iss` is VCSP issuer)
{
  "sub": "vmware.com:30236c0a-9626-46f3-ba9f-679776686a95",
  "iss": "https://console-stg.cloud.vmware.com",
  "context_name": "ae93ebb4-a249-4553-aa1e-c87c4b7f75e5",
  "_nonce": "7da40b60-33fd-11ef-9890-2d15ad0bbfa1",
  "azp": "tanzu-cli-client-id",
  "authorization_details": [],
  "domain": "vmware.com",
  "context": "38846449-0ad5-4211-8ccf-030dc3e2b209",
  "perms": [
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/project:e2db6ff4-ea19-4804-a694-1ab79ce1d6bd/tap:developer",
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/project:e2db6ff4-ea19-4804-a694-1ab79ce1d6bd/tap:viewer",
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/vrn/org:ae93ebb4-a249-4553-aa1e-c87c4b7f75e5/project:test-cli-proj/tap:member",
    "csp:org_member",
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/vrn/org:ae93ebb4-a249-4553-aa1e-c87c4b7f75e5/project:test-cli-proj/tap:admin",
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/vrn/org:ae93ebb4-a249-4553-aa1e-c87c4b7f75e5/project:test-cli-proj/tap:developer",
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/vrn/org:ae93ebb4-a249-4553-aa1e-c87c4b7f75e5/project:test-cli-proj/tap:viewer",
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/tap:developer",
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/tap:viewer",
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/tap:admin",
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/project:e2db6ff4-ea19-4804-a694-1ab79ce1d6bd/tap:admin",
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/project:e2db6ff4-ea19-4804-a694-1ab79ce1d6bd/tap:member",
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/tap:member"
  ],
  "exp": 1721067587,
  "iat": 1721065787,
  "jti": "3fb4d34d-a3d9-4a63-a9a7-a95105870744",
  "acct": "pkalle@vmware.com",
  "username": "pkalle"
}
```
- Now create a context using context command (using login command would overwrite the existing context) to create a context using TCSP issuer by exproting the environment variable `TANZU_CLI_USE_TANZU_CLOUD_SERVICE_PROVIDER` and verify both contexts works.
```
❯ export TANZU_CLI_USE_TANZU_CLOUD_SERVICE_PROVIDER=true

❯ ./bin/tanzu context create testTCSPIssureCtx --type tanzu --staging --endpoint https://api.tanzu-dev.cloud.vmware.com
[i] This tanzu context is being created using organization ID ae93ebb4-a249-4553-aa1e-c87c4b7f75e5 as set in the tanzu configuration (to unset, use `tanzu config unset env.TANZU_CLI_CLOUD_SERVICES_ORGANIZATION_ID`).
[i] Opening the browser window to complete the login
Log in by visiting this link:

    https://console-stg.tanzu.broadcom.com/csp/gateway/discovery?client_id=tanzu-cli-client-id&code_challenge=t8H5L_8LmH9YHGdEXViGjlow_JPjaU2WMqh1SavAaxo&code_challenge_method=S256&orgId=ae93ebb4-a249-4553-aa1e-c87c4b7f75e5&redirect_uri=http%3A%2F%2F127.0.0.1%3A57089%2Fcallback&response_type=code&state=5435ae79b573b407d5445e87cc9f9f75

    Optionally, paste your authorization code: [...]


[ok] Successfully logged into 'TAP pre-integration' organization and created a tanzu context


❯ ./bin/tanzu context list
  NAME                                  ISACTIVE  TYPE   PROJECT  SPACE
  TAP_pre-integration-staging-d03c5c97  false     tanzu
  testTCSPIssureCtx                     true      tanzu

[i] Use '--wide' to view additional columns.

### As expected at the moment since the backend is not updated to honor the token issued by the new CSP Issuer, it  fails
❯ ./bin/tanzu project list
Error: failed to get API group resources: unable to retrieve the complete list of server APIs: ucp.tanzu.vmware.com/v1: the server has asked for the client to provide credentials

### attaching the acces_token value of the  testTCSPIssureCtx context (you can check the issuer `iss` is TCSP issuer)
{
  "sub": "vmware.com:30236c0a-9626-46f3-ba9f-679776686a95",
  "iss": "https://console-stg.tanzu.broadcom.com",
  "context_name": "ae93ebb4-a249-4553-aa1e-c87c4b7f75e5",
  "_nonce": "5bb05470-42d3-11ef-80b0-b13079511a9f",
  "azp": "tanzu-cli-client-id",
  "authorization_details": [],
  "domain": "vmware.com",
  "context": "38846449-0ad5-4211-8ccf-030dc3e2b209",
  "perms": [
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/project:e2db6ff4-ea19-4804-a694-1ab79ce1d6bd/tap:developer",
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/project:e2db6ff4-ea19-4804-a694-1ab79ce1d6bd/tap:viewer",
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/vrn/org:ae93ebb4-a249-4553-aa1e-c87c4b7f75e5/project:test-cli-proj/tap:member",
    "csp:org_member",
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/vrn/org:ae93ebb4-a249-4553-aa1e-c87c4b7f75e5/project:test-cli-proj/tap:admin",
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/instance:a8c26706-6514-4374-b825-cdb754e9faa6/tap:viewer",
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/vrn/org:ae93ebb4-a249-4553-aa1e-c87c4b7f75e5/project:test-cli-proj/tap:developer",
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/vrn/org:ae93ebb4-a249-4553-aa1e-c87c4b7f75e5/project:test-cli-proj/tap:viewer",
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/tap:developer",
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/tap:viewer",
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/tap:admin",
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/instance:a8c26706-6514-4374-b825-cdb754e9faa6/tap:admin",
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/project:e2db6ff4-ea19-4804-a694-1ab79ce1d6bd/tap:admin",
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/project:e2db6ff4-ea19-4804-a694-1ab79ce1d6bd/tap:member",
    "external/39721d32-3962-4a75-83d9-9b3dae23c39d/tap:member"
  ],
  "exp": 1721067902,
  "iat": 1721066102,
  "jti": "d8cf0762-0db1-452e-8988-329e8c6e892a",
  "acct": "pkalle@vmware.com",
  "username": "pkalle"
}

```

- Verified the refresh tokens are obtained from the respective issuers (issuer stored in CLI contexts) for both contexts.(You can do that by modifying the expiration time to past time frame so that CLI would automatically refresh it.

- Now verify that by updating the central config to update the CLI contexts to new Issuer, the `TAP_pre-integration-staging-d03c5c97 ` context created using VCSP would be updated to new Issuer(and existing tokens are invalidated) and when we try to access the UCP plugin list it should trigger the Interactive login and fetch the access token from the new issuer. (Please set `cli.core.tanzu_cli_config_csp_issuer_update_flag: true` in "~/.cache/tanzu/plugin_inventory/default/central_config.yaml" so that CLI would update the issuer to new issuer URL and deactivate the interactive login tokens )

```
### by running any command the CLI context are updated 
❯ ./bin/tanzu version
version: v1.4.0-rc.0
buildDate: 2024-07-12
sha: 6ce31e03
arch: amd64

❯ ./bin/tanzu context list
  NAME                                  ISACTIVE  TYPE   PROJECT  SPACE
  TAP_pre-integration-staging-d03c5c97  true      tanzu
  testTCSPIssureCtx                     false     tanzu

[i] Use '--wide' to view additional columns.

### Now if you try to access the UCP, it would retrigger the interactive login(old tokens are invalidated) with the new issuer( you can check the login link in the command output pointing to new TCSP Issuer). Though the login was successful, since the backend is not updated to honor the new Issuer, "tanzu project list" command fails which is expected.

❯ ./bin/tanzu project list
[i] Opening the browser window to complete the login
Log in by visiting this link:

    https://console-stg.tanzu.broadcom.com/csp/gateway/discovery?client_id=tanzu-cli-client-id&code_challenge=2_iaiJj55Zagp21CfYCMjJeddWyAv7Si_FD0AD9AXHI&code_challenge_method=S256&orgId=ae93ebb4-a249-4553-aa1e-c87c4b7f75e5&redirect_uri=http%3A%2F%2F127.0.0.1%3A58430%2Fcallback&response_type=code&state=aaa4bb878a9553f2b35190bc78026a56

    Optionally, paste your authorization code: [...]

Error: failed to get API group resources: unable to retrieve the complete list of server APIs: ucp.tanzu.vmware.com/v1: the server has asked for the client to provide credentials

```



<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add support to update the CSP issuer to TCSP
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
