### PR TITLE
Fix context type detection logic and e2e tests for TMC context creation

### DIFF
--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -359,9 +359,11 @@ func createNewContext() (context *configtypes.Context, err error) {
 	var ctxCreationType ContextCreationType
 	contextType := getContextType()
 
-	if (contextType == configtypes.ContextTypeTanzu) || (endpoint != "" && isTanzuPlatformSaaSEndpoint(endpoint)) {
+	if contextType == configtypes.ContextTypeTMC {
+		ctxCreationType = contextMissionControl
+	} else if (contextType == configtypes.ContextTypeTanzu) || (endpoint != "" && isTanzuPlatformSaaSEndpoint(endpoint)) {
 		ctxCreationType = contextTanzu
-	} else if (contextType == configtypes.ContextTypeTMC) || (endpoint != "" && isGlobalContext(endpoint)) {
+	} else if endpoint != "" && isGlobalContext(endpoint) {
 		ctxCreationType = contextMissionControl
 	} else if endpoint != "" {
 		// user provided command line option endpoint is provided that is not globalTanzu or GlobalContext=> it is Kubernetes(Cluster Endpoint) type

--- a/pkg/command/context_test.go
+++ b/pkg/command/context_test.go
@@ -1023,6 +1023,19 @@ var _ = Describe("create new context", func() {
 		Context("with only endpoint and context name provided", func() {
 			It("should create context with given endpoint and context name", func() {
 				endpoint = fakeTMCEndpoint
+				forceCSP = true
+				contextTypeStr = contextTypeMissionControl
+				ctxName = testContextName
+				ctx, err = createNewContext()
+				Expect(err).To(BeNil())
+				Expect(ctx.Name).To(ContainSubstring("fake-context-name"))
+				Expect(string(ctx.ContextType)).To(ContainSubstring(contextTypeMissionControl))
+				Expect(ctx.GlobalOpts.Endpoint).To(ContainSubstring(endpoint))
+			})
+		})
+		Context("with only endpoint and context name provided", func() {
+			It("should create context with given endpoint and context name", func() {
+				endpoint = fakeTMCEndpoint
 				ctxName = testContextName
 				ctx, err = createNewContext()
 				Expect(err).To(BeNil())
@@ -1888,6 +1901,7 @@ func resetContextCommandFlags() {
 	contextTypeStr = ""
 	outputFormat = ""
 	shortCtx = false
+	forceCSP = false
 }
 
 func TestCreateContextWithTanzuTypeAndKubeconfigFlags(t *testing.T) {

--- a/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_suite_test.go
+++ b/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_suite_test.go
@@ -44,6 +44,7 @@ const tmcPluginsMockFile = "tmcPluginsMock.json"
 const numberOfPluginsToInstall = 3
 
 const forceCSPFlag = "--force-csp=true"
+const typeTMCFlag = "--type=tmc"
 const tmcConfigFolderName = "tmc"
 const numberOfPluginsSameAsNoOfPluginsInfoMocked = "number of plugins should be same as number of plugins mocked in tmc endpoint response"
 const pluginsInstalledAndMockedShouldBeSame = "plugins being installed and plugins being mocked in tmc endpoint response should be same"

--- a/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_test.go
+++ b/test/e2e/plugin_sync/tmc/plugin_sync_tmc_lifecycle_test.go
@@ -79,7 +79,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		// Test case: b. create context and validate current active context
 		It("create context for TMC target with http mock server URL as endpoint", func() {
 			contextName = f.ContextPrefixTMC + f.RandomString(4)
-			_, _, err = tf.ContextCmd.CreateContextWithEndPointStaging(contextName, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag))
+			_, _, err = tf.ContextCmd.CreateContextWithEndPointStaging(contextName, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag), f.AddAdditionalFlagAndValue(typeTMCFlag))
 			Expect(err).To(BeNil(), noErrorWhileCreatingContext)
 			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeTMC))
 			Expect(err).To(BeNil(), activeContextShouldExists)
@@ -143,7 +143,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		// Test case: b. create context and make sure context has created
 		It("create context for TMC target with http mock server URL as endpoint", func() {
 			contextName = f.ContextPrefixTMC + f.RandomString(4)
-			_, _, err = tf.ContextCmd.CreateContextWithEndPointStaging(contextName, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag))
+			_, _, err = tf.ContextCmd.CreateContextWithEndPointStaging(contextName, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag), f.AddAdditionalFlagAndValue(typeTMCFlag))
 			Expect(err).To(BeNil(), noErrorWhileCreatingContext)
 			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeTMC))
 			Expect(err).To(BeNil(), activeContextShouldExists)
@@ -272,7 +272,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		// Test case: b. create context and make sure context has created
 		It("create context for TMC target with http mock server URL as endpoint", func() {
 			contextName = f.ContextPrefixTMC + f.RandomString(4)
-			_, stdErr, err = tf.ContextCmd.CreateContextWithEndPointStaging(contextName, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag))
+			_, stdErr, err = tf.ContextCmd.CreateContextWithEndPointStaging(contextName, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag), f.AddAdditionalFlagAndValue(typeTMCFlag))
 			Expect(err).To(BeNil(), noErrorWhileCreatingContext)
 			Expect(stdErr).NotTo(BeNil(), "there should be stderr")
 			Expect(stdErr).To(ContainSubstring(f.UnableToSync), "there should be sync error as all plugins not available in repo")
@@ -380,7 +380,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			Expect(len(mockResPluginsInfo.Plugins)).Should(Equal(len(pluginsToGenerateMockResponseOne)), "the number of plugins in endpoint response and initially mocked should be same")
 
 			contextNameOne = f.ContextPrefixTMC + f.RandomString(4)
-			_, _, err = tf.ContextCmd.CreateContextWithEndPointStaging(contextNameOne, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag))
+			_, _, err = tf.ContextCmd.CreateContextWithEndPointStaging(contextNameOne, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag), f.AddAdditionalFlagAndValue(typeTMCFlag))
 			Expect(err).To(BeNil(), noErrorWhileCreatingContext)
 			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeTMC))
 			Expect(err).To(BeNil(), activeContextShouldExists)
@@ -411,7 +411,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			Expect(len(mockResPluginsInfo.Plugins)).Should(Equal(len(pluginsToGenerateMockResponseTwo)), "the number of plugins in endpoint response and initially mocked should be same")
 
 			contextNameTwo = f.ContextPrefixTMC + f.RandomString(4)
-			_, _, err = tf.ContextCmd.CreateContextWithEndPointStaging(contextNameTwo, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag))
+			_, _, err = tf.ContextCmd.CreateContextWithEndPointStaging(contextNameTwo, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag), f.AddAdditionalFlagAndValue(typeTMCFlag))
 			Expect(err).To(BeNil(), noErrorWhileCreatingContext)
 			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeTMC))
 			Expect(err).To(BeNil(), activeContextShouldExists)
@@ -482,7 +482,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			Expect(len(mockResPluginsInfo.Plugins)).Should(Equal(len(pluginsToGenerateMockResponseOne)), "the number of plugins in endpoint response and initially mocked should be same")
 
 			contextNameOne = f.ContextPrefixTMC + f.RandomString(4)
-			_, _, err = tf.ContextCmd.CreateContextWithEndPointStaging(contextNameOne, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag))
+			_, _, err = tf.ContextCmd.CreateContextWithEndPointStaging(contextNameOne, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag), f.AddAdditionalFlagAndValue(typeTMCFlag))
 			Expect(err).To(BeNil(), noErrorWhileCreatingContext)
 			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeTMC))
 			Expect(err).To(BeNil(), activeContextShouldExists)
@@ -626,7 +626,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		// Test case: f. TMC: create context and make sure context has created
 		It("create context for TMC target with http mock server URL as endpoint", func() {
 			contextNameTMC = f.ContextPrefixTMC + f.RandomString(4)
-			_, _, err = tf.ContextCmd.CreateContextWithEndPointStaging(contextNameTMC, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag))
+			_, _, err = tf.ContextCmd.CreateContextWithEndPointStaging(contextNameTMC, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag), f.AddAdditionalFlagAndValue(typeTMCFlag))
 			Expect(err).To(BeNil(), noErrorWhileCreatingContext)
 			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeTMC))
 			Expect(err).To(BeNil(), activeContextShouldExists)
@@ -814,7 +814,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 			Expect(err).To(BeNil(), thereShouldNotBeError+" while cleaning plugins")
 
 			contextNameTMC = f.ContextPrefixTMC + f.RandomString(4)
-			_, _, err = tf.ContextCmd.CreateContextWithEndPointStaging(contextNameTMC, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag))
+			_, _, err = tf.ContextCmd.CreateContextWithEndPointStaging(contextNameTMC, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag), f.AddAdditionalFlagAndValue(typeTMCFlag))
 			Expect(err).To(BeNil(), noErrorWhileCreatingContext)
 			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeTMC))
 			Expect(err).To(BeNil(), activeContextShouldExists)
@@ -1111,7 +1111,7 @@ var _ = f.CLICoreDescribe("[Tests:E2E][Feature:Plugin-Sync-TMC-lifecycle]", func
 		// Test case: g. TMC: create context and make sure context has created
 		It("create context for TMC target with http mock server URL as endpoint", func() {
 			contextNameTMC = f.ContextPrefixTMC + f.RandomString(4)
-			_, _, err := tf.ContextCmd.CreateContextWithEndPointStaging(contextNameTMC, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag))
+			_, _, err := tf.ContextCmd.CreateContextWithEndPointStaging(contextNameTMC, f.TMCMockServerEndpoint, f.AddAdditionalFlagAndValue(forceCSPFlag), f.AddAdditionalFlagAndValue(typeTMCFlag))
 			Expect(err).To(BeNil(), noErrorWhileCreatingContext)
 			active, err := tf.ContextCmd.GetActiveContext(string(types.ContextTypeTMC))
 			Expect(err).To(BeNil(), activeContextShouldExists)


### PR DESCRIPTION
### What this PR does / why we need it

    Updated e2e tests to specify mission-control context type in tests
    involving such contexts.

    Also fixed context type detection logic so that forceCSP does not take
    precedence over explicit context type provided.

### Describe testing done for PR

- Updated and ran unit tests.
- Ran e2e tests.
- Manually verify `tanzu context create --type mission-control --force-csp` creates a mission-control type context

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->

