### PR TITLE
[release-1.5] Cherrypick: Implement singleton pattern for NewRootCmd to prevent multiple creations

### DIFF
--- a/pkg/command/ceip_participation_test.go
+++ b/pkg/command/ceip_participation_test.go
@@ -158,7 +158,7 @@ func TestCompletionCeip(t *testing.T) {
 		t.Run(spec.test, func(t *testing.T) {
 			assert := assert.New(t)
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 
 			var out bytes.Buffer

--- a/pkg/command/cert_test.go
+++ b/pkg/command/cert_test.go
@@ -464,7 +464,7 @@ func TestCompletionCert(t *testing.T) {
 		t.Run(spec.test, func(t *testing.T) {
 			assert := assert.New(t)
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 
 			var out bytes.Buffer

--- a/pkg/command/completion_test.go
+++ b/pkg/command/completion_test.go
@@ -155,7 +155,7 @@ func TestCompletionCompletion(t *testing.T) {
 		t.Run(spec.test, func(t *testing.T) {
 			assert := assert.New(t)
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 
 			var out bytes.Buffer

--- a/pkg/command/config_test.go
+++ b/pkg/command/config_test.go
@@ -220,7 +220,7 @@ func TestCompletionConfig(t *testing.T) {
 		t.Run(spec.test, func(t *testing.T) {
 			assert := assert.New(t)
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 
 			var out bytes.Buffer

--- a/pkg/command/context_test.go
+++ b/pkg/command/context_test.go
@@ -1667,7 +1667,7 @@ func TestCompletionContext(t *testing.T) {
 		t.Run(spec.test, func(t *testing.T) {
 			assert := assert.New(t)
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 
 			var out bytes.Buffer
@@ -1942,7 +1942,7 @@ func TestContextCurrentCmd(t *testing.T) {
 				_ = config.SetContext(spec.activeContexts[i], true)
 			}
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 
 			var out bytes.Buffer

--- a/pkg/command/discovery_source_test.go
+++ b/pkg/command/discovery_source_test.go
@@ -124,7 +124,7 @@ func Test_createAndListDiscoverySources(t *testing.T) {
 	testSource1 := "harbor-repo.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest"
 	os.Setenv(constants.ConfigVariableAdditionalDiscoveryForTesting, testSource1)
 
-	rootCmd, err := NewRootCmd()
+	rootCmd, err := NewRootCmdForTest()
 	assert.Nil(err)
 	rootCmd.SetArgs([]string{"plugin", "source", "list"})
 	b := bytes.NewBufferString("")
@@ -221,7 +221,7 @@ func Test_initDiscoverySources(t *testing.T) {
 				}})
 			assert.Nil(err)
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 			rootCmd.SetArgs(spec.args)
 			b := bytes.NewBufferString("")
@@ -336,7 +336,7 @@ func Test_updateDiscoverySources(t *testing.T) {
 				}})
 			assert.Nil(err)
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 			rootCmd.SetArgs(spec.args)
 			b := bytes.NewBufferString("")
@@ -449,7 +449,7 @@ func Test_deleteDiscoverySource(t *testing.T) {
 				}})
 			assert.Nil(err)
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 			rootCmd.SetArgs(spec.args)
 			b := bytes.NewBufferString("")
@@ -576,7 +576,7 @@ func TestCompletionPluginSource(t *testing.T) {
 		t.Run(spec.test, func(t *testing.T) {
 			assert := assert.New(t)
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 
 			var out bytes.Buffer

--- a/pkg/command/doc_test.go
+++ b/pkg/command/doc_test.go
@@ -67,7 +67,7 @@ func TestGenDocs(t *testing.T) {
 	assert.Nil(err)
 	defer os.RemoveAll(docsDir)
 
-	rootCmd, err := NewRootCmd()
+	rootCmd, err := NewRootCmdForTest()
 	assert.Nil(err)
 	rootCmd.SetArgs([]string{"generate-all-docs", "--docs-dir", docsDir})
 	err = rootCmd.Execute()
@@ -124,7 +124,7 @@ func TestCompletionGenerateDocs(t *testing.T) {
 		t.Run(spec.test, func(t *testing.T) {
 			assert := assert.New(t)
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 
 			var out bytes.Buffer

--- a/pkg/command/eula_test.go
+++ b/pkg/command/eula_test.go
@@ -102,7 +102,7 @@ var _ = Describe("EULA command tests", func() {
 		Context("When invoking an arbitrary command", func() {
 			It("should invoke the eula prompt if EULA has not been accepted", func() {
 				os.Setenv("TANZU_CLI_EULA_PROMPT_ANSWER", "No")
-				cmd, err := NewRootCmd()
+				cmd, err := NewRootCmdForTest()
 				Expect(err).To(BeNil())
 				cmd.SetArgs([]string{"context", "list"})
 				err = cmd.Execute()
@@ -113,7 +113,7 @@ var _ = Describe("EULA command tests", func() {
 
 			It("should not invoke the eula prompt if EULA has been accepted", func() {
 				os.Setenv("TANZU_CLI_EULA_PROMPT_ANSWER", "yes")
-				cmd, err := NewRootCmd()
+				cmd, err := NewRootCmdForTest()
 				Expect(err).To(BeNil())
 				cmd.SetArgs([]string{"context", "list"})
 				err = cmd.Execute()
@@ -158,7 +158,7 @@ var _ = Describe("EULA version checking tests", func() {
 		err = config.SetEULAStatus(config.EULAStatusAccepted)
 		Expect(err).To(BeNil())
 
-		cmd, err := NewRootCmd()
+		cmd, err := NewRootCmdForTest()
 		Expect(err).To(BeNil())
 		cmd.SetArgs([]string{"context", "list"})
 		checkForPromptOnExecute(cmd, expectToPrompt)
@@ -214,7 +214,7 @@ func TestCompletionEULA(t *testing.T) {
 		t.Run(spec.test, func(t *testing.T) {
 			assert := assert.New(t)
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 
 			var out bytes.Buffer

--- a/pkg/command/init_test.go
+++ b/pkg/command/init_test.go
@@ -32,7 +32,7 @@ func TestCompletionInit(t *testing.T) {
 		t.Run(spec.test, func(t *testing.T) {
 			assert := assert.New(t)
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 
 			var out bytes.Buffer

--- a/pkg/command/plugin_bundle_test.go
+++ b/pkg/command/plugin_bundle_test.go
@@ -231,7 +231,7 @@ func TestCompletionPluginBundle(t *testing.T) {
 
 			downloadImageCalled = false
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 
 			var out bytes.Buffer

--- a/pkg/command/plugin_group_test.go
+++ b/pkg/command/plugin_group_test.go
@@ -87,7 +87,7 @@ func TestPluginGroupSearch(t *testing.T) {
 		t.Run(spec.test, func(t *testing.T) {
 			assert := assert.New(t)
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 
 			var out bytes.Buffer
@@ -191,7 +191,7 @@ func TestPluginGroupGet(t *testing.T) {
 		t.Run(spec.test, func(t *testing.T) {
 			assert := assert.New(t)
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 
 			var out bytes.Buffer
@@ -306,7 +306,7 @@ func TestCompletionPluginGroup(t *testing.T) {
 		t.Run(spec.test, func(t *testing.T) {
 			assert := assert.New(t)
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 
 			var out bytes.Buffer

--- a/pkg/command/plugin_search_test.go
+++ b/pkg/command/plugin_search_test.go
@@ -69,7 +69,7 @@ func TestPluginSearch(t *testing.T) {
 
 	for _, spec := range tests {
 		t.Run(spec.test, func(t *testing.T) {
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 			rootCmd.SetArgs(spec.args)
 
@@ -160,7 +160,7 @@ func TestCompletionPluginSearch(t *testing.T) {
 		t.Run(spec.test, func(t *testing.T) {
 			assert := assert.New(t)
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 
 			var out bytes.Buffer

--- a/pkg/command/plugin_test.go
+++ b/pkg/command/plugin_test.go
@@ -133,7 +133,7 @@ func TestPluginList(t *testing.T) {
 			}
 			cc.Unlock()
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 			rootCmd.SetArgs(spec.args)
 			b := bytes.NewBufferString("")
@@ -280,7 +280,7 @@ func TestDeletePlugin(t *testing.T) {
 			}
 			cupdater.Unlock()
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 			rootCmd.SetArgs(spec.args)
 
@@ -393,7 +393,7 @@ func TestInstallPlugin(t *testing.T) {
 
 	for _, spec := range tests {
 		t.Run(spec.test, func(t *testing.T) {
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 			rootCmd.SetArgs(spec.args)
 
@@ -444,7 +444,7 @@ func TestUpgradePlugin(t *testing.T) {
 
 	for _, spec := range tests {
 		t.Run(spec.test, func(t *testing.T) {
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 			rootCmd.SetArgs(spec.args)
 
@@ -947,7 +947,7 @@ func TestCompletionPlugin(t *testing.T) {
 		t.Run(spec.test, func(t *testing.T) {
 			assert := assert.New(t)
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 
 			var out bytes.Buffer

--- a/pkg/command/root_test.go
+++ b/pkg/command/root_test.go
@@ -180,7 +180,7 @@ func tearDownTestCLIEnvironment(env testCLIEnvironment) {
 
 func TestRootCmdWithNoAdditionalPlugins(t *testing.T) {
 	assert := assert.New(t)
-	rootCmd, err := NewRootCmd()
+	rootCmd, err := NewRootCmdForTest()
 	assert.Nil(err)
 	err = rootCmd.Execute()
 	assert.Nil(err)
@@ -188,7 +188,7 @@ func TestRootCmdWithNoAdditionalPlugins(t *testing.T) {
 
 func TestSubcommandNonexistent(t *testing.T) {
 	assert := assert.New(t)
-	rootCmd, err := NewRootCmd()
+	rootCmd, err := NewRootCmdForTest()
 	assert.Nil(err)
 	rootCmd.SetArgs([]string{"nonexistent", "say", "hello"})
 	err = rootCmd.Execute()
@@ -415,7 +415,7 @@ func TestSubcommands(t *testing.T) {
 			cc.Unlock()
 			assert.Nil(err)
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 			rootCmd.SetArgs(spec.args)
 
@@ -799,7 +799,7 @@ func TestTargetCommands(t *testing.T) {
 				assert.Nil(err)
 			}
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 			rootCmd.SetArgs(spec.args)
 
@@ -895,7 +895,7 @@ func TestGlobalInit(t *testing.T) {
 				},
 			)
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 			rootCmd.SetArgs(spec.args)
 
@@ -943,7 +943,7 @@ func TestSetLastVersion(t *testing.T) {
 
 			buildinfo.Version = spec.version
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 			// Execute any command to trigger the version update
 			rootCmd.SetArgs([]string{"plugin", "list"})
@@ -967,7 +967,7 @@ func TestEnvVarsSet(t *testing.T) {
 	err := config.ConfigureFeatureFlags(constants.DefaultCliFeatureFlags)
 	assert.Nil(err)
 
-	rootCmd, err := NewRootCmd()
+	rootCmd, err := NewRootCmdForTest()
 	assert.Nil(err)
 
 	envVarName := "SOME_TEST_ENV_VAR"
@@ -983,7 +983,7 @@ func TestEnvVarsSet(t *testing.T) {
 
 	// Re-initialize the CLI with the config files containing the variable.
 	// It is in this call that the CLI creates the OS variables.
-	_, err = NewRootCmd()
+	_, err = NewRootCmdForTest()
 	assert.Nil(err)
 	// Make sure the variable is now set during the call to the CLI
 	assert.Equal(envVarValue, os.Getenv(envVarName))
@@ -1051,7 +1051,7 @@ func TestCompletionShortHelpInActiveHelp(t *testing.T) {
 		t.Run(spec.test, func(t *testing.T) {
 			assert := assert.New(t)
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 
 			var out bytes.Buffer
@@ -2213,7 +2213,7 @@ func TestCommandRemapping(t *testing.T) {
 				assert.Nil(err)
 			}
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 			// To be able to test the "tanzu help" command, we need to set the os.Args
 			// instead of using the cobra command's SetArgs method.

--- a/pkg/command/version_test.go
+++ b/pkg/command/version_test.go
@@ -86,7 +86,7 @@ func TestCompletionVersion(t *testing.T) {
 		t.Run(spec.test, func(t *testing.T) {
 			assert := assert.New(t)
 
-			rootCmd, err := NewRootCmd()
+			rootCmd, err := NewRootCmdForTest()
 			assert.Nil(err)
 
 			var out bytes.Buffer


### PR DESCRIPTION
Cherry-pick: #840

* Only allow creating the NewRootCmd once with singleton pattern
* Fix unit tests by using NewRootCmdForTest

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
