### PR TITLE
Show scope path of the tanzu resource for context type tanzu

### DIFF
--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -1497,6 +1497,9 @@ func printContext(writer io.Writer, ctx *configtypes.Context) {
 				columns = append(columns, "Cluster Group")
 				row = append(row, resources.ClusterGroupName)
 			}
+			scopePath := getTanzuResourceScopePath(resources)
+			columns = append(columns, "Scope Path")
+			row = append(row, scopePath)
 		}
 	}
 
@@ -1515,6 +1518,27 @@ func printContext(writer io.Writer, ctx *configtypes.Context) {
 	outputWriter := component.NewOutputWriterWithOptions(writer, string(component.ListTableOutputType), []component.OutputWriterOption{}, columns...)
 	outputWriter.AddRow(row...)
 	outputWriter.Render()
+}
+
+// getTanzuResourceScopePath returns the scope path based on the ResourceInfo
+// TODO: Update this function when CLI context provides support for cluster/CF resources(CF Foundation/CF Org/CF Space)
+func getTanzuResourceScopePath(resources *config.ResourceInfo) string {
+	scopePath := ""
+	if resources.OrgID == "" {
+		return scopePath
+	}
+	// set org scope path as global scope "/" and update the path based on resource hierarchy
+	scopePath += "/"
+	if resources.ProjectName != "" {
+		scopePath += "projects/" + resources.ProjectName
+		if resources.SpaceName != "" {
+			scopePath += "/spaces/" + resources.SpaceName
+		} else if resources.ClusterGroupName != "" {
+			scopePath += "/clustergroups/" + resources.ClusterGroupName
+		}
+	}
+
+	return scopePath
 }
 
 func newDeleteCtxCmd() *cobra.Command {

--- a/pkg/command/context_test.go
+++ b/pkg/command/context_test.go
@@ -1860,6 +1860,7 @@ func TestContextCurrentCmd(t *testing.T) {
   Type:            tanzu
   Organization:    org-name (org-id)
   Project:         none set
+  Scope Path:      /
   Kube Config:     /home/user/.kube/config
   Kube Context:    kube-context-name
 `,
@@ -1877,6 +1878,7 @@ func TestContextCurrentCmd(t *testing.T) {
   Type:            tanzu
   Organization:    org-name (org-id)
   Project:         project-name (project-id)
+  Scope Path:      /projects/project-name
   Kube Config:     /home/user/.kube/config
   Kube Context:    kube-context-name
 `,
@@ -1895,6 +1897,7 @@ func TestContextCurrentCmd(t *testing.T) {
   Organization:    org-name (org-id)
   Project:         project-name (project-id)
   Space:           space-name
+  Scope Path:      /projects/project-name/spaces/space-name
   Kube Config:     /home/user/.kube/config
   Kube Context:    kube-context-name
 `,
@@ -1913,6 +1916,7 @@ func TestContextCurrentCmd(t *testing.T) {
   Organization:     org-name (org-id)
   Project:          project-name (project-id)
   Cluster Group:    clustergroup-name
+  Scope Path:       /projects/project-name/clustergroups/clustergroup-name
   Kube Config:      /home/user/.kube/config
   Kube Context:     kube-context-name
 `,


### PR DESCRIPTION
### What this PR does / why we need it
Show scope path of the tanzu resource for context type tanzu

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Verified with context pointing to org/project/space/clustergroup
```
❯ ./bin/tanzu context current
  Name:            tpsm-412d4f42
  Type:            tanzu
  Organization:    TPE PV Main (eac7cec7-8568-4683-a4a4-1a6e8a009fb7)
  Project:         none set
  Scope Path:      /
  Kube Config:     /Users/pkalle/.config/tanzu/kube/config
  Kube Context:    tanzu-cli-tpsm-412d4f42

❯ ./bin/tanzu project use  tpe_test
✓ Successfully set project to tpe_test
❯ ./bin/tanzu context current
  Name:            tpsm-412d4f42
  Type:            tanzu
  Organization:    TPE PV Main (eac7cec7-8568-4683-a4a4-1a6e8a009fb7)
  Project:         tpe_test (6b52eea7-2d4e-434c-9c87-14e42bda67a5)
  Scope Path:      /projects/tpe_test
  Kube Config:     /Users/pkalle/.config/tanzu/kube/config
  Kube Context:    tanzu-cli-tpsm-412d4f42:tpe_test

❯ ./bin/tanzu space use test-101
✓ Successfully set space to test-101
❯ ./bin/tanzu context current
  Name:            tpsm-412d4f42
  Type:            tanzu
  Organization:    TPE PV Main (eac7cec7-8568-4683-a4a4-1a6e8a009fb7)
  Project:         tpe_test (6b52eea7-2d4e-434c-9c87-14e42bda67a5)
  Space:           test-101
  Scope Path:      /projects/tpe_test/spaces/test-101
  Kube Config:     /Users/pkalle/.config/tanzu/kube/config
  Kube Context:    tanzu-cli-tpsm-412d4f42:tpe_test:test-101
❯ ./bin/tanzu operations clustergroup use build-cluster-group
ℹ  project has been set to tpe_test
ℹ  successfully set clustergroup to build-cluster-group
❯  ./bin/tanzu context current
  Name:             tpsm-412d4f42
  Type:             tanzu
  Organization:     TPE PV Main (eac7cec7-8568-4683-a4a4-1a6e8a009fb7)
  Project:          tpe_test (6b52eea7-2d4e-434c-9c87-14e42bda67a5)
  Cluster Group:    build-cluster-group
  Scope Path:       /projects/tpe_test/clustergroups/build-cluster-group
  Kube Config:      /Users/pkalle/.config/tanzu/kube/config
  Kube Context:     tanzu-cli-tpsm-412d4f42:tpe_test:build-cluster-group
```

Verified that scope path is not shown  for TMC context type

```
❯ tanzu context create --name tmc --endpoint unstable.tmc-dev.cloud.vmware.com --staging
Flag --name has been deprecated, it has been replaced by using an argument to the command
[i] API token env var is set

[ok] successfully created a TMC context
[...]

❯ ./bin/tanzu context current
  Name:        tmc
  Type:        mission-control
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Show scope path of the tanzu resource for context type tanzu
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
