### PR TITLE
Fix incorrect context name being created when using new tanzu platform endpoints

### DIFF
--- a/docs/full/README.md
+++ b/docs/full/README.md
@@ -214,7 +214,7 @@ from the repository. You can find more details in the
 
 ### User experience
 
-CLI verifies [cosign](https://docs.sigstore.dev/signing/quickstart/) signature of
+CLI verifies [cosign](https://docs.sigstore.dev/quickstart/quickstart-cosign/) signature of
 the plugin inventory image present in the repository. If the signature
 verification is successful, it would download the plugin inventory image on the
 user's machine and caches the verified plugin inventory image to improve the

--- a/pkg/command/login.go
+++ b/pkg/command/login.go
@@ -141,7 +141,7 @@ func getString(data interface{}) string {
 // pre-req orgName and endpoint is non-empty string
 func prepareTanzuContextName(orgName, ucpEndpoint string, isStaging bool) string {
 	var contextName string
-	idpType := getIDPType(ucpEndpoint)
+	idpType := getIDPType(endpoint)
 	if idpType == config.UAAIdpType {
 		contextName = "tpsm"
 	} else {


### PR DESCRIPTION
### What this PR does / why we need it

Fix incorrect context name being created when using new endpoints

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

**Before this change:**
```
$ tz login --staging --endpoint https://platform-dev.tanzu.broadcom.com

$ tz context list
  NAME                                      ISACTIVE  TYPE   PROJECT  SPACE
  tpsm-5a2f0150                             false     tanzu
```

**After this change:**
```
$ tz login --staging --endpoint https://platform-dev.tanzu.broadcom.com

$ tz context list
  NAME                                      ISACTIVE  TYPE   PROJECT  SPACE
  Falcons-staging-5a2f0150                  true      tanzu
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix incorrect context name being created when using new tanzu platform endpoints
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
