### PR TITLE
Improve startup speed

### DIFF
--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -4,16 +4,35 @@
 package config
 
 import (
-	"github.com/pkg/errors"
+	"crypto/sha256"
+	"encoding/hex"
 
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+
+	"github.com/vmware-tanzu/tanzu-cli/pkg/datastore"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/config"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
+
+type contextAndServerSha struct {
+	ContextsSha        string
+	CurrentContextsSha string
+	ServersSha         string
+	CurrentServerSha   string
+}
+
+const lastContextServerShasKey = "lastContextServerShas"
 
 // SyncContextsAndServers populate or sync contexts and servers
 func SyncContextsAndServers() error {
 	cfg, err := config.GetClientConfig()
 	if err != nil {
 		return errors.Wrap(err, "failed to get client config")
+	}
+
+	if !shouldSyncContextsAndServers(cfg) {
+		return nil
 	}
 
 	config.PopulateContexts(cfg)
@@ -34,5 +53,76 @@ func SyncContextsAndServers() error {
 			return errors.Wrap(err, "failed to set active context")
 		}
 	}
+
+	// After the sync, save the shas using the updated config
+	// so that next time, we avoid synching if the shas are the same
+	cfg, err = config.GetClientConfig()
+	if err == nil {
+		_ = saveContextAndServerShas(cfg)
+	}
 	return nil
+}
+
+func shouldSyncContextsAndServers(cfg *types.ClientConfig) bool {
+	var prevShas contextAndServerSha
+	err := datastore.GetDataStoreValue(lastContextServerShasKey, &prevShas)
+	if err != nil {
+		return true
+	}
+
+	newShas := computeShasForSync(cfg)
+	if newShas == nil || prevShas != *newShas {
+		return true
+	}
+	return false
+}
+
+//nolint:staticcheck // Deprecated
+func computeShasForSync(cfg *types.ClientConfig) *contextAndServerSha {
+	// tanzu contexts are not synced so we don't include them in the sha
+	// because even if they change, we don't need to sync them
+	var nonTanzuContexts []*types.Context
+	for i := range cfg.KnownContexts {
+		if cfg.KnownContexts[i].ContextType != types.ContextTypeTanzu {
+			nonTanzuContexts = append(nonTanzuContexts, cfg.KnownContexts[i])
+		}
+	}
+	ctxBytes, err := yaml.Marshal(nonTanzuContexts)
+	if err != nil {
+		return nil
+	}
+
+	// tanzu servers are not synced so we don't include them in the sha
+	// because even if they change, we don't need to sync them.
+	// Note that tanzu servers should normally not be in the known servers list
+	// but could happen for some older plugins or CLI versions which used to sync them.
+	var nonTanzuServers []*types.Server
+	for i := range cfg.KnownServers {
+		if cfg.KnownServers[i].Type != types.ServerType(types.ContextTypeTanzu) {
+			nonTanzuServers = append(nonTanzuServers, cfg.KnownServers[i])
+		}
+	}
+	serverBytes, err := yaml.Marshal(nonTanzuServers)
+	if err != nil {
+		return nil
+	}
+
+	return &contextAndServerSha{
+		ContextsSha: hashString(string(ctxBytes)),
+		// Only the k8s current context is synched
+		CurrentContextsSha: hashString(cfg.CurrentContext[types.ContextTypeK8s]),
+		ServersSha:         hashString(string(serverBytes)),
+		CurrentServerSha:   hashString(cfg.CurrentServer),
+	}
+}
+
+func saveContextAndServerShas(cfg *types.ClientConfig) error {
+	newShas := computeShasForSync(cfg)
+	return datastore.SetDataStoreValue(lastContextServerShasKey, newShas)
+}
+
+func hashString(str string) string {
+	h := sha256.New()
+	h.Write([]byte(str))
+	return hex.EncodeToString(h.Sum(nil))
 }


### PR DESCRIPTION
### What this PR does / why we need it

This PR avoids writing to the config files and the `.data-store.yaml` on startup if not necessary.

Writing to the config file to update the server list has a cost for each context.  I ended up with 27 contexts configured, which triggered writing to file over 50 times which added 0.65 seconds on my M1 Mac, making the startup jump from around 0.35 seconds to a full second. Having the CLI take a full second to execute any command implies that each call to shell completion takes at least 1 second, which is slow for the user.

Updating the server list does not actually need to be done all the time. 

Furthermore, the CLI currently writes to the `.data-store.yaml` and to the config files on every command when it stores the LastCLIVersionUsed.  This file writes are also unnecessary most of the time.

This PR has two commits:
1. compute a sha of the contexts and another for the servers and store it in the data-store.  Then for each command, instead of blindly synching contexts and servers, only do the sync if either sha has changed.
2. on write the last executed cli version to the data-store if the version is different than what is stored already, and only disable the `features.global.context-target-v2` feature if it is currently enabled (to avoid writing to the config files)

This reduces the execution time for commands that don't access the backend; this means that shell completion for commands and flags becomes noticeably more responsive when a user has multiple contexts configured.

Before this PR, running `tanzu version` with 9 contexts configures takes around 0.5 seconds.
With this PR is becomes closer to 0.3 seconds.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #823

### Describe testing done for PR

I use this little utility called `entr` which will execute a command whenever a specific file is changed.
```
# Monitor changes to the two config file and the datastore file
$ echo ~/.config/tanzu/config.yaml| entr echo config changed >>out.txt
$ echo ~/.config/tanzu/config-ng.yaml| entr echo config-ng changed >>out.txt
$ echo ~/.config/tanzu/.data-store.yaml | entr echo datastore changed >>out.txt
$ tail -f out.txt
```

Before the PR, if I run any command such as `tanzu -h >/dev/null` I see the config files change for every command multiple times (one for each context).

And for commands that trigger the lastTanzuVersion check (most commands), such as `tanzu plugin list >/dev/null`, I see the datastore file updated and the config files also. 

With this PR, running those same commands, I don't see any changes done to the config or datastore files.

I also ran some normal shell completion down the command tree, and the responsiveness is noticeably better.


### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Improve CLI execution speed, especially for shell completion responsiveness
```


### Additional information

#### Special notes for your reviewer
