### PR TITLE
Fix the API Token generation URL in API token prompt

### DIFF
--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -1015,13 +1015,14 @@ func promptContextName(defaultCtxName string) (cname string, err error) {
 
 // Interactive way to create a TMC context. User will be prompted for CSP API token.
 func promptAPIToken(endpointType string) (apiToken string, err error) {
-	hostVal := "console.cloud.vmware.com"
-	if staging {
-		hostVal = "console-stg.cloud.vmware.com"
+	issuer := csp.GetIssuer(staging)
+	u, err := url.ParseRequestURI(issuer)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to parse the issuer URL")
 	}
 	consoleURL := url.URL{
 		Scheme:   "https",
-		Host:     hostVal,
+		Host:     u.Hostname(),
 		Path:     "/csp/gateway/portal/",
 		Fragment: "/user/tokens",
 	}


### PR DESCRIPTION
### What this PR does / why we need it
This PR fixes the API Token generation URL in API token prompt
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Tested context creat with with both staging and production. The  API token URLs(fetched from central config) are shown correctly in API token prompt.

```
❯ ./bin/tanzu context create
? Select context creation type Mission Control
? Enter control plane endpoint test.tmc.tanzu.com
? Give the context a name test

[i] The API key can be provided by setting the TANZU_API_TOKEN environment variable

[i] If you don't have an API token, visit the VMware Cloud Services console, select your organization, and create an API token with the TMC service roles:
  https://console.tanzu.broadcom.com/csp/gateway/portal/#/user/tokens

? API Token
[x] : interrupt
```

```
❯ ./bin/tanzu context create --staging
? Select context creation type Mission Control
? Enter control plane endpoint test.com
? Give the context a name test

[i] The API key can be provided by setting the TANZU_API_TOKEN environment variable

[i] If you don't have an API token, visit the VMware Cloud Services console, select your organization, and create an API token with the TMC service roles:
  https://console-stg.tanzu.broadcom.com/csp/gateway/portal/#/user/tokens

? API Token
[x] : interrupt
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
