### PR TITLE
Sign the RPM package before moving it

### DIFF
--- a/hack/rpm/build_package.sh
+++ b/hack/rpm/build_package.sh
@@ -98,11 +98,15 @@ for arch in x86_64 aarch64; do
             --define "cli_version v${VERSION}" \
             -bb ${BASE_DIR}/tanzu-cli.spec \
             --target ${arch}
-   mv ${HOME}/rpmbuild/RPMS/${arch}/* ${PKG_DIR}/
 
+   # Sign the package before moving it to the common output directory
    if [[ ! -z "${RPM_SIGNER}" ]]; then
-     ${RPM_SIGNER} ${PKG_DIR}/tanzu-cli*${arch}.rpm
+     ${RPM_SIGNER} ${HOME}/rpmbuild/RPMS/${arch}/tanzu-cli*${arch}.rpm
    else
      echo skip rpmsigning packages for ${arch}
    fi
+
+   # Move the signed package to the output directory where the other packages
+   # also reside, so that we can build the repository at the very end 
+   mv ${HOME}/rpmbuild/RPMS/${arch}/* ${PKG_DIR}/
 done


### PR DESCRIPTION
### What this PR does / why we need it

Because the `hack/rpm/build_package.sh` script can get called more than once to build first a `tanzu-cli` package an then a `tanzu-cli-centos9` package, we ended up on the second call with a `${PKG_DIR}/` directory containing multiple packages.

Then, when signing everything in that directory using a `*`, we ended up only signing the first package that was passed as an argument to the signer.  This caused the `tanzu-cli-centos9` package not to get signed because it comes alphabetically after `tanzu-cli` when the `*` is expanded.

To solve this and still benefit from using the `*` which allows to avoid explicitly dealing with the `-unstable` and/or `-centos` suffixes we sign the package before we move it to the common `${PKG_DIR}/` directory.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

**Before this PR:**
```
# Build the needed CLI with a final release version
$ make build-cli-linux-amd64 BUILD_VERSION=v1.6.0
[...]

# Build the `tanzu-cli` package and use `echo` as a signer 
# This step works so we don't need the output
$ make rpm-package-only BUILD_VERSION=v1.6.0 RPM_SIGNER=echo
[...]

# Build the `tanzu-cli-centos9` package and use `echo` as a signer and notice
# that the WRONG package is passed first as an argument
$ make rpm-package-only BUILD_VERSION=v1.6.0 RPM_SIGNER=echo RPM_PACKAGE_NAME=tanzu-cli-centos9
[...]
+ [[ ! -z echo ]]
+ echo /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/tanzu-cli-1.6.0-1.x86_64.rpm /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/tanzu-cli-centos9-1.6.0-1.x86_64.rpm
/Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/tanzu-cli-1.6.0-1.x86_64.rpm /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/tanzu-cli-centos9-1.6.0-1.x86_64.rpm
[...]
+ [[ ! -z echo ]]
/Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/tanzu-cli-1.6.0-1.aarch64.rpm /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/tanzu-cli-centos9-1.6.0-1.aarch64.rpm
+ echo /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/tanzu-cli-1.6.0-1.aarch64.rpm /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/tanzu-cli-centos9-1.6.0-1.aarch64.rpm
```
I ran the same test but using a pre-release version `1.6.0-rc.0` to show that this one worked by simple luck because alphabetical ordering:
```
# Build the needed CLI with a final release version
$ make build-cli-linux-amd64 BUILD_VERSION=v1.6.0-rc.0
[...]

# Build the `tanzu-cli-unstable` package and use `echo` as a signer 
# This step works so we don't need the output
$ make rpm-package-only BUILD_VERSION=v1.6.0-rc.0 RPM_SIGNER=echo
[...]

# Build the `tanzu-cli-centos9-unstable` package and use `echo` as a signer and notice
# that the wrong number of arguments are passed to the signer
# BUT that by alphabetical luck, the first argument is the correct package
$ make rpm-package-only BUILD_VERSION=v1.6.0-rc.0 RPM_SIGNER=echo RPM_PACKAGE_NAME=tanzu-cli-centos9
[...]
+ [[ ! -z echo ]]
+ echo /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/tanzu-cli-centos9-unstable-1.6.0-0.1_rc.0.x86_64.rpm /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/tanzu-cli-unstable-1.6.0-0.1_rc.0.x86_64.rpm
/Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/tanzu-cli-centos9-unstable-1.6.0-0.1_rc.0.x86_64.rpm /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/tanzu-cli-unstable-1.6.0-0.1_rc.0.x86_64.rpm
[...]
+ [[ ! -z echo ]]
+ echo /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/tanzu-cli-centos9-unstable-1.6.0-0.1_rc.0.aarch64.rpm /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/tanzu-cli-unstable-1.6.0-0.1_rc.0.aarch64.rpm
/Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/tanzu-cli-centos9-unstable-1.6.0-0.1_rc.0.aarch64.rpm /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/tanzu-cli-unstable-1.6.0-0.1_rc.0.aarch64.rpm
```

**With this PR:**
```
# Build the needed CLI with a final release version
$ make build-cli-linux-amd64 BUILD_VERSION=v1.6.0
[...]

# Build the `tanzu-cli` package and use `echo` as a signer and notice
# that the correct package is passed as an argument
$ make rpm-package-only BUILD_VERSION=v1.6.0 RPM_SIGNER=echo
[...]
+ [[ ! -z echo ]]
+ echo /root/rpmbuild/RPMS/x86_64/tanzu-cli-1.6.0-1.x86_64.rpm
+ mv /root/rpmbuild/RPMS/x86_64/tanzu-cli-1.6.0-1.x86_64.rpm /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/
/root/rpmbuild/RPMS/x86_64/tanzu-cli-1.6.0-1.x86_64.rpm
[...]
+ [[ ! -z echo ]]
+ echo /root/rpmbuild/RPMS/aarch64/tanzu-cli-1.6.0-1.aarch64.rpm
/root/rpmbuild/RPMS/aarch64/tanzu-cli-1.6.0-1.aarch64.rpm
+ mv /root/rpmbuild/RPMS/aarch64/tanzu-cli-1.6.0-1.aarch64.rpm /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/

# Build the `tanzu-cli-centos9` package and use `echo` as a signer and notice
# that the correct package is passed as an argument
$ make rpm-package-only BUILD_VERSION=v1.6.0 RPM_SIGNER=echo RPM_PACKAGE_NAME=tanzu-cli-centos9
[...]
+ [[ ! -z echo ]]
+ echo /root/rpmbuild/RPMS/x86_64/tanzu-cli-centos9-1.6.0-1.x86_64.rpm
/root/rpmbuild/RPMS/x86_64/tanzu-cli-centos9-1.6.0-1.x86_64.rpm
+ mv /root/rpmbuild/RPMS/x86_64/tanzu-cli-centos9-1.6.0-1.x86_64.rpm /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/
[...]
+ [[ ! -z echo ]]
/root/rpmbuild/RPMS/aarch64/tanzu-cli-centos9-1.6.0-1.aarch64.rpm
+ echo /root/rpmbuild/RPMS/aarch64/tanzu-cli-centos9-1.6.0-1.aarch64.rpm
+ mv /root/rpmbuild/RPMS/aarch64/tanzu-cli-centos9-1.6.0-1.aarch64.rpm /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/
```
I ran the same test but using a pre-release version `1.6.0-rc.0`:
```
# Build the needed CLI with a final release version
$ make build-cli-linux-amd64 BUILD_VERSION=v1.6.0-rc.0
[...]

# Build the `tanzu-cli-unstable` package and use `echo` as a signer and notice
# that the correct package is passed as an argument
$ make rpm-package-only BUILD_VERSION=v1.6.0-rc.0 RPM_SIGNER=echo
[...]
+ [[ ! -z echo ]]
+ echo /root/rpmbuild/RPMS/x86_64/tanzu-cli-unstable-1.6.0-0.1_rc.0.x86_64.rpm
+ mv /root/rpmbuild/RPMS/x86_64/tanzu-cli-unstable-1.6.0-0.1_rc.0.x86_64.rpm /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/
/root/rpmbuild/RPMS/x86_64/tanzu-cli-unstable-1.6.0-0.1_rc.0.x86_64.rpm
[...]
+ [[ ! -z echo ]]
+ echo /root/rpmbuild/RPMS/aarch64/tanzu-cli-unstable-1.6.0-0.1_rc.0.aarch64.rpm
/root/rpmbuild/RPMS/aarch64/tanzu-cli-unstable-1.6.0-0.1_rc.0.aarch64.rpm
+ mv /root/rpmbuild/RPMS/aarch64/tanzu-cli-unstable-1.6.0-0.1_rc.0.aarch64.rpm /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/

# Build the `tanzu-cli-centos9-unstable` package and use `echo` as a signer and notice
# that the correct package is passed as an argument
$ make rpm-package-only BUILD_VERSION=v1.6.0-rc.0 RPM_SIGNER=echo RPM_PACKAGE_NAME=tanzu-cli-centos9
[...]
+ [[ ! -z echo ]]
+ echo /root/rpmbuild/RPMS/x86_64/tanzu-cli-centos9-unstable-1.6.0-0.1_rc.0.x86_64.rpm
/root/rpmbuild/RPMS/x86_64/tanzu-cli-centos9-unstable-1.6.0-0.1_rc.0.x86_64.rpm
+ mv /root/rpmbuild/RPMS/x86_64/tanzu-cli-centos9-unstable-1.6.0-0.1_rc.0.x86_64.rpm /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/
[...]
+ [[ ! -z echo ]]
+ echo /root/rpmbuild/RPMS/aarch64/tanzu-cli-centos9-unstable-1.6.0-0.1_rc.0.aarch64.rpm
/root/rpmbuild/RPMS/aarch64/tanzu-cli-centos9-unstable-1.6.0-0.1_rc.0.aarch64.rpm
+ mv /root/rpmbuild/RPMS/aarch64/tanzu-cli-centos9-unstable-1.6.0-0.1_rc.0.aarch64.rpm /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/

# Confirm that both packages for both archs are in the common location to build the repo
ls hack/rpm/_output/rpm/tanzu-cli/
tanzu-cli-centos9-unstable-1.6.0-0.1_rc.0.aarch64.rpm tanzu-cli-unstable-1.6.0-0.1_rc.0.aarch64.rpm
tanzu-cli-centos9-unstable-1.6.0-0.1_rc.0.x86_64.rpm  tanzu-cli-unstable-1.6.0-0.1_rc.0.x86_64.rpm

# Finally build the repo to see that it works
make rpm-package-repo RPM_SIGNER=echo
[...]
+ [[ ! -z echo ]]
+ echo /Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/repodata/repomd.xml
/Users/kmarc/git/tanzu-cli/hack/rpm/_output/rpm/tanzu-cli/repodata/repomd.xml
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix the special RPM signing for Centos9.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
