### PR TITLE
Respect the discovered plugin target if available

### DIFF
--- a/pkg/pluginmanager/manager.go
+++ b/pkg/pluginmanager/manager.go
@@ -200,13 +200,19 @@ func discoverServerPluginsForGivenContexts(contexts []*configtypes.Context) ([]d
 			discoveredPlugins[i].Status = common.PluginStatusNotInstalled
 			discoveredPlugins[i].ContextName = context.Name
 
-			// Associate Target of the plugin based on the Context Type of the Context
-			switch context.ContextType {
-			case configtypes.ContextTypeTMC:
-				discoveredPlugins[i].Target = configtypes.TargetTMC
-			default:
-				// All other context types are associated with the kubernetes target
-				discoveredPlugins[i].Target = configtypes.TargetK8s
+			if discoveredPlugins[i].Target == configtypes.TargetUnknown {
+				// Discovered plugin will have their target field set.
+				// Older plugins may have this information missing so we set it below.
+				// This happens for older plugins which could only be of target k8s or tmc.
+
+				// Associate Target of the plugin based on the Context Type of the Context
+				switch context.ContextType {
+				case configtypes.ContextTypeTMC:
+					discoveredPlugins[i].Target = configtypes.TargetTMC
+				default:
+					// All other context types are associated with the kubernetes target
+					discoveredPlugins[i].Target = configtypes.TargetK8s
+				}
 			}
 
 			// It is possible that server recommends shortened plugin version of format vMAJOR or vMAJOR.MINOR

--- a/pkg/pluginmanager/manager_test.go
+++ b/pkg/pluginmanager/manager_test.go
@@ -49,6 +49,28 @@ var expectedDiscoveredContextPlugins = []discovery.Discovered{
 		ContextName:        "tmc-fake",
 		Target:             configtypes.TargetTMC,
 	},
+	{
+		Name:               "apply",
+		RecommendedVersion: "v0.1.0",
+		Scope:              common.PluginScopeContext,
+		ContextName:        "mgmt",
+		Target:             configtypes.TargetOperations,
+	},
+	{
+		Name:               "resource",
+		RecommendedVersion: "v0.2.0",
+		Scope:              common.PluginScopeContext,
+		ContextName:        "mgmt",
+		Target:             configtypes.TargetGlobal,
+	},
+	{
+		Name:               "feature",
+		RecommendedVersion: "v0.31.1",
+		Scope:              common.PluginScopeContext,
+		ContextName:        "mgmt",
+		// Older plugins will get their target from the context
+		Target: configtypes.TargetK8s,
+	},
 }
 var expectedDiscoveredStandalonePlugins = []discovery.Discovered{
 	{

--- a/pkg/pluginmanager/test/local/discovery/context-mgmt/apply.yaml
+++ b/pkg/pluginmanager/test/local/discovery/context-mgmt/apply.yaml
@@ -1,0 +1,8 @@
+apiVersion: cli.tanzu.vmware.com/v1alpha1
+kind: CLIPlugin
+metadata:
+  name: apply
+spec:
+  description: Apply plugin
+  recommendedVersion: v0.1.0
+  target: operations

--- a/pkg/pluginmanager/test/local/discovery/context-mgmt/feature.yaml
+++ b/pkg/pluginmanager/test/local/discovery/context-mgmt/feature.yaml
@@ -1,0 +1,8 @@
+apiVersion: cli.tanzu.vmware.com/v1alpha1
+kind: CLIPlugin
+metadata:
+  name: feature
+spec:
+  description: Operate on features and featuregates
+  recommendedVersion: v0.31.1
+# don't specify a target to test older plugins

--- a/pkg/pluginmanager/test/local/discovery/context-mgmt/resource.yaml
+++ b/pkg/pluginmanager/test/local/discovery/context-mgmt/resource.yaml
@@ -1,0 +1,8 @@
+apiVersion: cli.tanzu.vmware.com/v1alpha1
+kind: CLIPlugin
+metadata:
+  name: resource
+spec:
+  description: Resource plugin
+  recommendedVersion: v0.2.0
+  target: global


### PR DESCRIPTION
### What this PR does / why we need it

This PR teaches the CLI to respect the discovered target of a plugin if that target is specified.
This is important since we have global plugins which should not be given the k8s target.

Originally, recommended plugins were only of either the k8s or tmc targets; furthermore, older recommended discoveries did not specify the target field for plugins, therefore, the CLI would infer the target based on the current context.

Now however, there are other types of targets: operations and global.  Those do not need to (and cannot) be inferred from the context as the recommended plugin data will include the target.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

I setup a kubernetes cluster which recommends 4 plugins of different targets.
```
$ k get cliplugins.cli.tanzu.vmware.com -o yaml | egrep -e 'name:|recommendedVersion:|target:'
    name: kubernetes-release
    recommendedVersion: v0.31.1
    target: kubernetes

    name: feature
    recommendedVersion: v0.31.1

    name: cluster
    recommendedVersion: v0.12.0
    target: operations

    name: appsv2
    recommendedVersion: v0.22.0
    target: global
```
Before this PR, notice how all 4 plugins are marked with a kubernetes target, which is not correct:
```
$ tz plugin sync
[i] Fetching recommended plugins for active context 'tkg1'...
[i] Installing the following plugins recommended by context 'tkg1':
  NAME                TARGET      INSTALLING
  appsv2              kubernetes  v0.22.0
  cluster             kubernetes  v0.12.0
  feature             kubernetes  v0.31.1
  kubernetes-release  kubernetes  v0.31.1
[i] Installed plugin 'feature:v0.31.1' with target 'kubernetes' (from cache)
[i] Installed plugin 'kubernetes-release:v0.31.1' with target 'kubernetes' (from cache)
[x] : [unable to find plugin 'appsv2' matching version 'v0.22.0' for target 'kubernetes', unable to find plugin 'cluster' matching version 'v0.12.0' for target 'kubernetes']
```
With this PR:
```
$ tz plugin sync
[i] Fetching recommended plugins for active context 'tkg1'...
[i] Installing the following plugins recommended by context 'tkg1':
  NAME                TARGET      CURRENT   INSTALLING
  appsv2              global      v0.21.2   v0.22.0
  cluster             operations  v0.11.10  v0.12.0
  feature             kubernetes            v0.31.1
  kubernetes-release  kubernetes            v0.31.1
[i] Installed plugin 'appsv2:v0.22.0' with target 'global' (from cache)
[i] Installed plugin 'cluster:v0.12.0' with target 'operations'
[i] Installed plugin 'feature:v0.31.1' with target 'kubernetes' (from cache)
[i] Installed plugin 'kubernetes-release:v0.31.1' with target 'kubernetes' (from cache)
[ok] Successfully installed all recommended plugins.
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Respect the discovered plugin target if available
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-cli/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
