### PR TITLE
Capture endpoint hash for global plugins telemetry

### DIFF
--- a/.github/workflows/cli-coexistence_tests.yaml
+++ b/.github/workflows/cli-coexistence_tests.yaml
@@ -49,7 +49,7 @@ jobs:
           build-args: |
             TANZU_CLI_COEXISTENCE_LEGACY_TANZU_CLI_DIR=/app/legacy-tanzu-cli
             TANZU_CLI_COEXISTENCE_LEGACY_TANZU_CLI_VERSION=v0.28.1
-            TANZU_CLI_COEXISTENCE_LEGACY_TANZU_CLI_URL=https://ent.box.com/shared/static/984uoy8mayq6rpdrfwh1omxurc0ixo57.gz
+            TANZU_CLI_COEXISTENCE_LEGACY_TANZU_CLI_URL=https://storage.googleapis.com/tanzu-cli-installer-packages/bin/v0.28.1/tanzu-cli-linux-amd64.tar.gz
             TANZU_CLI_COEXISTENCE_NEW_TANZU_CLI_DIR=/app/tanzu-cli
 
       - name: Run Docker image

--- a/Makefile
+++ b/Makefile
@@ -423,7 +423,7 @@ TANZU_CLI_COEXISTENCE_LEGACY_TANZU_CLI_VERSION = v0.28.1
 endif
 
 ifndef TANZU_CLI_COEXISTENCE_LEGACY_TANZU_CLI_URL
-TANZU_CLI_COEXISTENCE_LEGACY_TANZU_CLI_URL = https://ent.box.com/shared/static/984uoy8mayq6rpdrfwh1omxurc0ixo57.gz # tanzu-cli-linux-amd64 v0.28.1 bundle url
+TANZU_CLI_COEXISTENCE_LEGACY_TANZU_CLI_URL = https://storage.googleapis.com/tanzu-cli-installer-packages/bin/v0.28.1/tanzu-cli-linux-amd64.tar.gz # tanzu-cli-linux-amd64 v0.28.1 bundle url
 endif
 
 ifndef TANZU_CLI_CEIP_OPT_IN_PROMPT_ANSWER

--- a/pkg/telemetry/metrics_helper.go
+++ b/pkg/telemetry/metrics_helper.go
@@ -47,6 +47,18 @@ func computeEndpointSHAWithCtxTypePrefix(curCtx map[configtypes.ContextType]*con
 			return string(configtypes.ContextTypeTMC) + ":" + computeEndpointSHAForTMCContext(ctx)
 		}
 		return ""
+	case configtypes.TargetGlobal:
+		// If Target is "global" and tanzu context type is active, use it as most plugins in Tanzu Platform are global target plugins
+		ctx, exists := curCtx[configtypes.ContextTypeTanzu]
+		if exists {
+			return string(configtypes.ContextTypeTanzu) + ":" + computeEndpointSHAForTanzuContext(ctx)
+		}
+		// There could be "global" plugins which could use `k8s` contexts. So get endpoint from k8s context as a fallback
+		ctx, exists = curCtx[configtypes.ContextTypeK8s]
+		if exists {
+			return string(configtypes.ContextTypeK8s) + ":" + computeEndpointSHAForK8sContext(ctx)
+		}
+		return ""
 	}
 	return ""
 }


### PR DESCRIPTION
### What this PR does / why we need it
This PR adds changes to capture endpoint hash for global plugins telemetry data.
Since all the tanzu platform plugins are of `global` target type and operates on `tanzu` context type, it is reasonable to collect the endpoint hash if the tanzu context is active for all the global plugins telemetry
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Verified the global plugins now has the endpoint hash capture if the current active context is of tyep `tanzu`.
**Before the change:**
```
❯ tanzu apps list
Error: No space found in active context of type tanzu. Use the "tanzu space use" command to select one.
❯ sqlite3 -batch /Users/pkalle/.config/tanzu-cli-telemetry/cli_metrics.db  "select * from tanzu_cli_operations;"
cli_version|os_name|os_arch|plugin_name|plugin_version|command|cli_id|command_start_ts|command_end_ts|target|name_arg|endpoint|flags|exit_status|is_internal|error
v1.5.1|darwin|amd64|||context get-token|a736004c-f899-4d21-8605-551fa843ba89|1737654457403|1737654457408||7f32a002d9ba97086d31a6e2c6525ccbe6a2820872411af3e5c4a2b3d17879c1|||0|0|
v1.5.1|darwin|arm64|rbac|v0.0.0-dev-081e187|role|a736004c-f899-4d21-8605-551fa843ba89|1737654455543|1737654457985|global|||{"all":""}|0|0|
v1.5.1|darwin|arm64|||plugin list|a736004c-f899-4d21-8605-551fa843ba89|1737670048568|1737670048732|||||0|0|
v1.5.1|darwin|arm64|||plugin install|a736004c-f899-4d21-8605-551fa843ba89|1737670080541|1737670086035||appsv2||{"target":"global"}|0|0|
v1.5.1|darwin|arm64|appsv2|v0.21.2|app|a736004c-f899-4d21-8605-551fa843ba89|1737670090400|1737670090659|global||||2|0|
❯ tanzu role binding list --all
  ID                                    USER/GROUP               ROLE           SCOPE
  0300d31e-8c47-48a1-9c7a-6880a2ebc65d  prem.kalle@broadcom.com  Administrator  /
  0f2c386a-c69d-4f9b-8673-7fac938edc62  prem.kalle@broadcom.com  Administrator  /projects/app-management-new
  25028fee-7719-4542-b645-63a8bc78c190  prem.kalle@broadcom.com  Viewer         /
  37c6918b-408c-4ee0-8b3e-b06bd287975f  prem.kalle@broadcom.com  Administrator  /projects/tatanas
  45394006-e895-43f6-9be4-08eb359e25d0  vui.lam@broadcom.com     Administrator  /projects/anuj-project
  4929c419-9d9d-4121-8ac3-e94463c64cee  vui.lam@broadcom.com     Administrator  /projects/tatanas/clustergroups/bobi-autoscale
  526f32fc-9bf3-446a-bca0-7fd533927b40  prem.kalle@broadcom.com  Administrator  /projects/anuj-project
  5cc7d1e8-5ec1-45e6-ab28-71c6a1777d44  vui.lam@broadcom.com     Viewer         /
  7a1dd50f-e6b6-465b-adf6-ba65ad94c2d2  vui.lam@broadcom.com     Administrator  /projects/tatanas
  f097e38e-7860-424f-b72b-66b167687204  vui.lam@broadcom.com     Administrator  /projects/app-management-new
  f5b2944f-ddaf-4e4e-a0ee-8a6729de0faf  prem.kalle@broadcom.com  Administrator  /projects/tatanas/clustergroups/bobi-autoscale

❯ sqlite3 -batch /Users/pkalle/.config/tanzu-cli-telemetry/cli_metrics.db  "select * from tanzu_cli_operations;"
cli_version|os_name|os_arch|plugin_name|plugin_version|command|cli_id|command_start_ts|command_end_ts|target|name_arg|endpoint|flags|exit_status|is_internal|error
v1.5.1|darwin|amd64|||context get-token|a736004c-f899-4d21-8605-551fa843ba89|1737654457403|1737654457408||7f32a002d9ba97086d31a6e2c6525ccbe6a2820872411af3e5c4a2b3d17879c1|||0|0|
v1.5.1|darwin|arm64|rbac|v0.0.0-dev-081e187|role|a736004c-f899-4d21-8605-551fa843ba89|1737654455543|1737654457985|global|||{"all":""}|0|0|
v1.5.1|darwin|arm64|||plugin list|a736004c-f899-4d21-8605-551fa843ba89|1737670048568|1737670048732|||||0|0|
v1.5.1|darwin|arm64|||plugin install|a736004c-f899-4d21-8605-551fa843ba89|1737670080541|1737670086035||appsv2||{"target":"global"}|0|0|
v1.5.1|darwin|arm64|appsv2|v0.21.2|app|a736004c-f899-4d21-8605-551fa843ba89|1737670090400|1737670090659|global||||2|0|
v1.5.1|darwin|amd64|||context get-token|a736004c-f899-4d21-8605-551fa843ba89|1737670195004|1737670195627||7f32a002d9ba97086d31a6e2c6525ccbe6a2820872411af3e5c4a2b3d17879c1|||0|0|
v1.5.1|darwin|amd64|||context get-token|a736004c-f899-4d21-8605-551fa843ba89|1737670197005|1737670197009||7f32a002d9ba97086d31a6e2c6525ccbe6a2820872411af3e5c4a2b3d17879c1|||0|0|
v1.5.1|darwin|arm64|rbac|v0.0.0-dev-081e187|role|a736004c-f899-4d21-8605-551fa843ba89|1737670194326|1737670197694|global|||{"all":""}|0|0|
❯
```

**After the change:**
```
❯ ./bin/tanzu role binding list --all
  ID                                    USER/GROUP               ROLE           SCOPE
  0300d31e-8c47-48a1-9c7a-6880a2ebc65d  prem.kalle@broadcom.com  Administrator  /
  0f2c386a-c69d-4f9b-8673-7fac938edc62  prem.kalle@broadcom.com  Administrator  /projects/app-management-new
  25028fee-7719-4542-b645-63a8bc78c190  prem.kalle@broadcom.com  Viewer         /
  37c6918b-408c-4ee0-8b3e-b06bd287975f  prem.kalle@broadcom.com  Administrator  /projects/tatanas
  45394006-e895-43f6-9be4-08eb359e25d0  vui.lam@broadcom.com     Administrator  /projects/anuj-project
  4929c419-9d9d-4121-8ac3-e94463c64cee  vui.lam@broadcom.com     Administrator  /projects/tatanas/clustergroups/bobi-autoscale
  526f32fc-9bf3-446a-bca0-7fd533927b40  prem.kalle@broadcom.com  Administrator  /projects/anuj-project
  5cc7d1e8-5ec1-45e6-ab28-71c6a1777d44  vui.lam@broadcom.com     Viewer         /
  7a1dd50f-e6b6-465b-adf6-ba65ad94c2d2  vui.lam@broadcom.com     Administrator  /projects/tatanas
  f097e38e-7860-424f-b72b-66b167687204  vui.lam@broadcom.com     Administrator  /projects/app-management-new
  f5b2944f-ddaf-4e4e-a0ee-8a6729de0faf  prem.kalle@broadcom.com  Administrator  /projects/tatanas/clustergroups/bobi-autoscale

❯ sqlite3 -batch /Users/pkalle/.config/tanzu-cli-telemetry/cli_metrics.db  "select * from tanzu_cli_operations;"
cli_version|os_name|os_arch|plugin_name|plugin_version|command|cli_id|command_start_ts|command_end_ts|target|name_arg|endpoint|flags|exit_status|is_internal|error
v1.5.2-alpha.0|darwin|amd64|rbac|v0.0.0-dev-081e187|role|a736004c-f899-4d21-8605-551fa843ba89|1737670402467|1737670405105|global||tanzu:bb8a938ea5c5c7d5894398fcfe2aa12848d75b521e44ba5eebd6f0363d0ac98b|{"all":""}|0|0|
v1.5.2-alpha.0|darwin|amd64|||context get-token|a736004c-f899-4d21-8605-551fa843ba89|1737670487436|1737670487440||7f32a002d9ba97086d31a6e2c6525ccbe6a2820872411af3e5c4a2b3d17879c1|||0|0|
v1.5.2-alpha.0|darwin|amd64|||context get-token|a736004c-f899-4d21-8605-551fa843ba89|1737670488287|1737670488294||7f32a002d9ba97086d31a6e2c6525ccbe6a2820872411af3e5c4a2b3d17879c1|||0|0|
v1.5.2-alpha.0|darwin|amd64|rbac|v0.0.0-dev-081e187|role|a736004c-f899-4d21-8605-551fa843ba89|1737670486843|1737670488934|global||tanzu:bb8a938ea5c5c7d5894398fcfe2aa12848d75b521e44ba5eebd6f0363d0ac98b|{"all":""}|0|0|
❯ ./bin/tanzu space list
No Spaces found.

❯ sqlite3 -batch /Users/pkalle/.config/tanzu-cli-telemetry/cli_metrics.db  "select * from tanzu_cli_operations;"
cli_version|os_name|os_arch|plugin_name|plugin_version|command|cli_id|command_start_ts|command_end_ts|target|name_arg|endpoint|flags|exit_status|is_internal|error
v1.5.2-alpha.0|darwin|amd64|rbac|v0.0.0-dev-081e187|role|a736004c-f899-4d21-8605-551fa843ba89|1737670402467|1737670405105|global||tanzu:bb8a938ea5c5c7d5894398fcfe2aa12848d75b521e44ba5eebd6f0363d0ac98b|{"all":""}|0|0|
v1.5.2-alpha.0|darwin|amd64|||context get-token|a736004c-f899-4d21-8605-551fa843ba89|1737670487436|1737670487440||7f32a002d9ba97086d31a6e2c6525ccbe6a2820872411af3e5c4a2b3d17879c1|||0|0|
v1.5.2-alpha.0|darwin|amd64|||context get-token|a736004c-f899-4d21-8605-551fa843ba89|1737670488287|1737670488294||7f32a002d9ba97086d31a6e2c6525ccbe6a2820872411af3e5c4a2b3d17879c1|||0|0|
v1.5.2-alpha.0|darwin|amd64|rbac|v0.0.0-dev-081e187|role|a736004c-f899-4d21-8605-551fa843ba89|1737670486843|1737670488934|global||tanzu:bb8a938ea5c5c7d5894398fcfe2aa12848d75b521e44ba5eebd6f0363d0ac98b|{"all":""}|0|0|
v1.5.1|darwin|amd64|||context get-token|a736004c-f899-4d21-8605-551fa843ba89|1737670531811|1737670531816||7f32a002d9ba97086d31a6e2c6525ccbe6a2820872411af3e5c4a2b3d17879c1|||0|0|
v1.5.2-alpha.0|darwin|amd64|space|v0.3.0|space list|a736004c-f899-4d21-8605-551fa843ba89|1737670530095|1737670533441|global||tanzu:bb8a938ea5c5c7d5894398fcfe2aa12848d75b521e44ba5eebd6f0363d0ac98b||0|0|
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Capture endpoint hash for global plugins telemetry
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
