### PR TITLE
Update kube context with certmap info if necessary

### DIFF
--- a/pkg/auth/tanzu/kubeconfig_test.go
+++ b/pkg/auth/tanzu/kubeconfig_test.go
@@ -4,6 +4,7 @@
 package tanzu
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 
 	"k8s.io/client-go/tools/clientcmd"
 
+	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -31,21 +33,22 @@ const (
 var _ = Describe("Unit tests for tanzu auth", func() {
 	var (
 		err          error
-		endpoint     string
 		tanzuContext *configtypes.Context
 		oldHomeDir   string
 		tmpHomeDir   string
 	)
 
 	const (
-		fakeContextName = "fake-tanzu-context"
-		fakeAccessToken = "fake-access-token"
-		fakeOrgID       = "fake-org-id"
-		fakeEndpoint    = "fake.tanzu.cloud.vmware.com"
+		fakeContextName   = "fake-tanzu-context"
+		fakeAccessToken   = "fake-access-token"
+		fakeOrgID         = "fake-org-id"
+		fakeEndpoint      = "fake.tanzu.cloud.vmware.com"
+		fakeCACertContent = "-----BEGIN CERTIFICATE-----\nfake\n---"
 	)
 
 	Describe("GetTanzuKubeconfig()", func() {
 		var kubeConfigPath, kubeContext, clusterAPIServerURL string
+
 		BeforeEach(func() {
 			err = createTempDirectory("kubeconfig-test")
 			Expect(err).ToNot(HaveOccurred())
@@ -109,7 +112,7 @@ var _ = Describe("Unit tests for tanzu auth", func() {
 		})
 		Context("When endpointCACertPath is not provided and skipTLSVerify is set to true", func() {
 			BeforeEach(func() {
-				kubeConfigPath, kubeContext, clusterAPIServerURL, err = GetTanzuKubeconfig(tanzuContext, endpoint, fakeOrgID, "", true)
+				kubeConfigPath, kubeContext, clusterAPIServerURL, err = GetTanzuKubeconfig(tanzuContext, fakeEndpoint, fakeOrgID, "", true)
 			})
 			It("should not set the 'certificate-authority-data' in kubeconfig and 'insecure-skip-tls-verify' should be set", func() {
 				Expect(err).ToNot(HaveOccurred())
@@ -130,7 +133,115 @@ var _ = Describe("Unit tests for tanzu auth", func() {
 				Expect(user.Exec).To(Equal(getExecConfig(tanzuContext)))
 			})
 		})
+		Context("When endpointCACertPath is not provided and skipTLSVerify is set to false, but ca cert found in cert map", func() {
+			BeforeEach(func() {
+				certInfo := configtypes.Cert{
+					Host:           fakeEndpoint,
+					CACertData:     base64.StdEncoding.EncodeToString([]byte(fakeCACertContent)),
+					SkipCertVerify: "false",
+				}
 
+				err = configlib.SetCert(&certInfo)
+				Expect(err).ToNot(HaveOccurred())
+
+				tanzuContext.AdditionalMetadata = map[string]interface{}{
+					configlib.TanzuAuthEndpointKey: "https://" + fakeEndpoint + "/auth",
+				}
+
+				kubeConfigPath, kubeContext, clusterAPIServerURL, err = GetTanzuKubeconfig(tanzuContext, fakeEndpoint, fakeOrgID, "", false)
+			})
+			It("should set the 'certificate-authority-data' in kubeconfig base on the cert map contents", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(kubeConfigPath).Should(Equal(filepath.Join(tmpHomeDir, ".config", "tanzu", "kube", "config")))
+				Expect(kubeContext).Should(Equal("tanzu-cli-" + tanzuContext.Name))
+				config, err := clientcmd.LoadFromFile(kubeConfigPath)
+				Expect(err).ToNot(HaveOccurred())
+
+				gotClusterName := config.Contexts[kubeContext].Cluster
+				cluster := config.Clusters[config.Contexts[kubeContext].Cluster]
+				user := config.AuthInfos[config.Contexts[kubeContext].AuthInfo]
+
+				Expect(cluster.Server).To(Equal(clusterAPIServerURL))
+				Expect(config.Contexts[kubeContext].AuthInfo).To(Equal("tanzu-cli-" + tanzuContext.Name + "-user"))
+				Expect(gotClusterName).To(Equal("tanzu-cli-" + tanzuContext.Name))
+				Expect([]byte(fakeCACertContent)).To(Equal(cluster.CertificateAuthorityData))
+				Expect(cluster.InsecureSkipTLSVerify).To(Equal(false))
+				Expect(user.Exec).To(Equal(getExecConfig(tanzuContext)))
+			})
+		})
+		Context("When endpointCACertPath is not provided and skipTLSVerify is set to false, but skipVerify is true in cert map", func() {
+			BeforeEach(func() {
+				certInfo := configtypes.Cert{
+					Host:           fakeEndpoint,
+					SkipCertVerify: "true",
+				}
+
+				err = configlib.SetCert(&certInfo)
+				Expect(err).ToNot(HaveOccurred())
+
+				tanzuContext.AdditionalMetadata = map[string]interface{}{
+					configlib.TanzuAuthEndpointKey: "https://" + fakeEndpoint + "/auth",
+				}
+
+				kubeConfigPath, kubeContext, clusterAPIServerURL, err = GetTanzuKubeconfig(tanzuContext, fakeEndpoint, fakeOrgID, "", false)
+			})
+			It("should set the 'certificate-authority-data' in kubeconfig base on the cert map contents", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(kubeConfigPath).Should(Equal(filepath.Join(tmpHomeDir, ".config", "tanzu", "kube", "config")))
+				Expect(kubeContext).Should(Equal("tanzu-cli-" + tanzuContext.Name))
+				config, err := clientcmd.LoadFromFile(kubeConfigPath)
+				Expect(err).ToNot(HaveOccurred())
+
+				gotClusterName := config.Contexts[kubeContext].Cluster
+				cluster := config.Clusters[config.Contexts[kubeContext].Cluster]
+				user := config.AuthInfos[config.Contexts[kubeContext].AuthInfo]
+
+				Expect(cluster.Server).To(Equal(clusterAPIServerURL))
+				Expect(config.Contexts[kubeContext].AuthInfo).To(Equal("tanzu-cli-" + tanzuContext.Name + "-user"))
+				Expect(gotClusterName).To(Equal("tanzu-cli-" + tanzuContext.Name))
+				Expect(len(cluster.CertificateAuthorityData)).To(Equal(0))
+				Expect(cluster.InsecureSkipTLSVerify).To(Equal(true))
+				Expect(user.Exec).To(Equal(getExecConfig(tanzuContext)))
+			})
+		})
+		Context("When the endpoint caCertPath provided exists and skipTLSVerify is set to false and there is valid certmap data", func() {
+			BeforeEach(func() {
+				certInfo := configtypes.Cert{
+					Host:           fakeEndpoint,
+					CACertData:     base64.StdEncoding.EncodeToString([]byte(fakeCACertContent)),
+					SkipCertVerify: "false",
+				}
+
+				err = configlib.SetCert(&certInfo)
+				Expect(err).ToNot(HaveOccurred())
+
+				tanzuContext.AdditionalMetadata = map[string]interface{}{
+					configlib.TanzuAuthEndpointKey: "https://" + fakeEndpoint + "/auth",
+				}
+
+				kubeConfigPath, kubeContext, clusterAPIServerURL, err = GetTanzuKubeconfig(tanzuContext, fakeEndpoint, fakeOrgID, fakeCAcertPath, false)
+			})
+			It("should set the 'certificate-authority-data' in kubeconfig based on contents of provided ca cert path", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(kubeConfigPath).Should(Equal(filepath.Join(tmpHomeDir, ".config", "tanzu", "kube", "config")))
+				Expect(kubeContext).Should(Equal(kubeconfigContextName(tanzuContext.Name)))
+				config, err := clientcmd.LoadFromFile(kubeConfigPath)
+				Expect(err).ToNot(HaveOccurred())
+
+				gotClusterName := config.Contexts[kubeContext].Cluster
+				cluster := config.Clusters[config.Contexts[kubeContext].Cluster]
+				user := config.AuthInfos[config.Contexts[kubeContext].AuthInfo]
+
+				Expect(cluster.Server).To(Equal(clusterAPIServerURL))
+				Expect(config.Contexts[kubeContext].AuthInfo).To(Equal(kubeconfigUserName(tanzuContext.Name)))
+				Expect(gotClusterName).To(Equal(kubeconfigClusterName(tanzuContext.Name)))
+				Expect(user.Exec).To(Equal(getExecConfig(tanzuContext)))
+
+				caCertBytes, err := os.ReadFile(fakeCAcertPath)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(caCertBytes).To(Equal(cluster.CertificateAuthorityData))
+			})
+		})
 	})
 })
 


### PR DESCRIPTION
Since the cert data and skip verify intent is captured in the certmap for the endpoint that one `tanzu login`s to, subsequent tanzu login to the same endpoint can succeed without providing these values. However the kube context created with the subsequent login attempt does not incorporate these values when they originate from the cert map.

This change addresses this inconsistency, by ensuring that these values are incorporated unless command line arguments of alternative ones are provided in the login command.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Updated and ran unit tests

Also manually tested with following

first establish successfully login with 
```
tanzu login --endpoint https://tpsm-host --endpoint-ca-certificate ~/myca.crt 
OR
tanzu login --endpoint https://tpsm-host  --insecure-skip-tls-verify
```

then test with 
```
tanzu context delete -y tpsm-ef5efcd6; ./bin/tanzu login --endpoint https://tpsm-host; tanzu project use xxx; tanzu space list
```

```
[i] Refreshing plugin inventory cache for "projects.packages.broadcom.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Reading plugin inventory for "projects.packages.broadcom.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Deleting kubeconfig context 'tanzu-cli-tpsm-ef5efcd6:xxx' from the file '/Users/vuichiap/.config/tanzu/kube/config'
[ok] Successfully deleted context "tpsm-ef5efcd6"
[i] Opening the browser window to complete the login
Log in by visiting this link:

    https://tpsm-host/auth/oauth/authorize?client_id=tp_cli_app&code_challenge=sV_qnOMk4CG...

    Optionally, paste your authorization code: [...]


[ok] Successfully logged in to 'https://tpsm-airgap-bugbash.acc.broadcom.net' and created a tanzu context
✓ Successfully set project to xxx
```

prior to fix, this follows:
```
Error: failed to get API group resources: unable to retrieve the complete list of server APIs: spaces.tanzu.vmware.com/v1alpha1: Get "https://tpsm-airgap-bugbash.acc.broadcom.net/org/2b96f0c0-e25c-4f93-868d-41285e8e0dc4/project/7ae590c2-3f5b-4aee-9e03-85c2dc28ef56/apis/spaces.tanzu.vmware.com/v1alpha1": tls: failed to verify certificate: x509: certificate signed by unknown authority
```

after fix, tanzu space works as expected:

```
Listing spaces from organization yyyyyyyyyyy, project xxx
  NAME                         STATUS     PROFILES RESOLVED  REPLICAS  AGE
  accelerator-test             Ready      2/2                1/1       28h
...
```



<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
kubecontext constructed on successful `tanzu login` will incorporate custom cert or skip verification flag from the cert map if neither are explicitly provided in the command invocation
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
