### PR TITLE
Allow to specify a tanzu endpoint with no scheme (avoid panic)

### DIFF
--- a/pkg/command/login_helper.go
+++ b/pkg/command/login_helper.go
@@ -110,6 +110,11 @@ func isTanzuPlatformSaaSEndpoint(tpEndpoint string) bool {
 		return false
 	}
 
+	// If the url scheme is not provided by the user, default to using `https`
+	if !strings.HasPrefix(tpEndpoint, "http://") && !strings.HasPrefix(tpEndpoint, "https://") {
+		tpEndpoint = "https://" + tpEndpoint
+	}
+
 	saasEndpointRegularExpressions := centralconfig.DefaultCentralConfigReader.GetTanzuPlatformSaaSEndpointList()
 	for _, endpointRegex := range saasEndpointRegularExpressions {
 		// Create a regular expression pattern

--- a/pkg/command/login_helper_test.go
+++ b/pkg/command/login_helper_test.go
@@ -151,6 +151,12 @@ func TestIsTanzuPlatformSaaSEndpoint(t *testing.T) {
 			expected:                        true,
 		},
 		{
+			name:                            "valid SaaS endpoint without scheme",
+			tpEndpoint:                      "tanzu.vmware.com",
+			saasEndpointListInCentralConfig: []string{"https://tanzu.vmware.com"},
+			expected:                        true,
+		},
+		{
 			name:                            "invalid SaaS endpoint",
 			tpEndpoint:                      "https://example.com",
 			saasEndpointListInCentralConfig: []string{"https://tanzu.vmware.com"},


### PR DESCRIPTION
### What this PR does / why we need it

Creating a context through `tanzu login` or `tanzu create` for Tanzu Platform would fail if the scheme was not specified.  For `tanzu login` it would even panic.
Running `tanzu login --endpoint api.tanzu.cloud.vmware.com` will panic, while running `tanzu context create test --endpoint api.tanzu.cloud.vmware.com` will attempt to create a TMC context.

This PR adds the `https://` prefix before checking if the URL is a Tanzu Platform URL.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Before the PR
```
$ tz login --endpoint api.tanzu.cloud.vmware.com
panic: interface conversion: interface {} is nil, not string

goroutine 1 [running]:
github.com/vmware-tanzu/tanzu-cli/pkg/command.globalTanzuLoginUAA(0x14001da3e00, 0x14001bc2900?)
	/Users/kmarc/git/tanzu-cli/pkg/command/context.go:653 +0x248
github.com/vmware-tanzu/tanzu-cli/pkg/command.globalTanzuLogin(0x14001da3e00, 0xc8628c716f88aa8e?)
	/Users/kmarc/git/tanzu-cli/pkg/command/context.go:647 +0xe0
github.com/vmware-tanzu/tanzu-cli/pkg/command.login(0x14000af8300?, {0x140005a0f80?, 0x0?, 0x2?})
	/Users/kmarc/git/tanzu-cli/pkg/command/login.go:99 +0xc4
github.com/spf13/cobra.(*Command).execute(0x14000af8300, {0x140005a0f60, 0x2, 0x2})
	/Users/kmarc/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0x6d8
github.com/spf13/cobra.(*Command).ExecuteC(0x140009d6000)
	/Users/kmarc/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x348
github.com/spf13/cobra.(*Command).Execute(0x1400084deb8?)
	/Users/kmarc/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039 +0x1c
github.com/vmware-tanzu/tanzu-cli/pkg/command.Execute()
	/Users/kmarc/git/tanzu-cli/pkg/command/root.go:823 +0x24
main.main()
	/Users/kmarc/git/tanzu-cli/cmd/tanzu/main.go:15 +0x1c

$ tz login --endpoint platform.tanzu.broadcom.com
panic: interface conversion: interface {} is nil, not string

goroutine 1 [running]:
github.com/vmware-tanzu/tanzu-cli/pkg/command.globalTanzuLoginUAA(0x14001d11e00, 0x14001b6e930?)
	/Users/kmarc/git/tanzu-cli/pkg/command/context.go:653 +0x248
github.com/vmware-tanzu/tanzu-cli/pkg/command.globalTanzuLogin(0x14001d11e00, 0x6cef94a6690d4391?)
	/Users/kmarc/git/tanzu-cli/pkg/command/context.go:647 +0xe0
github.com/vmware-tanzu/tanzu-cli/pkg/command.login(0x140009e6900?, {0x1400027c240?, 0x0?, 0x2?})
	/Users/kmarc/git/tanzu-cli/pkg/command/login.go:99 +0xc4
github.com/spf13/cobra.(*Command).execute(0x140009e6900, {0x1400027c200, 0x2, 0x2})
	/Users/kmarc/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0x6d8
github.com/spf13/cobra.(*Command).ExecuteC(0x14000a28000)
	/Users/kmarc/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x348
github.com/spf13/cobra.(*Command).Execute(0x14000b51eb8?)
	/Users/kmarc/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039 +0x1c
github.com/vmware-tanzu/tanzu-cli/pkg/command.Execute()
	/Users/kmarc/git/tanzu-cli/pkg/command/root.go:823 +0x24
main.main()
	/Users/kmarc/git/tanzu-cli/cmd/tanzu/main.go:15 +0x1c

# Notice that with context create, if the scheme is not specified
# for a Tanzu URL, the CLI was interpreting it as a TMC URL
$ tz context create --endpoint api.tanzu.cloud.vmware.com
? Give the context a name test

[i] The API key can be provided by setting the TANZU_API_TOKEN environment variable

[i] If you don't have an API token, visit the VMware Cloud Services console, select your organization, and create an API token with the TMC service roles:
  https://console.cloud.vmware.com/csp/gateway/portal/#/user/tokens

? API Token
[x] : interrupt

$ tz context create --endpoint platform.tanzu.broadcom.com
? Give the context a name test
[x] : the 'pinniped-auth' plugin is not installed. This plugin is required to authenticate with TKG/vSphere with Kubernetes(TKGs), please install the plugin and retry
```

After the PR:
```
$ tz login --endpoint api.tanzu.cloud.vmware.com
[i] Opening the browser window to complete the login
Log in by visiting this link:

    https://console.tanzu.broadcom.com/csp/gateway/discovery?client_id=tanzu-cli-client-id&code_challenge=PI2yOXeb-svqCPvQjnYfKUYn7HteOOfRGP2oh-I_aIA&code_challenge_method=S256&redirect_uri=http%3A%2F%2F127.0.0.1%3A57399%2Fcallback&response_type=code&state=c2a0c44f82ecd914cf0bb13b79c6adae

    Optionally, paste your authorization code: [...]


[ok] Successfully logged into 'Tanzu Platform for K8s SaaS - Internal 1' organization and created a tanzu context
$ tz context current --short
Tanzu_Platform_for_K8s_SaaS_-_Internal_1:mfine:tjwa2

$ tz login --endpoint platform.tanzu.broadcom.com
[i] Opening the browser window to complete the login
Log in by visiting this link:

    https://console.tanzu.broadcom.com/csp/gateway/discovery?client_id=tanzu-cli-client-id&code_challenge=QtgqCTxRTvQ_vlWPnZNBMYDufn43yyrtLG_PB7k0ItA&code_challenge_method=S256&redirect_uri=http%3A%2F%2F127.0.0.1%3A57426%2Fcallback&response_type=code&state=82bd0d302150195aefd1b34baeeb19cf

    Optionally, paste your authorization code: [...]


[ok] Successfully logged into 'Tanzu Platform for K8s SaaS - Internal 1' organization and created a tanzu context
$ tz context current --short
Tanzu_Platform_for_K8s_SaaS_-_Internal_1-2dfd3362

$ tz context create --endpoint api.tanzu.cloud.vmware.com
? Give the context a name test
[i] Opening the browser window to complete the login
Log in by visiting this link:

    https://console.tanzu.broadcom.com/csp/gateway/discovery?client_id=tanzu-cli-client-id&code_challenge=DHt5mTvnxbrgnQdQTF1bwMqN1wpaS6jb3MtY8ZZhq1o&code_challenge_method=S256&redirect_uri=http%3A%2F%2F127.0.0.1%3A57452%2Fcallback&response_type=code&state=a3970984f223ced278a9b73d9406629d

    Optionally, paste your authorization code: [...]


[ok] Successfully logged into 'Tanzu Platform for K8s SaaS - Internal 1' organization and created a tanzu context
$ tz context current --short
test

$ tz context create testing --endpoint platform.tanzu.broadcom.com
[i] Opening the browser window to complete the login
Log in by visiting this link:

    https://console.tanzu.broadcom.com/csp/gateway/discovery?client_id=tanzu-cli-client-id&code_challenge=Ise4Ak6Q7-J1vmLD2BktAmEglyzI64PpLYCIM1Ff_Mk&code_challenge_method=S256&redirect_uri=http%3A%2F%2F127.0.0.1%3A57481%2Fcallback&response_type=code&state=120d04cbd1238a8a87f4d4b4f9ab1868

    Optionally, paste your authorization code: [...]


[ok] Successfully logged into 'Tanzu Platform for K8s SaaS - Internal 1' organization and created a tanzu context
$ tz context current --short
testing

# Try with staging
$ tz login --endpoint api.tanzu-stable.cloud.vmware.com --staging
[i] Opening the browser window to complete the login
Log in by visiting this link:

    https://console-stg.tanzu.broadcom.com/csp/gateway/discovery?client_id=tanzu-cli-client-id&code_challenge=G8bKm5rpZliPtqCoTME3KzA_8RcbCvj3SXjJKBMcrM4&code_challenge_method=S256&redirect_uri=http%3A%2F%2F127.0.0.1%3A57511%2Fcallback&response_type=code&state=06c60882e69ffecc316e53a7ef05c040

    Optionally, paste your authorization code: [...]


[ok] Successfully logged into 'Falcons' organization and created a tanzu context
$ tz context current --short
Falcons-staging-2761fd6c

$ tz login --endpoint platform-verify.tanzu.broadcom.com --staging
[i] Opening the browser window to complete the login
Log in by visiting this link:

    https://console-stg.tanzu.broadcom.com/csp/gateway/discovery?client_id=tanzu-cli-client-id&code_challenge=sNpH2kgGxsd4OwgiDkX5vzBEsbwvD1lyWEFzz9bN4n8&code_challenge_method=S256&redirect_uri=http%3A%2F%2F127.0.0.1%3A57529%2Fcallback&response_type=code&state=b8c99149f239b993319b2f0c7f297136

    Optionally, paste your authorization code: [...]


[ok] Successfully logged into 'Falcons' organization and created a tanzu context
$ tz context current --short
Falcons-staging-3fb994fb
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Allow to specify a tanzu endpoint with no scheme
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

I was unsure how to create a tanzu context for TPSM, so I still need to test that.
