### PR TITLE
Allow building multiple RPM packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,17 +189,32 @@ apt-package-in-docker: ## Build a debian package from within a container already
 .PHONY: apt-package
 apt-package: apt-package-only apt-package-repo  ## Build a debian package to use with APT
 
-.PHONY: rpm-package
-rpm-package: ## Build an RPM package
+.PHONY: rpm-package-only
+rpm-package-only: ## Build an RPM package
 	@if [ "$$(command -v docker)" == "" ]; then \
 		echo "Docker required to build rpm package" ;\
 		exit 1 ;\
 	fi
-	docker run --rm -e VERSION=$(BUILD_VERSION) -e RPM_SIGNER=$(RPM_SIGNER) -e RPM_METADATA_BASE_URI=$(RPM_METADATA_BASE_URI) -v $(ROOT_DIR):$(ROOT_DIR) $(RPM_IMAGE) $(ROOT_DIR)/hack/rpm/build_package.sh
+	docker run --rm -e VERSION=$(BUILD_VERSION) -e RPM_PACKAGE_NAME=$(RPM_PACKAGE_NAME) -e RPM_SIGNER=$(RPM_SIGNER) -v $(ROOT_DIR):$(ROOT_DIR) $(RPM_IMAGE) $(ROOT_DIR)/hack/rpm/build_package.sh
+
+.PHONY: rpm-package-repo
+rpm-package-repo: ## Build an RPM package repository
+	@if [ "$$(command -v docker)" == "" ]; then \
+		echo "Docker required to build rpm package" ;\
+		exit 1 ;\
+	fi
+	docker run --rm -e VERSION=$(BUILD_VERSION) -e RPM_SIGNER=$(RPM_SIGNER) -e RPM_METADATA_BASE_URI=$(RPM_METADATA_BASE_URI) -v $(ROOT_DIR):$(ROOT_DIR) $(RPM_IMAGE) $(ROOT_DIR)/hack/rpm/build_package_repo.sh
 
 .PHONY: rpm-package-in-docker
 rpm-package-in-docker: ## Build an RPM package from within a container already
 	VERSION=$(BUILD_VERSION) $(ROOT_DIR)/hack/rpm/build_package.sh
+
+.PHONY: rpm-package-repo-in-docker
+rpm-package-repo-in-docker: ## Build an RPM package repository from within a container already
+	VERSION=$(BUILD_VERSION) $(ROOT_DIR)/hack/rpm/build_package_repo.sh
+
+.PHONY: rpm-package
+rpm-package: rpm-package-only rpm-package-repo  ## Build an RPM package and repository to use with YUM/DNF
 
 .PHONY: choco-package
 choco-package: ## Build a Chocolatey package

--- a/hack/rpm/README.md
+++ b/hack/rpm/README.md
@@ -4,7 +4,7 @@ YUM and DNF (the replacement for YUM) use RPM packages for installation. This
 document describes how to build such packages for the Tanzu CLI, how to push
 them to a public repository and how to install the CLI from that repository.
 
-There are two package names that can be built:
+There are two package names that can be built by default:
 
 1. "tanzu-cli" for official releases
 2. "tanzu-cli-unstable" for pre-releases
@@ -14,15 +14,22 @@ used; a version with a `-` in it is considered a pre-release and will use the
 `tanzu-cli-unstable` package name, while other versions will use the
 official `tanzu-cli` package name.
 
+It is possible to specify the name of the package by setting the `RPM_PACKAGE_NAME`
+environment variable to replace the default name of `tanzu-cli`.  This should not
+normally be used as the package name is what the end-users will install and the
+default `tanzu-cli` name is the one users are familiar with.
+
 ## Building the RPM package
 
 Executing the `hack/rpm/build_package.sh` script will build the RPM packages
 under `hack/rpm/_output`. The `hack/rpm/build_package.sh` script is meant to
 be run on a Linux machine that has `dnf` or `yum` installed.
-This can be done in docker using the `fedora` image. To facilitate this
-operation, the new `rpm-package` Makefile target has been added; this Makefile
-target will first start a docker container and then run the
-`hack/rpm/build_package.sh` script.
+This can be done in docker using the `fedora` image.
+Once the packages are built, the `hack/rpm/build_package_repo.sh` script should
+be invoked to build the repository that will contain the packages.
+To facilitate this double operation, the `rpm-package` Makefile target can be used;
+this Makefile target will first start a docker container and then run the
+appropriate scripts.
 
 The remote location of the existing repository can be overridden by setting
 the variable `RPM_METADATA_BASE_URI`.  For example, the default value for

--- a/hack/rpm/build_package_repo.sh
+++ b/hack/rpm/build_package_repo.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script expects the RPM packages to already be present in the _output/rpm/tanzu-cli directory
+# It will create a repository in the same directory and sign it with the provided key
+# If the RPM_SIGNER environment variable is not set, the repository will not be signed
+
+set -e
+set -x
+
+if [ $(uname) != "Linux" ]; then
+   echo "This script must be run on a Linux system"
+   exit 1
+fi
+
+# Use DNF and if it is not installed fallback to YUM
+DNF=$(command -v dnf || command -v yum || true)
+if [ -z "$DNF" ]; then
+   echo "This script requires the presence of either DNF or YUM package manager"
+   exit 1
+fi
+
+BASE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}"); pwd)
+OUTPUT_DIR=${BASE_DIR}/_output/rpm/tanzu-cli
+# Directory where the packages are stored
+PKG_DIR=${OUTPUT_DIR}
+ROOT_DIR=${BASE_DIR}/../..
+
+# Install build dependencies
+if ! command -v createrepo &> /dev/null; then
+   $DNF install -y createrepo yum-utils
+fi
+
+cd ${ROOT_DIR}
+
+######################
+# Build the repository
+######################
+
+# Prepare the existing repository info so we can sync from it
+RPM_METADATA_BASE_URI=${RPM_METADATA_BASE_URI:=https://storage.googleapis.com/tanzu-cli-installer-packages}
+RPM_REPO_GPG_PUBLIC_KEY_URI=${RPM_REPO_GPG_PUBLIC_KEY_URI:=https://storage.googleapis.com/tanzu-cli-installer-packages/keys/TANZU-PACKAGING-GPG-RSA-KEY.gpg}
+if [ "${RPM_METADATA_BASE_URI}" = "new" ]; then
+   echo
+   echo "Building a brand new repository"
+   echo
+else
+   cat << EOF | tee /tmp/tanzu-cli.repo
+[tanzu-cli]
+name=Tanzu CLI
+baseurl=${RPM_METADATA_BASE_URI}/rpm/tanzu-cli
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=${RPM_REPO_GPG_PUBLIC_KEY_URI}
+EOF
+   
+   # Sync the metadata so we can update it
+   # Use the --source flag to avoid downloading the actual RPMs
+   reposync --repoid=tanzu-cli --download-metadata -p ${OUTPUT_DIR} -c /tmp/tanzu-cli.repo --norepopath --source -y
+   # Remove the old signature, which won't be valid anymore
+   rm -f ${OUTPUT_DIR}/repodata/repomd.xml.asc
+   
+   # Now list the existing RPMs so we can pretend to have them locally
+   for p in $(reposync --repoid=tanzu-cli -c /tmp/tanzu-cli.repo -u -y | grep ${RPM_METADATA_BASE_URI}); do
+      echo "Found package: $p"
+      touch ${PKG_DIR}/$(basename $p)
+   done
+fi
+
+# Create the repository metadata
+createrepo --update --skip-stat ${OUTPUT_DIR}
+
+# Now that the repo is created, remove the fake empty packages so they don't
+# risk being copied over the real ones in the final repository.
+find ${PKG_DIR} -type f -empty -delete
+
+if [[ ! -z "${RPM_SIGNER}" ]]; then
+  # instead of ... gpg --detach-sign --armor repodata/repomd.xml
+  ${RPM_SIGNER} ${OUTPUT_DIR}/repodata/repomd.xml
+else
+  echo skip rpmsigning repo
+fi

--- a/hack/rpm/tanzu-cli.spec
+++ b/hack/rpm/tanzu-cli.spec
@@ -1,13 +1,4 @@
-%if "%{unstable}" == "false"
-Name:       tanzu-cli
-Provides:   tanzu-cli
-Obsoletes:  tanzu-cli  < %{rpm_package_version}
-%else
-Name:       tanzu-cli-unstable
-Provides:   tanzu-cli-unstable
-Obsoletes:  tanzu-cli-unstable  < %{rpm_package_version}
-%endif
-
+Name:       %{rpm_package_name}
 Version:    %{rpm_package_version}
 Release:    %{rpm_release_version}
 License:    Apache 2.0


### PR DESCRIPTION
### What this PR does / why we need it

This PR splits the RPM package-building script into two scripts:
- one to build a package and sign it
- one to build the repo with all the packages that may have been built

The first script can be called more than once by specifying the new `RPM_PACKAGE_NAME` with a different name.  This allows to build the same RPM package but with a different name,  The value in doing this is that a different signer can be used for the different package; for example, a different signing key could be used for a second package.

This will allow to build a package specific to Centos8/9 which will be signed with a special key that works on those OS:s.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

I have built the package and repo locally using the same make target as before and confirms it builds like before and is installable.  This is not a signed package.  Notice I fake a version to build a `tanzu-cli` package instead of a `tanzu-cli-unstable` package
```
$ make build-cli-linux-amd64 BUILD_VERSION=v1.12.0
build linux-amd64 CLI with version: v1.12.0
$ make rpm-package BUILD_VERSION=v1.12.0
[...]
$ ls hack/rpm/_output/rpm/tanzu-cli/
repodata                       tanzu-cli-1.12.0-1.aarch64.rpm tanzu-cli-1.12.0-1.x86_64.rpm
```
I have build the unstable package ONLY and then built a second unstable package ONLY by overriding the name, which is what we will do for Centos8/9, then built a repo containing both:
```
$ make build-cli-linux-amd64
build linux-amd64 CLI with version: v1.6.0-dev
$ make rpm-package-only
[...]
$ ls hack/rpm/_output/rpm/tanzu-cli/
tanzu-cli-unstable-1.6.0-0.1_dev.aarch64.rpm tanzu-cli-unstable-1.6.0-0.1_dev.x86_64.rpm

# Build a second package with a different name (would normally use a different signer)
# Notice that the packages accumulate in the directory
$ make rpm-package-only RPM_PACKAGE_NAME=tanzu-cli-centos9
$ ls hack/rpm/_output/rpm/tanzu-cli/
tanzu-cli-centos9-unstable-1.6.0-0.1_dev.aarch64.rpm tanzu-cli-unstable-1.6.0-0.1_dev.aarch64.rpm
tanzu-cli-centos9-unstable-1.6.0-0.1_dev.x86_64.rpm  tanzu-cli-unstable-1.6.0-0.1_dev.x86_64.rpm

# Now build the repo
$ make rpm-package-repo
[...]
$ ls hack/rpm/_output/rpm/tanzu-cli/
repodata                                             tanzu-cli-unstable-1.6.0-0.1_dev.aarch64.rpm
tanzu-cli-centos9-unstable-1.6.0-0.1_dev.aarch64.rpm tanzu-cli-unstable-1.6.0-0.1_dev.x86_64.rpm
tanzu-cli-centos9-unstable-1.6.0-0.1_dev.x86_64.rpm

# Using vi I can look at the repo metadata and confirm it contains both the standard unstable 1.6.0-dev package
# and the centos9 unstable 1.6.0-dev package
vi hack/rpm/_output/rpm/tanzu-cli/repodata/d4de9bf00fa8dd470abc166a7feaada659037cb9926d9ede4e8efed25189e1c2-filelists.xml.zst
```
I have testing that both packages can be installed using docker.

I've also ran the above tests with the `rpm-*-in-docker` make targets to confirm they work as expected.


### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Support building multiple RPM packages to be used with different signing keys.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
