### PR TITLE
Enable customization of org id and name when connecting to uaa-base endpoint

### DIFF
--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -656,8 +656,21 @@ func globalTanzuLoginUAA(c *configtypes.Context, generateContextNameFunc func(or
 		return err
 	}
 
-	// UAA-based authentication does not provide org id or name yet
-	orgName := ""
+	// UAA-based authentication does not provide org id or name yet.
+	// Note: org id/name may be discoverable in UAA-based auth in the future.
+	var orgID string
+	orgName := "self-managed"
+	uaaOrgIDValue, ok := os.LookupEnv(constants.UAALoginOrgID)
+	if ok {
+		orgID = uaaOrgIDValue
+	}
+	claims.OrgID = orgID
+	uaaOrgNameValue, ok := os.LookupEnv(constants.UAALoginOrgName)
+	if ok {
+		orgName = uaaOrgNameValue
+	} else if orgID != "" {
+		orgName = orgID
+	}
 
 	if err := updateContextOnTanzuLogin(c, generateContextNameFunc, claims, orgName); err != nil {
 		return err

--- a/pkg/command/context_test.go
+++ b/pkg/command/context_test.go
@@ -942,7 +942,7 @@ var _ = Describe("create new context", func() {
 		fakeTanzuEndpoint                 = "https://fake.tanzu.cloud.vmware.com"
 		fakeAlternateTanzuEndpoint        = "https://fake.acme.com"
 		expectedAlternateTanzuHubEndpoint = "https://fake.acme.com/hub"
-		expectedAlternateTanzuUCPEndpoint = "https://fake.acme.com/ucp"
+		expectedAlternateTanzuUCPEndpoint = "https://fake.acme.com"
 		expectedAlternateTanzuTMCEndpoint = "https://fake.acme.com"
 
 		expectedTanzuHubEndpoint = "https://api.fake.tanzu.cloud.vmware.com/hub"
@@ -1156,7 +1156,6 @@ var _ = Describe("create new context", func() {
 					Expect(string(idpType)).To(ContainSubstring("uaa"))
 				})
 			})
-
 			Context("context name already exists", func() {
 				It("should return error", func() {
 					endpoint = fakeTanzuEndpoint

--- a/pkg/command/login_helper.go
+++ b/pkg/command/login_helper.go
@@ -95,7 +95,7 @@ func configureTanzuPlatformServiceEndpointsForSM(tpEndpoint string) error {
 
 	tanzuHubEndpoint = fmt.Sprintf("%s://%s/hub", u.Scheme, u.Host)
 	tanzuTMCEndpoint = fmt.Sprintf("%s://%s", u.Scheme, u.Host)
-	tanzuUCPEndpoint = fmt.Sprintf("%s://%s/ucp", u.Scheme, u.Host)
+	tanzuUCPEndpoint = fmt.Sprintf("%s://%s", u.Scheme, u.Host)
 	tanzuAuthEndpoint = fmt.Sprintf("%s://%s/auth", u.Scheme, u.Host)
 
 	return nil

--- a/pkg/constants/env_variables.go
+++ b/pkg/constants/env_variables.go
@@ -58,6 +58,14 @@ const (
 	// https://docs.vmware.com/en/VMware-Cloud-services/services/Using-VMware-Cloud-Services/GUID-CF9E9318-B811-48CF-8499-9419997DC1F8.html
 	CSPLoginOrgID = "TANZU_CLI_CLOUD_SERVICES_ORGANIZATION_ID"
 
+	// UaaLoginOrgID overrides OrgID associated with the UAA based endpoint
+	// This may not be necessary or could be discoverable in the future, at which point this will be ignored.
+	UAALoginOrgID = "TANZU_CLI_SM_ORGANIZATION_ID"
+
+	// UaaLoginOrgName overrides name of the Org associated with the UAA based endpoint
+	// This may not be necessary or could be discoverable in the future, at which point this will be ignored.
+	UAALoginOrgName = "TANZU_CLI_SM_ORGANIZATION_NAME"
+
 	// TanzuCLIOAuthLocalListenerPort is the port to be used by local listener for OAuth authorization flow
 	TanzuCLIOAuthLocalListenerPort = "TANZU_CLI_OAUTH_LOCAL_LISTENER_PORT"
 


### PR DESCRIPTION
Also: update the ucp url to the correct one for uaa-based endpoints

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Ran unit tests.
Additional manually tested the following:

```
# verify env vars are picked up

> TANZU_CLI_SM_ORGANIZATION_NAME=testsm TANZU_CLI_SM_ORGANIZATION_ID=dcc5a0d5-92bd-4580-..... /bin/tanzu login --endpoint https://hubsm-host/ --insecure-skip-tls-verify

[i] Opening the browser window to complete the login
Log in by visiting this link:

    https://hubsm-host/oauth/authorize?client_id=tp_cli_app&code_challenge=wIM6VMLFW1EuJH6vow17fFgvYHdyn2jqIHBWK2UjBMw&code_challenge_method=S256&redirect_uri=http%3A%2F%2F127.0.0.1%3A51009%2Fcallback&response_type=code&state=bc39ff2c76ebd543474cfb83d7cb0870

    Optionally, paste your authorization code: [...]

[ok] Successfully logged in to 'https://hubsm-host/' and created a tanzu context

> tanzu context current
  Name:            tpsm-a436fc44
  Type:            tanzu
  Organization:    testsm (dcc5a0d5-92bd-4580-aa24-76f603e004b2)
  Project:         test (9fd5e29a-d556-459e-b1f8-137f605e8550)
  Kube Config:     /Users/johndoe/.config/tanzu/kube/config
  Kube Context:    tanzu-cli-tpsm-a436fc44:test

> grep -C2 testsm ~/.config/tanzu/config-ng.yaml
        tanzuMissionControlEndpoint: https://hubsm-host
        tanzuOrgID: dcc5a0d5-92bd-4580-aa24-76f603e004b2
        tanzuOrgName: testsm
currentContext:
    tanzu: tpsm-a436fc44

> grep -C2 dcc5a0d5-92bd-4580-aa24-76f603e004b2 ~/.config/tanzu/kube/config
- cluster:
    insecure-skip-tls-verify: true
    server: https://hubsm-host/dcc5a0d5-92bd-4580-aa24-76f603e004b2
  name: tanzu-cli-tpsm-a436fc44
contexts:

# verify that generated kube config is usable against UCP

> ./bin/tanzu project list
Listing projects from testsm org

  NAME  AGE  INTEGRATIONS
  abcd  26h  TANZU_APPLICATION_ENGINE
  test  26h  TANZU_APPLICATION_ENGINE

To set your active project use 'tanzu project use NAME'

> ./bin/tanzu project use test
Successfully set project to test
> ./bin/tanzu space list
No Spaces found.

> ./bin/tanzu avt list
No availability targets found.
```


### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Enable TANZU_CLI_SM_ORGANIZATION_NAME TANZU_CLI_SM_ORGANIZATION_ID to configure the Org name and id of a self-managed Tanzu Platform environment.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
