### PR TITLE
Fix double-encoding of ca cert data in kube context

### DIFF
--- a/pkg/auth/tanzu/kubeconfig_test.go
+++ b/pkg/auth/tanzu/kubeconfig_test.go
@@ -100,8 +100,11 @@ var _ = Describe("Unit tests for tanzu auth", func() {
 				Expect(cluster.Server).To(Equal(clusterAPIServerURL))
 				Expect(config.Contexts[kubeContext].AuthInfo).To(Equal(kubeconfigUserName(tanzuContext.Name)))
 				Expect(gotClusterName).To(Equal(kubeconfigClusterName(tanzuContext.Name)))
-				Expect(len(cluster.CertificateAuthorityData)).ToNot(Equal(0))
 				Expect(user.Exec).To(Equal(getExecConfig(tanzuContext)))
+
+				caCertBytes, err := os.ReadFile(fakeCAcertPath)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(caCertBytes).To(Equal(cluster.CertificateAuthorityData))
 			})
 		})
 		Context("When endpointCACertPath is not provided and skipTLSVerify is set to true", func() {


### PR DESCRIPTION
### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

When a tanzu CLI context is created with a custom ca cert. The ca cert data was erroneously base64 encoded before being given to the json Marshaler, which base64 encodes all []byte fields anyway.
This leads to invalide ca cert data being stored in the kube context, and the follow errors when used:

```
Error: Unable to create http client unable to load root certificates: unable to parse bytes as PEM block
Error: Unable to create rest mapper. signk8s.io/dynamicrestmapper states httpClient must not be nil, consider using rest.HTTPClientFor(c) to create a client
```

Fixes #

### Describe testing done for PR

Updated and ran unit tests.
Verified that after the fix that kube clients is able to use the custom ca cert data to validate calls to an endpoint with custom certs

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Properly support the use of custom ca cert data for tanzu type CLI contexts.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
