### PR TITLE
Print stderr output of plugin when doing completion

### DIFF
--- a/pkg/cli/plugin_cmd.go
+++ b/pkg/cli/plugin_cmd.go
@@ -211,10 +211,14 @@ func getCmdForPluginEx(p *PluginInfo, cmdName string, mapEntry *plugin.CommandMa
 		runner := NewRunner(p.Name, p.InstallationPath, completion)
 		ctx := context.Background()
 		setupPluginEnv(srcHierarchy, dstHierarchy)
-		output, _, err := runner.RunOutput(ctx)
+		output, errOutput, err := runner.RunOutput(ctx)
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}
+
+		// Print the stderr output from the plugin back to stderr.
+		// This allows for debugging printouts to be seen.
+		fmt.Fprint(cmd.ErrOrStderr(), errOutput)
 
 		lines := strings.Split(strings.Trim(output, "\n"), "\n")
 


### PR DESCRIPTION
### What this PR does / why we need it

A plugin, when doing shell completion, may print debug printouts to stderr.  When the plugin is invoked through the tanzu cli, those printouts were being lost.  This PR prints them out to stderr to allow for better troubleshooting of plugin shell completion.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Before the PR:
```
# Notice that if I call the __complete command directly on the plugin, I get a debug printout "EDS query"
# This printout is on stderr
$ TANZU_BIN=tanzu TANZU_CLI_LOG_LEVEL=7 $rbac/artifacts/plugins/darwin/arm64/global/rbac/v0.0.0-dev-31f037f/tanzu-rbac-darwin_arm64 __complete role get '' > /dev/null
[i] Fetched 4 roles from EDS Query
Completion ended with directive: ShellCompDirectiveNoFileComp

# Notice here however, that if I call the __complete command on the tanzu CLI
# which will in turn call __complete on the plugin, the debug printout is not seen
$ TANZU_CLI_LOG_LEVEL=7 tanzu __complete rbac role get '' > /dev/null
Completion ended with directive: ShellCompDirectiveNoFileComp
```
With this PR:
```
# Now the debug printout is visible.
# Notice also that as a side-effect, there is a second "directive" printout;
# the first one is coming from the plugin, which was previously lost, while
# the second is the one from the CLI itself.
$ TANZU_CLI_LOG_LEVEL=7 tanzu __complete rbac role get '' > /dev/null
[i] Fetched 4 roles from EDS Query
Completion ended with directive: ShellCompDirectiveNoFileComp
Completion ended with directive: ShellCompDirectiveNoFileComp
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Improve shell completion debugging by showing debug printouts.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
