### PR TITLE
Support Activating plugins on Plugin Group Publish/Activation

### DIFF
--- a/pkg/constants/env_variables.go
+++ b/pkg/constants/env_variables.go
@@ -87,4 +87,8 @@ const (
 	// UseStableKubeContextNameForTanzuContext uses the stable kube context name associated with tanzu context.
 	// CLI would not change the context name when the TAP resource pointed by the CLI context is changed.
 	UseStableKubeContextNameForTanzuContext = "TANZU_CLI_USE_STABLE_KUBE_CONTEXT_NAME"
+
+	// ActivatePluginsOnPluginGroupPublish activates all the plugins specified within the plugin group
+	// as part of the plugin group publishing
+	ActivatePluginsOnPluginGroupPublish = "TANZU_CLI_ACTIVATE_PLUGINS_ON_PLUGIN_GROUP_PUBLISH"
 )


### PR DESCRIPTION
### What this PR does / why we need it
There might be a use case where teams want to publish their plugins to the production in a deactivated state and only enable the plugins as part of the `PluginGroup` publishing process when the`PluginGroup` is Activated.

This PR supports this use case by exposing the `TANZU_CLI_ACTIVATE_PLUGINS_ON_PLUGIN_GROUP_PUBLISH` environment variable. If this environment variable is set to `true` as part of plugin group publishing or plugin group activation it will also activate the plugins within the plugin group.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
- Added Unit Tests
- Manual tests

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Support Activating plugins on Plugin Group Publish/Activation
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
