### PR TITLE
Document how to install on RHEL/CentOS 8/9

### DIFF
--- a/docs/quickstart/install.md
+++ b/docs/quickstart/install.md
@@ -188,6 +188,12 @@ To uninstall: `sudo apt remove tanzu-cli-unstable`
 
 ### From yum/dnf (RHEL)
 
+> **_NOTE:_** When installing on versions 8 and 9 of RHEL and CentOS, a special `tanzu-cli-centos9`
+> package should be used along with a second GPG key.  Please refer to section:
+> [Using yum/dnf on RHEL/CentOS versions 8 and 9](#using-yumdnf-on-rhelcentos-versions-8-and-9)
+
+For normal installation (not RHEL/CentOS 8/9):
+
 ```console
 cat << EOF | sudo tee /etc/yum.repos.d/tanzu-cli.repo
 [tanzu-cli]
@@ -242,6 +248,47 @@ sudo yum install tanzu-cli-unstable
 ```
 
 To uninstall: `sudo yum remove tanzu-cli-unstable`
+
+#### Using yum/dnf on RHEL/CentOS versions 8 and 9
+
+On RHEL/CentOS 8 and 9, yum/dnf is unable to verify the signature of the standard
+`tanzu-cli`/`tanzu-cli-unstable` packages and the above instructions will fail with a
+"GPG check FAILED" error. Although it is possible to deactivate the gpg-check when
+installing, such an approach should be avoided for security reasons.
+
+A different VMware/Broadcom GPG key and special packages `tanzu-cli-centos9` and
+`tanzu-cli-centos9-unstable` should be used instead; those packages have been signed
+with this different GPG key which can be used on RHEL/CentOS 8 and 9. Other than the
+key used to sign those packages, they are identical to the standard Tanzu CLI packages.
+
+> **_NOTE:_** The `tanzu-cli-centos9` and `tanzu-cli-centos9-unstable` packages are
+> available starting with Tanzu CLI `v1.5.2`.  To install older versions on RHEL/CentOS 8/9
+> you will need to deactivate the gpg check using the `--nogpgcheck` flag.
+> For example, to install `v1.3.0`, use: `sudo yum install -y --nogpgcheck tanzu-cli-1.3.0`.
+
+To install those packages (RHEL/CentOS 8 and 9 only and CLI >= v1.5.2):
+
+```console
+# Same configuration as for any other situation
+cat << EOF | sudo tee /etc/yum.repos.d/tanzu-cli.repo
+[tanzu-cli]
+name=Tanzu CLI
+baseurl=https://storage.googleapis.com/tanzu-cli-installer-packages/rpm/tanzu-cli
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://storage.googleapis.com/tanzu-cli-installer-packages/keys/TANZU-PACKAGING-GPG-RSA-KEY.gpg
+EOF
+
+# Import the special key needed for the special packages
+sudo rpm --import https://storage.googleapis.com/tanzu-cli-installer-packages/keys/TANZU-PACKAGING-GPG-RSA-KEY-CENTOS9.gpg
+
+# Install the latest official release which was specifically signed for Centos
+sudo yum install -y tanzu-cli-centos9 # dnf install can also be used
+
+# or install the latest pre-release which was specifically signed for Centos
+sudo yum install -y tanzu-cli-centos9-unstable # dnf install can also be used
+```
 
 ### asdf (MacOS and Linux)
 


### PR DESCRIPTION
### What this PR does / why we need it

This PR documents how to install the Tanzu CLI on RHEL/CentOS 8 and 9.

The idea is that users should install the CLI as follows when running on RHEL/CentOS 8 and 9:
```
cat << EOF | sudo tee /etc/yum.repos.d/tanzu-cli.repo
[tanzu-cli]
name=Tanzu CLI
baseurl=https://storage.googleapis.com/tanzu-cli-installer-packages/rpm/tanzu-cli
enabled=1
gpgcheck=1
repo_gpgcheck=1
gpgkey=https://storage.googleapis.com/tanzu-cli-installer-packages/keys/TANZU-PACKAGING-GPG-RSA-KEY-CENTOS9.gpg
       https://storage.googleapis.com/tanzu-cli-installer-packages/keys/TANZU-PACKAGING-GPG-RSA-KEY.gpg
EOF

sudo rpm --import https://storage.googleapis.com/tanzu-cli-installer-packages/keys/TANZU-PACKAGING-GPG-RSA-KEY-CENTOS9.gpg

sudo yum install -y tanzu-cli-centos9 # dnf install can also be used

# or for pre-releases
sudo yum install -y tanzu-cli-centos9-unstable # dnf install can also be used
```

**Why we need to run `rpm --import` manually?**

When testing on a real VM running Centos 9, I learned that because both key are configured in the `/etc/yum.repos.d/tanzu-cli.repo` file, yum will run an `rpm --import` on both and will fail on the standard key `TANZU-PACKAGING-GPG-RSA-KEY.gpg` and the installation will still fail.

So, I did two things to fix this:
1- put the `TANZU-PACKAGING-GPG-RSA-KEY-CENTOS9.gpg` key first in the list of keys in the `/etc/yum.repos.d/tanzu-cli.repo` file.  This means that on a first `yum install` the key will be imported successfully, although the `yum install` will still fail; this allows to run `yum install` a second time, and have it succeed because it will find the required key.
2- have the user run `rpm --import` manually first, to avoid the first failure.

With the instructions in this PR, there should be no `yum install` failure at all.

An alternative since we ask users to import the new `TANZU-PACKAGING-GPG-RSA-KEY-CENTOS9.gpg` key manually, is that we could remove that key from the `/etc/yum.repos.d/tanzu-cli.repo` file.  The value in doing that is that it would keep the instructions the same as for the normal `tanzu-cli` package except for the `rpm –import` and the `yum install tanzu-cli-centos9`.  The value in leaving that second key in the file is that if the user forgets to run the `rpm –import`, then running `yum install` twice will work.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Let CI run

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Document special installation instructions for RHEL/CentOS 8/9
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

The new `tanzu-cli-centos` packages will only be made available starting with CLI `v1.5.2`.
To make them available for already released versions would require building each RPM package with the new name and signing it with the new key.  This would take more effort than we felt was worthwhile.
To install older versions on Centos 8/9, users will need to deactivate the gpg check using `--nogpgcheck`; I have specified this in the documentation update in this PR.