### PR TITLE
Do not hide remapped subcommands

### DIFF
--- a/pkg/cli/plugin_cmd.go
+++ b/pkg/cli/plugin_cmd.go
@@ -155,6 +155,7 @@ func getCmdForPluginEx(p *PluginInfo, cmdName string, mapEntry *plugin.CommandMa
 	var srcHierarchy, dstHierarchy []string
 	aliases := p.Aliases
 	description := p.Description
+	hidden := p.Hidden
 
 	if mapEntry != nil {
 		srcHierarchy = hierarchyFromPath(mapEntry.SourceCommandPath)
@@ -163,6 +164,12 @@ func getCmdForPluginEx(p *PluginInfo, cmdName string, mapEntry *plugin.CommandMa
 		// is not a toplevel command
 		if len(srcHierarchy) > 0 {
 			aliases = mapEntry.Aliases
+			// There currently is no "mapEntry.Hidden" field, so there is
+			// no way to hide a remapped subcommand.
+			// But we want to make sure a remapped subcommand is not
+			// hidden even if the plugin root command is hidden, so we force
+			// the hidden field to false for subcommands.
+			hidden = false
 		}
 		if mapEntry.Description != "" {
 			description = mapEntry.Description
@@ -192,7 +199,7 @@ func getCmdForPluginEx(p *PluginInfo, cmdName string, mapEntry *plugin.CommandMa
 			"type":                   common.CommandTypePlugin,
 			"pluginInstallationPath": p.InstallationPath,
 		},
-		Hidden:  p.Hidden,
+		Hidden:  hidden,
 		Aliases: aliases,
 	}
 


### PR DESCRIPTION
### What this PR does / why we need it

If the plugin's descriptor's `Hidden` field is set to true, only the root command of the plugin should be hidden while any mapped subcommands should stay visible.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #830 

### Describe testing done for PR

I tested with a plugin that set the descriptor's `Hidden` field to true, and remaps a subcommand.
```
$ tz rbac info | jq
{
  "name": "rbac",
 [...]
 "hidden": true,
  "completionType": 0,
  "commandMap": [
    {
      "srcPath": "role",
      "dstPath": "role",
      "overrides": "",
      "description": "Tanzu Platform Role-Based Access Control",
      "aliases": [
        "roles"
      ]
    }
  ],
  "pluginRuntimeVersion": "v1.4.3",
  "binaryArch": "arm64"
}

# Notice that the role command is visible and that the rbac command is hidden
# Before this fix, the role command was also hidden
$ tz -h | egrep 'rbac|role'
    role                    Tanzu Platform Role-Based Access Control
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Do not hide remapped subcommands when the plugin's root command is hidden.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
