### PR TITLE
Read default database refresh threshold from Central Config

### DIFF
--- a/pkg/centralconfig/central_config.go
+++ b/pkg/centralconfig/central_config.go
@@ -25,6 +25,12 @@ type CentralConfig interface {
 	// GetDefaultTanzuEndpoint returns default endpoint for the tanzu platform from the default
 	// central configuration file
 	GetDefaultTanzuEndpoint() (string, error)
+	// GetPluginDBCacheRefreshThresholdSeconds returns default value for central db cache refresh in seconds
+	// from the default central configuration file
+	GetPluginDBCacheRefreshThresholdSeconds() (int, error)
+	// GetInventoryRefreshTTLSeconds returns default value for central db refresh TTL in seconds
+	// from the default central configuration file
+	GetInventoryRefreshTTLSeconds() (int, error)
 	// GetTanzuPlatformEndpointToServiceEndpointMap returns Map of tanzu platform endpoint to service endpoints
 	// from the default central configuration file
 	GetTanzuPlatformEndpointToServiceEndpointMap() (TanzuPlatformEndpointToServiceEndpointMap, error)

--- a/pkg/centralconfig/central_config_defaults.go
+++ b/pkg/centralconfig/central_config_defaults.go
@@ -8,6 +8,15 @@ var (
 	// It serves as a fallback default only if reading the central configuration fails.
 	DefaultTanzuPlatformEndpoint = "https://api.tanzu.cloud.vmware.com"
 
+	// DefaultPluginDBCacheRefreshThresholdSeconds is the default value for db cache refresh
+	// For testing, it can be overridden using the environment variable TANZU_CLI_PLUGIN_DB_CACHE_REFRESH_THRESHOLD_SECONDS.
+	// It serves as a fallback default only if reading the central configuration fails.
+	DefaultPluginDBCacheRefreshThresholdSeconds = 24 * 60 * 60 // 24 hours
+
+	// DefaultInventoryRefreshTTLSeconds is the interval in seconds between two checks of the inventory digest.
+	// For testing, it can be overridden using the environment variable TANZU_CLI_PLUGIN_DB_CACHE_TTL_SECONDS.
+	DefaultInventoryRefreshTTLSeconds = 30 * 60 // 30 minutes
+
 	defaultSaaSEndpoints = []string{
 		"https://(www.)?platform(.)*.tanzu.broadcom.com",
 		"https://api.tanzu(.)*.cloud.vmware.com",
@@ -23,5 +32,15 @@ func init() {
 	endpoint, _ := DefaultCentralConfigReader.GetDefaultTanzuEndpoint()
 	if endpoint != "" {
 		DefaultTanzuPlatformEndpoint = endpoint
+	}
+	// initialize the value of `DefaultPluginDBCacheRefreshThresholdSeconds` from default central configuration if specified there
+	secondsThreshold, err := DefaultCentralConfigReader.GetPluginDBCacheRefreshThresholdSeconds()
+	if err == nil && secondsThreshold > 0 {
+		DefaultPluginDBCacheRefreshThresholdSeconds = secondsThreshold
+	}
+	// initialize the value of `DefaultInventoryRefreshTTLSeconds` from default central configuration if specified there
+	secondsTTL, err := DefaultCentralConfigReader.GetInventoryRefreshTTLSeconds()
+	if err == nil && secondsTTL > 0 {
+		DefaultInventoryRefreshTTLSeconds = secondsTTL
 	}
 }

--- a/pkg/centralconfig/central_config_keys.go
+++ b/pkg/centralconfig/central_config_keys.go
@@ -6,6 +6,8 @@ package centralconfig
 
 const (
 	KeyDefaultTanzuEndpoint                          = "cli.core.tanzu_default_endpoint"
+	KeyDefaultPluginDBCacheRefreshThresholdSeconds   = "cli.core.tanzu_cli_default_plugin_db_cache_refresh_threshold_seconds"
+	KeyDefaultInventoryRefreshTTLSeconds             = "cli.core.tanzu_cli_default_inventory_refresh_ttl_seconds"
 	KeyTanzuEndpointMap                              = "cli.core.tanzu_endpoint_map"
 	KeyTanzuPlatformSaaSEndpointsAsRegularExpression = "cli.core.tanzu_cli_platform_saas_endpoints_as_regular_expression"
 	KeyTanzuConfigEndpointUpdateVersion              = "cli.core.tanzu_cli_config_endpoint_update_version"

--- a/pkg/centralconfig/central_config_reader.go
+++ b/pkg/centralconfig/central_config_reader.go
@@ -3,12 +3,46 @@
 
 package centralconfig
 
+import "strconv"
+
 // GetDefaultTanzuEndpoint returns default endpoint for the tanzu platform from the default
 // central configuration file
 func (c *centralConfigYamlReader) GetDefaultTanzuEndpoint() (string, error) {
 	endpoint := ""
 	err := c.GetCentralConfigEntry(KeyDefaultTanzuEndpoint, &endpoint)
 	return endpoint, err
+}
+
+// GetPluginDBCacheRefreshThresholdSeconds returns default value for central db cache refresh in seconds
+// from the default central configuration file
+func (c *centralConfigYamlReader) GetPluginDBCacheRefreshThresholdSeconds() (int, error) {
+	secondsStr := ""
+	err := c.GetCentralConfigEntry(KeyDefaultPluginDBCacheRefreshThresholdSeconds, &secondsStr)
+	if err != nil {
+		return 0, err
+	}
+
+	seconds, err := strconv.ParseInt(secondsStr, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return int(seconds), nil
+}
+
+// GetInventoryRefreshTTLSeconds returns default value for central db refresh TTL in seconds
+// from the default central configuration file
+func (c *centralConfigYamlReader) GetInventoryRefreshTTLSeconds() (int, error) {
+	secondsStr := ""
+	err := c.GetCentralConfigEntry(KeyDefaultInventoryRefreshTTLSeconds, &secondsStr)
+	if err != nil {
+		return 0, err
+	}
+
+	seconds, err := strconv.ParseInt(secondsStr, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return int(seconds), nil
 }
 
 // GetTanzuPlatformEndpointToServiceEndpointMap returns Map of tanzu platform endpoint to service endpoints

--- a/pkg/centralconfig/central_config_reader_test.go
+++ b/pkg/centralconfig/central_config_reader_test.go
@@ -72,6 +72,124 @@ cli.core.tanzu_default_endpoint: ""
 	}
 }
 
+func TestGetPluginDBCacheRefreshThresholdSeconds(t *testing.T) {
+	tcs := []struct {
+		name            string
+		cfgContent      string
+		expectedSeconds int
+		expectError     bool
+	}{
+		{
+			name:            "when the key does not exist",
+			cfgContent:      "testKey: testValue",
+			expectedSeconds: 0,
+			expectError:     true,
+		},
+		{
+			name: "when the key exists",
+			cfgContent: `
+testKey: testValue
+cli.core.tanzu_cli_default_plugin_db_cache_refresh_threshold_seconds: 200
+`,
+			expectedSeconds: 200,
+		},
+		{
+			name: "when the key exists but value is set to 0",
+			cfgContent: `
+testKey: testValue
+cli.core.tanzu_cli_default_plugin_db_cache_refresh_threshold_seconds: 0
+`,
+			expectedSeconds: 0,
+		},
+	}
+
+	dir, err := os.MkdirTemp("", "test-central-config")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+	common.DefaultCacheDir = dir
+	reader := newCentralConfigReader("my_discovery")
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			path := reader.(*centralConfigYamlReader).configFile
+			// Write the central config test content to the file
+			err = os.MkdirAll(filepath.Dir(path), 0755)
+			assert.Nil(t, err)
+
+			err = os.WriteFile(path, []byte(tc.cfgContent), 0644)
+			assert.Nil(t, err)
+
+			seconds, err := reader.GetPluginDBCacheRefreshThresholdSeconds()
+
+			if tc.expectError {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+			assert.Equal(t, tc.expectedSeconds, seconds)
+		})
+	}
+}
+
+func TestGetInventoryRefreshTTLSeconds(t *testing.T) {
+	tcs := []struct {
+		name            string
+		cfgContent      string
+		expectedSeconds int
+		expectError     bool
+	}{
+		{
+			name:            "when the key does not exist",
+			cfgContent:      "testKey: testValue",
+			expectedSeconds: 0,
+			expectError:     true,
+		},
+		{
+			name: "when the key exists",
+			cfgContent: `
+testKey: testValue
+cli.core.tanzu_cli_default_inventory_refresh_ttl_seconds: 200
+`,
+			expectedSeconds: 200,
+		},
+		{
+			name: "when the key exists but value is set to 0",
+			cfgContent: `
+testKey: testValue
+cli.core.tanzu_cli_default_inventory_refresh_ttl_seconds: 0
+`,
+			expectedSeconds: 0,
+		},
+	}
+
+	dir, err := os.MkdirTemp("", "test-central-config")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+	common.DefaultCacheDir = dir
+	reader := newCentralConfigReader("my_discovery")
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			path := reader.(*centralConfigYamlReader).configFile
+			// Write the central config test content to the file
+			err = os.MkdirAll(filepath.Dir(path), 0755)
+			assert.Nil(t, err)
+
+			err = os.WriteFile(path, []byte(tc.cfgContent), 0644)
+			assert.Nil(t, err)
+
+			seconds, err := reader.GetInventoryRefreshTTLSeconds()
+
+			if tc.expectError {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+			assert.Equal(t, tc.expectedSeconds, seconds)
+		})
+	}
+}
+
 func TestGetTanzuPlatformEndpointToServiceEndpointMap(t *testing.T) {
 	tcs := []struct {
 		name                           string

--- a/pkg/centralconfig/fakes/central_config_fake.go
+++ b/pkg/centralconfig/fakes/central_config_fake.go
@@ -32,6 +32,30 @@ type CentralConfig struct {
 		result1 string
 		result2 error
 	}
+	GetInventoryRefreshTTLSecondsStub        func() (int, error)
+	getInventoryRefreshTTLSecondsMutex       sync.RWMutex
+	getInventoryRefreshTTLSecondsArgsForCall []struct {
+	}
+	getInventoryRefreshTTLSecondsReturns struct {
+		result1 int
+		result2 error
+	}
+	getInventoryRefreshTTLSecondsReturnsOnCall map[int]struct {
+		result1 int
+		result2 error
+	}
+	GetPluginDBCacheRefreshThresholdSecondsStub        func() (int, error)
+	getPluginDBCacheRefreshThresholdSecondsMutex       sync.RWMutex
+	getPluginDBCacheRefreshThresholdSecondsArgsForCall []struct {
+	}
+	getPluginDBCacheRefreshThresholdSecondsReturns struct {
+		result1 int
+		result2 error
+	}
+	getPluginDBCacheRefreshThresholdSecondsReturnsOnCall map[int]struct {
+		result1 int
+		result2 error
+	}
 	GetTanzuConfigEndpointUpdateMappingStub        func() (map[string]string, error)
 	getTanzuConfigEndpointUpdateMappingMutex       sync.RWMutex
 	getTanzuConfigEndpointUpdateMappingArgsForCall []struct {
@@ -196,6 +220,118 @@ func (fake *CentralConfig) GetDefaultTanzuEndpointReturnsOnCall(i int, result1 s
 	}
 	fake.getDefaultTanzuEndpointReturnsOnCall[i] = struct {
 		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *CentralConfig) GetInventoryRefreshTTLSeconds() (int, error) {
+	fake.getInventoryRefreshTTLSecondsMutex.Lock()
+	ret, specificReturn := fake.getInventoryRefreshTTLSecondsReturnsOnCall[len(fake.getInventoryRefreshTTLSecondsArgsForCall)]
+	fake.getInventoryRefreshTTLSecondsArgsForCall = append(fake.getInventoryRefreshTTLSecondsArgsForCall, struct {
+	}{})
+	stub := fake.GetInventoryRefreshTTLSecondsStub
+	fakeReturns := fake.getInventoryRefreshTTLSecondsReturns
+	fake.recordInvocation("GetInventoryRefreshTTLSeconds", []interface{}{})
+	fake.getInventoryRefreshTTLSecondsMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *CentralConfig) GetInventoryRefreshTTLSecondsCallCount() int {
+	fake.getInventoryRefreshTTLSecondsMutex.RLock()
+	defer fake.getInventoryRefreshTTLSecondsMutex.RUnlock()
+	return len(fake.getInventoryRefreshTTLSecondsArgsForCall)
+}
+
+func (fake *CentralConfig) GetInventoryRefreshTTLSecondsCalls(stub func() (int, error)) {
+	fake.getInventoryRefreshTTLSecondsMutex.Lock()
+	defer fake.getInventoryRefreshTTLSecondsMutex.Unlock()
+	fake.GetInventoryRefreshTTLSecondsStub = stub
+}
+
+func (fake *CentralConfig) GetInventoryRefreshTTLSecondsReturns(result1 int, result2 error) {
+	fake.getInventoryRefreshTTLSecondsMutex.Lock()
+	defer fake.getInventoryRefreshTTLSecondsMutex.Unlock()
+	fake.GetInventoryRefreshTTLSecondsStub = nil
+	fake.getInventoryRefreshTTLSecondsReturns = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *CentralConfig) GetInventoryRefreshTTLSecondsReturnsOnCall(i int, result1 int, result2 error) {
+	fake.getInventoryRefreshTTLSecondsMutex.Lock()
+	defer fake.getInventoryRefreshTTLSecondsMutex.Unlock()
+	fake.GetInventoryRefreshTTLSecondsStub = nil
+	if fake.getInventoryRefreshTTLSecondsReturnsOnCall == nil {
+		fake.getInventoryRefreshTTLSecondsReturnsOnCall = make(map[int]struct {
+			result1 int
+			result2 error
+		})
+	}
+	fake.getInventoryRefreshTTLSecondsReturnsOnCall[i] = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *CentralConfig) GetPluginDBCacheRefreshThresholdSeconds() (int, error) {
+	fake.getPluginDBCacheRefreshThresholdSecondsMutex.Lock()
+	ret, specificReturn := fake.getPluginDBCacheRefreshThresholdSecondsReturnsOnCall[len(fake.getPluginDBCacheRefreshThresholdSecondsArgsForCall)]
+	fake.getPluginDBCacheRefreshThresholdSecondsArgsForCall = append(fake.getPluginDBCacheRefreshThresholdSecondsArgsForCall, struct {
+	}{})
+	stub := fake.GetPluginDBCacheRefreshThresholdSecondsStub
+	fakeReturns := fake.getPluginDBCacheRefreshThresholdSecondsReturns
+	fake.recordInvocation("GetPluginDBCacheRefreshThresholdSeconds", []interface{}{})
+	fake.getPluginDBCacheRefreshThresholdSecondsMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *CentralConfig) GetPluginDBCacheRefreshThresholdSecondsCallCount() int {
+	fake.getPluginDBCacheRefreshThresholdSecondsMutex.RLock()
+	defer fake.getPluginDBCacheRefreshThresholdSecondsMutex.RUnlock()
+	return len(fake.getPluginDBCacheRefreshThresholdSecondsArgsForCall)
+}
+
+func (fake *CentralConfig) GetPluginDBCacheRefreshThresholdSecondsCalls(stub func() (int, error)) {
+	fake.getPluginDBCacheRefreshThresholdSecondsMutex.Lock()
+	defer fake.getPluginDBCacheRefreshThresholdSecondsMutex.Unlock()
+	fake.GetPluginDBCacheRefreshThresholdSecondsStub = stub
+}
+
+func (fake *CentralConfig) GetPluginDBCacheRefreshThresholdSecondsReturns(result1 int, result2 error) {
+	fake.getPluginDBCacheRefreshThresholdSecondsMutex.Lock()
+	defer fake.getPluginDBCacheRefreshThresholdSecondsMutex.Unlock()
+	fake.GetPluginDBCacheRefreshThresholdSecondsStub = nil
+	fake.getPluginDBCacheRefreshThresholdSecondsReturns = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *CentralConfig) GetPluginDBCacheRefreshThresholdSecondsReturnsOnCall(i int, result1 int, result2 error) {
+	fake.getPluginDBCacheRefreshThresholdSecondsMutex.Lock()
+	defer fake.getPluginDBCacheRefreshThresholdSecondsMutex.Unlock()
+	fake.GetPluginDBCacheRefreshThresholdSecondsStub = nil
+	if fake.getPluginDBCacheRefreshThresholdSecondsReturnsOnCall == nil {
+		fake.getPluginDBCacheRefreshThresholdSecondsReturnsOnCall = make(map[int]struct {
+			result1 int
+			result2 error
+		})
+	}
+	fake.getPluginDBCacheRefreshThresholdSecondsReturnsOnCall[i] = struct {
+		result1 int
 		result2 error
 	}{result1, result2}
 }
@@ -428,6 +564,10 @@ func (fake *CentralConfig) Invocations() map[string][][]interface{} {
 	defer fake.getCentralConfigEntryMutex.RUnlock()
 	fake.getDefaultTanzuEndpointMutex.RLock()
 	defer fake.getDefaultTanzuEndpointMutex.RUnlock()
+	fake.getInventoryRefreshTTLSecondsMutex.RLock()
+	defer fake.getInventoryRefreshTTLSecondsMutex.RUnlock()
+	fake.getPluginDBCacheRefreshThresholdSecondsMutex.RLock()
+	defer fake.getPluginDBCacheRefreshThresholdSecondsMutex.RUnlock()
 	fake.getTanzuConfigEndpointUpdateMappingMutex.RLock()
 	defer fake.getTanzuConfigEndpointUpdateMappingMutex.RUnlock()
 	fake.getTanzuConfigEndpointUpdateVersionMutex.RLock()

--- a/pkg/centralconfiginit/central_config_cache_init.go
+++ b/pkg/centralconfiginit/central_config_cache_init.go
@@ -1,7 +1,8 @@
 // Copyright 2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package centralconfig
+// Package centralconfiginit is used to add inventory updater to the globalinitializer
+package centralconfiginit
 
 import (
 	"io"

--- a/pkg/centralconfiginit/central_config_cache_init_test.go
+++ b/pkg/centralconfiginit/central_config_cache_init_test.go
@@ -1,7 +1,7 @@
 // Copyright 2024 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package centralconfig
+package centralconfiginit
 
 import (
 	"fmt"

--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -22,6 +22,7 @@ import (
 	commonauth "github.com/vmware-tanzu/tanzu-cli/pkg/auth/common"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/auth/csp"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/catalog"
+	_ "github.com/vmware-tanzu/tanzu-cli/pkg/centralconfiginit" // Force import to run init function
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cli"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
 	cliconfig "github.com/vmware-tanzu/tanzu-cli/pkg/config"
@@ -35,8 +36,8 @@ import (
 	"github.com/vmware-tanzu/tanzu-cli/pkg/recommendedversion"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/telemetry"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/utils"
-	"github.com/vmware-tanzu/tanzu-plugin-runtime/component"
 
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/component"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/log"

--- a/pkg/constants/defaults.go
+++ b/pkg/constants/defaults.go
@@ -27,14 +27,6 @@ const (
 	// DefaultCLIEssentialsPluginGroupName  name of the essentials plugin group which is used to install essential plugins
 	DefaultCLIEssentialsPluginGroupName = "vmware-tanzucli/essentials"
 
-	// DefaultPluginDBCacheRefreshThresholdSeconds is the default value for db cache refresh
-	// For testing, it can be overridden using the environment variable TANZU_CLI_PLUGIN_DB_CACHE_REFRESH_THRESHOLD_SECONDS.
-	DefaultPluginDBCacheRefreshThresholdSeconds = 24 * 60 * 60 // 24 hours
-
-	// DefaultInventoryRefreshTTLSeconds is the interval in seconds between two checks of the inventory digest.
-	// For testing, it can be overridden using the environment variable TANZU_CLI_PLUGIN_DB_CACHE_TTL_SECONDS.
-	DefaultInventoryRefreshTTLSeconds = 30 * 60 // 30 minutes
-
 	// TanzuContextPluginDiscoveryEndpointPath specifies the default plugin discovery endpoint path
 	// Note: This path value needs to be updated once the Tanzu context backend support the context-scoped
 	// plugin discovery and the endpoint value gets finalized

--- a/pkg/discovery/oci_dbbacked.go
+++ b/pkg/discovery/oci_dbbacked.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/vmware-tanzu/tanzu-cli/pkg/airgapped"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/carvelhelpers"
+	"github.com/vmware-tanzu/tanzu-cli/pkg/centralconfig"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/cosignhelper/sigverifier"
@@ -419,7 +420,7 @@ func (od *DBBackedOCIDiscovery) checkDigestFileExistence(hashHexVal, digestPrefi
 }
 
 func getCacheTTLValue() int {
-	cacheTTL := constants.DefaultInventoryRefreshTTLSeconds
+	cacheTTL := centralconfig.DefaultInventoryRefreshTTLSeconds
 	cacheTTLOverride := os.Getenv(constants.ConfigVariablePluginDBCacheTTLSeconds)
 	if cacheTTLOverride != "" {
 		cacheTTLOverrideValue, err := strconv.Atoi(cacheTTLOverride)

--- a/pkg/discovery/utils.go
+++ b/pkg/discovery/utils.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/vmware-tanzu/tanzu-cli/pkg/centralconfig"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/common"
 	"github.com/vmware-tanzu/tanzu-cli/pkg/constants"
 
@@ -86,7 +87,7 @@ func getDiscoverySourceNameAndURL(source configtypes.PluginDiscovery) (string, s
 // RefreshDatabase function refreshes the plugin inventory database if the digest timestamp is past 24 hours
 func RefreshDatabase() error {
 	// Initialize digestExpirationThreshold with the default value
-	dbCacheRefreshThreshold := constants.DefaultPluginDBCacheRefreshThresholdSeconds
+	dbCacheRefreshThreshold := centralconfig.DefaultPluginDBCacheRefreshThresholdSeconds
 
 	// Check if the user has set a custom value for digest expiration threshold
 	if dbCacheRefreshThresholdOverride, ok := os.LookupEnv(constants.ConfigVariablePluginDBCacheRefreshThresholdSeconds); ok {


### PR DESCRIPTION
### What this PR does / why we need it
- Read default database refresh threshold from Central Config

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

- Run any command first to make sure the inventory database fetch is done recently.
- Now simulate the central configuration update (in production scenarios this can be done with central configuration fetch that currently happens every 24 hours with 30 min TTL)

Add following two keys to the central configuration to simulate the behavior
```
$ cat ~/.cache/tanzu/plugin_inventory/default/central_config.yaml
cli.core.tanzu_cli_default_inventory_refresh_ttl_seconds: 2
cli.core.tanzu_cli_default_plugin_db_cache_refresh_threshold_seconds: 2
```

- Run any command again with 2 second interval and notice the database update is triggered. When running command within 2 seconds the database update will not get triggered.
```
$ date && tz context list
Thu Sep 12 21:09:10 PDT 2024
[i] Refreshing plugin inventory cache for "projects.packages.broadcom.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
  NAME                                      ISACTIVE  TYPE   PROJECT  SPACE
...

$ date && tz context list
Thu Sep 12 21:09:16 PDT 2024
[i] Refreshing plugin inventory cache for "projects.packages.broadcom.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
  NAME                                      ISACTIVE  TYPE   PROJECT  SPACE
...

$ date && tz context list
Thu Sep 12 21:09:17 PDT 2024
  NAME                                      ISACTIVE  TYPE   PROJECT  SPACE

```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Read default database refresh threshold from Central Config
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
